### PR TITLE
Honor `--no-https` for `library://hostname/...` URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
   options that increase OCI/Docker compatibility. Infers `--containall,
   --no-init, --no-umask, --writable-tmpfs`. Does not use user, uts, or
   network namespaces as these may not be supported on many installations.
+- `--no-https` now applies to connections made to library services specified
+  in `--library://<hostname>/...` URIs.
 
 ### Bug Fixes
 

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -92,7 +92,11 @@ func handleLibrary(ctx context.Context, imgCache *cache.Handle, pullFrom string)
 	// Default "" = use current remote endpoint
 	var libraryURI string
 	if r.Host != "" {
-		libraryURI = "https://" + r.Host
+		if noHTTPS {
+			libraryURI = "http://" + r.Host
+		} else {
+			libraryURI = "https://" + r.Host
+		}
 	}
 
 	c, err := getLibraryClientConfig(libraryURI)

--- a/cmd/internal/cli/delete.go
+++ b/cmd/internal/cli/delete.go
@@ -28,6 +28,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&deleteImageArchFlag, deleteImageCmd)
 		cmdManager.RegisterFlagForCmd(&deleteImageTimeoutFlag, deleteImageCmd)
 		cmdManager.RegisterFlagForCmd(&deleteLibraryURIFlag, deleteImageCmd)
+		cmdManager.RegisterFlagForCmd(&commonNoHTTPSFlag, deleteImageCmd)
 	})
 }
 
@@ -90,8 +91,6 @@ var deleteImageCmd = &cobra.Command{
 	Example: docs.DeleteExample,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		sylog.Debugf("Using library service URI: %s", deleteLibraryURI)
-
 		imageRef, err := library.NormalizeLibraryRef(args[0])
 		if err != nil {
 			sylog.Fatalf("Error parsing library ref: %v", err)
@@ -106,8 +105,14 @@ var deleteImageCmd = &cobra.Command{
 			libraryURI = deleteLibraryURI
 		} else if imageRef.Host != "" {
 			// override libraryURI if ref contains host name
-			libraryURI = "https://" + imageRef.Host
+			if noHTTPS {
+				libraryURI = "http://" + imageRef.Host
+			} else {
+				libraryURI = "https://" + imageRef.Host
+			}
 		}
+
+		sylog.Debugf("Using library service URI: %s", libraryURI)
 
 		r := fmt.Sprintf("%s:%s", imageRef.Path, imageRef.Tags[0])
 

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -217,7 +217,11 @@ func pullRun(cmd *cobra.Command, args []string) {
 			libraryURI = pullLibraryURI
 		} else if ref.Host != "" {
 			// override libraryURI if ref contains host name
-			libraryURI = "https://" + ref.Host
+			if noHTTPS {
+				libraryURI = "http://" + ref.Host
+			} else {
+				libraryURI = "https://" + ref.Host
+			}
 		}
 
 		lc, err := getLibraryClientConfig(libraryURI)


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a `library://hostname/...` is specified to a command, the
`--no-https` flag should be honored, to connect to hostname via http
instead of https.


### This fixes or addresses the following GitHub issues:

 - Fixes #236


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
