### PR TITLE
fix: Check for *host* non-root uid when setting unsquashfs flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
   is specified in the `library://` URI / definition file.
 - Fix download of default `pacman.conf` in `arch` bootstrap.
 - Properly escape single quotes in Docker `CMD` / `ENTRYPOINT` translation.
+- Use host uid when choosing unsquashfs flags, to avoid selinux xattr errors
+  with `--fakeroot` on non-EL/Fedora distributions with recent squashfs-tools.
 
 ## v3.8.1 \[2021-07-20\]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

We were previously setting `--user-xattrs` / `--no-xattrs` based on
the current euid when calling `unsquashfs`. However, in a non-setuid
install `--fakeroot` build the euid is 0, so the flags will not be
set. On distributions other than EL / Fedora (i.e. Debian / Ubuntu
which are not selinux native), this can cause failed extraction.

Decide if we are performing a rootless extraction based on the host
uid, outside of any namespace that is in play.

### This fixes or addresses the following GitHub issues:

 - Fixes #266 

See also https://github.com/hpcng/singularity/issues/6113

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
