### PR TITLE
fix: check remote build bootstrap valid before submitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 - Example log-plugin rewritten as a CLI callback that can log all commands
   executed, intead of only container execution, and has access to command
   arguments.
+- An invalid remote build source (bootstrap) will be identified before
+  attempting to submit the build.
 
 ### New features / functionalities
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -188,6 +188,14 @@ func runBuildRemote(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 		sylog.Fatalf("Unable to build from %s: %v", spec, err)
 	}
 
+	// Ensure that the definition bootstrap source is valid before we submit a remote build
+	if _, err := build.NewConveyorPacker(def); err != nil {
+		sylog.Fatalf("Unable to build from %s: %v", spec, err)
+	}
+	if bs, ok := def.Header["bootstrap"]; ok && bs == "localimage" {
+		sylog.Fatalf("Building from a \"localimage\" source with the remote builder is not supported.")
+	}
+
 	// path SIF from remote builder should be placed
 	rbDst := dst
 	if buildArgs.sandbox {

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -172,7 +172,7 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		s.b.Opts = conf.Opts
 		// dont need to get cp if we're skipping bootstrap
 		if !conf.Opts.Update || conf.Opts.Force {
-			if c, err := conveyorPacker(d); err == nil {
+			if c, err := NewConveyorPacker(d); err == nil {
 				s.c = c
 			} else {
 				return nil, fmt.Errorf("unable to get conveyorpacker: %s", err)

--- a/internal/pkg/build/conveyorPacker.go
+++ b/internal/pkg/build/conveyorPacker.go
@@ -30,9 +30,14 @@ type ConveyorPacker interface {
 	Packer
 }
 
-// conveyorPacker returns a valid ConveyorPacker for the given image definition.
-func conveyorPacker(def types.Definition) (ConveyorPacker, error) {
-	switch def.Header["bootstrap"] {
+// NewConveyorPacker returns a valid ConveyorPacker for the given image definition.
+func NewConveyorPacker(def types.Definition) (ConveyorPacker, error) {
+	bs, ok := def.Header["bootstrap"]
+	if !ok {
+		return nil, fmt.Errorf("no bootstrap specification found")
+	}
+
+	switch bs {
 	case "library":
 		return &sources.LibraryConveyorPacker{}, nil
 	case "oras":
@@ -58,6 +63,6 @@ func conveyorPacker(def types.Definition) (ConveyorPacker, error) {
 	case "":
 		return nil, fmt.Errorf("no bootstrap specification found")
 	default:
-		return nil, fmt.Errorf("invalid build source %s", def.Header["bootstrap"])
+		return nil, fmt.Errorf("invalid build source %q", def.Header["bootstrap"])
 	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

When we submit a remote build we should check that the 'bootstrap' header is valid before we submit the remote build.

Also ensure it is not a 'localimage' source, as this is not supported at present.

Example...

```
04:51 PM $ singularity build -r test.sif libary://alpine
FATAL:   Unable to build from libary://alpine: invalid build source "libary"
```


### This fixes or addresses the following GitHub issues:

 - Fixes #10


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
