### PR TITLE
Allow `remote add --insecure` for http endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
   network namespaces as these may not be supported on many installations.
 - `--no-https` now applies to connections made to library services specified
   in `--library://<hostname>/...` URIs.
+- `remote add --insecure` may be used to configure endpoints that are only
+  accessible via http.
 
 ### Bug Fixes
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -165,7 +165,11 @@ func runBuildRemote(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 	// service URLs, since there is no straightforward foolproof way to work back from them to a
 	// matching frontend URL.
 	if !cmd.Flag("builder").Changed && !cmd.Flag("library").Changed {
-		buildArgs.webURL = URI()
+		webURL, err := currentRemoteEndpoint.GetURL()
+		if err != nil {
+			sylog.Fatalf("Unable to find remote web URI %v", err)
+		}
+		buildArgs.webURL = webURL
 	}
 
 	// submitting a remote build requires a valid authToken

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -107,12 +107,17 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Unable to get keyserver client configuration: %v", err)
 			}
 
+			feURL, err := currentRemoteEndpoint.GetURL()
+			if err != nil {
+				sylog.Fatalf("Unable to find remote web URI %v", err)
+			}
+
 			pushSpec := singularity.LibraryPushSpec{
 				SourceFile:    file,
 				DestRef:       dest,
 				Description:   pushDescription,
 				AllowUnsigned: unsignedPush,
-				FrontendURI:   URI(),
+				FrontendURI:   feURL,
 			}
 
 			err = singularity.LibraryPush(ctx, pushSpec, lc, co)

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -36,6 +36,7 @@ var (
 	remoteNoLogin           bool
 	global                  bool
 	remoteUseExclusive      bool
+	remoteAddInsecure       bool
 )
 
 // assemble values of remoteConfig for user/sys locations
@@ -151,6 +152,16 @@ var remoteKeyserverInsecureFlag = cmdline.Flag{
 	Usage:        "allow insecure connection to keyserver",
 }
 
+// -i|--insecure
+var remoteAddInsecureFlag = cmdline.Flag{
+	ID:           "remoteAddInsecureFlag",
+	Value:        &remoteAddInsecure,
+	DefaultValue: false,
+	Name:         "insecure",
+	ShortHand:    "i",
+	Usage:        "allow connection to an insecure http remote",
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(RemoteCmd)
@@ -170,8 +181,9 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&remoteTokenFileFlag, RemoteLoginCmd, RemoteAddCmd)
 		// add --global flag to remote add/remove/use commands
 		cmdManager.RegisterFlagForCmd(&remoteGlobalFlag, RemoteAddCmd, RemoteRemoveCmd, RemoteUseCmd)
-		// add --no-login flag to add command
+		// add --insecure, --no-login flags to add command
 		cmdManager.RegisterFlagForCmd(&remoteNoLoginFlag, RemoteAddCmd)
+		cmdManager.RegisterFlagForCmd(&remoteAddInsecureFlag, RemoteAddCmd)
 
 		cmdManager.RegisterFlagForCmd(&remoteLoginUsernameFlag, RemoteLoginCmd)
 		cmdManager.RegisterFlagForCmd(&remoteLoginPasswordFlag, RemoteLoginCmd)
@@ -225,7 +237,7 @@ var RemoteAddCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		name := args[0]
 		uri := args[1]
-		if err := singularity.RemoteAdd(remoteConfig, name, uri, global); err != nil {
+		if err := singularity.RemoteAdd(remoteConfig, name, uri, global, remoteAddInsecure); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 		sylog.Infof("Remote %q added.", name)

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -658,7 +658,3 @@ func getBuilderClientConfig(uri string) (*scsbuildclient.Config, error) {
 
 	return currentRemoteEndpoint.BuilderClientConfig(uri)
 }
-
-func URI() string {
-	return "https://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
-}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.4.0 // indirect
 	github.com/gorilla/websocket v1.4.2
+	github.com/gosimple/slug v1.10.0
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kr/pty v1.1.8
 	github.com/moby/sys/mount v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,10 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosimple/slug v1.10.0 h1:3XbiQua1IpCdrvuntWvGBxVm+K99wCSxJjlxkP49GGQ=
+github.com/gosimple/slug v1.10.0/go.mod h1:MICb3w495l9KNdZm+Xn5b6T2Hn831f9DMxiJ1r+bAjw=
+github.com/gosimple/unidecode v1.0.0 h1:kPdvM+qy0tnk4/BrnkrbdJ82xe88xn7c9hcaipDz4dQ=
+github.com/gosimple/unidecode v1.0.0/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/internal/app/singularity/remote_add.go
+++ b/internal/app/singularity/remote_add.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,7 +17,7 @@ import (
 )
 
 // RemoteAdd adds remote to configuration
-func RemoteAdd(configFile, name, uri string, global bool) (err error) {
+func RemoteAdd(configFile, name, uri string, global, insecure bool) (err error) {
 	// Explicit handling of corner cases: name and uri must be valid strings
 	if strings.TrimSpace(name) == "" {
 		return fmt.Errorf("invalid name: cannot have empty name")
@@ -51,7 +51,7 @@ func RemoteAdd(configFile, name, uri string, global bool) (err error) {
 	if err != nil {
 		return err
 	}
-	e := endpoint.Config{URI: path.Join(u.Host + u.Path), System: global}
+	e := endpoint.Config{URI: path.Join(u.Host + u.Path), System: global, Insecure: insecure}
 
 	if err := c.Add(name, &e); err != nil {
 		return err

--- a/internal/app/singularity/remote_add_test.go
+++ b/internal/app/singularity/remote_add_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -104,6 +104,7 @@ func TestRemoteAdd(t *testing.T) {
 		remoteName string
 		uri        string
 		global     bool
+		insecure   bool
 		shallPass  bool
 	}{
 		{
@@ -163,7 +164,7 @@ func TestRemoteAdd(t *testing.T) {
 			shallPass:  false,
 		},
 		{
-			name:       "8: valid config gile; invalid remote name; invalid URI; local",
+			name:       "8: valid config file; valid remote name; invalid URI; local",
 			cfgfile:    validCfgFile,
 			remoteName: validRemoteName,
 			uri:        invalidURI,
@@ -341,6 +342,15 @@ func TestRemoteAdd(t *testing.T) {
 			global:     false,
 			shallPass:  true,
 		},
+		{
+			name:       "30: valid config file; valid remote name; valid URI; local; insecure",
+			cfgfile:    validCfgFile,
+			remoteName: validRemoteName,
+			uri:        validURI,
+			global:     false,
+			insecure:   true,
+			shallPass:  true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -366,7 +376,7 @@ func TestRemoteAdd(t *testing.T) {
 				remote.SystemConfigPath = tt.cfgfile
 			}
 
-			err := RemoteAdd(tt.cfgfile, tt.remoteName, tt.uri, tt.global)
+			err := RemoteAdd(tt.cfgfile, tt.remoteName, tt.uri, tt.global, tt.insecure)
 			if tt.shallPass == true && err != nil {
 				restoreSysConfig()
 				t.Fatalf("valid case failed: %s\n", err)

--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,7 +15,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/remote"
 )
 
-const listLine = "%s\t%s\t%s\t%s\t%s\n"
+const listLine = "%s\t%s\t%s\t%s\t%s\t%s\n"
 
 // RemoteList prints information about remote configurations
 func RemoteList(usrConfigFile string) (err error) {
@@ -64,7 +64,7 @@ func RemoteList(usrConfigFile string) (err error) {
 	fmt.Println()
 
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, listLine, "NAME", "URI", "ACTIVE", "GLOBAL", "EXCLUSIVE")
+	fmt.Fprintf(tw, listLine, "NAME", "URI", "ACTIVE", "GLOBAL", "EXCLUSIVE", "INSECURE")
 	for _, n := range names {
 		sys := "NO"
 		if c.Remotes[n].System {
@@ -74,11 +74,16 @@ func RemoteList(usrConfigFile string) (err error) {
 		if c.Remotes[n].Exclusive {
 			excl = "YES"
 		}
+		insec := "NO"
+		if c.Remotes[n].Insecure {
+			insec = "YES"
+		}
 		active := "NO"
 		if c.DefaultRemote != "" && c.DefaultRemote == n {
 			active = "YES"
 		}
-		fmt.Fprintf(tw, listLine, n, c.Remotes[n].URI, active, sys, excl)
+
+		fmt.Fprintf(tw, listLine, n, c.Remotes[n].URI, active, sys, excl, insec)
 	}
 	tw.Flush()
 

--- a/internal/app/singularity/remote_login.go
+++ b/internal/app/singularity/remote_login.go
@@ -125,7 +125,12 @@ func endPointLogin(ep *endpoint.Config, args *LoginArgs) error {
 			}
 		}
 
-		fmt.Printf("Generate an access token at https://%s/auth/tokens, and paste it here.\n", ep.URI)
+		webURL, err := ep.GetURL()
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Generate an access token at %s/auth/tokens, and paste it here.\n", webURL)
 		fmt.Println("Token entered will be hidden for security.")
 		token, err = interactive.AskQuestionNoEcho("Access Token: ")
 		if err != nil {

--- a/internal/app/singularity/remote_remove.go
+++ b/internal/app/singularity/remote_remove.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/app/singularity/remote_remove_test.go
+++ b/internal/app/singularity/remote_remove_test.go
@@ -48,7 +48,7 @@ func TestRemoteRemove(t *testing.T) {
 	}
 
 	// Add remotes based on our config file
-	err := RemoteAdd(validCfgFile, "cloud_testing", "cloud.random.io", false)
+	err := RemoteAdd(validCfgFile, "cloud_testing", "cloud.random.io", false, false)
 	if err != nil {
 		t.Fatalf("cannot add remote \"cloud\" for testing: %s\n", err)
 	}

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -7,12 +7,15 @@
 package endpoint
 
 import (
+	"errors"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/gosimple/slug"
 	"github.com/sylabs/singularity/internal/pkg/remote/credential"
 	"github.com/sylabs/singularity/pkg/syfs"
 )
@@ -25,12 +28,15 @@ var DefaultEndpointConfig = &Config{
 	System: true,
 }
 
+var ErrNoURI = errors.New("no URI set for endpoint")
+
 // Config describes a single remote endpoint.
 type Config struct {
-	URI        string           `yaml:"URI,omitempty"`
+	URI        string           `yaml:"URI,omitempty"` // hostname/path - no protocol expected
 	Token      string           `yaml:"Token,omitempty"`
-	System     bool             `yaml:"System"`    // Was this EndPoint set from system config file
-	Exclusive  bool             `yaml:"Exclusive"` // true if the endpoint must be used exclusively
+	System     bool             `yaml:"System"`             // Was this EndPoint set from system config file
+	Exclusive  bool             `yaml:"Exclusive"`          // true if the endpoint must be used exclusively
+	Insecure   bool             `yaml:"Insecure,omitempty"` // Allow use of http for service discovery
 	Keyservers []*ServiceConfig `yaml:"Keyservers,omitempty"`
 
 	// for internal purpose
@@ -40,6 +46,27 @@ type Config struct {
 
 func (e *Config) SetCredentials(creds []*credential.Config) {
 	e.credentials = creds
+}
+
+// GetUrl returns a URL with the correct https or http protocol for the endpoint.
+// The protocol depends on whether the endpoint is set 'Insecure'.
+func (e *Config) GetURL() (string, error) {
+	if e.URI == "" {
+		return "", ErrNoURI
+	}
+
+	u, err := url.Parse(e.URI)
+	if err != nil {
+		return "", err
+	}
+
+	if e.Insecure {
+		u.Scheme = "http"
+	} else {
+		u.Scheme = "https"
+	}
+
+	return u.String(), nil
 }
 
 type ServiceConfig struct {
@@ -67,7 +94,8 @@ func getCachedConfig(uri string) io.ReadCloser {
 	if dir == "" {
 		return nil
 	}
-	config := filepath.Join(dir, uri+".json")
+	uriSlug := slug.Make(uri)
+	config := filepath.Join(dir, uriSlug+".json")
 	fi, err := os.Stat(config)
 	if err != nil {
 		return nil

--- a/internal/pkg/remote/endpoint/token.go
+++ b/internal/pkg/remote/endpoint/token.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -19,10 +19,6 @@ import (
 // If token is provided as an argument, it will verify the provided token.
 // If token is "", it will attempt to verify the configured token for the endpoint.
 func (ep *Config) VerifyToken(token string) (err error) {
-	if ep.URI == "" {
-		return fmt.Errorf("no endpoint URI")
-	}
-
 	defer func() {
 		if err == nil {
 			sylog.Infof("Access Token Verified!")

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
@@ -1002,6 +1003,59 @@ func TestSetDefaultRemote(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if err := test.old.SetDefault(test.id, false); err == nil {
 				t.Error("unexpected success setting default remote")
+			}
+		})
+	}
+}
+
+func TestGetURL(t *testing.T) {
+	tests := []remoteTest{
+		{
+			name: "get uri https",
+			old: Config{
+				DefaultRemote: "cloud",
+				Remotes: map[string]*endpoint.Config{
+					"cloud": {
+						URI: "cloud.example.com",
+					},
+				},
+			},
+			id: "cloud",
+		},
+		{
+			name: "get uri http",
+			old: Config{
+				DefaultRemote: "cloud",
+				Remotes: map[string]*endpoint.Config{
+					"cloud": {
+						URI:      "cloud.example.com",
+						Insecure: true,
+					},
+				},
+			},
+			id: "cloud",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var ep *endpoint.Config
+			ep, err := test.old.GetRemote(test.id)
+			if err != nil {
+				t.Fatal("failed to get endpoint from config")
+			}
+
+			u, err := ep.GetURL()
+			if err != nil {
+				t.Errorf("unexpected error from GetURL: %v", err)
+			}
+
+			if ep.Insecure && !strings.HasPrefix(u, "http://") {
+				t.Errorf("insecure GetURL scheme must be http, but found %s", u)
+			}
+
+			if !ep.Insecure && !strings.HasPrefix(u, "https://") {
+				t.Errorf("secure GetURL scheme must be https, but found %s", u)
 			}
 		})
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Previously, `https://` was always prefixed to a remote endpoint's
configured `URI`. This meant that remote service discovery was not
possible against an http-only server.

Patches have been circulated by the community to allow use of http for
development etc.

This PR allows the `--insecure` flag to be specified to `remote add`.
An insecure endpoint configuration will perform service discovery over
http.

Additionally, the filename for caching remote configs is changed to a
safe 'slug' version of the remote URI. This allows URIs with a '/' or
other special characters in them.


### This fixes or addresses the following GitHub issues:

 - Fixes #237 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
