### PR TITLE
fix: interpret individual Stmt in internalExecHandler & e2e-test for conda env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@
 
 ### Bug fixes
 
- - Fix regression when files `source`d from `%environment` contain `\` escaped
-   shell builtins (fixes issue with `source` of conda profile.d script).
+- Fix regression when files `source`d from `%environment` contain `\` escaped
+  shell builtins (fixes issue with `source` of conda profile.d script).
 
 ## v3.8.2 \[2021-08-19\]
 

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -447,5 +447,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5057":               c.issue5057, // https://github.com/sylabs/hpcng/issues/5057
 		"issue 5426":               c.issue5426, // https://github.com/sylabs/hpcng/issues/5426
 		"issue 43":                 c.issue43,   // https://github.com/sylabs/singularity/issues/43
+		"issue 274":                c.issue274,  // https://github.com/sylabs/singularity/issues/274
 	}
 }

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -119,6 +120,61 @@ func (c ctx) issue43(t *testing.T) {
 		e2e.ExpectExit(
 			0,
 			e2e.ExpectOutput(e2e.ExactMatch, `/foo/bar/$LIB/baz.so`),
+		),
+	)
+}
+
+// https://github.com/sylabs/singularity/issues/274
+// The conda profile.d script must be able to be source'd from %environment.
+// This has been broken by changes to mvdan.cc/sh interacting badly with our
+// custom internalExecHandler.
+// The test is quite heavyweight, but is warranted IMHO to ensure that conda
+// environment activation works as expected, as this is a common use-case
+// for SingularityCE.
+func (c ctx) issue274(t *testing.T) {
+	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue274-", "")
+	defer cleanup(t)
+	imagePath := filepath.Join(imageDir, "container")
+
+	// Create a minimal conda environment on the current miniconda3 base.
+	// Source the conda profile.d code and activate the env from `%environment`.
+	def := `Bootstrap: docker
+From: continuumio/miniconda3:latest
+
+%post
+
+	. /opt/conda/etc/profile.d/conda.sh
+	conda create -n env python=3
+
+%environment
+
+	source /opt/conda/etc/profile.d/conda.sh
+	conda activate env
+`
+	defFile, err := e2e.WriteTempFile(imageDir, "deffile", def)
+	if err != nil {
+		t.Fatalf("Unable to create test definition file: %v", err)
+	}
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("build"),
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(imagePath, defFile),
+		e2e.ExpectExit(0),
+	)
+	// An exec of `conda info` in the container should show environment active, no errors.
+	// I.E. the `%environment` section should have worked.
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("exec"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(imagePath, "conda", "info"),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(e2e.ContainMatch, "active environment : env"),
+			e2e.ExpectError(e2e.ExactMatch, ""),
 		),
 	)
 }

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -171,13 +171,11 @@ func (s *Shell) internalExecHandler() interp.ExecHandlerFunc {
 				// implies an `exit`, and causes https://github.com/sylabs/singularity/issues/274
 				// with the exit/trap changes in https://github.com/mvdan/sh/commit/fb5052e7a0109c9ef5553a310c05f3b8c04cca5f
 				for _, stmt := range node.Stmts {
-					err := s.runner.Run(ctx, stmt)
-					if err != nil {
+					if err := s.runner.Run(ctx, stmt); err != nil {
 						return err
 					}
 				}
 				return nil
-
 			}
 		}
 		return defaultExecHandler(ctx, args)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Changes to exit handling with the implementation of `trap` in `mvdan.cc/sh` mean that we need to interpret individual `syntax.Stmt`, rather than a full parsed `syntax.File` when we are handling built-ins prefixed with `\` in internalExecHandler`.

Also add an e2e-test for building and using a container with a conda environment, which is activated in `%environment`. This is quite a heavyweight e2e test, unfortunately. However, conda is commonly used in Singularity and this will exercise the normal flow that would have caught this error, and would find others.

### This fixes or addresses the following GitHub issues:

 - Fixes #274 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
