### PR TITLE
Use Default Working Directory in CI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,6 @@ jobs:
 
   check-darwin:
     executor: macos-machine
-    working_directory: /Users/distiller/go/src/github.com/sylabs/singularity
     steps:
       - checkout
       - go/install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ executors:
     macos:
       xcode: 12.4.0
   ubuntu-machine:
-    working_directory: ~/go/singularity
     machine:
       image: ubuntu-2004:202104-01
 


### PR DESCRIPTION
Support for `GOPATH` mode will be dropped in Go 1.17 ([ref](https://blog.golang.org/go116-module-changes#TOC_2.)). Modify `check-darwin` job to exercise building outside `GOPATH`. Drop unnecessary `working_directory` directive from `ubuntu-machine` executor for consistency.