### PR TITLE
Replace golang.org/x/crypto/ssh/terminal (master)

### DIFF
--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -35,7 +35,7 @@ import (
 	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/singularityconf"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // cmdInits holds all the init function to be called
@@ -254,7 +254,7 @@ func setSylogMessageLevel() {
 	}
 
 	color := true
-	if nocolor || !terminal.IsTerminal(2) {
+	if nocolor || !term.IsTerminal(2) {
 		color = false
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
 	golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55
+	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
 	mvdan.cc/sh/v3 v3.3.1

--- a/internal/app/singularity/oci_attach_linux.go
+++ b/internal/app/singularity/oci_attach_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -24,7 +24,7 @@ import (
 	"github.com/sylabs/singularity/pkg/ociruntime"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/unix"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 func resize(controlSocket string, oversized bool) {
@@ -65,7 +65,7 @@ func resize(controlSocket string, oversized bool) {
 }
 
 func attach(engineConfig *oci.EngineConfig, run bool) error {
-	var ostate *terminal.State
+	var ostate *term.State
 	var conn net.Conn
 	var wg sync.WaitGroup
 
@@ -79,7 +79,7 @@ func attach(engineConfig *oci.EngineConfig, run bool) error {
 	}
 
 	hasTerminal := engineConfig.OciConfig.Process.Terminal
-	if hasTerminal && !terminal.IsTerminal(0) {
+	if hasTerminal && !term.IsTerminal(0) {
 		return fmt.Errorf("attach requires a terminal when terminal config is set to true")
 	}
 
@@ -91,7 +91,7 @@ func attach(engineConfig *oci.EngineConfig, run bool) error {
 	defer conn.Close()
 
 	if hasTerminal {
-		ostate, _ = terminal.MakeRaw(0)
+		ostate, _ = term.MakeRaw(0)
 		resize(state.ControlSocket, true)
 		resize(state.ControlSocket, false)
 	}
@@ -130,7 +130,7 @@ func attach(engineConfig *oci.EngineConfig, run bool) error {
 
 		if hasTerminal {
 			fmt.Printf("\r")
-			return terminal.Restore(0, ostate)
+			return term.Restore(0, ostate)
 		}
 		return nil
 	}

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -41,8 +41,8 @@ import (
 	"github.com/sylabs/singularity/pkg/util/namespaces"
 	"github.com/sylabs/singularity/pkg/util/singularityconf"
 	"github.com/sylabs/singularity/pkg/util/slice"
-	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/sys/unix"
+	"golang.org/x/term"
 )
 
 // global variables used by master process only at various steps:
@@ -1360,7 +1360,7 @@ func (c *container) addDevMount(system *mount.System) error {
 		}
 		// add /dev/console mount pointing to original tty if there is one
 		for fd := 0; fd <= 2; fd++ {
-			if !terminal.IsTerminal(fd) {
+			if !term.IsTerminal(fd) {
 				continue
 			}
 			// Found a tty on stdin, stdout, or stderr.

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -43,8 +43,8 @@ import (
 	singularityConfig "github.com/sylabs/singularity/pkg/runtime/engine/singularity/config"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/rlimit"
-	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/sys/unix"
+	"golang.org/x/term"
 	"mvdan.cc/sh/v3/interp"
 )
 
@@ -88,7 +88,7 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 		//   place.  Also, programs that don't use ttyname() and instead
 		//   directly do readlink() on /proc/self/fd/X need this.
 		for fd := 0; fd <= 2; fd++ {
-			if !terminal.IsTerminal(fd) {
+			if !term.IsTerminal(fd) {
 				continue
 			}
 			consfile, err := os.OpenFile("/dev/console", os.O_RDWR, 0o600)
@@ -99,7 +99,7 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 			sylog.Debugf("Replacing tty descriptors with /dev/console")
 			consfd := int(consfile.Fd())
 			for ; fd <= 2; fd++ {
-				if !terminal.IsTerminal(fd) {
+				if !term.IsTerminal(fd) {
 					continue
 				}
 				syscall.Close(fd)

--- a/internal/pkg/util/interactive/interactive.go
+++ b/internal/pkg/util/interactive/interactive.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	"github.com/sylabs/singularity/pkg/sylog"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 var (
@@ -136,9 +136,9 @@ func AskQuestionNoEcho(format string, a ...interface{}) (string, error) {
 	// underlying file descriptor is associated to a VT100 terminal, not with
 	// other file descriptors, including when redirecting Stdin to an actual
 	// file in the context of testing or in the context of pipes.
-	if terminal.IsTerminal(int(os.Stdin.Fd())) {
+	if term.IsTerminal(int(os.Stdin.Fd())) {
 		var resp []byte
-		resp, err = terminal.ReadPassword(int(os.Stdin.Fd()))
+		resp, err = term.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Replace the deprecated `golang.org/x/crypto/ssh/terminal` package with `golang.org/x/term`.

### This fixes or addresses the following GitHub issues:

 - Fixes #295 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
