### PR TITLE
e2e: Disable busybox bootstrap due to frequent dl failures

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -61,12 +61,13 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 		buildSpec   string
 		requireArch string
 	}{
-		{
-			name:      "BusyBox",
-			buildSpec: "../examples/busybox/Singularity",
-			// TODO: example has arch hard coded in download URL
-			requireArch: "amd64",
-		},
+		// Disabled due to frequent download failures of the busybox tgz
+		// {
+		// 	name:      "BusyBox",
+		// 	buildSpec: "../examples/busybox/Singularity",
+		// 	// TODO: example has arch hard coded in download URL
+		// 	requireArch: "amd64",
+		// },
 		{
 			name:       "Debootstrap",
 			dependency: "debootstrap",

--- a/internal/pkg/build/sources/conveyorPacker_busybox_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox_test.go
@@ -21,6 +21,9 @@ import (
 const busyBoxDef = "../../../../examples/busybox/Singularity"
 
 func TestBusyBoxConveyor(t *testing.T) {
+	// 2021-09-07 - Always skip due to frequent download failures
+	t.SkipNow()
+
 	if testing.Short() {
 		t.SkipNow()
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Disable busybox bootstrap from tgz, as the download from the busybox site has been failing often, disrupting CI / merges.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
