### PR TITLE
Update restrictive permissions sandbox warning

### DIFF
--- a/internal/pkg/build/sources/oci_unpack.go
+++ b/internal/pkg/build/sources/oci_unpack.go
@@ -183,11 +183,9 @@ func checkPerms(rootfs string) (err error) {
 	})
 
 	if errors.Is(err, errRestrictivePerm) {
-		sylog.Warningf("Permission handling has changed in Singularity 3.5 for improved OCI compatibility")
-		sylog.Warningf("The sandbox will contain files/dirs that cannot be removed until permissions are modified")
-		sylog.Warningf("Use 'chmod -R u+rwX' to set permissions that allow removal")
-		sylog.Warningf("Use the '--fix-perms' option to 'singularity build' to modify permissions at build time")
-		sylog.Warningf("You can provide feedback about this change at https://github.com/sylabs/singularity/issues/4671")
+		sylog.Warningf("The sandbox contain files/dirs that cannot be removed with 'rm'.")
+		sylog.Warningf("Use 'chmod -R u+rwX' to set permissions that allow removal.")
+		sylog.Warningf("Use the '--fix-perms' option to 'singularity build' to modify permissions at build time.")
 		// It's not an error any further up... the rootfs is still usable
 		return nil
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Change to sandbox to keep restrictive permissions was made in Singularity 3.5. It's now appropriate to revise the message so it doesn't point to a discussion thread, and is just a plain warning

### This fixes or addresses the following GitHub issues:

 - Fixes #85


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
