### PR TITLE
Copy globbed files to correct destination in `%files`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   section of the build with a ephemeral tmpfs overlay, permitting tests that
   write to the container filesystem.
 
+### Bug Fixes
+
+- When destination is ommitted in `%files` entry in definition file, ensure
+  globbed files are copied to correct resolved path.
+
 ## v3.8.1 \[2021-07-20\]
 
 ### Bug Fixes

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -19,20 +19,20 @@ import (
 )
 
 // makeParentDir ensures existence of the expected destination directory for the cp command
-// based on the supplied path and the number of source paths to copy
-func makeParentDir(path string, numSrcPaths int) error {
+// based on the supplied path.
+func makeParentDir(path string) error {
 	_, err := os.Stat(path)
 	if !os.IsNotExist(err) {
 		return nil
 	}
 
-	// if path ends with a trailing '/' or if there are multiple source paths to copy
-	// always ensure the full path exists as a directory because 'cp' is expecting a
-	// dir in these cases
-	if strings.HasSuffix(path, "/") || numSrcPaths > 1 {
+	// if path ends with a trailing '/' always ensure the full path exists as a directory
+	// because 'cp' is expecting a dir in these cases
+	if strings.HasSuffix(path, "/") {
 		if err := os.MkdirAll(filepath.Clean(path), 0755); err != nil {
 			return fmt.Errorf("while creating full path: %s", err)
 		}
+		return nil
 	}
 
 	// only make parent directory
@@ -45,7 +45,8 @@ func makeParentDir(path string, numSrcPaths int) error {
 
 // CopyFromHost should be used to copy files into the rootfs from the host fs.
 // src is a path relative to CWD on the host, or an absolute path on the host.
-// dstRel is a destination path inside dstRootfs
+// dstRel is a destination path inside dstRootfs.
+// An empty dstRel "" means copy the src file to the same path in the rootfs.
 // All symlinks encountered in the copy will be dereferenced (cp -L behavior).
 func CopyFromHost(src, dstRel, dstRootfs string) error {
 	// resolve any globbing in filepath
@@ -57,36 +58,40 @@ func CopyFromHost(src, dstRel, dstRootfs string) error {
 		return fmt.Errorf("no source files found matching: %s", src)
 	}
 
-	// Resolve our destination within the container rootfs
-	dstResolved, err := secureJoinKeepSlash(dstRootfs, dstRel)
-	if err != nil {
-		return fmt.Errorf("while resolving destination: %s: %s", dstRel, err)
-	}
+	for _, srcGlobbed := range paths {
+		// If the dstRel is "" then we are copying to the full source path, appended to the rootfs prefix
+		if dstRel == "" {
+			dstRel = srcGlobbed
+		}
 
-	// Create any parent dirs for dst that don't already exist
-	if err := makeParentDir(dstResolved, len(paths)); err != nil {
-		return fmt.Errorf("while creating parent dir: %v", err)
-	}
+		// Resolve our destination within the container rootfs
+		dstResolved, err := secureJoinKeepSlash(dstRootfs, dstRel)
+		if err != nil {
+			return fmt.Errorf("while resolving destination: %s: %s", dstRel, err)
+		}
 
-	args := []string{"-fLr"}
-	// append file(s) to be copied
-	args = append(args, paths...)
-	// append dst as last arg
-	args = append(args, dstResolved)
+		// Create any parent dirs for dst that don't already exist
+		if err := makeParentDir(dstResolved); err != nil {
+			return fmt.Errorf("while creating parent dir: %v", err)
+		}
 
-	var output, stderr bytes.Buffer
-	// copy each file into bundle rootfs
-	copy := exec.Command("/bin/cp", args...)
-	copy.Stdout = &output
-	copy.Stderr = &stderr
-	if err := copy.Run(); err != nil {
-		return fmt.Errorf("while copying %s to %s: %s: %s", paths, dstResolved, err, stderr.String())
+		args := []string{"-fLr", srcGlobbed, dstResolved}
+		var output, stderr bytes.Buffer
+		// copy each file into bundle rootfs
+		copy := exec.Command("/bin/cp", args...)
+		copy.Stdout = &output
+		copy.Stderr = &stderr
+		if err := copy.Run(); err != nil {
+			return fmt.Errorf("while copying %s to %s: %v: %s", paths, dstResolved, args, stderr.String())
+		}
+
 	}
 	return nil
 }
 
 // CopyFromStage should be used to copy files into the rootfs from a previous stage.
 // The src and dst are paths relative to the srcRootfs and dstRootfs.
+// An empty dst "" means copy the src file to the same path in the dst rootfs.
 // Symlinks are only dereferenced for the specified source or files that resolve
 // directly from a specified glob pattern. Any additional links inside a directory
 // being copied are not dereferenced.
@@ -124,13 +129,17 @@ func CopyFromStage(src, dst, srcRootfs, dstRootfs string) error {
 			return fmt.Errorf("while resolving source: %s: %s", srcGlobbedRel, err)
 		}
 
+		// If the dst is "" then we are copying to the same path in dstRootfs, as src is in srcRootfs.
+		if dst == "" {
+			dst = srcGlobbedRel
+		}
 		// Resolve the destination path, keeping any final slash
 		dstResolved, err := secureJoinKeepSlash(dstRootfs, dst)
 		if err != nil {
 			return fmt.Errorf("while resolving destination: %s: %s", dst, err)
 		}
 		// Create any parent dirs for dstResolved that don't already exist.
-		if err := makeParentDir(dstResolved, len(paths)); err != nil {
+		if err := makeParentDir(dstResolved); err != nil {
 			return fmt.Errorf("while creating parent dir: %v", err)
 		}
 

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -25,37 +25,16 @@ func TestMakeParentDir(t *testing.T) {
 	}{
 		{
 			name:   "basic",
-			srcNum: 1,
 			path:   "basic/path",
 			parent: true,
 		},
 		{
 			name:   "trailing slash",
-			srcNum: 1,
 			path:   "trailing/slash/",
 			parent: false,
 		},
 		{
-			name:   "multiple",
-			srcNum: 2,
-			path:   "multiple/files",
-			parent: false,
-		},
-		{
-			name:   "multiple trailing slash",
-			srcNum: 2,
-			path:   "multiple/trailing/slash/",
-			parent: false,
-		},
-		{
 			name:   "exists",
-			srcNum: 1,
-			path:   "", // this will create a path of just the testdir, which will always exist
-			parent: false,
-		},
-		{
-			name:   "exists multiple",
-			srcNum: 2,
 			path:   "", // this will create a path of just the testdir, which will always exist
 			parent: false,
 		},
@@ -73,7 +52,7 @@ func TestMakeParentDir(t *testing.T) {
 
 			// concatenate test path with directory, do not use a join function so that we do not remove a trailing slash
 			path := dir + "/" + tt.path
-			if err := makeParentDir(path, tt.srcNum); err != nil {
+			if err := makeParentDir(path); err != nil {
 				t.Errorf("")
 			}
 
@@ -131,6 +110,12 @@ func TestCopyFromHost(t *testing.T) {
 	if err := os.Mkdir(srcSpaceDir, 0755); err != nil {
 		t.Fatal(err)
 	}
+	// Nested File (to test multi level glob)
+	srcFileNested := filepath.Join(dir, "srcDir/srcFileNested")
+	if err := ioutil.WriteFile(srcFileNested, []byte(sourceFileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	srcFileNestedGlob := filepath.Join(dir, "srcDi?/srcFil?Nested")
 	// Source Symlinks
 	srcFileLinkAbs := filepath.Join(dir, "srcFileLinkAbs")
 	if err := os.Symlink(srcFile, srcFileLinkAbs); err != nil {
@@ -162,7 +147,7 @@ func TestCopyFromHost(t *testing.T) {
 			name:       "SrcFileNoDest",
 			src:        srcFile,
 			dst:        "",
-			expectPath: "srcFile",
+			expectPath: srcFile,
 			expectFile: true,
 		},
 		{
@@ -189,7 +174,7 @@ func TestCopyFromHost(t *testing.T) {
 		{
 			name:       "srcFileSpace",
 			src:        srcSpaceFile,
-			dst:        "",
+			dst:        "src File",
 			expectPath: "src File",
 			expectFile: true,
 		},
@@ -208,8 +193,29 @@ func TestCopyFromHost(t *testing.T) {
 			expectFile: true,
 		},
 		{
+			name:       "srcFileGlobNoDest",
+			src:        srcFileGlob,
+			dst:        "",
+			expectPath: srcFile,
+			expectFile: true,
+		},
+		{
+			name:       "srcFileNestedGlob",
+			src:        srcFileNestedGlob,
+			dst:        "dstDir/",
+			expectPath: "dstDir/srcFileNested",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileNestedGlobNoDest",
+			src:        srcFileNestedGlob,
+			dst:        "",
+			expectPath: srcFileNested,
+			expectFile: true,
+		},
+		{
 			name: "dstRestricted",
-			src:  srcFileGlob,
+			src:  srcFile,
 			// Will be restricted to `/` in the rootfs and should copy to there OK
 			dst:        "../../../../",
 			expectPath: "srcFile",
@@ -220,7 +226,7 @@ func TestCopyFromHost(t *testing.T) {
 			name:       "SrcDirNoDest",
 			src:        srcDir,
 			dst:        "",
-			expectPath: "srcDir",
+			expectPath: srcDir,
 			expectDir:  true,
 		},
 		{
@@ -247,7 +253,7 @@ func TestCopyFromHost(t *testing.T) {
 		{
 			name:       "srcDirSpace",
 			src:        srcSpaceDir,
-			dst:        "",
+			dst:        "src Dir",
 			expectPath: "src Dir",
 			expectDir:  true,
 		},
@@ -265,11 +271,18 @@ func TestCopyFromHost(t *testing.T) {
 			expectPath: "dstDir/srcDir",
 			expectDir:  true,
 		},
+		{
+			name:       "srcDirGlobNoDest",
+			src:        srcDirGlob,
+			dst:        "",
+			expectPath: srcDir,
+			expectDir:  true,
+		},
 		// Source is a Symlink
 		{
 			name:       "srcFileLinkRel",
 			src:        srcFileLinkRel,
-			dst:        "",
+			dst:        "srcFileLinkRel",
 			expectPath: "srcFileLinkRel",
 			// Copied the file, not the link itself
 			expectFile: true,
@@ -277,7 +290,7 @@ func TestCopyFromHost(t *testing.T) {
 		{
 			name:       "srcFileLinkAbs",
 			src:        srcFileLinkAbs,
-			dst:        "",
+			dst:        "srcFileLinkAbs",
 			expectPath: "srcFileLinkAbs",
 			// Copied the file, not the link itself
 			expectFile: true,
@@ -285,7 +298,7 @@ func TestCopyFromHost(t *testing.T) {
 		{
 			name:       "srcDirLinkRel",
 			src:        srcDirLinkRel,
-			dst:        "",
+			dst:        "srcDirLinkRel",
 			expectPath: "srcDirLinkRel",
 			// Copied the dir, not the link itself
 			expectDir: true,
@@ -293,7 +306,7 @@ func TestCopyFromHost(t *testing.T) {
 		{
 			name:       "srcDirLinkAbs",
 			src:        srcDirLinkAbs,
-			dst:        "",
+			dst:        "srcDirLinkAbs",
 			expectPath: "srcDirLinkAbs",
 			// Copied the dir, not the link itself
 			expectDir: true,
@@ -390,7 +403,7 @@ func TestCopyFromHostNested(t *testing.T) {
 	defer os.RemoveAll(dstDir)
 
 	// Copy our source innerDir over into the destination dir
-	if err := CopyFromHost(innerDir, "", dstDir); err != nil {
+	if err := CopyFromHost(innerDir, "innerDir", dstDir); err != nil {
 		t.Errorf("unexpected failure copying directory: %s", err)
 	}
 
@@ -475,6 +488,11 @@ func TestCopyFromStage(t *testing.T) {
 	}
 	srcSpaceDir := filepath.Join(srcRoot, "src Dir")
 	if err := os.Mkdir(srcSpaceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Nested File (to test multi level glob)
+	srcFileNested := filepath.Join(srcRoot, "srcDir/srcFileNested")
+	if err := ioutil.WriteFile(srcFileNested, []byte(sourceFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Symlinks
@@ -562,6 +580,27 @@ func TestCopyFromStage(t *testing.T) {
 			expectFile: true,
 		},
 		{
+			name:       "srcFileGlobNoDest",
+			srcRel:     "srcF?*",
+			dstRel:     "",
+			expectPath: "srcFile",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileNestedGlob",
+			srcRel:     "srcDi?/srcFil?Nested",
+			dstRel:     "dstDir/",
+			expectPath: "dstDir/srcFileNested",
+			expectFile: true,
+		},
+		{
+			name:       "srcFileNestedGlobNoDest",
+			srcRel:     "srcDi?/srcFil?Nested",
+			dstRel:     "",
+			expectPath: "srcDir/srcFileNested",
+			expectFile: true,
+		},
+		{
 			name:   "dstRestricted",
 			srcRel: "srcFile",
 			// Will be cleaned to `/` in the dst rootfs and should copy to there OK
@@ -625,6 +664,13 @@ func TestCopyFromStage(t *testing.T) {
 			srcRel:     "srcD?*",
 			dstRel:     "dstDir/",
 			expectPath: "dstDir/srcDir",
+			expectDir:  true,
+		},
+		{
+			name:       "srcDirGlobNoDest",
+			srcRel:     "srcD?*",
+			dstRel:     "",
+			expectPath: "srcDir",
 			expectDir:  true,
 		},
 		// Source is a Symlink

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -174,11 +174,6 @@ func (s *stage) copyFilesFrom(b *Build) error {
 				sylog.Warningf("Attempt to copy file with no name, skipping.")
 				continue
 			}
-			// dest = source if not specified
-			if transfer.Dst == "" {
-				transfer.Dst = transfer.Src
-			}
-
 			// copy each file into bundle rootfs
 			sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)
 			if err := files.CopyFromStage(transfer.Src, transfer.Dst, srcRootfsPath, dstRootfsPath); err != nil {
@@ -206,10 +201,6 @@ func (s *stage) copyFiles() error {
 		if transfer.Src == "" {
 			sylog.Warningf("Attempt to copy file with no name, skipping.")
 			continue
-		}
-		// dest = source if not specified
-		if transfer.Dst == "" {
-			transfer.Dst = transfer.Src
 		}
 		// copy each file into bundle rootfs
 		sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)


### PR DESCRIPTION
## Description of the Pull Request (PR):

When the destination of a line in the `%files` section is ommitted, the
file should be copied to the same full path within the destination
rootfs as it is in the source.

Previously we naively set dst = src in this case, but src might be a
globbing pattern. In this case the file copy destination was the glob
pattern, not the matched path(s) after globbing.

Handle a blank "" dest in the CopyFromHost / CopyFromStage functions,
where globbing occurs. Copy to the correct full path after globbing.
Update tests to capture this behavior.

### This fixes or addresses the following GitHub issues:

 - Fixes #196

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
