### PR TITLE
Split ParseBindPath from config Get/Setters & add basic tests

### DIFF
--- a/pkg/runtime/engine/singularity/config/bind.go
+++ b/pkg/runtime/engine/singularity/config/bind.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// BindOption represents a bind option with its associated
+// value if any.
+type BindOption struct {
+	Value string `json:"value,omitempty"`
+}
+
+const (
+	flagOption  = true
+	valueOption = false
+)
+
+// bindOptions is a map of option strings valid in bind specifications.
+// If true, the option is a flag. If false, the option takes a value.
+var bindOptions = map[string]bool{
+	"ro":        flagOption,
+	"rw":        flagOption,
+	"image-src": valueOption,
+	"id":        valueOption,
+}
+
+// BindPath stores a parsed bind path specification. Source and Destination
+// paths are required.
+type BindPath struct {
+	Source      string                 `json:"source"`
+	Destination string                 `json:"destination"`
+	Options     map[string]*BindOption `json:"options"`
+}
+
+// ImageSrc returns the value of the option image-src for a BindPath, or an
+// empty string if the option wasn't set.
+func (b *BindPath) ImageSrc() string {
+	if b.Options != nil && b.Options["image-src"] != nil {
+		src := b.Options["image-src"].Value
+		if src == "" {
+			return "/"
+		}
+		return src
+	}
+	return ""
+}
+
+// ID returns the value of the option id for a BindPath, or an empty string if
+// the option wasn't set.
+func (b *BindPath) ID() string {
+	if b.Options != nil && b.Options["id"] != nil {
+		return b.Options["id"].Value
+	}
+	return ""
+}
+
+// Readonly returns true if the ro option was set for a BindPath.
+func (b *BindPath) Readonly() bool {
+	return b.Options != nil && b.Options["ro"] != nil
+}
+
+// ParseBindPath parses a string specifying one or more (comma separated) bind
+// paths in src[:dst[:options]] format, and returns all encountered bind paths
+// as a slice. Options may be simple flags, e.g. 'rw', or take a value, e.g.
+// 'id=2'. Multiple options are separated with commas. Note that multiple binds
+// are also separated with commas, so the logic must distinguish.
+func ParseBindPath(bindpaths string) ([]BindPath, error) {
+	var bind string
+	var binds []BindPath
+	var elem int
+
+	// there is a better regular expression to handle
+	// that directly without all the logic below ...
+	// we need to parse various syntax:
+	// source1
+	// source1:destination1
+	// source1:destination1:option1
+	// source1:destination1:option1,option2
+	// source1,source2
+	// source1:destination1:option1,source2
+	re := regexp.MustCompile(`([^,^:]+:?)`)
+
+	// with the regex above we get string array:
+	// - source1 -> [source1]
+	// - source1:destination1 -> [source1:, destination1]
+	// - source1:destination1:option1 -> [source1:, destination1:, option1]
+	// - source1:destination1:option1,option2 -> [source1:, destination1:, option1, option2]
+	for _, m := range re.FindAllString(bindpaths, -1) {
+		s := strings.TrimSpace(m)
+		isColon := bind != "" && bind[len(bind)-1] == ':'
+
+		// options are taken only if the bind has a source
+		// and a destination
+		if elem == 2 {
+			isOption := false
+
+			for option, flag := range bindOptions {
+				if flag {
+					if s == option {
+						isOption = true
+						break
+					}
+				} else {
+					if strings.HasPrefix(s, option+"=") {
+						isOption = true
+						break
+					}
+				}
+			}
+			if isOption {
+				if !isColon {
+					bind += ","
+				}
+				bind += s
+				continue
+			}
+		} else if elem > 2 {
+			return nil, fmt.Errorf("wrong bind syntax: %s", bind)
+		}
+
+		elem++
+
+		if bind != "" {
+			if isColon {
+				bind += s
+				continue
+			}
+			bp, err := newBindPath(bind)
+			if err != nil {
+				return nil, fmt.Errorf("while getting bind path: %s", err)
+			}
+			binds = append(binds, bp)
+			elem = 1
+		}
+		// new bind path
+		bind = s
+	}
+
+	if bind != "" {
+		bp, err := newBindPath(bind)
+		if err != nil {
+			return nil, fmt.Errorf("while getting bind path: %s", err)
+		}
+		binds = append(binds, bp)
+	}
+
+	return binds, nil
+}
+
+// newBindPath returns BindPath record based on the provided bind
+// string argument and ensures that the options are valid.
+func newBindPath(bind string) (BindPath, error) {
+	var bp BindPath
+
+	splitted := strings.SplitN(bind, ":", 3)
+
+	bp.Source = splitted[0]
+	if bp.Source == "" {
+		return bp, fmt.Errorf("empty bind source for bind path %q", bind)
+	}
+
+	bp.Destination = bp.Source
+
+	if len(splitted) > 1 {
+		bp.Destination = splitted[1]
+	}
+
+	if len(splitted) > 2 {
+		bp.Options = make(map[string]*BindOption)
+
+		for _, value := range strings.Split(splitted[2], ",") {
+			valid := false
+			for optName, isFlag := range bindOptions {
+				if isFlag && optName == value {
+					bp.Options[optName] = &BindOption{}
+					valid = true
+					break
+				} else if strings.HasPrefix(value, optName+"=") {
+					bp.Options[optName] = &BindOption{Value: value[len(optName+"="):]}
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				return bp, fmt.Errorf("%s is not a valid bind option", value)
+			}
+		}
+	}
+
+	return bp, nil
+}

--- a/pkg/runtime/engine/singularity/config/bind_test.go
+++ b/pkg/runtime/engine/singularity/config/bind_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseBindPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		bindpaths string
+		want      []BindPath
+		wantErr   bool
+	}{
+		{
+			name:      "srcOnly",
+			bindpaths: "/opt",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/opt",
+				},
+			},
+		},
+		{
+			name:      "srcOnlyMultiple",
+			bindpaths: "/opt,/tmp",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/opt",
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/tmp",
+				},
+			},
+		},
+		{
+			name:      "srcDst",
+			bindpaths: "/opt:/other",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/other",
+				},
+			},
+		},
+		{
+			name:      "srcDstMultiple",
+			bindpaths: "/opt:/other,/tmp:/other2",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/other",
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/other2",
+				},
+			},
+		},
+		{
+			name:      "srcDstRO",
+			bindpaths: "/opt:/other:ro",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/other",
+					Options: map[string]*BindOption{
+						"ro": {},
+					},
+				},
+			},
+		},
+		{
+			name:      "srcDstROMultiple",
+			bindpaths: "/opt:/other:ro,/tmp:/other2:ro",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/other",
+					Options: map[string]*BindOption{
+						"ro": {},
+					},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/other2",
+					Options: map[string]*BindOption{
+						"ro": {},
+					},
+				},
+			},
+		},
+		{
+			// This doesn't make functional sense (ro & rw), but is testing
+			// parsing multiple simple options.
+			name:      "srcDstRORW",
+			bindpaths: "/opt:/other:ro,rw",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/other",
+					Options: map[string]*BindOption{
+						"ro": {},
+						"rw": {},
+					},
+				},
+			},
+		},
+		{
+			// This doesn't make functional sense (ro & rw), but is testing
+			// parsing multiple binds, with multiple options each. Note the
+			// complex parsing here that has to distinguish between comma
+			// delimiting an additional option, vs an additional bind.
+			name:      "srcDstRORWMultiple",
+			bindpaths: "/opt:/other:ro,rw,/tmp:/other2:ro,rw",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/other",
+					Options: map[string]*BindOption{
+						"ro": {},
+						"rw": {},
+					},
+				},
+				{
+					Source:      "/tmp",
+					Destination: "/other2",
+					Options: map[string]*BindOption{
+						"ro": {},
+						"rw": {},
+					},
+				},
+			},
+		},
+		{
+			name:      "srcDstImageSrc",
+			bindpaths: "test.sif:/other:image-src=/opt",
+			want: []BindPath{
+				{
+					Source:      "test.sif",
+					Destination: "/other",
+					Options: map[string]*BindOption{
+						"image-src": {"/opt"},
+					},
+				},
+			},
+		},
+		{
+			// Can't use image-src without a value
+			name:      "srcDstImageSrcNoVal",
+			bindpaths: "test.sif:/other:image-src",
+			want:      []BindPath{},
+			wantErr:   true,
+		},
+		{
+			name:      "srcDstId",
+			bindpaths: "test.sif:/other:image-src=/opt,id=2",
+			want: []BindPath{
+				{
+					Source:      "test.sif",
+					Destination: "/other",
+					Options: map[string]*BindOption{
+						"image-src": {"/opt"},
+						"id":        {"2"},
+					},
+				},
+			},
+		},
+		{
+			name:      "invalidOption",
+			bindpaths: "/opt:/other:invalid",
+			want:      []BindPath{},
+			wantErr:   true,
+		},
+		{
+			name:      "invalidSpec",
+			bindpaths: "/opt:/other:rw:invalid",
+			want:      []BindPath{},
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseBindPath(tt.bindpaths)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseBindPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseBindPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -8,7 +8,6 @@ package singularity
 import (
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci"
@@ -58,46 +57,6 @@ type FuseMount struct {
 	FromContainer bool      `json:"fromContainer,omitempty"` // is FUSE driver program is run from container or from host
 	Daemon        bool      `json:"daemon,omitempty"`        // is FUSE driver program is run in daemon/background mode
 	Cmd           *exec.Cmd `json:"-"`                       // holds the process exec command when FUSE driver run in foreground mode
-}
-
-// BindOption represents a bind option with its associated
-// value if any.
-type BindOption struct {
-	Value string `json:"value,omitempty"`
-}
-
-// BindPath stores bind path.
-type BindPath struct {
-	Source      string                 `json:"source"`
-	Destination string                 `json:"destination"`
-	Options     map[string]*BindOption `json:"options"`
-}
-
-// ImageSrc returns the value of option image-src or an empty
-// string if the option wasn't set.
-func (b *BindPath) ImageSrc() string {
-	if b.Options != nil && b.Options["image-src"] != nil {
-		src := b.Options["image-src"].Value
-		if src == "" {
-			return "/"
-		}
-		return src
-	}
-	return ""
-}
-
-// ID returns the value of option id or an empty
-// string if the option wasn't set.
-func (b *BindPath) ID() string {
-	if b.Options != nil && b.Options["id"] != nil {
-		return b.Options["id"].Value
-	}
-	return ""
-}
-
-// Readonly returns the option ro was set or not.
-func (b *BindPath) Readonly() bool {
-	return b.Options != nil && b.Options["ro"] != nil
 }
 
 // JSONConfig stores engine specific confguration that is allowed to be set by the user.
@@ -313,141 +272,6 @@ func (e *EngineConfig) SetCustomHome(custom bool) {
 // GetCustomHome retrieves if home path is a custom path.
 func (e *EngineConfig) GetCustomHome() bool {
 	return e.JSON.CustomHome
-}
-
-// ParseBindPath parses a string and returns all encountered
-// bind paths as array.
-func ParseBindPath(bindpaths string) ([]BindPath, error) {
-	var bind string
-	var binds []BindPath
-	var elem int
-
-	validOptions := map[string]bool{
-		"ro":        true,
-		"rw":        true,
-		"image-src": false,
-		"id":        false,
-	}
-
-	// there is a better regular expression to handle
-	// that directly without all the logic below ...
-	// we need to parse various syntax:
-	// source1
-	// source1:destination1
-	// source1:destination1:option1
-	// source1:destination1:option1,option2
-	// source1,source2
-	// source1:destination1:option1,source2
-	re := regexp.MustCompile(`([^,^:]+:?)`)
-
-	// with the regex above we get string array:
-	// - source1 -> [source1]
-	// - source1:destination1 -> [source1:, destination1]
-	// - source1:destination1:option1 -> [source1:, destination1:, option1]
-	// - source1:destination1:option1,option2 -> [source1:, destination1:, option1, option2]
-	for _, m := range re.FindAllString(bindpaths, -1) {
-		s := strings.TrimSpace(m)
-		isColon := bind != "" && bind[len(bind)-1] == ':'
-
-		// options are taken only if the bind has a source
-		// and a destination
-		if elem == 2 {
-			isOption := false
-
-			for option, flag := range validOptions {
-				if flag {
-					if s == option {
-						isOption = true
-						break
-					}
-				} else {
-					if strings.HasPrefix(s, option+"=") {
-						isOption = true
-						break
-					}
-				}
-			}
-			if isOption {
-				if !isColon {
-					bind += ","
-				}
-				bind += s
-				continue
-			}
-		} else if elem > 2 {
-			return nil, fmt.Errorf("wrong bind syntax: %s", bind)
-		}
-
-		elem++
-
-		if bind != "" {
-			if isColon {
-				bind += s
-				continue
-			}
-			bp, err := newBindPath(bind, validOptions)
-			if err != nil {
-				return nil, fmt.Errorf("while getting bind path: %s", err)
-			}
-			binds = append(binds, bp)
-			elem = 1
-		}
-		// new bind path
-		bind = s
-	}
-
-	if bind != "" {
-		bp, err := newBindPath(bind, validOptions)
-		if err != nil {
-			return nil, fmt.Errorf("while getting bind path: %s", err)
-		}
-		binds = append(binds, bp)
-	}
-
-	return binds, nil
-}
-
-// newBindPath returns BindPath record based on the provided bind
-// string argument and ensures that the options are valid.
-func newBindPath(bind string, validOptions map[string]bool) (BindPath, error) {
-	var bp BindPath
-
-	splitted := strings.SplitN(bind, ":", 3)
-
-	bp.Source = splitted[0]
-	if bp.Source == "" {
-		return bp, fmt.Errorf("empty bind source for bind path %q", bind)
-	}
-
-	bp.Destination = bp.Source
-
-	if len(splitted) > 1 {
-		bp.Destination = splitted[1]
-	}
-
-	if len(splitted) > 2 {
-		bp.Options = make(map[string]*BindOption)
-
-		for _, value := range strings.Split(splitted[2], ",") {
-			valid := false
-			for optName, optFlag := range validOptions {
-				if optFlag && optName == value {
-					bp.Options[optName] = &BindOption{}
-					valid = true
-					break
-				} else if strings.HasPrefix(value, optName+"=") {
-					bp.Options[optName] = &BindOption{Value: value[len(optName+"="):]}
-					valid = true
-					break
-				}
-			}
-			if !valid {
-				return bp, fmt.Errorf("%s is not a valid bind option", value)
-			}
-		}
-	}
-
-	return bp, nil
 }
 
 // SetBindPath sets the paths to bind into container.


### PR DESCRIPTION
## Description of the Pull Request (PR):

The parsing routines for bind mount specifications are buried among a large amount of simple Getter/Setter code for the main config struct within `pkg/runtime/engine/singularity/config`. There are also no unit tests on the parsing, and it's a little under-described.

In advance of #118 work, split the parsing functions into a separate file for clarity, and add basic testing. Add a couple of comments, and constants to make things a bit clearer. No real logic changes here - code was just moved.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
