### PR TITLE
Fix LGTM uint32 parse warnings

### DIFF
--- a/internal/pkg/fakeroot/fakeroot.go
+++ b/internal/pkg/fakeroot/fakeroot.go
@@ -142,7 +142,7 @@ func (c *Config) parseEntry(line string) {
 		e.disabled = true
 	}
 
-	uid, err := strconv.Atoi(username)
+	uid, err := strconv.ParseUint(username, 10, 32)
 	if err == nil {
 		e.UID = uint32(uid)
 	} else {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1075,7 +1075,7 @@ func (c *container) addImageBindMount(system *mount.System) error {
 
 		imagePath := bind.Source
 		destination := bind.Destination
-		id := 0
+		partID := uint32(0)
 		imageSource := "/"
 
 		if src := bind.ImageSrc(); src != "" {
@@ -1083,14 +1083,13 @@ func (c *container) addImageBindMount(system *mount.System) error {
 		}
 
 		if idStr := bind.ID(); idStr != "" {
-			var err error
-
-			id, err = strconv.Atoi(idStr)
+			p, err := strconv.ParseUint(idStr, 10, 32)
 			if err != nil {
 				return fmt.Errorf("while parsing id bind option: %s", err)
-			} else if id <= 0 {
+			} else if p <= 0 {
 				return fmt.Errorf("id number must be greater than 0")
 			}
+			partID = uint32(p)
 		}
 
 		for _, img := range imageList {
@@ -1104,13 +1103,13 @@ func (c *container) addImageBindMount(system *mount.System) error {
 			data := (*image.Section)(nil)
 
 			// id is only meaningful for SIF images
-			if img.Type == image.SIF && id > 0 {
+			if img.Type == image.SIF && partID > 0 {
 				partitions, err := img.GetAllPartitions()
 				if err != nil {
 					return fmt.Errorf("while getting partitions for %s: %s", img.Path, err)
 				}
 				for _, part := range partitions {
-					if part.ID == uint32(id) {
+					if part.ID == partID {
 						data = &part
 						break
 					}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Explicitly parse 32-bit uint, instead of using strconv.Atoi.

Fixes remaining warnings listed at: https://lgtm.com/projects/g/sylabs/singularity/alerts/?mode=list

Fixes #318 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
