### PR TITLE
Revert "CI: use alpine3.13 due to CircleCI docker issue"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
   build-source-alpine:
     executor:
       name: golang
-      variant: alpine3.13
+      variant: alpine
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Now seeing Docker 20.10.7 in CircleCI, which does not have the issue with latest version of alpine from #120 

This reverts commit 849e759eebc8848d779b3d76376a7c63ac81477c.

### This fixes or addresses the following GitHub issues:

 - Fixes #122 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
