### PR TITLE
Bump Go to 1.16.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: 1.16.5
+    default: 1.16.6
 
 executors:
   golang:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove `/u
 reinstalling it._
 
 ```
-$ export VERSION=1.16.5 OS=linux ARCH=amd64  # change this as you need
+$ export VERSION=1.16.6 OS=linux ARCH=amd64  # change this as you need
 
 $ wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz && \
   sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz


### PR DESCRIPTION
Use Go 1.16.6 in CI and `INSTALL.md`.