### PR TITLE
Remove --nonet flag (unused)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   paths, but not destination paths, leading to unexpected copy behaviour.
   Globbing for source files will now follow the Go `filepath.Match` pattern
   syntax.
+- Removed `--nonet` flag, which was intended to disable networking for in-VM
+  execution, but has no effect.
 
 ### New features / functionalities
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -53,7 +53,6 @@ var (
 	NoUmask         bool
 	VM              bool
 	VMErr           bool
-	NoNet           bool
 	IsSyOS          bool
 	disableCache    bool
 
@@ -268,16 +267,6 @@ var actionVMIPFlag = cmdline.Flag{
 	Usage:        "IP Address to assign for container usage. Defaults to DHCP within bridge network.",
 	Tag:          "<IP Address>",
 	EnvKeys:      []string{"VM_IP"},
-}
-
-// --nonet
-var actionNONETFlag = cmdline.Flag{
-	ID:           "actionNONETFlag",
-	Value:        &NoNet,
-	DefaultValue: false,
-	Name:         "nonet",
-	Usage:        "disable VM network handling",
-	EnvKeys:      []string{"VM_NONET"},
 }
 
 // hidden flag to handle SINGULARITY_CONTAINLIBS environment variable
@@ -673,7 +662,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionNoHomeFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoMountFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoInitFlag, actionsInstanceCmd...)
-		cmdManager.RegisterFlagForCmd(&actionNONETFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoNvidiaFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoRocmFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoPrivsFlag, actionsInstanceCmd...)


### PR DESCRIPTION
## Description of the Pull Request (PR):

The `--nonet` flag is confusing as it doesn't follow the `no-` hyphenation
pattern, and should apply to VM invocation only, but does not have a
`--vm-` prefix.

On further investigation the `NoNet` variable it sets is never
used. Let's just remove the flag.


### This fixes or addresses the following GitHub issues:

 - Fixes #239 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
