### PR TITLE
fix: honor hostname in library:// URI for `singularity delete`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
   value of `runtime.GOARCH`. E.g. `ppc64el -> ppc64le`.
 - Ensure repeated `remote login` to same URI does not create duplicate entries
   in `~/.singularity/remote.yaml`.
+- `singularity delete` will use the correct library service when the hostname
+  is specified in the `library://` URI.
 
 ## v3.8.1 \[2021-07-20\]
 

--- a/cmd/internal/cli/delete.go
+++ b/cmd/internal/cli/delete.go
@@ -97,6 +97,18 @@ var deleteImageCmd = &cobra.Command{
 			sylog.Fatalf("Error parsing library ref: %v", err)
 		}
 
+		if deleteLibraryURI != "" && imageRef.Host != "" {
+			sylog.Fatalf("Conflicting arguments; do not use --library with a library URI containing host name")
+		}
+
+		var libraryURI string
+		if deleteLibraryURI != "" {
+			libraryURI = deleteLibraryURI
+		} else if imageRef.Host != "" {
+			// override libraryURI if ref contains host name
+			libraryURI = "https://" + imageRef.Host
+		}
+
 		r := fmt.Sprintf("%s:%s", imageRef.Path, imageRef.Tags[0])
 
 		if !deleteForce {
@@ -109,7 +121,7 @@ var deleteImageCmd = &cobra.Command{
 			}
 		}
 
-		libraryConfig, err := getLibraryClientConfig(deleteLibraryURI)
+		libraryConfig, err := getLibraryClientConfig(libraryURI)
 		if err != nil {
 			sylog.Fatalf("Error while getting library client config: %v", err)
 		}

--- a/e2e/delete/delete.go
+++ b/e2e/delete/delete.go
@@ -23,6 +23,7 @@ func (c ctx) testDeleteCmd(t *testing.T) {
 		args       []string
 		agree      string
 		expectExit int
+		expect     e2e.SingularityCmdResultOp
 	}{
 		{
 			name:       "delete unauthorized arch",
@@ -66,6 +67,13 @@ func (c ctx) testDeleteCmd(t *testing.T) {
 			agree:      "y",
 			expectExit: 255,
 		},
+		{
+			name:       "delete host in uri",
+			args:       []string{"library://library.example.com/test/default/test:v0.0.3"},
+			agree:      "y",
+			expectExit: 255,
+			expect:     e2e.ExpectError(e2e.ContainMatch, "dial tcp: lookup library.example.com: no such host"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -76,7 +84,7 @@ func (c ctx) testDeleteCmd(t *testing.T) {
 			e2e.WithCommand("delete"),
 			e2e.WithArgs(tt.args...),
 			e2e.WithStdin(bytes.NewBufferString(tt.agree)),
-			e2e.ExpectExit(tt.expectExit),
+			e2e.ExpectExit(tt.expectExit, tt.expect),
 		)
 	}
 }


### PR DESCRIPTION
`singularity delete` would accept a hostname in the library:// URI
provided, but would perform the request against the default remote.

Fix this, so it is handled in the same way as for push/pull.

### This fixes or addresses the following GitHub issues:

 - Fixes #243 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
