### PR TITLE
Update Go Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@1.6
+  go: circleci/go@1.7
 
 parameters:
   go-version:
@@ -152,7 +152,6 @@ jobs:
       - checkout
       - go/install:
           version: << pipeline.parameters.go-version >>
-          cache: no
       - stop-background-apt
       - install-deps-apt
       - install-singularity
@@ -167,7 +166,6 @@ jobs:
       - check-changes
       - go/install:
           version: << pipeline.parameters.go-version >>
-          cache: no
       - stop-background-apt
       - install-deps-apt
       - install-singularity
@@ -183,7 +181,6 @@ jobs:
       - check-changes
       - go/install:
           version: << pipeline.parameters.go-version >>
-          cache: no
       - stop-background-apt
       - install-deps-apt
       - install-singularity


### PR DESCRIPTION
Use latest version of `circleci/go` Orb. Remove `cache:no` override, as this version has addressed a bug where a pre-existing Go install was not removed when a cached version was used.