### PR TITLE
fix: always check dest for globbed %files 

### DIFF
--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -60,14 +60,15 @@ func CopyFromHost(src, dstRel, dstRootfs string) error {
 
 	for _, srcGlobbed := range paths {
 		// If the dstRel is "" then we are copying to the full source path, appended to the rootfs prefix
+		dstRelGlobbed := dstRel
 		if dstRel == "" {
-			dstRel = srcGlobbed
+			dstRelGlobbed = srcGlobbed
 		}
 
 		// Resolve our destination within the container rootfs
-		dstResolved, err := secureJoinKeepSlash(dstRootfs, dstRel)
+		dstResolved, err := secureJoinKeepSlash(dstRootfs, dstRelGlobbed)
 		if err != nil {
-			return fmt.Errorf("while resolving destination: %s: %s", dstRel, err)
+			return fmt.Errorf("while resolving destination: %s: %s", dstRelGlobbed, err)
 		}
 
 		// Create any parent dirs for dst that don't already exist
@@ -130,13 +131,14 @@ func CopyFromStage(src, dst, srcRootfs, dstRootfs string) error {
 		}
 
 		// If the dst is "" then we are copying to the same path in dstRootfs, as src is in srcRootfs.
+		dstGlobbed := dst
 		if dst == "" {
-			dst = srcGlobbedRel
+			dstGlobbed = srcGlobbedRel
 		}
 		// Resolve the destination path, keeping any final slash
-		dstResolved, err := secureJoinKeepSlash(dstRootfs, dst)
+		dstResolved, err := secureJoinKeepSlash(dstRootfs, dstGlobbed)
 		if err != nil {
-			return fmt.Errorf("while resolving destination: %s: %s", dst, err)
+			return fmt.Errorf("while resolving destination: %s: %s", dstGlobbed, err)
 		}
 		// Create any parent dirs for dstResolved that don't already exist.
 		if err := makeParentDir(dstResolved); err != nil {

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -110,6 +110,7 @@ func TestCopyFromHost(t *testing.T) {
 	if err := os.Mkdir(srcSpaceDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	srcGlob := filepath.Join(dir, "src*")
 	// Nested File (to test multi level glob)
 	srcFileNested := filepath.Join(dir, "srcDir/srcFileNested")
 	if err := ioutil.WriteFile(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
@@ -310,6 +311,22 @@ func TestCopyFromHost(t *testing.T) {
 			expectPath: "srcDirLinkAbs",
 			// Copied the dir, not the link itself
 			expectDir: true,
+		},
+		// issue 261 - multiple globbed sources, with no dest
+		// both srcfile and srcdir should be copied for glob of "src*"
+		{
+			name:       "srcDirGlobNoDestMulti1",
+			src:        srcGlob,
+			dst:        "",
+			expectPath: srcDir,
+			expectDir:  true,
+		},
+		{
+			name:       "srcDirGlobNoDestMulti2",
+			src:        srcGlob,
+			dst:        "",
+			expectPath: srcFile,
+			expectFile: true,
 		},
 	}
 
@@ -704,6 +721,22 @@ func TestCopyFromStage(t *testing.T) {
 			expectPath: "srcDirLinkAbs",
 			// Copied the dir, not the link itself
 			expectDir: true,
+		},
+		// issue 261 - multiple globbed sources, with no dest
+		// both srcfile and srcdir should be copied for glob of "src*"
+		{
+			name:       "srcDirGlobNoDestMulti1",
+			srcRel:     "src*",
+			dstRel:     "",
+			expectPath: "srcDir",
+			expectDir:  true,
+		},
+		{
+			name:       "srcDirGlobNoDestMulti2",
+			srcRel:     "src*",
+			dstRel:     "",
+			expectPath: "srcFile",
+			expectFile: true,
 		},
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

When the source in a `%files` entry is a glob that matches multiple files, and the destination is `""`, make sure we always set the correct real destination for each file.

This is a fix for a case not tested, and not handled properly in #197 

### This fixes or addresses the following GitHub issues:

 - Fixes #261 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
