### PR TITLE
Improve OCI login docs, and be explicit on no --tokenfile support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
   container env var.
 - Handle absolute symlinks correctly in multi-stage build `%copy from` blocks.
 - Fix incorrect reference in sandbox restrictive permissions warning.
+- Return an error if `--tokenfile` used for `remote login` to an OCI registry,
+  as this is not supported.
 
 ## v3.8.0 \[2021-05-26\]
 

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -67,7 +67,7 @@ var remoteTokenFileFlag = cmdline.Flag{
 	Value:        &loginTokenFile,
 	DefaultValue: "",
 	Name:         "tokenfile",
-	Usage:        "path to the file holding token",
+	Usage:        "path to the file holding auth token for login (remote endpoints only)",
 }
 
 // --no-login
@@ -86,7 +86,7 @@ var remoteLoginUsernameFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "username",
 	ShortHand:    "u",
-	Usage:        "username to authenticate with (leave it empty for token authentication)",
+	Usage:        "username to authenticate with (required for Docker/OCI registry login)",
 	EnvKeys:      []string{"LOGIN_USERNAME"},
 }
 
@@ -97,7 +97,7 @@ var remoteLoginPasswordFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "password",
 	ShortHand:    "p",
-	Usage:        "password to authenticate with",
+	Usage:        "password / token to authenticate with",
 	EnvKeys:      []string{"LOGIN_PASSWORD"},
 }
 

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -14,23 +14,43 @@ const (
 	RemoteUse   string = `remote [remote options...]`
 	RemoteShort string = `Manage singularity remote endpoints, keyservers and OCI/Docker registry credentials`
 	RemoteLong  string = `
-  The 'remote' commands allow you to manage Singularity remote endpoints, keyservers
-  and OCI/Docker registry credentials through its subcommands. The remote configuration
-  is stored in $HOME/.singularity/remotes.yaml by default.`
+  The 'remote' command allows you to manage Singularity remote endpoints,
+  standalone keyservers and OCI/Docker registry credentials through its
+  subcommands.
+
+  A 'remote endpoint' is the Sylabs Cloud, a Singularity Enterprise installation,
+  or a compatible group of services. The remote endpoint is a single address,
+  e.g. 'cloud.sylabs.io' through which linked library, builder and keystore
+  sevices will be automatically discovered.
+
+  To configure a remote endpoint you must 'remote add' it. You can 'remote login' if
+  you will be performing actions needing authentication. Switch between
+  configured remote endpoints with the 'remote use' command. The active remote
+  endpoint will be used for remote builds, key operations, and 'library://' pull
+  and push. You can also 'remote logout' from and 'remote remove' an endpoint that
+  is no longer required.
+
+  To configure credentials for OCI registries that should be used when pulling or
+  pushing from/to 'docker://'' or 'oras://' URIs, use the 'remote login' command
+  only. You do not have to 'remote add' OCI registries. To remove credentials
+  'remote logout' with the same URI. You do not need to 'remote remove' OCI
+  credentials.
+
+  The remote configuration is stored in $HOME/.singularity/remotes.yaml by default.`
 	RemoteExample string = `
   All group commands have their own help output:
 
-	$ singularity help remote list
-	$ singularity remote list`
+    $ singularity help remote list
+    $ singularity remote list`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote add command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteAddUse   string = `add [add options...] <remote_name> <remote_URI>`
-	RemoteAddShort string = `Create a new singularity remote endpoint`
+	RemoteAddShort string = `Add a new singularity remote endpoint`
 	RemoteAddLong  string = `
-	The 'remote add' command allows you to create a new remote endpoint to be
-	be used for singularity remote services. Authentication with a newly created
-	endpoint will occur automatically.`
+  The 'remote add' command allows you to add a new remote endpoint to be
+  be used for singularity remote services. Authentication with a newly created
+  endpoint will occur automatically.`
 	RemoteAddExample string = `
   $ singularity remote add SylabsCloud cloud.sylabs.io`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -57,28 +77,39 @@ const (
 	// remote list command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteListUse   string = `list`
-	RemoteListShort string = `List all singularity remote endpoints and services that are configured`
+	RemoteListShort string = `List all singularity remote endpoints, keyservers, and OCI credentials that are configured`
 	RemoteListLong  string = `
-  The 'remote list' command lists all remote endpoints configured for use. If a remote
-  is in use, its name will be encompassed by brackets.`
+  The 'remote list' command lists all remote endpoints, keyservers, and OCI registry
+  credentials configured for use.
+
+  The current remote is indicated by 'YES' in the 'ACTIVE' column and can be changed
+  with the 'remote use' command.`
 	RemoteListExample string = `
   $ singularity remote list`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote login command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteLoginUse   string = `login [login options...] <remote_name|registry_uri>`
-	RemoteLoginShort string = `Log into a singularity remote endpoint, an OCI/Docker registry or a keyserver using credentials`
+	RemoteLoginShort string = `Login to a singularity remote endpoint, an OCI/Docker registry or a keyserver using credentials`
 	RemoteLoginLong  string = `
   The 'remote login' command allows you to set credentials for a specific endpoint,
-  an OCI/Docker registry or a keyserver. This command can produce a link directing you to
-  the token service you can use to generate a valid token. If no endpoint or registry is
-  specified, it will try the default remote endpoint (SylabsCloud).`
+  an OCI/Docker registry or a keyserver.
+
+  If no endpoint or registry is specified, the command will login to the currently
+  active remote endpoint. This is cloud.sylabs.io by default.`
 	RemoteLoginExample string = `
   To log in to an endpoint:
   $ singularity remote login SylabsCloud
 
   To login in to a docker/OCI registry:
-  $ singularity remote login --username foo --password bar docker://docker.io`
+  $ singularity remote login --username foo docker://docker.io
+  $ singularity remote login --username foo oras://myregistry.example.com
+
+  Note that many cloud OCI registries use token based authentication. The token
+  should be specified as the password for login. A username is still required. E.g.
+  when using a standard Azure identity and token to login to an ACR registry the
+  username '00000000-0000-0000-0000-000000000000' is required. Consult your provider
+  documentation for detail of their login requirements.`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote logout command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -87,7 +118,8 @@ const (
 	RemoteLogoutLong  string = `
   The 'remote logout' command allows you to log out from a singularity specific endpoint,
   an OCI/Docker registry or a keyserver. If no endpoint or service is specified, it will
-  try the default remote endpoint (SylabsCloud).`
+  logout from the current active remote endpoint.
+  `
 	RemoteLogoutExample string = `
   To log out from an endpoint
   $ singularity remote logout SylabsCloud

--- a/internal/app/singularity/remote_login.go
+++ b/internal/app/singularity/remote_login.go
@@ -70,6 +70,9 @@ func RemoteLogin(usrConfigFile string, args *LoginArgs) (err error) {
 		}
 	} else {
 		// services (oci registry, single keyserver etc.)
+		if args.Tokenfile != "" {
+			return fmt.Errorf("--tokenfile is only supported for login to a remote endpoint, not OCI (docker/oras) or keyservers")
+		}
 		if err := c.Login(args.Name, args.Username, args.Password, args.Insecure); err != nil {
 			return fmt.Errorf("while login to %s: %s", args.Name, err)
 		}

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -44,7 +44,7 @@ func init() {
 // function just return the password provided as argument.
 func ensurePassword(password string) (string, error) {
 	if password == "" {
-		question := "Password (or token when username is empty): "
+		question := "Password / Token: "
 		input, err := interactive.AskQuestionNoEcho(question)
 		if err != nil {
 			return "", fmt.Errorf("failed to read password: %s", err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

fix: --tokenfile is not supported for oci login so give error

docs: revise CLI help for remote login 
Be much more explicit in what a remote endpoint is vs OCI credentials.
Generally expand the descriptive text.


### This fixes or addresses the following GitHub issues:

 - Fixes #211 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
