### PR TITLE
Use Latest Debian in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
   check-debian:
     executor:
       name: golang
-      variant: stretch
+      variant: buster
     steps:
       - checkout
       - install-deps-apt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
           name: Check Module Tidiness
           command: git diff --exit-code -- go.mod go.sum
 
-  check-stretch:
+  check-debian:
     executor:
       name: golang
       variant: stretch
@@ -226,7 +226,7 @@ workflows:
   build_and_test:
     jobs:
       - check-go-mod
-      - check-stretch
+      - check-debian
       - check-alpine
       - check-darwin
       - short-unit-tests


### PR DESCRIPTION
Rename `check-stretch` to `check-debian`. Update `golang:stretch` to `golang:buster`, the most recent stable version of Debian.