### PR TITLE
Pick #121 / #151 (CI related) to release-3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: 1.16.4
+    default: 1.16.6
 
 executors:
   golang:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
   check-alpine:
     executor:
       name: golang
-      variant: alpine
+      variant: alpine3.13
     steps:
       - checkout
       - run:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove `/u
 reinstalling it._
 
 ```
-$ export VERSION=1.16.4 OS=linux ARCH=amd64  # change this as you need
+$ export VERSION=1.16.6 OS=linux ARCH=amd64  # change this as you need
 
 $ wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz && \
   sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz


### PR DESCRIPTION
- CI: use alpine3.13 due to CircleCI docker issue #121
- Bump Go to 1.16.6 #151