### PR TITLE
Handle absolute symlinks in multi-stage copy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/containers/image/v5 v5.13.2
+	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/fatih/color v1.12.0
 	github.com/garyburd/redigo v1.6.0 // indirect
 	github.com/go-log/log v0.2.0

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -10,8 +10,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
 // makeParentDir ensures existence of the expected destination directory for the cp command
@@ -39,33 +42,33 @@ func makeParentDir(path string, numSrcPaths int) error {
 	return nil
 }
 
-// Copy calls cp with src and dst as its arguments
-// Checks dst and creates parent directories if they do not exist
-// before calling cp.
-// If followLinks is true, the -L flag to cp will follow all symlinks
-// If followLinks is false, the -H flag to cp will only follow links for specified
-// files or files that resolve directly from a glob pattern. It will not follow
-// links found during directory traversal.
-func Copy(src, dst string, followLinks bool) error {
+// CopyFromHost should be used to copy files into the rootfs from the host fs.
+// src is a path relative to CWD on the host, or an absolute path on the host.
+// dstRel is a destination path inside dstRootfs
+// All symlinks encountered in the copy will be dereferenced (cp -L behavior).
+func CopyFromHost(src, dstRel, dstRootfs string) error {
 	// resolve any bash globbing in filepath
 	paths, err := expandPath(src)
 	if err != nil {
 		return fmt.Errorf("while expanding source path with bash: %s: %s", src, err)
 	}
 
-	if err := makeParentDir(dst, len(paths)); err != nil {
+	// Resolve our destination within the container rootfs
+	dstResolved, err := secureJoinKeepSlash(dstRootfs, dstRel)
+	if err != nil {
+		return fmt.Errorf("while resolving destination: %s: %s", dstRel, err)
+	}
+
+	// Create any parent dirs for dst that don't already exist
+	if err := makeParentDir(dstResolved, len(paths)); err != nil {
 		return fmt.Errorf("while creating parent dir: %v", err)
 	}
 
-	// set flags for cp
-	args := []string{"-fHr"}
-	if followLinks {
-		args = []string{"-fLr"}
-	}
+	args := []string{"-fLr"}
 	// append file(s) to be copied
 	args = append(args, paths...)
 	// append dst as last arg
-	args = append(args, dst)
+	args = append(args, dstResolved)
 
 	var output, stderr bytes.Buffer
 	// copy each file into bundle rootfs
@@ -73,7 +76,64 @@ func Copy(src, dst string, followLinks bool) error {
 	copy.Stdout = &output
 	copy.Stderr = &stderr
 	if err := copy.Run(); err != nil {
-		return fmt.Errorf("while copying %s to %s: %s: %s", paths, dst, err, stderr.String())
+		return fmt.Errorf("while copying %s to %s: %s: %s", paths, dstResolved, err, stderr.String())
+	}
+	return nil
+}
+
+// CopyFromStage should be used to copy files into the rootfs from a previous stage.
+// The srcRel and dstRel are src / dst paths relative to the srcRootfs and dstRootfs.
+// Symlinks are only dereferenced for the specified source or files that resolve
+// directly from a specified glob pattern. Any additional links inside a directory
+// being copied are not dereferenced.
+func CopyFromStage(srcRel, dstRel, srcRootfs, dstRootfs string) error {
+	// An absolute path is required for globbing... but with no symlink resolution or
+	// path cleaning yet.
+	srcAbs := joinKeepSlash(srcRootfs, srcRel)
+
+	// resolve any bash globbing in filepath
+	paths, err := expandPath(srcAbs)
+	if err != nil {
+		return fmt.Errorf("while expanding source path with bash: %s: %s", srcAbs, err)
+	}
+
+	// We manually dereference first-level src symlinks only.
+	for _, srcGlobbed := range paths {
+		// Now re-resolve the source files after globbing by using securejoin,
+		// so that absolute symlinks are dereferenced relative to the source rootfs,
+		// and the source is enforced to be inside the rootfs.
+		srcGlobbedRel := strings.TrimPrefix(srcGlobbed, srcRootfs)
+		srcResolved, err := secureJoinKeepSlash(srcRootfs, srcGlobbedRel)
+		if err != nil {
+			return fmt.Errorf("while resolving source: %s: %s", srcGlobbedRel, err)
+		}
+		// If we are copying into a directory then we must use the original source filename,
+		// for the destination filename, not the one that was resolved out.
+		// I.E. if copying `/opt/view` to `/opt/` where `/opt/view links-> /opt/.view/abc123`
+		// we want to create `/opt/view` in the dest, not `/opt/abc123`.
+		dstResolved, err := secureJoinKeepSlash(dstRootfs, dstRel)
+		if err != nil {
+			return fmt.Errorf("while resolving destination: %s: %s", dstRel, err)
+		}
+		if fs.IsDir(dstResolved) {
+			_, srcName := path.Split(srcGlobbedRel)
+			dstResolved = path.Join(dstResolved, srcName)
+		}
+
+		// Create any parent dirs for dst that don't already exist.
+		if err := makeParentDir(dstResolved, len(paths)); err != nil {
+			return fmt.Errorf("while creating parent dir: %v", err)
+		}
+
+		// Set flags for cp to perform a recursive copy without further symlink dereference.
+		args := []string{"-fr", srcResolved, dstResolved}
+		var output, stderr bytes.Buffer
+		copy := exec.Command("/bin/cp", args...)
+		copy.Stdout = &output
+		copy.Stderr = &stderr
+		if err := copy.Run(); err != nil {
+			return fmt.Errorf("while copying %s to %s: %s: %s", paths, dstResolved, err, stderr.String())
+		}
 	}
 	return nil
 }

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -101,7 +101,9 @@ func TestMakeParentDir(t *testing.T) {
 	}
 }
 
-func TestCopyFile(t *testing.T) {
+// TestCopyFromHost tests that copying non-nested source dirs, files, links to various
+// destinations works. CopyFromHost should always resolve symlinks.
+func TestCopyFromHost(t *testing.T) {
 	// create tmpdir
 	dir, err := ioutil.TempDir("", "copy-test-src-")
 	if err != nil {
@@ -109,65 +111,237 @@ func TestCopyFile(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	// prep src file to copy
-	srcFile := filepath.Join(dir, "sourceFile")
+	// Source Files
+	srcFile := filepath.Join(dir, "srcFile")
 	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-	srcSpaceFile := filepath.Join(dir, "source File")
+	srcFileGlob := filepath.Join(dir, "srcFi?*")
+	srcSpaceFile := filepath.Join(dir, "src File")
 	if err := ioutil.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
+	// Source Dirs
+	srcDir := filepath.Join(dir, "srcDir")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	srcDirGlob := filepath.Join(dir, "srcD?*")
+	srcSpaceDir := filepath.Join(dir, "src Dir")
+	if err := os.Mkdir(srcSpaceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Source Symlinks
+	srcFileLinkAbs := filepath.Join(dir, "srcFileLinkAbs")
+	if err := os.Symlink(srcFile, srcFileLinkAbs); err != nil {
+		t.Fatal(err)
+	}
+	srcFileLinkRel := filepath.Join(dir, "srcFileLinkRel")
+	if err := os.Symlink("./srcFile", srcFileLinkRel); err != nil {
+		t.Fatal(err)
+	}
+	srcDirLinkAbs := filepath.Join(dir, "srcDirLinkAbs")
+	if err := os.Symlink(srcDir, srcDirLinkAbs); err != nil {
+		t.Fatal(err)
+	}
+	srcDirLinkRel := filepath.Join(dir, "srcDirLinkRel")
+	if err := os.Symlink("./srcDir", srcDirLinkRel); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
-		name      string
-		src       string
-		dst       string
-		finalpath string
+		name       string
+		src        string
+		dst        string
+		expectPath string
+		expectFile bool
+		expectDir  bool
 	}{
-		{"ToDir", srcFile, "", "sourceFile"},
-		{"ToDirSlash", srcFile, "destDir/", "destDir/sourceFile"},
-		{"ToFile", srcFile, "destDir/destFile", "destDir/destFile"},
-		{"LongPathToFile", srcFile, "destDir/long/path/to/destFile", "destDir/long/path/to/destFile"},
-		{"FromSpace", srcSpaceFile, "", "source File"},
-		{"ToSpace", srcFile, "dest File", "dest File"},
+		// Source is a file
+		{
+			name:       "SrcFileNoDest",
+			src:        srcFile,
+			dst:        "",
+			expectPath: "srcFile",
+			expectFile: true,
+		},
+		{
+			name:       "SrcFileToDir",
+			src:        srcFile,
+			dst:        "dstDir/",
+			expectPath: "dstDir/srcFile",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileToFile",
+			src:        srcFile,
+			dst:        "dstDir/dstFile",
+			expectPath: "dstDir/dstFile",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileToFileLongPath",
+			src:        srcFile,
+			dst:        "dstDir/long/path/to/dstFile",
+			expectPath: "dstDir/long/path/to/dstFile",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileSpace",
+			src:        srcSpaceFile,
+			dst:        "",
+			expectPath: "src File",
+			expectFile: true,
+		},
+		{
+			name:       "dstFileSpace",
+			src:        srcFile,
+			dst:        "dst File",
+			expectPath: "dst File",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileGlob",
+			src:        srcFileGlob,
+			dst:        "dstDir/",
+			expectPath: "dstDir/srcFile",
+			expectFile: true,
+		},
+		{
+			name: "dstRestricted",
+			src:  srcFileGlob,
+			// Will be restricted to `/` in the rootfs and should copy to there OK
+			dst:        "../../../../",
+			expectPath: "srcFile",
+			expectFile: true,
+		},
+		// Source is a Directory
+		{
+			name:       "SrcDirNoDest",
+			src:        srcDir,
+			dst:        "",
+			expectPath: "srcDir",
+			expectDir:  true,
+		},
+		{
+			name:       "SrcDirDest",
+			src:        srcDir,
+			dst:        "dstDir",
+			expectPath: "dstDir",
+			expectDir:  true,
+		},
+		{
+			name:       "SrcDirToDir",
+			src:        srcDir,
+			dst:        "dstDir/",
+			expectPath: "dstDir/srcDir",
+			expectDir:  true,
+		},
+		{
+			name:       "srcDirToDirLongPath",
+			src:        srcDir,
+			dst:        "dstDir/long/path/to/srcDir",
+			expectPath: "dstDir/long/path/to/srcDir",
+			expectDir:  true,
+		},
+		{
+			name:       "srcDirSpace",
+			src:        srcSpaceDir,
+			dst:        "",
+			expectPath: "src Dir",
+			expectDir:  true,
+		},
+		{
+			name:       "dstDirSpace",
+			src:        srcDir,
+			dst:        "dst Dir",
+			expectPath: "dst Dir",
+			expectDir:  true,
+		},
+		{
+			name:       "srcDirGlob",
+			src:        srcDirGlob,
+			dst:        "dstDir/",
+			expectPath: "dstDir/srcDir",
+			expectDir:  true,
+		},
+		// Source is a Symlink
+		{
+			name:       "srcFileLinkRel",
+			src:        srcFileLinkRel,
+			dst:        "",
+			expectPath: "srcFileLinkRel",
+			// Copied the file, not the link itself
+			expectFile: true,
+		},
+		{
+			name:       "srcFileLinkAbs",
+			src:        srcFileLinkAbs,
+			dst:        "",
+			expectPath: "srcFileLinkAbs",
+			// Copied the file, not the link itself
+			expectFile: true,
+		},
+		{
+			name:       "srcDirLinkRel",
+			src:        srcDirLinkRel,
+			dst:        "",
+			expectPath: "srcDirLinkRel",
+			// Copied the dir, not the link itself
+			expectDir: true,
+		},
+		{
+			name:       "srcDirLinkAbs",
+			src:        srcDirLinkAbs,
+			dst:        "",
+			expectPath: "srcDirLinkAbs",
+			// Copied the dir, not the link itself
+			expectDir: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// create tmpdir
-			dstDir, err := ioutil.TempDir("", "copy-test-dst-")
+			// Create outer destination dir
+			dstRoot, err := ioutil.TempDir("", "copy-test-dst-")
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer os.RemoveAll(dstDir)
+			defer os.RemoveAll(dstRoot)
 
-			// manually concatenating because I don't want a Join function to clean the trailing slash
-			dst := dstDir + "/" + tt.dst
-			if err := Copy(tt.src, dst, false); err != nil {
+			if err := CopyFromHost(tt.src, tt.dst, dstRoot); err != nil {
 				t.Errorf("unexpected failure running %s test: %s", t.Name(), err)
 			}
 
-			dstFinal := filepath.Join(dstDir, tt.finalpath)
+			dstFinal := filepath.Join(dstRoot, tt.expectPath)
 			// verify file was copied
 			_, err = os.Stat(dstFinal)
+			if err != nil && !os.IsNotExist(err) {
+				t.Fatalf("while checking for destination file: %s", err)
+			}
 			if os.IsNotExist(err) {
-				t.Errorf("failure to correctly copy file %s test: %s", t.Name(), err)
+				t.Errorf("expected destination %s does not exist", dstFinal)
 			}
 
-			// verify file contents
-			content, err := ioutil.ReadFile(dstFinal)
-			if err != nil {
-				t.Errorf("unexpected failure reading file %s test: %s", t.Name(), err)
+			// File when expected?
+			if tt.expectFile && !fs.IsFile(dstFinal) {
+				t.Errorf("destination should be a file, but isn't")
 			}
-			if string(content) != sourceFileContent {
-				t.Errorf("failure reading file %s test: %s", t.Name(), err)
+			// Dir when expected?
+			if tt.expectDir && !fs.IsDir(dstFinal) {
+				t.Errorf("destination should be a directory, but isn't")
+			}
+			// None of these test cases should result in dst being a symlink
+			if fs.IsLink(dstFinal) {
+				t.Errorf("destination should not be a symlink, but is")
 			}
 		})
 	}
 }
 
-func TestCopyDir(t *testing.T) {
+// TestCopyFromHostNested tests that copying a single directory containing nested dirs, files, links
+// works. CopyFromHost should always resolve symlinks, even those nested inside a source dir.
+func TestCopyFromHostNested(t *testing.T) {
 	// create tmpdir
 	dir, err := ioutil.TempDir("", "copy-test-src-")
 	if err != nil {
@@ -175,172 +349,474 @@ func TestCopyDir(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	// prep src dir to copy
-	srcDir := filepath.Join(dir, "sourceDir")
-	if err := os.Mkdir(srcDir, 0755); err != nil {
+	// All our test files/dirs/links will be nested inside innerDir
+	innerDir := filepath.Join(dir, "innerDir")
+	if err := os.Mkdir(innerDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-
-	// prep src file
-	srcFile := filepath.Join(srcDir, "sourceFile")
+	// Source Files
+	srcFile := filepath.Join(innerDir, "srcFile")
 	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-
-	tests := []struct {
-		name      string
-		src       string
-		dst       string
-		finalpath string
-	}{
-		{"ToDir", srcDir, "destDir", "destDir"},
-		{"ToDirSlash", srcDir, "destDir/", "destDir/sourceDir"},
-		{"LongPathToDir", srcDir, "long/path/to/destDir", "long/path/to/destDir"},
+	// Source Dirs
+	srcDir := filepath.Join(innerDir, "srcDir")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Source Symlinks
+	srcFileLinkAbs := filepath.Join(innerDir, "srcFileLinkAbs")
+	if err := os.Symlink(srcFile, srcFileLinkAbs); err != nil {
+		t.Fatal(err)
+	}
+	srcFileLinkRel := filepath.Join(innerDir, "srcFileLinkRel")
+	if err := os.Symlink("./srcFile", srcFileLinkRel); err != nil {
+		t.Fatal(err)
+	}
+	srcDirLinkAbs := filepath.Join(innerDir, "srcDirLinkAbs")
+	if err := os.Symlink(srcDir, srcDirLinkAbs); err != nil {
+		t.Fatal(err)
+	}
+	srcDirLinkRel := filepath.Join(innerDir, "srcDirLinkRel")
+	if err := os.Symlink("./srcDir", srcDirLinkRel); err != nil {
+		t.Fatal(err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// create tmpdir
-			dstDir, err := ioutil.TempDir("", "copy-test-dst-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dstDir)
-
-			// manually concatenating because I don't want a Join function to clean the trailing slash
-			dst := dstDir + "/" + tt.dst
-			if err := Copy(tt.src, dst, false); err != nil {
-				t.Errorf("unexpected failure running %s test: %s", t.Name(), err)
-			}
-
-			dstFinal := filepath.Join(dstDir, tt.finalpath)
-			// verify file was copied
-			f, err := os.Stat(dstFinal)
-			if os.IsNotExist(err) {
-				t.Errorf("failure to correctly copy dir %s test: %s", t.Name(), err)
-			} else if !f.IsDir() {
-				t.Errorf("failure to correctly copy dir %s test: dst is not a dir", t.Name())
-			}
-
-			// verify file contents
-			content, err := ioutil.ReadFile(filepath.Join(dstFinal, "sourceFile"))
-			if err != nil {
-				t.Errorf("unexpected failure reading file %s test: %s", t.Name(), err)
-			}
-			if string(content) != sourceFileContent {
-				t.Errorf("failure reading file %s test: %s", t.Name(), err)
-			}
-		})
-	}
-}
-
-func TestCopySymlink(t *testing.T) {
-	// create tmpdir
-	dir, err := ioutil.TempDir("", "copy-test-src-")
+	// Create outer destination dir
+	dstDir, err := ioutil.TempDir("", "copy-test-dst-")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dstDir)
 
-	// prep src dir to copy
-	srcDir := filepath.Join(dir, "sourceDir")
-	if err := os.Mkdir(srcDir, 0755); err != nil {
-		t.Fatal(err)
+	// Copy our source innerDir over into the destination dir
+	if err := CopyFromHost(innerDir, "", dstDir); err != nil {
+		t.Errorf("unexpected failure copying directory: %s", err)
 	}
 
-	// prep src file
-	srcFile := filepath.Join(srcDir, "sourceFile")
+	// Now verify all the nested copied files are as expected
+	tests := []struct {
+		expectPath string
+		expectFile bool
+		expectDir  bool
+	}{
+		{
+			expectPath: "innerDir/srcFile",
+			expectFile: true,
+		},
+		{
+			expectPath: "innerDir/srcDir",
+			expectDir:  true,
+		},
+		// Source is a Symlink
+		// Should always have copied the target, not the link.
+		{
+			expectPath: "innerDir/srcFileLinkRel",
+			expectFile: true,
+		},
+		{
+			expectPath: "innerDir/srcFileLinkAbs",
+			expectFile: true,
+		},
+		{
+			expectPath: "innerDir/srcDirLinkRel",
+			expectDir:  true,
+		},
+		{
+			expectPath: "innerDir/srcDirLinkAbs",
+			expectDir:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expectPath, func(t *testing.T) {
+			dstFinal := filepath.Join(dstDir, tt.expectPath)
+			// File when expected?
+			if tt.expectFile && !fs.IsFile(dstFinal) {
+				t.Errorf("destination should be a file, but isn't")
+			}
+			// Dir when expected?
+			if tt.expectDir && !fs.IsDir(dstFinal) {
+				t.Errorf("destination should be a directory, but isn't")
+			}
+			// None of these test cases should result in dst being a symlink
+			if fs.IsLink(dstFinal) {
+				t.Errorf("destination should not be a symlink, but is")
+			}
+		})
+	}
+
+}
+
+// TestCopyFromStage tests that copying non-nested source dirs, files, links to various
+// destinations works. CopyFromStage should resolve top-level symlinks for sources it is
+// called against.
+func TestCopyFromStage(t *testing.T) {
+	// create tmpdir
+	srcRoot, err := ioutil.TempDir("", "copy-test-src-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(srcRoot)
+
+	// Source Files
+	srcFile := filepath.Join(srcRoot, "srcFile")
 	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-
-	// prep src symlink
-	srcLink := filepath.Join(srcDir, "sourceLink")
-	if err := os.Symlink(srcFile, srcLink); err != nil {
+	srcSpaceFile := filepath.Join(srcRoot, "src File")
+	if err := ioutil.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Source Dirs
+	srcDir := filepath.Join(srcRoot, "srcDir")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	srcSpaceDir := filepath.Join(srcRoot, "src Dir")
+	if err := os.Mkdir(srcSpaceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Source Symlinks
+	// Note the absolute links are absolute paths inside the srcRoot
+	srcFileLinkAbs := filepath.Join(srcRoot, "srcFileLinkAbs")
+	if err := os.Symlink("/srcFile", srcFileLinkAbs); err != nil {
+		t.Fatal(err)
+	}
+	srcFileLinkRel := filepath.Join(srcRoot, "srcFileLinkRel")
+	if err := os.Symlink("./srcFile", srcFileLinkRel); err != nil {
+		t.Fatal(err)
+	}
+	srcDirLinkAbs := filepath.Join(srcRoot, "srcDirLinkAbs")
+	if err := os.Symlink("/srcDir", srcDirLinkAbs); err != nil {
+		t.Fatal(err)
+	}
+	srcDirLinkRel := filepath.Join(srcRoot, "srcDirLinkRel")
+	if err := os.Symlink("./srcDir", srcDirLinkRel); err != nil {
 		t.Fatal(err)
 	}
 
 	tests := []struct {
-		name         string
-		src          string
-		dst          string
-		finalpath    string
-		shouldFollow bool
+		name       string
+		srcRel     string
+		dstRel     string
+		expectPath string
+		expectFile bool
+		expectDir  bool
 	}{
-		// When copied via traversal the symlink should not be followed
-		{"DirectoryNoFollow", srcDir, "destDir/", "destDir/sourceDir/sourceLink", false},
-		// When copied as a specified source, the link should be followed
-		{"LinkFollow", srcLink, "destDir/", "destDir/sourceLink", true},
-		// When copied via a glob pattern that resolves to the link directly the link should be followed
-		{"GlobFollow", srcLink, "destDir/", "destDir/sourceLink", true},
+		// Source is a file
+		{
+			name:       "SrcFileNoDest",
+			srcRel:     "srcFile",
+			dstRel:     "",
+			expectPath: "srcFile",
+			expectFile: true,
+		},
+		{
+			name:       "SrcFileAbs",
+			srcRel:     "/srcFile",
+			dstRel:     "",
+			expectPath: "srcFile",
+			expectFile: true,
+		},
+		{
+			name:       "SrcFileToDir",
+			srcRel:     "srcFile",
+			dstRel:     "dstDir/",
+			expectPath: "dstDir/srcFile",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileToFile",
+			srcRel:     "srcFile",
+			dstRel:     "dstDir/dstFile",
+			expectPath: "dstDir/dstFile",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileToFileLongPath",
+			srcRel:     "srcFile",
+			dstRel:     "dstDir/long/path/to/dstFile",
+			expectPath: "dstDir/long/path/to/dstFile",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileSpace",
+			srcRel:     "src File",
+			dstRel:     "",
+			expectPath: "src File",
+			expectFile: true,
+		},
+		{
+			name:       "dstFileSpace",
+			srcRel:     "srcFile",
+			dstRel:     "dst File",
+			expectPath: "dst File",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileGlob",
+			srcRel:     "srcF?*",
+			dstRel:     "dstDir/",
+			expectPath: "dstDir/srcFile",
+			expectFile: true,
+		},
+		{
+			name:   "dstRestricted",
+			srcRel: "srcFile",
+			// Will be restricted to `/` in the dst rootfs and should copy to there OK
+			dstRel:     "../../../../",
+			expectPath: "srcFile",
+			expectFile: true,
+		},
+		{
+			name: "srcRestricted",
+			// Will be restricted to `/srcFile` in the src rootfs and should copy from there OK
+			srcRel:     "../../../../srcFile",
+			dstRel:     "",
+			expectPath: "srcFile",
+			expectFile: true,
+		},
+		// Source is a Directory
+		{
+			name:       "SrcDirNoDest",
+			srcRel:     "srcDir",
+			dstRel:     "",
+			expectPath: "srcDir",
+			expectDir:  true,
+		},
+		{
+			name:       "SrcDirDest",
+			srcRel:     "srcDir",
+			dstRel:     "dstDir",
+			expectPath: "dstDir",
+			expectDir:  true,
+		},
+		{
+			name:       "SrcDirToDir",
+			srcRel:     "srcDir",
+			dstRel:     "dstDir/",
+			expectPath: "dstDir/srcDir",
+			expectDir:  true,
+		},
+		{
+			name:       "srcDirToDirLongPath",
+			srcRel:     "srcDir",
+			dstRel:     "dstDir/long/path/to/srcDir",
+			expectPath: "dstDir/long/path/to/srcDir",
+			expectDir:  true,
+		},
+		{
+			name:       "srcDirSpace",
+			srcRel:     "src Dir",
+			dstRel:     "",
+			expectPath: "src Dir",
+			expectDir:  true,
+		},
+		{
+			name:       "dstDirSpace",
+			srcRel:     "srcDir",
+			dstRel:     "dst Dir",
+			expectPath: "dst Dir",
+			expectDir:  true,
+		},
+		{
+			name:       "srcDirGlob",
+			srcRel:     "srcD?*",
+			dstRel:     "dstDir/",
+			expectPath: "dstDir/srcDir",
+			expectDir:  true,
+		},
+		// Source is a Symlink
+		{
+			name:       "srcFileLinkRel",
+			srcRel:     "srcFileLinkRel",
+			dstRel:     "",
+			expectPath: "srcFileLinkRel",
+			// Copied the file, not the link itself
+			expectFile: true,
+		},
+		{
+			name:       "srcFileLinkAbs",
+			srcRel:     "srcFileLinkAbs",
+			dstRel:     "",
+			expectPath: "srcFileLinkAbs",
+			// Copied the file, not the link itself
+			expectFile: true,
+		},
+		{
+			name:       "srcDirLinkRel",
+			srcRel:     "srcDirLinkRel",
+			dstRel:     "",
+			expectPath: "srcDirLinkRel",
+			// Copied the dir, not the link itself
+			expectDir: true,
+		},
+		{
+			name:       "srcDirLinkAbs",
+			srcRel:     "srcDirLinkAbs",
+			dstRel:     "",
+			expectPath: "srcDirLinkAbs",
+			// Copied the dir, not the link itself
+			expectDir: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// create tmpdir
-			dstDir, err := ioutil.TempDir("", "copy-test-dst-")
+			// Create outer destination dir
+			dstRoot, err := ioutil.TempDir("", "copy-test-dst-")
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer os.RemoveAll(dstDir)
+			defer os.RemoveAll(dstRoot)
 
-			// manually concatenating because I don't want a Join function to clean the trailing slash
-			dst := dstDir + "/" + tt.dst
-			if err := Copy(tt.src, dst, false); err != nil {
+			// Manually concatenating because we need to preserve any trailing slash that is
+			// stripped by Join.
+			if err := CopyFromStage(tt.srcRel, tt.dstRel, srcRoot, dstRoot); err != nil {
 				t.Errorf("unexpected failure running %s test: %s", t.Name(), err)
 			}
 
-			dstFinal := filepath.Join(dstDir, tt.finalpath)
+			dstFinal := filepath.Join(dstRoot, tt.expectPath)
 			// verify file was copied
 			_, err = os.Stat(dstFinal)
+			if err != nil && !os.IsNotExist(err) {
+				t.Fatalf("while checking for destination file: %s", err)
+			}
 			if os.IsNotExist(err) {
-				t.Errorf("failure to copy link %s test: %s", t.Name(), err)
+				t.Errorf("expected destination %s does not exist", tt.expectPath)
 			}
 
-			// check if we have a correctly followed/non-followed link
-			if !tt.shouldFollow && !fs.IsLink(dstFinal) {
-				t.Errorf("%s should be a symlink", dstFinal)
+			// File when expected?
+			if tt.expectFile && !fs.IsFile(dstFinal) {
+				t.Errorf("destination should be a file, but isn't")
 			}
-
-			if tt.shouldFollow && fs.IsLink(dstFinal) {
-				t.Errorf("%s should not be a symlink", dstFinal)
+			// Dir when expected?
+			if tt.expectDir && !fs.IsDir(dstFinal) {
+				t.Errorf("destination should be a directory, but isn't")
+			}
+			// None of these test cases should result in dst being a symlink
+			if fs.IsLink(dstFinal) {
+				t.Errorf("destination should not be a symlink, but is")
 			}
 		})
 	}
 }
 
-func TestCopyFail(t *testing.T) {
+// TestCopyFromStageNested tests that copying a single directory containing nested dirs, files, links
+// works. CopyFromStage should *not* resolve the symlinks that are nested in the dir.
+func TestCopyFromStageNested(t *testing.T) {
 	// create tmpdir
-	dir, err := ioutil.TempDir("", "copy-test-src")
+	srcRoot, err := ioutil.TempDir("", "copy-test-src-")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer os.RemoveAll(srcRoot)
 
+	// All our test files/dirs/links will be nested inside innerDir
+	innerDir := filepath.Join(srcRoot, "innerDir")
+	if err := os.Mkdir(innerDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Source Files
+	srcFile := filepath.Join(innerDir, "srcFile")
+	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Source Dirs
+	srcDir := filepath.Join(innerDir, "srcDir")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Source Symlinks
+	srcFileLinkAbs := filepath.Join(innerDir, "srcFileLinkAbs")
+	if err := os.Symlink(srcFile, srcFileLinkAbs); err != nil {
+		t.Fatal(err)
+	}
+	srcFileLinkRel := filepath.Join(innerDir, "srcFileLinkRel")
+	if err := os.Symlink("./srcFile", srcFileLinkRel); err != nil {
+		t.Fatal(err)
+	}
+	srcDirLinkAbs := filepath.Join(innerDir, "srcDirLinkAbs")
+	if err := os.Symlink(srcDir, srcDirLinkAbs); err != nil {
+		t.Fatal(err)
+	}
+	srcDirLinkRel := filepath.Join(innerDir, "srcDirLinkRel")
+	if err := os.Symlink("./srcDir", srcDirLinkRel); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create outer destination dir
+	dstRoot, err := ioutil.TempDir("", "copy-test-dst-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dstRoot)
+
+	// Copy our source innerDir over into the destination dir
+	if err := CopyFromStage("innerDir", "", srcRoot, dstRoot); err != nil {
+		t.Errorf("unexpected failure copying directory: %s", err)
+	}
+
+	// Now verify all the nested copied files are as expected
 	tests := []struct {
-		name string
-		src  string
-		dst  string
+		expectPath string
+		expectFile bool
+		expectDir  bool
+		expectLink bool
 	}{
-		{"NoSrc", filepath.Join(dir, "not/a/file"), "file"},
+		{
+			expectPath: "innerDir/srcFile",
+			expectFile: true,
+		},
+		{
+			expectPath: "innerDir/srcDir",
+			expectDir:  true,
+		},
+		// Nested symlink, inside the src directory.
+		// Should always have copied the link itself.
+		{
+			expectPath: "innerDir/srcFileLinkRel",
+			expectFile: true,
+			expectLink: true,
+		},
+		{
+			expectPath: "innerDir/srcFileLinkAbs",
+			expectFile: true,
+			expectLink: true,
+		},
+		{
+			expectPath: "innerDir/srcDirLinkRel",
+			expectDir:  true,
+			expectLink: true,
+		},
+		{
+			expectPath: "innerDir/srcDirLinkAbs",
+			expectDir:  true,
+			expectLink: true,
+		},
 	}
 
 	for _, tt := range tests {
-		// make src and dst relative to tmpdir
-		filepath.Join(dir, tt.src)
-
-		t.Run(tt.name, func(t *testing.T) {
-			// create tmpdir
-			dstDir, err := ioutil.TempDir("", "copy-test-dst-")
-			if err != nil {
-				t.Fatal(err)
+		t.Run(tt.expectPath, func(t *testing.T) {
+			dstFinal := filepath.Join(dstRoot, tt.expectPath)
+			// File when expected?
+			if tt.expectFile && !fs.IsFile(dstFinal) {
+				t.Errorf("destination should be a file, but isn't")
 			}
-			defer os.RemoveAll(dstDir)
-
-			dst := filepath.Join(dstDir, tt.dst)
-			if err := Copy(tt.src, dst, false); err == nil {
-				t.Errorf("unexpected success running %s test: %s", t.Name(), err)
+			// Dir when expected?
+			if tt.expectDir && !fs.IsDir(dstFinal) {
+				t.Errorf("destination should be a directory, but isn't")
+			}
+			// Link when expected?
+			if tt.expectLink && !fs.IsLink(dstFinal) {
+				t.Errorf("destination should be a symlink, but isn't")
+			}
+			// Not a link when not expected
+			if !tt.expectLink && fs.IsLink(dstFinal) {
+				t.Errorf("destination should not be a symlink, but is")
 			}
 		})
 	}
+
 }

--- a/internal/pkg/build/files/files_test.go
+++ b/internal/pkg/build/files/files_test.go
@@ -254,7 +254,7 @@ func TestExpandPath(t *testing.T) {
 	}
 }
 
-func TestAddPrefix(t *testing.T) {
+func TestJoinSlash(t *testing.T) {
 	tests := []struct {
 		name    string
 		prefix  string
@@ -296,7 +296,72 @@ func TestAddPrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// run it through wildcard function
-			path := AddPrefix(tt.prefix, tt.path)
+			path := joinKeepSlash(tt.prefix, tt.path)
+			if path != tt.correct {
+				t.Errorf("join created incorrect path: %s correct: %s", path, tt.correct)
+			}
+		})
+	}
+}
+
+func TestSecureJoinSlash(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		path    string
+		correct string
+	}{
+		{
+			name:    "sanity",
+			prefix:  "",
+			path:    "/some/path",
+			correct: "/some/path",
+		},
+		{
+			name:    "basicPrepend",
+			prefix:  "/some",
+			path:    "/path",
+			correct: "/some/path",
+		},
+		{
+			name:    "basicJoinTrailingSlash",
+			prefix:  "/some",
+			path:    "/path/",
+			correct: "/some/path/",
+		},
+		{
+			name:    "manySlashes",
+			prefix:  "/some/",
+			path:    "//path/to/dest//",
+			correct: "/some/path/to/dest/",
+		},
+		{
+			name:    "root",
+			prefix:  "",
+			path:    "/",
+			correct: "/",
+		},
+		{
+			name:    "escape dir",
+			prefix:  "/some/",
+			path:    "/../../../../",
+			correct: "/some/",
+		},
+		{
+			name:    "escape root",
+			prefix:  "",
+			path:    "/../../../../",
+			correct: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// run it through wildcard function
+			path, err := secureJoinKeepSlash(tt.prefix, tt.path)
+			if err != nil {
+				t.Errorf("failed with error: %s", err)
+			}
 			if path != tt.correct {
 				t.Errorf("join created incorrect path: %s correct: %s", path, tt.correct)
 			}

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -162,6 +162,9 @@ func (s *stage) copyFilesFrom(b *Build) error {
 			return err
 		}
 
+		srcRootfsPath := b.stages[stageIndex].b.RootfsPath
+		dstRootfsPath := s.b.RootfsPath
+
 		sylog.Debugf("Copying files from stage: %s", args[1])
 
 		// iterate through filetransfers
@@ -177,12 +180,8 @@ func (s *stage) copyFilesFrom(b *Build) error {
 			}
 
 			// copy each file into bundle rootfs
-			// prepend appropriate bundle path to supplied paths
-			// copying between stages should not follow symlinks
-			transfer.Src = files.AddPrefix(b.stages[stageIndex].b.RootfsPath, transfer.Src)
-			transfer.Dst = files.AddPrefix(s.b.RootfsPath, transfer.Dst)
 			sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)
-			if err := files.Copy(transfer.Src, transfer.Dst, false); err != nil {
+			if err := files.CopyFromStage(transfer.Src, transfer.Dst, srcRootfsPath, dstRootfsPath); err != nil {
 				return err
 			}
 		}
@@ -213,10 +212,8 @@ func (s *stage) copyFiles() error {
 			transfer.Dst = transfer.Src
 		}
 		// copy each file into bundle rootfs
-		// copying from host to container should follow symlinks
-		transfer.Dst = files.AddPrefix(s.b.RootfsPath, transfer.Dst)
 		sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)
-		if err := files.Copy(transfer.Src, transfer.Dst, true); err != nil {
+		if err := files.CopyFromHost(transfer.Src, transfer.Dst, s.b.RootfsPath); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In a multi-stage build `%copy`, if the source for the copy line is a
symlink we should dereference it and copy the target. Note that if we
are copying a directory we shouldn't dereference any symlinks
within the directory, only the directory itself.

Previously we were doing a straight `cp -frH` to implement this, but
it does not handle the case where a symlink to be copied is an
absolute symlink. The absolute symlink's target is correct in the
context of the stage's rootfs, but we are copying in the host context.

To fix this we manually dereference the top level src of a `%copy` line,
in a manner that will resolve absolute symlinks relative to the src
stage's rootfs correctly.

This PR also:

 - Splits host->rootfs copy, and stage->stage copy functions.
 - Rewrites the tests for host->rootfs and stage->stage copy
   functions to cover more cases including top-level and nested source
   files, dirs, and absolute + relative symlinks.
 - Uses securejoin to restrict resolution of paths to being inside of a
   rootfs where this is appropriate. This is for least-surprise rather
   than security, as the hostfs is still modifiable in `%setup` etc.

### This fixes or addresses the following GitHub issues:

 - Fixes #159


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
