### PR TITLE
fix: honor hostname in library URI for `singularity build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
   in `~/.singularity/remote.yaml`.
 - `singularity delete` will use the correct library service when the hostname
   is specified in the `library://` URI.
+- `singularity build` will use the correct library service when the hostname
+  is specified in the `library://` URI / definition file.
 - Fix download of default `pacman.conf` in `arch` bootstrap.
 
 ## v3.8.1 \[2021-07-20\]

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -1379,6 +1379,32 @@ func (c imgBuildTests) testWritableTmpfs(t *testing.T) {
 	)
 }
 
+func (c imgBuildTests) buildLibraryHost(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	tmpdir, cleanup := c.tempDir(t, "build-libraryhost-test")
+	defer cleanup()
+
+	// Library hostname in the From URI
+	// The hostname is invalid, and we should get an error to that effect.
+	definition := "Bootstrap: library\nFrom: library.example.com/test/test/test:latest\n"
+
+	defFile := e2e.RawDefFile(t, tmpdir, strings.NewReader(definition))
+	imagePath := filepath.Join(tmpdir, "image-libaryhost")
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("-F", imagePath, defFile),
+		e2e.PostRun(func(t *testing.T) {
+			os.Remove(defFile)
+		}),
+		e2e.ExpectExit(255,
+			e2e.ExpectError(e2e.ContainMatch, "dial tcp: lookup library.example.com: no such host"),
+		),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := imgBuildTests{
@@ -1398,6 +1424,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"fingerprint check":               c.buildWithFingerprint,      // definition file includes fingerprint check
 		"build with bind mount":           c.buildBindMount,            // build image with bind mount
 		"test with writable tmpfs":        c.testWritableTmpfs,         // build image, using writable tmpfs in the test step
+		"library host":                    c.buildLibraryHost,          // build image with hostname in library URI
 		"issue 3848":                      c.issue3848,                 // https://github.com/hpcng/singularity/issues/3848
 		"issue 4203":                      c.issue4203,                 // https://github.com/sylabs/singularity/issues/4203
 		"issue 4407":                      c.issue4407,                 // https://github.com/sylabs/singularity/issues/4407

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -50,13 +50,22 @@ func (cp *LibraryConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err 
 		libraryURL = customLib
 	}
 
-	sylog.Debugf("LibraryURL: %v", libraryURL)
-	sylog.Debugf("LibraryRef: %v", b.Recipe.Header["from"])
-
 	imageRef, err := library.NormalizeLibraryRef(b.Recipe.Header["from"])
 	if err != nil {
 		return fmt.Errorf("error parsing libraryRef: %v", err)
 	}
+
+	if imageRef.Host != "" {
+		if b.Opts.NoHTTPS {
+			libraryURL = "http://" + imageRef.Host
+		} else {
+			libraryURL = "https://" + imageRef.Host
+		}
+	}
+
+	sylog.Debugf("LibraryURL: %v", libraryURL)
+	sylog.Debugf("LibraryRef: %v", imageRef.String())
+
 	libraryConfig := &client.Config{
 		BaseURL:   libraryURL,
 		AuthToken: authToken,


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a hostname is included in a `library://` URI, or the def file, make sure it is honored by `singularity build`.


### This fixes or addresses the following GitHub issues:

 - Fixes #246


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
