### PR TITLE
fix: use correct Debian arch for debootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - When destination is ommitted in `%files` entry in definition file, ensure
   globbed files are copied to correct resolved path.
 - Avoid panic when mountinfo line has a blank field.
+- Call `debootstrap` with correct Debian arch when it is not identical to the
+  value of `runtime.GOARCH`. E.g. `ppc64el -> ppc64le`.
 
 ## v3.8.1 \[2021-07-20\]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Sometime the Debian arch string is not identical to the `runtime.GOARCH`
value for a platform. Map from `runtime.GOARCH` to the Debian arch to
address this.

### This fixes or addresses the following GitHub issues:

 - Fixes #204

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
