### PR TITLE
Change `--nohttps` flag to `--no-https`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   syntax.
 - Removed `--nonet` flag, which was intended to disable networking for in-VM
   execution, but has no effect.
+- `--nohttps` flag has been deprecated in favour of `--no-https`. The old flag
+  is still accepted, but will display a deprecation warning.
 
 ### New features / functionalities
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -688,6 +688,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionWritableFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionWritableTmpfsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonNoHTTPSFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&commonOldNoHTTPSFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&dockerLoginFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&dockerPasswordFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&dockerUsernameFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -184,14 +184,24 @@ var commonForceFlag = cmdline.Flag{
 	EnvKeys:      []string{"FORCE"},
 }
 
-// --nohttps
+// --no-https
 var commonNoHTTPSFlag = cmdline.Flag{
 	ID:           "commonNoHTTPSFlag",
 	Value:        &noHTTPS,
 	DefaultValue: false,
+	Name:         "no-https",
+	Usage:        "use http instead of https for docker:// oras:// and library://<hostname>/... URIs",
+	EnvKeys:      []string{"NOHTTPS", "NO_HTTPS"},
+}
+
+// --nohttps (deprecated)
+var commonOldNoHTTPSFlag = cmdline.Flag{
+	ID:           "commonOldNoHTTPSFlag",
+	Value:        &noHTTPS,
+	DefaultValue: false,
 	Name:         "nohttps",
-	Usage:        "do NOT use HTTPS with the docker:// transport (useful for local docker registries without a certificate)",
-	EnvKeys:      []string{"NOHTTPS"},
+	Deprecated:   "use --no-https",
+	Usage:        "use http instead of https for docker:// oras:// and library://<hostname>/... URIs",
 }
 
 // --tmpdir

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -382,7 +382,7 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 			t,
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
-			e2e.WithArgs("--nohttps", imagePath, defFile),
+			e2e.WithArgs("--no-https", imagePath, defFile),
 			e2e.PostRun(func(t *testing.T) {
 				defer os.Remove(imagePath)
 				defer os.Remove(defFile)

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -58,7 +58,7 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		return err
 	}
 
-	// DockerInsecureSkipTLSVerify is set only if --nohttps is specified to honor
+	// DockerInsecureSkipTLSVerify is set only if --no-https is specified to honor
 	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
 	// can have three possible values true/false and undefined, so we left it as undefined instead
 	// of forcing it to false in order to delegate decision to /etc/containers/registries.conf:

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -23,7 +23,7 @@ import (
 
 // pull will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
 func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS, noCleanUp bool) (imagePath string, err error) {
-	// DockerInsecureSkipTLSVerify is set only if --nohttps is specified to honor
+	// DockerInsecureSkipTLSVerify is set only if --no-https is specified to honor
 	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
 	// can have three possible values true/false and undefined, so we left it as undefined instead
 	// of forcing it to false in order to delegate decision to /etc/containers/registries.conf:


### PR DESCRIPTION
## Description of the Pull Request (PR):

The `--nohttps` flag does not fit into the pattern of `--no-` prefixes
with a hyphen for negative flags.

Add a `--no-https` flag and deprecate the existing `--nohttps` flag.

### This fixes or addresses the following GitHub issues:

 - Fixes #238 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
