### PR TITLE
fix: Allow env vars with literal $ via \\\$ in SINGULARITYENV_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
     the `%test` section of the build with a ephemeral tmpfs overlay,
     permitting tests that write to the container filesystem.
 
+### Bug Fixes
+
+  - Allow escaped `\$` in a SINGULARITYENV_ var to set a literal `$` in
+    a container env var.
+
 ## v3.8.0 [2021-05-26]
 
 This is the first release of SingularityCE 3.8.0, the Community

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -446,5 +446,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"environment file":         c.singularityEnvFile,
 		"issue 5057":               c.issue5057, // https://github.com/sylabs/hpcng/issues/5057
 		"issue 5426":               c.issue5426, // https://github.com/sylabs/hpcng/issues/5426
+		"issue 43":                 c.issue43,   // https://github.com/sylabs/singularity/issues/43
 	}
 }

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/env"
 	"github.com/sylabs/singularity/internal/pkg/util/fs/files"
 	"github.com/sylabs/singularity/internal/pkg/util/machine"
+	"github.com/sylabs/singularity/internal/pkg/util/shell"
 	"github.com/sylabs/singularity/internal/pkg/util/shell/interpreter"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 	singularitycallback "github.com/sylabs/singularity/pkg/plugin/callback/runtime/engine/singularity"
@@ -632,18 +633,22 @@ func injectEnvHandler(senv map[string]string) interpreter.OpenHandler {
 			`
 			b.WriteString(fmt.Sprintf(defaultPathSnippet, env.DefaultPath))
 
+			// https://github.com/sylabs/singularity/issues/43
+			// We wrap the value of the export in double quotes manually, and do not use
+			// go's %q format string as it prevents passing an escaped literal $ in
+			// a SINGULARITYENV_ as \$
 			snippet := `
 			if test -v %[1]s; then
 				sylog debug "Overriding %[1]s environment variable"
 			fi
-			export %[1]s=%[2]q
+			export %[1]s="%[2]s"
 			`
 			for key, value := range senv {
 				if key == "LD_LIBRARY_PATH" && value != "" {
 					b.WriteString(fmt.Sprintf(snippet, key, value+":/.singularity.d/libs"))
 					continue
 				}
-				b.WriteString(fmt.Sprintf(snippet, key, value))
+				b.WriteString(fmt.Sprintf(snippet, key, shell.EscapeQuotes(value)))
 			}
 		})
 

--- a/internal/pkg/util/shell/escape.go
+++ b/internal/pkg/util/shell/escape.go
@@ -24,3 +24,8 @@ func Escape(s string) string {
 	escaped = strings.Replace(escaped, `$`, `\$`, -1)
 	return escaped
 }
+
+// EscapeQuotes performs escaping of double quotes only
+func EscapeQuotes(s string) string {
+	return strings.Replace(s, `"`, `\"`, -1)
+}

--- a/internal/pkg/util/shell/escape_test.go
+++ b/internal/pkg/util/shell/escape_test.go
@@ -51,3 +51,24 @@ func TestEscape(t *testing.T) {
 	}
 
 }
+
+func TestEscapeQuotes(t *testing.T) {
+	var escapeQuotesTests = []struct {
+		input    string
+		expected string
+	}{
+		{`Hello`, `Hello`},
+		{`"Hello"`, `\"Hello\"`},
+		{`Hell"o`, `Hell\"o`},
+	}
+
+	for _, test := range escapeQuotesTests {
+		t.Run(test.input, func(t *testing.T) {
+			escaped := EscapeQuotes(test.input)
+			if escaped != test.expected {
+				t.Errorf("got %s, expected %s", escaped, test.expected)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

From Singularity 3.6, SINGULARITYENV_ prefixed env vars on the host become env vars in the container by:

 - Creating an injectable script which will `export KEY=VAL`.
 - Sourcing this script in the container setup, through the embedded shell interpreter.

When the injectable script was written, the value for each export statement was being quoted automatically using the Go `q` Printf style formatting. This handles double quoting the value, but also escapes other things in the value per Go string syntax.

It would be expected that a `\\\$LIB` in a SINGULARITYENV_ export at the host shell would resolve to a literal `$LIB` in the container...

 - In the host shell `\\\$LIB` is evaluated and becomes `\$LIB`, which will be used as the VAL in the injectable script.
 - In the Singularity embedded shell `\$LIB` is then evaluated and becomes a literal `$LIB` in the container env var.

However, the use of `q` Go string formatting means that `\$LIB` is greedily escaped according to Go string syntax expectations to become `\\$LIB` in the injectable script. This results in the container env var being `\` plus the evaluated value of an env var `$LIB`, rather than a literal `$LIB`.

To allow literal `$` in a container env var we:

 - Manually double quote the VAL in the injectable script export statement.
 - Manually escape only embedded `"` in the env var value, so that the meaning of other shell escapes is not modified.

This allows:

```
$ export SINGULARITYENV_LD_PRELOAD="/foo/bar/\\\$LIB/baz.so"
$ singularity run library://alpine env | grep PRELOAD
LD_PRELOAD=/foo/bar/$LIB/baz.so
```

Or if you bypass the host shell interpretation via exporting the SINGULARITYENV_ with single quotes:

```
$ export SINGULARITYENV_LD_PRELOAD='/foo/bar/\$LIB/baz.so'
$ singularity run library://alpine env | grep PRELOAD
LD_PRELOAD=/foo/bar/$LIB/baz.so
```

### This fixes or addresses the following GitHub issues:

 - Fixes #43


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
