### PR TITLE
Pick #267 to release-3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
     in `~/.singularity/remote.yaml`.
   - Avoid panic when mountinfo line has a blank field.
   - Properly escape single quotes in Docker `CMD` / `ENTRYPOINT` translation.
+  - Use host uid when choosing unsquashfs flags, to avoid selinux xattr errors
+    with `--fakeroot` on non-EL/Fedora distributions with recent squashfs-tools.
 
 ## v3.8.1 [2021-07-20]
 


### PR DESCRIPTION
Picking #267 

fix: Check for *host* non-root uid when setting unsquashfs flags

We were previously setting `--user-xattrs` / `--no-xattrs` based on
the current euid when calling `unsquashfs`. However, in a non-setuid
install `--fakeroot` build the euid is 0, so the flags will not be
set. On distributions other than EL / Fedora (i.e. Debian / Ubuntu
which are not selinux native), this can cause failed extraction.

Decide if we are performing a rootless extraction based on the host
uid, outside of any namespace that is in play.

Fixes: #266

