### PR TITLE
fix: avoid duplicate `remote.yaml` entries from multiple login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Avoid panic when mountinfo line has a blank field.
 - Call `debootstrap` with correct Debian arch when it is not identical to the
   value of `runtime.GOARCH`. E.g. `ppc64el -> ppc64le`.
+- Ensure repeated `remote login` to same URI does not create duplicate entries
+  in `~/.singularity/remote.yaml`.
 
 ## v3.8.1 \[2021-07-20\]
 

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -412,17 +412,17 @@ func (c ctx) remoteTestFlag(t *testing.T) {
 		{
 			name:           "add help",
 			cmdArgs:        []string{"add", "--help"},
-			expectedOutput: "Create a new singularity remote endpoint",
+			expectedOutput: "Add a new singularity remote endpoint",
 		},
 		{
 			name:           "list help",
 			cmdArgs:        []string{"list", "--help"},
-			expectedOutput: "List all singularity remote endpoints and services that are configured",
+			expectedOutput: "List all singularity remote endpoints, keyservers, and OCI credentials that are configured",
 		},
 		{
 			name:           "login help",
 			cmdArgs:        []string{"login", "--help"},
-			expectedOutput: "Log into a singularity remote endpoint, an OCI/Docker registry or a keyserver using credentials",
+			expectedOutput: "Login to a singularity remote endpoint, an OCI/Docker registry or a keyserver using credentials",
 		},
 		{
 			name:           "remove help",


### PR DESCRIPTION
## Description of the Pull Request (PR):

Repeated `remote login` with the same URI can cause duplicate
`Credentials` entries in `~/remote.yaml`.

Ensure a `remote login` with an existing configured URI replaces the
existing entry. Make `remote logout` remove all entries to clean up the
result of this bug.

Also has a commit to correct e2e test looking for usage messages that were changed in #217 - but e2e was not triggered there.

### This fixes or addresses the following GitHub issues:

 - Fixes #214 
 - Fixes #222 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
