### PR TITLE
Update Ubuntu CI Image to Latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ executors:
   ubuntu-machine:
     working_directory: ~/go/singularity
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202104-01
 
 commands:
   check-changes:


### PR DESCRIPTION
Update `ubuntu-machine` image used in CI to latest ([ref](https://circleci.com/docs/2.0/configuration-reference/#available-machine-images)).