### PR TITLE
CI: use alpine3.13 due to CircleCI docker issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
   build-source-alpine:
     executor:
       name: golang
-      variant: alpine
+      variant: alpine3.13
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use alpine3.13 as 3.14 cannot run properly under the version of Docker in use on CircleCI.

See: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396

### This fixes or addresses the following GitHub issues:

 - Fixes #120

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
