### PR TITLE
Fix LGTM warning: Unreachable statement

### DIFF
--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -9,7 +9,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
@@ -125,7 +124,6 @@ var PushCmd = &cobra.Command{
 				fmt.Printf("TIP: You can push unsigned images with 'singularity push -U %s'.\n", file)
 				fmt.Printf("TIP: Learn how to sign your own containers by using 'singularity help sign'\n\n")
 				sylog.Fatalf("Unable to upload container: unable to verify signature")
-				os.Exit(3)
 			} else if err != nil {
 				sylog.Fatalf("Unable to push image to library: %v", err)
 			}


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes that LGTM.com warning:
https://lgtm.com/projects/g/sylabs/singularity/snapshot/5763d01e852b40a6c51c48f0b8f3ed92ceba2676/files/cmd/internal/cli/push.go#x133b9ad5a6cec035:1

According to the [log.Fatalf documentation](https://pkg.go.dev/log#Fatalf):
> Fatalf is equivalent to Printf() followed by a call to os.Exit(1).

Therefore, calling `os.Exit(3)` right after `log.Fatalf()` is redundant.

### This fixes or addresses the following GitHub issues:

 - Fixes #309.

#### Before submitting a PR, make sure you have done the following:

✅ Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
❌ Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
✅ Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
✅ Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
❌ Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)