### PR TITLE
Merge 'v3.8.1' to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,15 @@
     the `%test` section of the build with a ephemeral tmpfs overlay,
     permitting tests that write to the container filesystem.
 
+## v3.8.1 [2021-07-20]
+
 ### Bug Fixes
 
   - Allow escaped `\$` in a SINGULARITYENV_ var to set a literal `$` in
     a container env var.
+  - Handle absolute symlinks correctly in multi-stage build `%copy from`
+    blocks.
+  - Fix incorrect reference in sandbox restrictive permissions warning.
 
 ## v3.8.0 [2021-05-26]
 
@@ -71,6 +76,7 @@ of `make test` for ease of use:
   - `make testall` runs the full unit/integration/e2e test suite that
     requires docker credentials to be set with `E2E_DOCKER_USERNAME`
     and `E2E_DOCKER_PASSWORD` environment variables.
+  - Fix privilege handling issue with tests on Go >=1.16.
 
 ----
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ $ mkdir -p ${GOPATH}/src/github.com/sylabs && \
 To build a specific version of SingularityCE, check out a [release tag](https://github.com/sylabs/singularity/tags) before compiling:
 
 ```
-$ git checkout v3.8.0
+$ git checkout v3.8.1
 ```
 
 ## Compiling SingularityCE
@@ -125,7 +125,7 @@ as shown above.  Then download the latest
 and use it to install the RPM like this: 
 
 ```
-$ export VERSION=3.8.0  # this is the singularity version, change as you need
+$ export VERSION=3.8.1  # this is the singularity version, change as you need
 
 $ wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-ce-${VERSION}.tar.gz && \
     rpmbuild -tb singularity-ce-${VERSION}.tar.gz && \
@@ -141,7 +141,7 @@ tarball and use it to install Singularity:
 $ cd $GOPATH/src/github.com/sylabs/singularity && \
   ./mconfig && \
   make -C builddir rpm && \
-  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-ce-3.8.0*.x86_64.rpm # or whatever version you built
+  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-ce-3.8.1*.x86_64.rpm # or whatever version you built
 ```
 
 To build an rpm with an alternative install prefix set RPMPREFIX on the


### PR DESCRIPTION
Brings in the markdown file changes made on the `release-3.8` branch.