### PR TITLE
Cherry pick hpcng  #6127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
   in `~/.singularity/remote.yaml`.
 - `singularity delete` will use the correct library service when the hostname
   is specified in the `library://` URI.
+- Fix download of default `pacman.conf` in `arch` bootstrap.
 
 ## v3.8.1 \[2021-07-20\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@ The following have contributed code and/or documentation to this repository.
 - Amanda Duffy <aduffy@lenovo.com>
 - Ana Guerrero Lopez <aguerrero@suse.com>
 - Ángel Bejarano <abejarano@ontropos.com>
+- Apuã Paquola <apuapaquola@gmail.com>
 - Aron Öfjörð Jóhannesson <aron1991@gmail.com>
 - Bernard Li <bernardli@lbl.gov>
 - Brian Bockelman <bbockelm@cse.unl.edu>

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	pacmanConfURL = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/pacman.conf?h=packages/pacman"
+	pacmanConfURL = "https://github.com/archlinux/svntogit-packages/raw/master/pacman/trunk/pacman.conf"
 )
 
 // Default list of packages to install when bootstrapping arch
@@ -195,14 +195,9 @@ func (cp *ArchConveyorPacker) getPacConf(pacmanConfURL string) (pacConf string, 
 	}
 	defer resp.Body.Close()
 
-	bytesWritten, err := io.Copy(pacConfFile, resp.Body)
+	_, err = io.Copy(pacConfFile, resp.Body)
 	if err != nil {
 		return
-	}
-
-	// Simple check to make sure file received is the correct size
-	if bytesWritten != resp.ContentLength {
-		return "", fmt.Errorf("file received is not the right size. supposed to be: %v actually: %v", resp.ContentLength, bytesWritten)
 	}
 
 	return pacConfFile.Name(), nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix for arch Linux bootstrap issue downloading the default pacman.conf.

https://github.com/hpcng/singularity/pull/6127

### This fixes or addresses the following GitHub issues:

 - Fixes #254 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
