### PR TITLE
Replace Deprecated Golint Linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,12 +8,12 @@ linters:
     - deadcode
     - gofmt
     - goimports
-    - golint
     - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
+    - revive
     # we would like to add these
     # - dupl
     # - staticcheck

--- a/cmd/internal/cli/buildconfig.go
+++ b/cmd/internal/cli/buildconfig.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -27,10 +27,7 @@ var BuildConfigCmd = &cobra.Command{
 		if len(args) > 0 {
 			name = args[0]
 		}
-		if err := printParam(name); err != nil {
-			return err
-		}
-		return nil
+		return printParam(name)
 	},
 	DisableFlagsInUseLine: true,
 

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2017-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2017-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -71,11 +71,11 @@ func init() {
 		cmdManager.RegisterCmd(KeyCmd)
 
 		cmdManager.RegisterSubCmd(KeyCmd, KeyNewPairCmd)
-		cmdManager.RegisterFlagForCmd(KeyNewPairNameFlag, KeyNewPairCmd)
-		cmdManager.RegisterFlagForCmd(KeyNewPairEmailFlag, KeyNewPairCmd)
-		cmdManager.RegisterFlagForCmd(KeyNewPairCommentFlag, KeyNewPairCmd)
-		cmdManager.RegisterFlagForCmd(KeyNewPairPasswordFlag, KeyNewPairCmd)
-		cmdManager.RegisterFlagForCmd(KeyNewPairPushFlag, KeyNewPairCmd)
+		cmdManager.RegisterFlagForCmd(keyNewPairNameFlag, KeyNewPairCmd)
+		cmdManager.RegisterFlagForCmd(keyNewPairEmailFlag, KeyNewPairCmd)
+		cmdManager.RegisterFlagForCmd(keyNewPairCommentFlag, KeyNewPairCmd)
+		cmdManager.RegisterFlagForCmd(keyNewPairPasswordFlag, KeyNewPairCmd)
+		cmdManager.RegisterFlagForCmd(keyNewPairPushFlag, KeyNewPairCmd)
 
 		cmdManager.RegisterSubCmd(KeyCmd, KeyListCmd)
 		cmdManager.RegisterSubCmd(KeyCmd, KeySearchCmd)

--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2017-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2017-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,7 +23,7 @@ import (
 
 var (
 	keyNewPairName     string
-	KeyNewPairNameFlag = &cmdline.Flag{
+	keyNewPairNameFlag = &cmdline.Flag{
 		ID:           "KeyNewPairNameFlag",
 		Value:        &keyNewPairName,
 		DefaultValue: "",
@@ -33,7 +33,7 @@ var (
 	}
 
 	keyNewPairEmail     string
-	KeyNewPairEmailFlag = &cmdline.Flag{
+	keyNewPairEmailFlag = &cmdline.Flag{
 		ID:           "KeyNewPairEmailFlag",
 		Value:        &keyNewPairEmail,
 		DefaultValue: "",
@@ -43,7 +43,7 @@ var (
 	}
 
 	keyNewPairComment     string
-	KeyNewPairCommentFlag = &cmdline.Flag{
+	keyNewPairCommentFlag = &cmdline.Flag{
 		ID:           "KeyNewPairCommentFlag",
 		Value:        &keyNewPairComment,
 		DefaultValue: "",
@@ -53,7 +53,7 @@ var (
 	}
 
 	keyNewPairPassword     string
-	KeyNewPairPasswordFlag = &cmdline.Flag{
+	keyNewPairPasswordFlag = &cmdline.Flag{
 		ID:           "KeyNewPairPasswordFlag",
 		Value:        &keyNewPairPassword,
 		DefaultValue: "",
@@ -63,7 +63,7 @@ var (
 	}
 
 	keyNewPairPush     bool
-	KeyNewPairPushFlag = &cmdline.Flag{
+	keyNewPairPushFlag = &cmdline.Flag{
 		ID:           "KeyNewPairPushFlag",
 		Value:        &keyNewPairPush,
 		DefaultValue: false,
@@ -132,7 +132,7 @@ func collectInput(cmd *cobra.Command) (*keyNewPairOptions, error) {
 	var genOpts keyNewPairOptions
 
 	// check flags
-	if cmd.Flags().Changed(KeyNewPairNameFlag.Name) {
+	if cmd.Flags().Changed(keyNewPairNameFlag.Name) {
 		genOpts.Name = keyNewPairName
 	} else {
 		n, err := interactive.AskQuestion("Enter your name (e.g., John Doe) : ")
@@ -143,7 +143,7 @@ func collectInput(cmd *cobra.Command) (*keyNewPairOptions, error) {
 		genOpts.Name = n
 	}
 
-	if cmd.Flags().Changed(KeyNewPairEmailFlag.Name) {
+	if cmd.Flags().Changed(keyNewPairEmailFlag.Name) {
 		genOpts.Email = keyNewPairEmail
 	} else {
 		e, err := interactive.AskQuestion("Enter your email address (e.g., john.doe@example.com) : ")
@@ -153,7 +153,7 @@ func collectInput(cmd *cobra.Command) (*keyNewPairOptions, error) {
 		genOpts.Email = e
 	}
 
-	if cmd.Flags().Changed(KeyNewPairCommentFlag.Name) {
+	if cmd.Flags().Changed(keyNewPairCommentFlag.Name) {
 		genOpts.Comment = keyNewPairComment
 	} else {
 		c, err := interactive.AskQuestion("Enter optional comment (e.g., development keys) : ")
@@ -163,7 +163,7 @@ func collectInput(cmd *cobra.Command) (*keyNewPairOptions, error) {
 		genOpts.Comment = c
 	}
 
-	if cmd.Flags().Changed(KeyNewPairPasswordFlag.Name) {
+	if cmd.Flags().Changed(keyNewPairPasswordFlag.Name) {
 		genOpts.Password = keyNewPairPassword
 	} else {
 		// get a password
@@ -186,7 +186,7 @@ func collectInput(cmd *cobra.Command) (*keyNewPairOptions, error) {
 		genOpts.Password = p
 	}
 
-	if cmd.Flags().Changed(KeyNewPairPushFlag.Name) {
+	if cmd.Flags().Changed(keyNewPairPushFlag.Name) {
 		genOpts.PushToKeyStore = keyNewPairPush
 	} else {
 		a, err := interactive.AskYNQuestion("y", "Would you like to push it to the keystore? [Y,n] ")

--- a/cmd/internal/cli/key_newpair_test.go
+++ b/cmd/internal/cli/key_newpair_test.go
@@ -1,3 +1,8 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
 package cli
 
 import (
@@ -22,11 +27,11 @@ const (
 )
 
 func Test_collectInput_flags(t *testing.T) {
-	nameF := pflag.Flag{Name: KeyNewPairNameFlag.Name, Changed: true}
-	emailF := pflag.Flag{Name: KeyNewPairEmailFlag.Name, Changed: true}
-	commentF := pflag.Flag{Name: KeyNewPairCommentFlag.Name, Changed: true}
-	passwordF := pflag.Flag{Name: KeyNewPairPasswordFlag.Name, Changed: true}
-	pushF := pflag.Flag{Name: KeyNewPairPushFlag.Name, Changed: true}
+	nameF := pflag.Flag{Name: keyNewPairNameFlag.Name, Changed: true}
+	emailF := pflag.Flag{Name: keyNewPairEmailFlag.Name, Changed: true}
+	commentF := pflag.Flag{Name: keyNewPairCommentFlag.Name, Changed: true}
+	passwordF := pflag.Flag{Name: keyNewPairPasswordFlag.Name, Changed: true}
+	pushF := pflag.Flag{Name: keyNewPairPushFlag.Name, Changed: true}
 
 	c := cobra.Command{}
 	c.Flags().AddFlag(&nameF)

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -455,7 +455,7 @@ func ExecuteSingularity() {
 	}
 }
 
-// GenBashCompletionFile
+// GenBashCompletion writes the bash completion file to w.
 func GenBashCompletion(w io.Writer) error {
 	Init(false)
 	return singularityCmd.GenBashCompletion(w)

--- a/docs/plugin.go
+++ b/docs/plugin.go
@@ -1,14 +1,12 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 package docs
 
+// Plugin command usage.
 const (
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// plugin command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	PluginUse   string = `plugin [plugin options...]`
 	PluginShort string = `Manage Singularity plugins`
 	PluginLong  string = `
@@ -19,10 +17,10 @@ const (
 
   $ singularity help plugin compile
   $ singularity plugin list --help`
+)
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// plugin compile command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Plugin compile command usage.
+const (
 	PluginCompileUse   string = `compile [compile options...] <host_path>`
 	PluginCompileShort string = `Compile a Singularity plugin`
 	PluginCompileLong  string = `
@@ -31,10 +29,10 @@ const (
   location of the plugin's source code. A compiled plugin is packed into a SIF file.`
 	PluginCompileExample string = `
   $ singularity plugin compile $HOME/singularity/test-plugin`
+)
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// plugin install command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Plugin install command usage.
+const (
 	PluginInstallUse   string = `install <plugin_path>`
 	PluginInstallShort string = `Install a compiled Singularity plugin`
 	PluginInstallLong  string = `
@@ -42,20 +40,20 @@ const (
   into the appropriate directory on the host.`
 	PluginInstallExample string = `
   $ singularity plugin install $HOME/singularity/test-plugin/test-plugin.sif`
+)
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// plugin uninstall command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Plugin uninstall command usage.
+const (
 	PluginUninstallUse   string = `uninstall <name>`
 	PluginUninstallShort string = `Uninstall removes the named plugin from the system`
 	PluginUninstallLong  string = `
   The 'plugin uninstall' command removes the named plugin from the system`
 	PluginUninstallExample string = `
   $ singularity plugin uninstall example.org/plugin`
+)
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// plugin list command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Plugin list command usage.
+const (
 	PluginListUse   string = `list [list options...]`
 	PluginListShort string = `List installed Singularity plugins`
 	PluginListLong  string = `
@@ -64,10 +62,10 @@ const (
   $ singularity plugin list
   ENABLED  NAME
       yes  example.org/plugin`
+)
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// plugin enable command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Plugin enable command usage.
+const (
 	PluginEnableUse   string = `enable <name>`
 	PluginEnableShort string = `Enable an installed Singularity plugin`
 	PluginEnableLong  string = `
@@ -75,10 +73,10 @@ const (
   installed in the system and which has been previously disabled.`
 	PluginEnableExample string = `
   $ singularity plugin enable example.org/plugin`
+)
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// plugin disable command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Plugin disable command usage.
+const (
 	PluginDisableUse   string = `disable <name>`
 	PluginDisableShort string = `disable an installed Singularity plugin`
 	PluginDisableLong  string = `
@@ -86,10 +84,10 @@ const (
   installed in the system and which has been previously enabled.`
 	PluginDisableExample string = `
   $ singularity plugin disable example.org/plugin`
+)
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// plugin inspect command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Plugin inspect command usage.
+const (
 	PluginInspectUse   string = `inspect (<name>|<image>)`
 	PluginInspectShort string = `Inspect a singularity plugin (either an installed one or an image)`
 	PluginInspectLong  string = `
@@ -101,10 +99,10 @@ const (
   Description: A test Singularity plugin.
   Author: Sylabs
   Version: 0.1.0`
+)
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// plugin create command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Plugin create command usage.
+const (
 	PluginCreateUse   string = `create <host_path> <name>`
 	PluginCreateShort string = `Create a plugin skeleton directory`
 	PluginCreateLong  string = `

--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,6 +16,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/syecl"
 )
 
+// KeyMap contains test keys.
 var KeyMap = map[string]string{
 	"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
 	"key2": "78F8AD36B0DCB84B707F23853D608DAE21C8CA10",

--- a/e2e/internal/e2e/docker_auth_server.go
+++ b/e2e/internal/e2e/docker_auth_server.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -16,7 +17,9 @@ import (
 )
 
 const (
-	DefaultUsername  = "e2e"
+	// DefaultUsername is the default E2E username.
+	DefaultUsername = "e2e"
+	// DefaultPassword is the default E2E password.
 	DefaultPassword  = "e2e"
 	privateNamespace = "private"
 )

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -45,7 +45,7 @@ const (
 	ContainMatch MatchType = iota
 	// ExactMatch is for exact match
 	ExactMatch
-	// UnwaantedContainMatch checks that output does not contain text
+	// UnwantedContainMatch checks that output does not contain text
 	UnwantedContainMatch
 	// UnwantedExactMatch checks that output does not exactly match text
 	UnwantedExactMatch

--- a/internal/app/singularity/plugin_uninstall_linux.go
+++ b/internal/app/singularity/plugin_uninstall_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,13 +13,13 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/plugin"
 )
 
-var ErrPluginNotFound = errors.New("plugin not found")
+var errPluginNotFound = errors.New("plugin not found")
 
 // UninstallPlugin removes the named plugin from the system.
 func UninstallPlugin(name string) error {
 	err := plugin.Uninstall(name)
 	if errors.Is(err, os.ErrNotExist) {
-		return ErrPluginNotFound
+		return errPluginNotFound
 	}
 	if err != nil {
 		return fmt.Errorf("could not uninstall plugin: %w", err)

--- a/internal/app/singularity/remote_use.go
+++ b/internal/app/singularity/remote_use.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -30,11 +30,7 @@ func syncSysConfig(cUsr *remote.Config) error {
 	}
 
 	// sync cUsr with system config cSys
-	if err := cUsr.SyncFrom(cSys); err != nil {
-		return err
-	}
-
-	return nil
+	return cUsr.SyncFrom(cSys)
 
 }
 

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the URIs of this project regarding your
 // rights to use or distribute this software.
@@ -272,11 +272,7 @@ func createAppRoot(b *types.Bundle, a *App) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appData(b, a), "/output/"), 0755); err != nil {
-		return err
-	}
-
-	return nil
+	return os.MkdirAll(filepath.Join(appData(b, a), "/output/"), 0755)
 }
 
 // %appenv and 01-base.sh

--- a/internal/pkg/build/sources/base_environment.go
+++ b/internal/pkg/build/sources/base_environment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -309,10 +309,7 @@ func makeDirs(rootPath string) error {
 	if err := os.MkdirAll(filepath.Join(rootPath, "sys"), 0755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "home"), 0755); err != nil {
-		return err
-	}
-	return nil
+	return os.MkdirAll(filepath.Join(rootPath, "home"), 0755)
 }
 
 func makeSymlinks(rootPath string) error {
@@ -410,10 +407,7 @@ func makeFiles(rootPath string) error {
 	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "runscript"), 0755, runscriptFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "startscript"), 0755, startscriptFileContent); err != nil {
-		return err
-	}
-	return nil
+	return makeFile(filepath.Join(rootPath, ".singularity.d", "startscript"), 0755, startscriptFileContent)
 }
 
 func makeBaseEnv(rootPath string) (err error) {

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -85,11 +85,7 @@ func (c *BusyBoxConveyor) insertBaseFiles() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0664); err != nil {
-		return err
-	}
-
-	return nil
+	return ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0664)
 }
 
 func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, err error) {
@@ -133,11 +129,7 @@ func (c *BusyBoxConveyor) insertBaseEnv() (err error) {
 }
 
 func (cp *BusyBoxConveyorPacker) insertRunScript() error {
-	if err := ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0755); err != nil {
-		return err
-	}
-
-	return nil
+	return ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0755)
 }
 
 // CleanUp removes any tmpfs owned by the conveyorPacker on the filesystem

--- a/internal/pkg/build/util.go
+++ b/internal/pkg/build/util.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// ConvertOciToSIf will convert an OCI source into a SIF using the build routines
+// ConvertOciToSIF will convert an OCI source into a SIF using the build routines
 func ConvertOciToSIF(ctx context.Context, imgCache *cache.Handle, image, cachedImgPath, tmpDir string, noHTTPS, noCleanUp bool, authConf *ocitypes.DockerAuthConfig) error {
 	if imgCache == nil {
 		return fmt.Errorf("image cache is undefined")

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -21,16 +21,13 @@ import (
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
-var (
-	ErrBadChecksum      = errors.New("hash does not match")
-	ErrInvalidCacheType = errors.New("invalid cache type")
-)
+var errInvalidCacheType = errors.New("invalid cache type")
 
 const (
 	// DirEnv specifies the environment variable which can set the directory
 	// for image downloads to be cached in
 	DirEnv = "SINGULARITY_CACHEDIR"
-	// DisableCacheEnv specifies whether the image should be used
+	// DisableEnv specifies whether the image should be used
 	DisableEnv = "SINGULARITY_DISABLE_CACHE"
 	// SubDirName specifies the name of the directory relative to the
 	// ParentDir specified when the cache is created.
@@ -38,21 +35,22 @@ const (
 	// will not clash with any 2.x cache directory.
 	SubDirName = "cache"
 
-	// The Library cache holds SIF images pulled from the library
+	// LibraryCacheType specifies the cache holds SIF images pulled from the library
 	LibraryCacheType = "library"
-	// The OCITemp cache holds SIF images created from OCI sources
+	// OciTempCacheType specifies the cache holds SIF images created from OCI sources
 	OciTempCacheType = "oci-tmp"
-	// The OCIBlob cache holds OCI blobs (layers) pulled from OCI sources
+	// OciBlobCacheType specifies the cache holds OCI blobs (layers) pulled from OCI sources
 	OciBlobCacheType = "blob"
-	// The Shub cache holds images pulled from Singularity Hub
+	// ShubCacheType specifies the cache holds images pulled from Singularity Hub
 	ShubCacheType = "shub"
-	// The Oras cache holds SIF images pulled from Oras sources
+	// OrasCacheType specifies the cache holds SIF images pulled from Oras sources
 	OrasCacheType = "oras"
-	// The Net cache holds images pulled from http(s) internet sources
+	// NetCacheType specifies the cache holds images pulled from http(s) internet sources
 	NetCacheType = "net"
 )
 
 var (
+	// FileCacheTypes specifies the file cache types.
 	FileCacheTypes = []string{
 		LibraryCacheType,
 		OciTempCacheType,
@@ -60,6 +58,7 @@ var (
 		OrasCacheType,
 		NetCacheType,
 	}
+	// OciCacheTypes specifies the OCI cache types.
 	OciCacheTypes = []string{
 		OciBlobCacheType,
 	}
@@ -90,14 +89,14 @@ type Handle struct {
 
 func (h *Handle) GetFileCacheDir(cacheType string) (cacheDir string, err error) {
 	if !stringInSlice(cacheType, FileCacheTypes) {
-		return "", ErrInvalidCacheType
+		return "", errInvalidCacheType
 	}
 	return h.getCacheTypeDir(cacheType), nil
 }
 
 func (h *Handle) GetOciCacheDir(cacheType string) (cacheDir string, err error) {
 	if !stringInSlice(cacheType, OciCacheTypes) {
-		return "", ErrInvalidCacheType
+		return "", errInvalidCacheType
 	}
 	return h.getCacheTypeDir(cacheType), nil
 }

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -39,7 +39,7 @@ const (
 	// SifDefaultTag is the tag to use when a tag is not specified
 	SifDefaultTag = "latest"
 
-	// SifConfigMediaType is the config descriptor mediaType
+	// SifConfigMediaTypeV1 is the config descriptor mediaType
 	// Since we only ever send a null config this should not have the
 	// format extension appended:
 	//   https://github.com/deislabs/oras/#pushing-artifacts-with-single-files
@@ -55,7 +55,7 @@ const (
 	SifLayerMediaTypeProto = "appliciation/vnd.sylabs.sif.layer.tar"
 )
 
-var SifLayerMediaTypes = []string{SifLayerMediaTypeV1, SifLayerMediaTypeProto}
+var sifLayerMediaTypes = []string{SifLayerMediaTypeV1, SifLayerMediaTypeProto}
 
 func getResolver(ociAuth *ocitypes.DockerAuthConfig) (remotes.Resolver, error) {
 	opts := docker.ResolverOptions{Credentials: genCredfn(ociAuth)}
@@ -106,9 +106,9 @@ func DownloadImage(imagePath, ref string, ociAuth *ocitypes.DockerAuthConfig) er
 	// so we have to allow an overwrite here.
 	store.DisableOverwrite = false
 
-	allowedMediaTypes := oras.WithAllowedMediaTypes(SifLayerMediaTypes)
+	allowedMediaTypes := oras.WithAllowedMediaTypes(sifLayerMediaTypes)
 	handlerFunc := func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		for _, mt := range SifLayerMediaTypes {
+		for _, mt := range sifLayerMediaTypes {
 			if desc.MediaType == mt {
 				// Ensure descriptor is of a single file
 				// AnnotationUnpack indicates that the descriptor is of a directory
@@ -277,7 +277,7 @@ func ImageSHA(ctx context.Context, uri string, ociAuth *ocitypes.DockerAuthConfi
 
 	// search image layers for sif image and return sha
 	for _, l := range man.Layers {
-		for _, t := range SifLayerMediaTypes {
+		for _, t := range sifLayerMediaTypes {
 			if l.MediaType == t {
 				// only allow sha256 digests
 				if l.Digest.Algorithm() != digest.SHA256 {

--- a/internal/pkg/plugin/meta.go
+++ b/internal/pkg/plugin/meta.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -105,11 +105,7 @@ func (m *Meta) install(img *image.Image) error {
 		return err
 	}
 
-	if err := m.installMeta(); err != nil {
-		return err
-	}
-
-	return nil
+	return m.installMeta()
 }
 
 func (m *Meta) installBinary(img *image.Image) error {

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -19,6 +19,7 @@ import (
 
 var cacheDuration = 720 * time.Hour
 
+// DefaultEndpointConfig is the default remote configuration.
 var DefaultEndpointConfig = &Config{
 	URI:    SCSDefaultCloudURI,
 	System: true,

--- a/internal/pkg/remote/endpoint/keyserver.go
+++ b/internal/pkg/remote/endpoint/keyserver.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -24,9 +25,9 @@ const (
 	KeyserverPushOp KeyserverOp = iota
 	// KeyserverPullOp represents a key pull operation.
 	KeyserverPullOp
-	// KeyserverSearch represents a key search operation.
+	// KeyserverSearchOp represents a key search operation.
 	KeyserverSearchOp
-	// KeyserverVerify represents a key verification operation.
+	// KeyserverVerifyOp represents a key verification operation.
 	KeyserverVerifyOp
 )
 

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -22,6 +22,7 @@ import (
 
 const defaultTimeout = 10 * time.Second
 
+// Default Sylabs cloud service endpoints.
 const (
 	SCSDefaultCloudURI     = "cloud.sylabs.io"
 	SCSDefaultLibraryURI   = "https://library.sylabs.io"

--- a/internal/pkg/runtime/engine/config/oci/generate/generate.go
+++ b/internal/pkg/runtime/engine/config/oci/generate/generate.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -171,7 +171,7 @@ func (g *Generator) SetProcessTerminal(b bool) {
 	g.Config.Process.Terminal = b
 }
 
-// SetProcessCwd sets container root filesystem path.
+// SetRootPath sets container root filesystem path.
 func (g *Generator) SetRootPath(path string) {
 	g.initRoot()
 	g.Config.Root.Path = path

--- a/internal/pkg/runtime/engine/config/oci/generate/generate_test.go
+++ b/internal/pkg/runtime/engine/config/oci/generate/generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -203,7 +203,8 @@ func TestSave(t *testing.T) {
 
 		d, err := ioutil.ReadAll(r)
 		if err != nil {
-			t.Fatalf("while reading pipe: %s", err) // nolint
+			t.Errorf("while reading pipe: %s", err)
+			return
 		}
 		content := string(d)
 		if content != ociJSON {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -507,11 +507,7 @@ func (c *container) setPropagationMount(system *mount.System) error {
 		pflags |= syscall.MS_PRIVATE
 	}
 
-	if err := c.rpcOps.Mount("", "/", "", pflags, ""); err != nil {
-		return err
-	}
-
-	return nil
+	return c.rpcOps.Mount("", "/", "", pflags, "")
 }
 
 // addMountinfo handles the case where hidepid is set on /proc mount

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -79,7 +79,7 @@ type SendFuseFdArgs struct {
 	Fds    []int
 }
 
-// OpenFuseFdArgs defines the arguments to open and send a fuse file descriptor.
+// OpenSendFuseFdArgs defines the arguments to open and send a fuse file descriptor.
 type OpenSendFuseFdArgs struct {
 	Socket int
 }

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -206,7 +206,7 @@ func (t *RPC) EvalRelative(name string, root string) string {
 	return reply
 }
 
-// Lchown calls the lchown RPC using the supplied arguments.
+// Readlink calls the readlink RPC using the supplied arguments.
 func (t *RPC) Readlink(name string) (string, error) {
 	arguments := &args.ReadlinkArgs{
 		Name: name,

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -1,10 +1,11 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 package files
 
+// ActionScript is the action script content.
 var ActionScript = `#!/bin/sh
 
 declare -r __exported_env__=$(getallenv)
@@ -214,6 +215,7 @@ start)
 esac
 `
 
+// RuntimeVars is the runtime variables script.
 var RuntimeVars = `#!/bin/sh
 if test -n "${SING_USER_DEFINED_PREPEND_PATH:-}"; then
     PATH="${SING_USER_DEFINED_PREPEND_PATH}:${PATH}"

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -20,10 +20,10 @@ import (
 )
 
 const (
-	KiB = 1024
-	MiB = KiB * 1024
-	GiB = MiB * 1024
-	TiB = GiB * 1024
+	kiB = 1024
+	miB = kiB * 1024
+	giB = miB * 1024
+	tiB = giB * 1024
 )
 
 // Abs resolves a path to an absolute path.
@@ -588,17 +588,17 @@ func FindSize(size int64) string {
 	var factor float64
 	var unit string
 	switch {
-	case size < MiB:
-		factor = KiB
+	case size < miB:
+		factor = kiB
 		unit = "KiB"
-	case size < GiB:
-		factor = MiB
+	case size < giB:
+		factor = miB
 		unit = "MiB"
-	case size < TiB:
-		factor = GiB
+	case size < tiB:
+		factor = giB
 		unit = "GiB"
 	default:
-		factor = TiB
+		factor = tiB
 		unit = "TiB"
 	}
 	return fmt.Sprintf("%.2f %s", float64(size)/factor, unit)

--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -111,6 +111,7 @@ func (v *defaultVFS) WriteFile(filename string, data []byte, perm os.FileMode) e
 	return err
 }
 
+// DefaultVFS is the default VFS.
 var DefaultVFS VFS = &defaultVFS{}
 
 // Manager manages a filesystem layout in a given path

--- a/internal/pkg/util/goversion/goversion.go
+++ b/internal/pkg/util/goversion/goversion.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -14,5 +14,5 @@ package goversion
 // Keep the name of this variable in sync with the minimum required
 // version specified in the build tag above.
 //
-// nolint:golint
+//nolint:revive
 const __BUILD_REQUIRES_GO_VERSION_1_13_OR_LATER__ = uint8(0)

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -86,7 +86,7 @@ func (b *BindPath) ImageSrc() string {
 	return ""
 }
 
-// ImageSrc returns the value of option id or an empty
+// ID returns the value of option id or an empty
 // string if the option wasn't set.
 func (b *BindPath) ID() string {
 	if b.Options != nil && b.Options["id"] != nil {
@@ -172,12 +172,12 @@ func (e *EngineConfig) GetImage() string {
 	return e.JSON.Image
 }
 
-// SetKey sets the key for the image's system partition.
+// SetEncryptionKey sets the key for the image's system partition.
 func (e *EngineConfig) SetEncryptionKey(key []byte) {
 	e.JSON.EncryptionKey = key
 }
 
-// GetKey retrieves the key for image's system partition.
+// GetEncryptionKey retrieves the key for image's system partition.
 func (e *EngineConfig) GetEncryptionKey() []byte {
 	return e.JSON.EncryptionKey
 }
@@ -607,12 +607,12 @@ func (e *EngineConfig) GetNoTmp() bool {
 	return e.JSON.NoTmp
 }
 
-// SetNoHostFs set flag to not mount all host mounts.
+// SetNoHostfs set flag to not mount all host mounts.
 func (e *EngineConfig) SetNoHostfs(val bool) {
 	e.JSON.NoHostfs = val
 }
 
-// SetNoHostfs returns if no-hostfs flag is set or not.
+// GetNoHostfs returns if no-hostfs flag is set or not.
 func (e *EngineConfig) GetNoHostfs() bool {
 	return e.JSON.NoHostfs
 }
@@ -622,7 +622,7 @@ func (e *EngineConfig) SetNoCwd(val bool) {
 	e.JSON.NoCwd = val
 }
 
-// SetNoCwd returns if no-cwd flag is set or not.
+// GetNoCwd returns if no-cwd flag is set or not.
 func (e *EngineConfig) GetNoCwd() bool {
 	return e.JSON.NoCwd
 }
@@ -926,7 +926,7 @@ func (e *EngineConfig) SetUmask(umask int) {
 	e.JSON.Umask = umask
 }
 
-// SetUmask returns the umask to be used in the container launched process.
+// GetUmask returns the umask to be used in the container launched process.
 func (e *EngineConfig) GetUmask() int {
 	return e.JSON.Umask
 }

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,6 +17,7 @@ import (
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
+// Configuration files/directories.
 const (
 	RemoteConfFile = "remote.yaml"
 	RemoteCache    = "remote-cache"

--- a/pkg/sylog/sylog.go
+++ b/pkg/sylog/sylog.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -165,12 +165,12 @@ func Writer() io.Writer {
 // as the scs-library-client
 type DebugLogger struct{}
 
-// Output a log message via sylog.Debugf
+// Log outputs a log message via sylog.Debugf
 func (t DebugLogger) Log(v ...interface{}) {
 	writef(DebugLevel, "%s", fmt.Sprint(v...))
 }
 
-// Output a formatted log message via sylog.Debugf
+// Logf outputs a formatted log message via sylog.Debugf
 func (t DebugLogger) Logf(format string, v ...interface{}) {
 	writef(DebugLevel, format, v...)
 }

--- a/pkg/sylog/sylog_common.go
+++ b/pkg/sylog/sylog_common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,6 +7,7 @@ package sylog
 
 type messageLevel int
 
+// Log levels.
 const (
 	FatalLevel    messageLevel = iota - 4 // FatalLevel    : -4
 	ErrorLevel                            // ErrorLevel    : -3

--- a/pkg/sypgp/keyring.go
+++ b/pkg/sypgp/keyring.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -54,7 +54,7 @@ func NewHybridKeyRing(ctx context.Context, opts ...client.Option) (openpgp.KeyRi
 }
 
 // KeysById returns the set of keys that have the given key id.
-//nolint:golint  // golang/x/crypto uses Id instead of ID so we have to too
+//nolint:revive  // golang/x/crypto uses Id instead of ID so we have to too
 func (kr *hybridKeyRing) KeysById(id uint64) []openpgp.Key {
 	if keys := kr.local.KeysById(id); len(keys) > 0 {
 		return keys
@@ -71,7 +71,7 @@ func (kr *hybridKeyRing) KeysById(id uint64) []openpgp.Key {
 
 // KeysByIdUsage returns the set of keys with the given id that also meet the key usage given by
 // requiredUsage. The requiredUsage is expressed as the bitwise-OR of packet.KeyFlag* values.
-//nolint:golint  // golang/x/crypto uses Id instead of ID so we have to too
+//nolint:revive  // golang/x/crypto uses Id instead of ID so we have to too
 func (kr *hybridKeyRing) KeysByIdUsage(id uint64, requiredUsage byte) []openpgp.Key {
 	if keys := kr.local.KeysByIdUsage(id, requiredUsage); len(keys) > 0 {
 		return keys
@@ -116,7 +116,7 @@ func NewMultiKeyRing(keyrings ...openpgp.KeyRing) openpgp.KeyRing {
 }
 
 // KeysById returns the set of keys that have the given key id.
-//nolint:golint  // golang/x/crypto uses Id instead of ID so we have to too
+//nolint:revive  // golang/x/crypto uses Id instead of ID so we have to too
 func (mkr *multiKeyRing) KeysById(id uint64) []openpgp.Key {
 	for _, kr := range mkr.keyrings {
 		if keys := kr.KeysById(id); len(keys) > 0 {
@@ -128,7 +128,7 @@ func (mkr *multiKeyRing) KeysById(id uint64) []openpgp.Key {
 
 // KeysByIdUsage returns the set of keys with the given id that also meet the key usage given by
 // requiredUsage. The requiredUsage is expressed as the bitwise-OR of packet.KeyFlag* values.
-//nolint:golint  // golang/x/crypto uses Id instead of ID so we have to too
+//nolint:revive  // golang/x/crypto uses Id instead of ID so we have to too
 func (mkr *multiKeyRing) KeysByIdUsage(id uint64, requiredUsage byte) []openpgp.Key {
 	for _, kr := range mkr.keyrings {
 		if keys := kr.KeysByIdUsage(id, requiredUsage); len(keys) > 0 {

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -228,11 +228,8 @@ func (keyring *Handle) PathsCheck() error {
 	if err := fs.EnsureFileWithPermission(keyring.SecretPath(), 0600); err != nil {
 		return err
 	}
-	if err := fs.EnsureFileWithPermission(keyring.PublicPath(), 0600); err != nil {
-		return err
-	}
 
-	return nil
+	return fs.EnsureFileWithPermission(keyring.PublicPath(), 0600)
 }
 
 func loadKeyring(fn string) (openpgp.EntityList, error) {
@@ -939,11 +936,7 @@ func RecryptKey(k *openpgp.Entity, passphrase []byte) error {
 		return err
 	}
 
-	if err := k.PrivateKey.Encrypt(passphrase); err != nil {
-		return err
-	}
-
-	return nil
+	return k.PrivateKey.Encrypt(passphrase)
 }
 
 // ExportPrivateKey Will export a private key into a file (kpath).
@@ -1094,11 +1087,7 @@ func (keyring *Handle) importPrivateKey(entity *openpgp.Entity, setNewPassword b
 	}
 
 	// Store the private key
-	if err := keyring.appendPrivateKey(&newEntity); err != nil {
-		return err
-	}
-
-	return nil
+	return keyring.appendPrivateKey(&newEntity)
 }
 
 // importPublicKey imports the specified openpgp Entity, which should
@@ -1114,11 +1103,7 @@ func (keyring *Handle) importPublicKey(entity *openpgp.Entity) error {
 		return &KeyExistsError{fingerprint: entity.PrimaryKey.Fingerprint}
 	}
 
-	if err := keyring.appendPubKey(entity); err != nil {
-		return err
-	}
-
-	return nil
+	return keyring.appendPubKey(entity)
 }
 
 // ImportKey imports one or more keys from the specified file. The keys

--- a/pkg/util/capabilities/process_unsupported.go
+++ b/pkg/util/capabilities/process_unsupported.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 )
 
+// ErrCapNotSupported indicates capabilities are not supported on the current operating system.
 var ErrCapNotSupported = fmt.Errorf("capabilities not supported on this OS: %s", runtime.GOOS)
 
 // GetProcessEffective returns effective capabilities for

--- a/pkg/util/crypt/key.go
+++ b/pkg/util/crypt/key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -22,15 +22,22 @@ import (
 )
 
 var (
+	// ErrEncryptedKeyNotFound indicates the encrypted key is not found.
 	ErrEncryptedKeyNotFound = errors.New("encrypted key not found")
-	ErrUnsupportedKeyURI    = errors.New("unsupported key URI")
-	ErrNoEncryptedKeyData   = errors.New("no encrypted key data")
-	ErrNoPEMData            = errors.New("No PEM data")
+	// ErrUnsupportedKeyURI indicates the key URI is not supported.
+	ErrUnsupportedKeyURI = errors.New("unsupported key URI")
+	// ErrNoEncryptedKeyData indicates there is no encrypted key data.
+	ErrNoEncryptedKeyData = errors.New("no encrypted key data")
+	// ErrNoPEMData indicates there is no PEM data.
+	ErrNoPEMData = errors.New("No PEM data")
 )
 
 const (
+	// Unknown indicates the key material format is not known.
 	Unknown = iota
+	// Passphrase indicates the key material is formatted as a passphrase.
 	Passphrase
+	// PEM indicates the key material is formatted as a PEM file.
 	PEM
 )
 

--- a/pkg/util/fs/lock/lock.go
+++ b/pkg/util/fs/lock/lock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -30,10 +30,7 @@ func Exclusive(path string) (fd int, err error) {
 // Release removes a lock on path referenced by fd
 func Release(fd int) error {
 	defer unix.Close(fd)
-	if err := unix.Flock(fd, unix.LOCK_UN); err != nil {
-		return err
-	}
-	return nil
+	return unix.Flock(fd, unix.LOCK_UN)
 }
 
 // ErrByteRangeAcquired corresponds to the error returned


### PR DESCRIPTION
Replace deprecated `golint` linter with `revive`. Fix lint found by `revive` linter.

Fixes #63