### PR TITLE
Disable Go runtime GC for starter process

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
 Copyright (c) 2016-2017, The Regents of the University of California. All right reserved.
 Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
-Copyright (c) 2018-2019, Sylabs, Inc. All rights reserved.
+Copyright (c) 2018-2021, Sylabs, Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2018-2020, Sylabs, Inc. All rights reserved.
+  Copyright (c) 2018-2021, Sylabs, Inc. All rights reserved.
 
   This software is licensed under a 3-clause BSD license.  Please
   consult LICENSE.md file distributed with the sources of this project regarding
@@ -1145,9 +1145,9 @@ static void cleanenv(void) {
      * debugging purposes.
      */
     for (e = environ; *e != NULL; e++) {
-        if ( strncmp(MSGLVL_ENV "=", *e, sizeof(MSGLVL_ENV)) == 0 ||
-             strncmp("GOGC" "=", *e, sizeof("GOGC")) == 0 ||
-             strncmp("GODEBUG" "=", *e, sizeof("GODEBUG")) == 0 ) {
+        if ( strncmp(MSGLVL_ENV "=", *e, strlen(MSGLVL_ENV "=")) == 0 ||
+             strncmp("GOGC" "=", *e, strlen("GOGC" "=")) == 0 ||
+             strncmp("GODEBUG" "=", *e, strlen("GODEBUG" "=")) == 0 ) {
             debugf("Keeping env var %s\n", *e);
         } else {
             debugf("Clearing env var %s\n", *e);

--- a/internal/pkg/util/starter/starter.go
+++ b/internal/pkg/util/starter/starter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -89,6 +89,8 @@ func Exec(name string, config *config.Common, ops ...CommandOp) error {
 	if err := c.init(config, ops...); err != nil {
 		return fmt.Errorf("while initializing starter command: %s", err)
 	}
+	sylog.Debugf("Setting GOGC=off for starter")
+	c.env = append(c.env, "GOGC=off")
 	err := unix.Exec(c.path, []string{name}, c.env)
 	return fmt.Errorf("while executing %s: %s", c.path, err)
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

This is an inelegant, but effective work around for #7 that will prevent GC cycle triggered errors until the effects of closing fds in container startup can be further considered for possible re-work.

Allow debug of Go runtime issues in starter

 - Do not clear GOGC and GODEBUG in starter C init
 - Log FD_CLOEXEC on fds

Disable GC for the starter
 - Prevent a GC cycle firing after fds have been closed, which can cause
a netpoll panic.

Co-authored-by: Adam Hughes <tri-adam@users.noreply.github.com>




### This fixes or addresses the following GitHub issues:

 - Fixes #7 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
