### PR TITLE
Track release-3.8 branch with dependabot

### DIFF
--- a/.github/RELEASE_PROCEDURE.md
+++ b/.github/RELEASE_PROCEDURE.md
@@ -83,6 +83,9 @@ bug(s), and well covered by tests.
 
 1. Create and merge a PR from the `release-3.x` branch into `master`,
    so that history from the RC process etc. is captured on `master`.
-2. If the release is a new major version, move the prior `release-3.x`
-   branch to `vault/release-3.x`.
-3. Start scheduling / setting up milestones etc. to track the next release!
+2. If the release is a new major/minor version, move the prior
+   `release-3.x` branch to `vault/release-3.x`.
+3. If the release is a new major/minor version, update the
+   `.github/dependabot.yml` configuration so that dependabot is tracking
+   the new stable release branch.
+4. Start scheduling / setting up milestones etc. to track the next release!

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    target-branch: master
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: release-3.8
+


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add dependabot monitoring of the current stable branch (currently release-3.8). This will allow dependency updates to be handled smoothly for patch releases.

Previously we have cherry-picked or merged PRs from master, but where master changes its dependency set this runs the risk of missing dep updates on the stable branch.


### This fixes or addresses the following GitHub issues:

 - Fixes #123 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
