### PR TITLE
e2e: Bump OpenSUSE example, add arm64 for OpenSUSE & CentOS bootstrap

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -99,17 +99,28 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 			buildSpec: c.env.OrasTestImage,
 		},
 		{
-			name:       "Yum",
-			dependency: "yum",
-			buildSpec:  "../examples/centos/Singularity",
-			// TODO - Centos puts non-amd64 at a different mirror location
-			// need multiple def files to test on other archs
+			name:        "Yum",
+			dependency:  "yum",
+			buildSpec:   "../examples/centos/Singularity",
 			requireArch: "amd64",
 		},
 		{
-			name:       "Zypper",
-			dependency: "zypper",
-			buildSpec:  "../examples/opensuse/Singularity",
+			name:        "YumArm64",
+			dependency:  "yum",
+			buildSpec:   "../examples/centos-arm64/Singularity",
+			requireArch: "arm64",
+		},
+		{
+			name:        "Zypper",
+			dependency:  "zypper",
+			buildSpec:   "../examples/opensuse/Singularity",
+			requireArch: "amd64",
+		},
+		{
+			name:        "ZypperArm64",
+			dependency:  "zypper",
+			buildSpec:   "../examples/opensuse-arm64/Singularity",
+			requireArch: "arm64",
 		},
 	}
 

--- a/examples/centos-arm64/Singularity
+++ b/examples/centos-arm64/Singularity
@@ -1,0 +1,12 @@
+BootStrap: yum
+OSVersion: 7
+MirrorURL: http://mirror.centos.org/altarch/%{OSVERSION}/os/aarch64/
+Include: yum
+
+%runscript
+    echo "This is what happens when you run the container..."
+
+
+%post
+    echo "Hello from inside the container"
+    yum -y install vim-minimal

--- a/examples/opensuse-arm64/Singularity
+++ b/examples/opensuse-arm64/Singularity
@@ -1,6 +1,6 @@
 BootStrap: zypper
 OSVersion: 15.3
-MirrorURL: http://download.opensuse.org/distribution/leap/%{OSVERSION}/repo/oss/
+MirrorURL: http://download.opensuse.org/ports/aarch64/distribution/leap/%{OSVERSION}/repo/oss/
 Include: zypper
 
 %runscript


### PR DESCRIPTION
## Description of the Pull Request (PR):

Make OpenSUSE example use LEAP 15.3 which works under fakeroot.

While we are at it, add arm64 OpenSUSE and CentOS boostraps to e2e testing.

### This fixes or addresses the following GitHub issues:

 - Fixes #307


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
