### PR TITLE
Bump Go to 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: 1.15.12
+    default: 1.16.4
 
 executors:
   golang:

--- a/e2e/internal/e2e/priv_linux.go
+++ b/e2e/internal/e2e/priv_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019,2020 Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,10 +7,10 @@ package e2e
 
 import (
 	"runtime"
-	"syscall"
 	"testing"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 // Privileged wraps the supplied test function with calls to ensure
@@ -21,21 +21,21 @@ func Privileged(f func(*testing.T)) func(*testing.T) {
 
 		runtime.LockOSThread()
 
-		if err := syscall.Setresuid(0, 0, origUID); err != nil {
+		if err := unix.Setresuid(0, 0, origUID); err != nil {
 			err = errors.Wrap(err, "changing user ID to 0")
 			t.Fatalf("privileges escalation failed: %+v", err)
 		}
-		if err := syscall.Setresgid(0, 0, origGID); err != nil {
+		if err := unix.Setresgid(0, 0, origGID); err != nil {
 			err = errors.Wrap(err, "changing group ID to 0")
 			t.Fatalf("privileges escalation failed: %+v", err)
 		}
 
 		defer func() {
-			if err := syscall.Setresgid(origGID, origGID, 0); err != nil {
+			if err := unix.Setresgid(origGID, origGID, 0); err != nil {
 				err = errors.Wrapf(err, "changing group ID to %d", origUID)
 				t.Fatalf("privileges drop failed: %+v", err)
 			}
-			if err := syscall.Setresuid(origUID, origUID, 0); err != nil {
+			if err := unix.Setresuid(origUID, origUID, 0); err != nil {
 				err = errors.Wrapf(err, "changing group ID to %d", origGID)
 				t.Fatalf("privileges drop failed: %+v", err)
 			}

--- a/internal/pkg/test/privilege_linux.go
+++ b/internal/pkg/test/privilege_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,8 +13,9 @@ import (
 	"os/user"
 	"runtime"
 	"strconv"
-	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 var origUID, origGID, unprivUID, unprivGID int
@@ -38,12 +39,12 @@ func DropPrivilege(t *testing.T) {
 	runtime.LockOSThread()
 
 	if os.Getgid() == 0 {
-		if err := syscall.Setresgid(unprivGID, unprivGID, origGID); err != nil {
+		if err := unix.Setresgid(unprivGID, unprivGID, origGID); err != nil {
 			t.Fatalf("failed to set group identity: %v", err)
 		}
 	}
 	if os.Getuid() == 0 {
-		if err := syscall.Setresuid(unprivUID, unprivUID, origUID); err != nil {
+		if err := unix.Setresuid(unprivUID, unprivUID, origUID); err != nil {
 			t.Fatalf("failed to set user identity: %v", err)
 		}
 
@@ -55,10 +56,10 @@ func DropPrivilege(t *testing.T) {
 
 // ResetPrivilege returns effective privilege to the original user.
 func ResetPrivilege(t *testing.T) {
-	if err := syscall.Setresuid(origUID, origUID, unprivUID); err != nil {
+	if err := unix.Setresuid(origUID, origUID, unprivUID); err != nil {
 		t.Fatalf("failed to reset user identity: %v", err)
 	}
-	if err := syscall.Setresgid(origGID, origGID, unprivGID); err != nil {
+	if err := unix.Setresgid(origGID, origGID, unprivGID); err != nil {
 		t.Fatalf("failed to reset group identity: %v", err)
 	}
 	if err := os.Setenv("HOME", origHome); err != nil {


### PR DESCRIPTION
Use Go 1.16 in CI. Replace `syscall` package usage for `Setresuid()`/`Setresgid()` in test helpers with `unix` package. As of Go 1.16, the `syscall` functions now include wrappers that ensure all OSThreads mirror a common system call (related discussion [here](https://github.com/golang/go/issues/1435)). This is not compatible with the approach we have taken in our test cases. The `unix` package retains the original semantics, so we use that.