### PR TITLE
Allow --writable-tmpfs for %test step of build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # SingularityCE Changelog
 
+## Changes since last release
+
+### New features / functionalities
+
+  - `--writable-tmpfs` can be used with `singularity build` to run
+    the `%test` section of the build with a ephemeral tmpfs overlay,
+    permitting tests that write to the container filesystem.
+
 ## v3.8.0 [2021-05-26]
 
 This is the first release of SingularityCE 3.8.0, the Community

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -29,25 +29,26 @@ import (
 )
 
 var buildArgs struct {
-	sections     []string
-	bindPaths    []string
-	arch         string
-	builderURL   string
-	libraryURL   string
-	keyServerURL string
-	webURL       string
-	detached     bool
-	encrypt      bool
-	fakeroot     bool
-	fixPerms     bool
-	isJSON       bool
-	noCleanUp    bool
-	noTest       bool
-	remote       bool
-	sandbox      bool
-	update       bool
-	nvidia       bool
-	rocm         bool
+	sections      []string
+	bindPaths     []string
+	arch          string
+	builderURL    string
+	libraryURL    string
+	keyServerURL  string
+	webURL        string
+	detached      bool
+	encrypt       bool
+	fakeroot      bool
+	fixPerms      bool
+	isJSON        bool
+	noCleanUp     bool
+	noTest        bool
+	remote        bool
+	sandbox       bool
+	update        bool
+	nvidia        bool
+	rocm          bool
+	writableTmpfs bool // For test section only
 }
 
 // -s|--sandbox
@@ -243,6 +244,16 @@ var buildBindFlag = cmdline.Flag{
 	EnvHandler: cmdline.EnvAppendValue,
 }
 
+// --writable-tmpfs
+var buildWritableTmpfsFlag = cmdline.Flag{
+	ID:           "buildWritableTmpfsFlag",
+	Value:        &buildArgs.writableTmpfs,
+	DefaultValue: false,
+	Name:         "writable-tmpfs",
+	Usage:        "during the %test section, makes the file system accessible as read-write with non persistent data (with overlay support only)",
+	EnvKeys:      []string{"WRITABLE_TMPFS"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(buildCmd)
@@ -276,6 +287,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&buildNvFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildRocmFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildBindFlag, buildCmd)
+		cmdManager.RegisterFlagForCmd(&buildWritableTmpfsFlag, buildCmd)
 	})
 }
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -115,6 +115,15 @@ func runBuild(cmd *cobra.Command, args []string) {
 		}
 		os.Setenv("SINGULARITY_BINDPATH", strings.Join(buildArgs.bindPaths, ","))
 	}
+	if buildArgs.writableTmpfs {
+		if buildArgs.remote {
+			sylog.Fatalf("--writable-tmpfs option is not supported for remote build")
+		}
+		if buildArgs.fakeroot {
+			sylog.Fatalf("--writable-tmpfs option is not supported for fakeroot build")
+		}
+		os.Setenv("SINGULARITY_WRITABLE_TMPFS", "1")
+	}
 
 	if buildArgs.arch != runtime.GOARCH && !buildArgs.remote {
 		sylog.Fatalf("Requested architecture (%s) does not match host (%s). Cannot build locally.", buildArgs.arch, runtime.GOARCH)

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -109,7 +109,7 @@ func (s *stage) runPostScript(configFile, sessionResolv, sessionHosts string) er
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = "/"
-		cmd.Env = currentEnvNoSingularity()
+		cmd.Env = currentEnvNoSingularity([]string{"NV", "ROCM", "BINDPATH"})
 
 		sylog.Infof("Running post scriptlet")
 		return cmd.Run()
@@ -135,7 +135,7 @@ func (s *stage) runTestScript(configFile, sessionResolv, sessionHosts string) er
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = "/"
-		cmd.Env = currentEnvNoSingularity()
+		cmd.Env = currentEnvNoSingularity([]string{"NV", "ROCM", "BINDPATH", "WRITABLE_TMPFS"})
 
 		sylog.Infof("Running testscript")
 		return cmd.Run()

--- a/internal/pkg/build/util.go
+++ b/internal/pkg/build/util.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sylabs/singularity/pkg/build/types"
 	buildtypes "github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/util/slice"
 	"golang.org/x/sys/unix"
 )
 
@@ -137,7 +138,10 @@ func getSectionScriptArgs(name string, script string, s types.Script) ([]string,
 	return args, nil
 }
 
-func currentEnvNoSingularity() []string {
+// currentEnvNoSingularity returns the current environment, minus any SINGULARITY_ vars,
+// but allowing those specified in the permitted slice. E.g. 'NV' in the permitted slice
+// will pass through `SINGULARITY_NV`, but strip out `SINGULARITY_OTHERVAR`.
+func currentEnvNoSingularity(permitted []string) []string {
 	envs := make([]string, 0)
 
 	for _, e := range os.Environ() {
@@ -145,8 +149,8 @@ func currentEnvNoSingularity() []string {
 			envs = append(envs, e)
 		} else {
 			envKey := strings.SplitN(e, "=", 2)
-			switch strings.TrimPrefix(envKey[0], env.SingularityPrefix) {
-			case "NV", "ROCM", "BINDPATH":
+			if slice.ContainsString(permitted, strings.TrimPrefix(envKey[0], env.SingularityPrefix)) {
+				sylog.Debugf("Passing through env var %s to singularity", e)
 				envs = append(envs, e)
 			}
 		}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Some software will unavoidably write to the container fs during reasonable tests. Using a build time bind to permit this is problematic as it is host specific (path available to bind), and the files created by the test likely shouldn't really stick around. Allow specifying `--writable-tmpfs` for a `singularity build` to use a writeable tmpfs in the `%test` section of the build only.

### This fixes or addresses the following GitHub issues:

 - Fixes #109


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
