### PR TITLE
Ensure lolcow references point to non-fortune image

### DIFF
--- a/internal/pkg/util/uri/uri.go
+++ b/internal/pkg/util/uri/uri.go
@@ -53,7 +53,7 @@ func IsValid(source string) (valid bool, err error) {
 }
 
 // GetName turns a transport:ref URI into a name containing the top-level identifier
-// of the image. For example, docker://godlovedc/lolcow returns lolcow
+// of the image. For example, docker://sylabsio/lolcow returns lolcow
 //
 // Returns "" when not in transport:ref format
 func GetName(uri string) string {

--- a/internal/pkg/util/uri/uri_test.go
+++ b/internal/pkg/util/uri/uri_test.go
@@ -17,8 +17,8 @@ func Test_GetName(t *testing.T) {
 	}{
 		{"docker basic", "docker://ubuntu", "ubuntu_latest.sif"},
 		{"docker scoped", "docker://user/image", "image_latest.sif"},
-		{"dave's magical lolcow", "docker://godlovedc/lolcow", "lolcow_latest.sif"},
-		{"docker w/ tags", "docker://godlovedc/lolcow:3.7", "lolcow_3.7.sif"},
+		{"dave's magical lolcow", "docker://sylabs.io/lolcow", "lolcow_latest.sif"},
+		{"docker w/ tags", "docker://sylabs.io/lolcow:3.7", "lolcow_3.7.sif"},
 	}
 
 	for _, tt := range tests {
@@ -39,8 +39,8 @@ func Test_Split(t *testing.T) {
 	}{
 		{"docker basic", "docker://ubuntu", "docker", "//ubuntu"},
 		{"docker scoped", "docker://user/image", "docker", "//user/image"},
-		{"dave's magical lolcow", "docker://godlovedc/lolcow", "docker", "//godlovedc/lolcow"},
-		{"docker with tags", "docker://godlovedc/lolcow:latest", "docker", "//godlovedc/lolcow:latest"},
+		{"dave's magical lolcow", "docker://sylabs.io/lolcow", "docker", "//sylabs.io/lolcow"},
+		{"docker with tags", "docker://sylabs.io/lolcow:latest", "docker", "//sylabs.io/lolcow:latest"},
 		{"library basic", "library://image", "library", "//image"},
 		{"library scoped", "library://collection/image", "library", "//collection/image"},
 		{"without transport", "ubuntu", "", "ubuntu"},


### PR DESCRIPTION
## Description of the Pull Request (PR):

The Sylabs lolcow image has been modified so that it no longer uses
`fortune`, which produced offensive output. Ensure all references to a
lolcow image are to the fixed Sylabs version.

Fixes #248

### This fixes or addresses the following GitHub issues:

 - Fixes #248


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
