### PR TITLE
fix: Escape ' in docker CMD / ENTRYPOINT for runscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - `singularity delete` will use the correct library service when the hostname
   is specified in the `library://` URI.
 - Fix download of default `pacman.conf` in `arch` bootstrap.
+- Properly escape single quotes in Docker `CMD` / `ENTRYPOINT` translation.
 
 ## v3.8.1 \[2021-07-20\]
 

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -437,6 +437,19 @@ func (c ctx) testDockerLabels(t *testing.T) {
 	)
 }
 
+// https://github.com/sylabs/singularity/issues/233
+func (c ctx) testDockerCMDQuotes(t *testing.T) {
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("run"),
+		e2e.WithArgs("docker://sylabsio/issue233"),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(e2e.ContainMatch, "Test run"),
+		),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
@@ -451,5 +464,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"registry":         c.testDockerRegistry,
 		"whiteout symlink": c.testDockerWhiteoutSymlink,
 		"labels":           c.testDockerLabels,
+		"cmd quotes":       c.testDockerCMDQuotes,
 	}
 }

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -327,7 +327,9 @@ func (cp *OCIConveyorPacker) insertRunScript() (err error) {
 	}
 
 	if len(cp.imgConfig.Entrypoint) > 0 {
-		_, err = f.WriteString("OCI_ENTRYPOINT='" + shell.ArgsQuoted(cp.imgConfig.Entrypoint) + "'\n")
+		_, err = f.WriteString("OCI_ENTRYPOINT='" +
+			shell.EscapeSingleQuotes(shell.ArgsQuoted(cp.imgConfig.Entrypoint)) +
+			"'\n")
 		if err != nil {
 			return
 		}
@@ -339,7 +341,9 @@ func (cp *OCIConveyorPacker) insertRunScript() (err error) {
 	}
 
 	if len(cp.imgConfig.Cmd) > 0 {
-		_, err = f.WriteString("OCI_CMD='" + shell.ArgsQuoted(cp.imgConfig.Cmd) + "'\n")
+		_, err = f.WriteString("OCI_CMD='" +
+			shell.EscapeSingleQuotes(shell.ArgsQuoted(cp.imgConfig.Cmd)) +
+			"'\n")
 		if err != nil {
 			return
 		}

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -648,7 +648,7 @@ func injectEnvHandler(senv map[string]string) interpreter.OpenHandler {
 					b.WriteString(fmt.Sprintf(snippet, key, value+":/.singularity.d/libs"))
 					continue
 				}
-				b.WriteString(fmt.Sprintf(snippet, key, shell.EscapeQuotes(value)))
+				b.WriteString(fmt.Sprintf(snippet, key, shell.EscapeDoubleQuotes(value)))
 			}
 		})
 

--- a/internal/pkg/util/shell/escape.go
+++ b/internal/pkg/util/shell/escape.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+// Copyright (c) 2018-2021 Sylabs, Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license.  Please
 // consult LICENSE.md file distributed with the sources of this project regarding
 // your rights to use or distribute this software.
@@ -16,7 +16,8 @@ func ArgsQuoted(a []string) (quoted string) {
 	return
 }
 
-// Escape performs escaping of shell quotes, backticks and $ characters
+// Escape performs escaping of shell double quotes, backticks and $ characters.
+// Does not escape single quotes - apply EscapeSingleQuotes separately for this.
 func Escape(s string) string {
 	escaped := strings.Replace(s, `\`, `\\`, -1)
 	escaped = strings.Replace(escaped, `"`, `\"`, -1)
@@ -25,7 +26,12 @@ func Escape(s string) string {
 	return escaped
 }
 
-// EscapeQuotes performs escaping of double quotes only
-func EscapeQuotes(s string) string {
+// EscapeQuotes performs shell escaping of double quotes only
+func EscapeDoubleQuotes(s string) string {
 	return strings.Replace(s, `"`, `\"`, -1)
+}
+
+// EscapeSingleQuotes performs shell escaping of single quotes only
+func EscapeSingleQuotes(s string) string {
+	return strings.Replace(s, `'`, `'"'"'`, -1)
 }

--- a/internal/pkg/util/shell/escape_test.go
+++ b/internal/pkg/util/shell/escape_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+// Copyright (c) 2018-2021 Sylabs, Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license.  Please
 // consult LICENSE file distributed with the sources of this project regarding
 // your rights to use or distribute this software.
@@ -50,7 +50,7 @@ func TestEscape(t *testing.T) {
 	}
 }
 
-func TestEscapeQuotes(t *testing.T) {
+func TestEscapeDoubleQuotes(t *testing.T) {
 	escapeQuotesTests := []struct {
 		input    string
 		expected string
@@ -62,7 +62,27 @@ func TestEscapeQuotes(t *testing.T) {
 
 	for _, test := range escapeQuotesTests {
 		t.Run(test.input, func(t *testing.T) {
-			escaped := EscapeQuotes(test.input)
+			escaped := EscapeDoubleQuotes(test.input)
+			if escaped != test.expected {
+				t.Errorf("got %s, expected %s", escaped, test.expected)
+			}
+		})
+	}
+}
+
+func TestEscapeSingleQuotes(t *testing.T) {
+	escapeQuotesTests := []struct {
+		input    string
+		expected string
+	}{
+		{`Hello`, `Hello`},
+		{`'Hello'`, `'"'"'Hello'"'"'`},
+		{`Hell'o`, `Hell'"'"'o`},
+	}
+
+	for _, test := range escapeQuotesTests {
+		t.Run(test.input, func(t *testing.T) {
+			escaped := EscapeSingleQuotes(test.input)
 			if escaped != test.expected {
 				t.Errorf("got %s, expected %s", escaped, test.expected)
 			}


### PR DESCRIPTION
## Description of the Pull Request (PR):

The `CMD` / `ENTRYPOINT` translation is single quoted in the runscript, so we must escape single quotes in `CMD` and `ENTRYPOINT`.

### This fixes or addresses the following GitHub issues:

 - Fixes #233

See also https://github.com/hpcng/singularity/issues/6128

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
