### PR TITLE
build(deps): update oras-go module name

### DIFF
--- a/e2e/internal/e2e/dockerhub_auth.go
+++ b/e2e/internal/e2e/dockerhub_auth.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	auth "github.com/oras-project/oras-go/pkg/auth/docker"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"github.com/sylabs/singularity/pkg/syfs"
+	auth "oras.land/oras-go/pkg/auth/docker"
 )
 
 const dockerHub = "docker.io"

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -18,15 +18,15 @@ import (
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes/docker"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/oras-project/oras-go/pkg/content"
-	"github.com/oras-project/oras-go/pkg/context"
-	"github.com/oras-project/oras-go/pkg/oras"
 	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
 	syoras "github.com/sylabs/singularity/internal/pkg/client/oras"
 	"github.com/sylabs/singularity/internal/pkg/util/uri"
 	"golang.org/x/sys/unix"
+	"oras.land/oras-go/pkg/content"
+	"oras.land/oras-go/pkg/context"
+	"oras.land/oras-go/pkg/oras"
 )
 
 type ctx struct {

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/opencontainers/runtime-tools v0.9.1-0.20210326182921-59cdde06764b
 	github.com/opencontainers/selinux v1.8.2
 	github.com/opencontainers/umoci v0.4.7
-	github.com/oras-project/oras-go v0.3.0
 	github.com/pelletier/go-toml v1.9.2
 	github.com/pkg/errors v0.9.1
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -65,9 +64,10 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
 	mvdan.cc/sh/v3 v3.2.4
+	oras.land/oras-go v0.4.0
 )
 
-// These are required for github.com/oras-project/oras-go@v0.3.0
+// These are required for oras.land/oras-go@v0.4.0
 replace (
 	github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
 	github.com/docker/docker => github.com/moby/moby v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible

--- a/go.sum
+++ b/go.sum
@@ -659,8 +659,6 @@ github.com/opencontainers/selinux v1.8.2 h1:c4ca10UMgRcvZ6h0K4HtS15UaVSBEaE+iln2
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/umoci v0.4.7 h1:mbIbtMpZ3v9oMpKaLopnWoLykgmnixeLzq51EzAX5nQ=
 github.com/opencontainers/umoci v0.4.7/go.mod h1:lgJ4bnwJezsN1o/5d7t/xdRPvmf8TvBko5kKYJsYvgo=
-github.com/oras-project/oras-go v0.3.0 h1:NCcXeTPPlf2Ys2Pdpdu82lpaWSg3EdXxeZQgLfvgpBw=
-github.com/oras-project/oras-go v0.3.0/go.mod h1:iGamc9+xWzQodKeX5l7FF0VgmmJ8aTRS2kJA6CedmjU=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -1251,6 +1249,8 @@ k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157/go.mod h1:Ge4atmRUYqueGppvJ7JNrtqpqokoJEFxYbP0Z+WeKS8=
 mvdan.cc/sh/v3 v3.2.4 h1:+fZaWcXWRjYAvqzEKoDhDM3DkxdDUykU2iw0VMKFe9s=
 mvdan.cc/sh/v3 v3.2.4/go.mod h1:fPQmabBpREM/XQ9YXSU5ZFZ/Sm+PmKP9/vkFHgYKJEI=
+oras.land/oras-go v0.4.0 h1:u6+7D+raZDYHwlz/uOwNANiRmyYDSSMW7A9E1xXycUQ=
+oras.land/oras-go v0.4.0/go.mod h1:VJcU+VE4rkclUbum5C0O7deEZbBYnsnpbGSACwTjOcg=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -26,13 +26,13 @@ import (
 	ocitypes "github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	auth "github.com/oras-project/oras-go/pkg/auth/docker"
-	"github.com/oras-project/oras-go/pkg/content"
-	orasctx "github.com/oras-project/oras-go/pkg/context"
-	"github.com/oras-project/oras-go/pkg/oras"
 	"github.com/sylabs/singularity/pkg/image"
 	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
+	auth "oras.land/oras-go/pkg/auth/docker"
+	"oras.land/oras-go/pkg/content"
+	orasctx "oras.land/oras-go/pkg/context"
+	"oras.land/oras-go/pkg/oras"
 )
 
 const (

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -13,10 +13,10 @@ import (
 	"net/url"
 	"time"
 
-	auth "github.com/oras-project/oras-go/pkg/auth/docker"
 	"github.com/sylabs/singularity/internal/pkg/util/interactive"
 	"github.com/sylabs/singularity/pkg/syfs"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+	auth "oras.land/oras-go/pkg/auth/docker"
 )
 
 // loginHandlers contains the registered handlers by scheme.


### PR DESCRIPTION
The authors of `github.com/oras-project/oras-go` have changed their import path ["just for fun"](https://github.com/oras-project/oras-go/pull/7) as of v0.4.0.

It doesn't appear as if Dependabot has tracked the new version (presumably due to the new path.)

Update the import paths and dependency version to reflect.