### PR TITLE
Use Latest Xcode in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ executors:
           password: $CIRCLE_CI_DOCKER_PASSWORD
   macos-machine:
     macos:
-      xcode: "10.2.0"
+      xcode: 12.4.0
   ubuntu-machine:
     working_directory: ~/go/singularity
     machine:


### PR DESCRIPTION
We are currently using Xcode 10.2.0, which is no longer a supported version ([ref](https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions)). Update Xcode to latest supported version.