### PR TITLE
e2e: fix registry instance for Skopeo 1.4.0

### DIFF
--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -26,7 +26,7 @@ from: registry:2.7.1
     # wait until docker registry is up
     while ! wget -q -O /dev/null 127.0.0.1:5000 ; do sleep 0.5; done
 
-    skopeo --dest-tls-verify=false --insecure-policy copy docker://busybox docker://localhost:5000/my-busybox
+    skopeo --insecure-policy copy --dest-tls-verify=false docker://busybox docker://localhost:5000/my-busybox
 
     # e2e PrepRegistry will repeatedly trying to connect to this port
     # giving indication that it can start


### PR DESCRIPTION
## Description of the Pull Request (PR):

The `--dest-tls-verify` must now be specified as a flag to `copy` and
not as a global flag for Skopeo 1.4.0.

### This fixes or addresses the following GitHub issues:

 - Fixes #219 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
