### PR TITLE
testing: skip hugetlb cgroup limit for non-2MB page size

### DIFF
--- a/internal/pkg/cgroups/example/cgroups-no-hugetlb.toml
+++ b/internal/pkg/cgroups/example/cgroups-no-hugetlb.toml
@@ -102,9 +102,9 @@
 # Hugetlb limit (in bytes)
 # - pagesize: the hugepage size
 # - limit: the limit of "hugepagesize" hugetlb usage
-[[hugepageLimits]]
-  limit = 9223372036854771712
-  pageSize = "16MB"
+# [[hugepageLimits]]
+#   limit = 9223372036854771712
+#   pageSize = "16MB"
 
 
 # Network restriction configuration


### PR DESCRIPTION
## Description of the Pull Request (PR):

If the system page size is not 2MB just test cgroups without a hugetlb
limit, rather than putting in more complex logic to work up configs for
different page sizes.

### This fixes or addresses the following GitHub issues:

 - Fixes #9


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
