### PR TITLE
ci: Enforce no dependency on buildcfg in pkg/...

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,18 @@ commands:
                 exit $rc
                 ;;
             esac
+  check-pkg-no-buildcfg:
+    steps:
+      - run:
+          name: Check pkg/... doesn't depend on buildcfg
+          command: |-
+            if go list -f '{{.Deps}}' ./pkg/... | grep -q buildcfg
+            then
+              echo "Prohibited buildcfg dependency found in pkg/:"
+              echo
+              go list -f '{{.ImportPath}} - {{.Deps}}' ./pkg/... | grep buildcfg
+              exit 1
+            fi
   stop-background-apt:
     steps:
       - run:
@@ -159,6 +171,7 @@ jobs:
       - run:
           name: Check for Lint
           command: make -C ./builddir check
+      - check-pkg-no-buildcfg
 
   short-unit-tests:
     executor: ubuntu-machine


### PR DESCRIPTION
## Description of the Pull Request (PR):

Ensure no package in pkg/.. depends directly or indirectly on buildcfg,
as that would prevent use from another project.

### This fixes or addresses the following GitHub issues:

 - Fixes #183


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
