### PR TITLE
Add version to extracted dir from tarball

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -135,10 +135,10 @@ and use it to install the RPM like this:
 ```
 $ export VERSION=3.7.3  # this is the singularity version, change as you need
 
-$ wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+$ wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-ce-${VERSION}.tar.gz && \
     rpmbuild -tb singularity-${VERSION}.tar.gz && \
-    sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-${VERSION}-1.el7.x86_64.rpm && \
-    rm -rf ~/rpmbuild singularity-${VERSION}*.tar.gz
+    sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-ce-${VERSION}-1.el7.x86_64.rpm && \
+    rm -rf ~/rpmbuild singularity-ce-${VERSION}*.tar.gz
 ```
 
 Alternatively, to build an RPM from the latest master you can 
@@ -149,7 +149,7 @@ tarball and use it to install Singularity:
 $ cd $GOPATH/src/github.com/sylabs/singularity && \
   ./mconfig && \
   make -C builddir rpm && \
-  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-3.7.3*.x86_64.rpm # or whatever version you built
+  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-ce-3.7.3*.x86_64.rpm # or whatever version you built
 ```
 
 To build an rpm with an alternative install prefix set RPMPREFIX on the

--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -101,7 +101,7 @@ export PATH=$GOPATH/bin:$PATH
 
 # Perform the build outside of GOPATH as we are using go modules
 tar -xf "%SOURCE0"
-cd %{name}
+cd %{name}-@PACKAGE_VERSION@
 
 # Not all of these parameters currently have an effect, but they might be
 #  used someday.  They are the same parameters as in the configure macro.
@@ -131,7 +131,7 @@ export GOPATH=$PWD/gopath
 export PATH=$GOPATH/bin:$PATH
 
 # Enter the source builddir for the install
-cd %{name}/builddir
+cd %{name}-@PACKAGE_VERSION@/builddir
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
 make DESTDIR=$RPM_BUILD_ROOT install man
 

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -28,7 +28,7 @@ rmfiles="VERSION"
 tarball="${package_name}-${version}.tar.gz"
 echo " DIST create tarball: $tarball"
 rm -f $tarball
-pathtop="$package_name"
+pathtop="${package_name}-${version}"
 ln -sf .. builddir/$pathtop
 rmfiles="$rmfiles builddir/$pathtop"
 trap "rm -f $rmfiles" 0


### PR DESCRIPTION
Extracting the `make dist` tarball will now place the source code in a dir `singularity-<version>` rather than just `singularity` to avoid confusion and extracting over an older source tree.

Fixes: #15

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
