### PR TITLE
Bump Go to 1.17.2 (release-3.8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.17.1'
+    default: '1.17.2'
 
 executors:
   golang:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove `/u
 reinstalling it._
 
 ```sh
-$ export VERSION=1.17.1 OS=linux ARCH=amd64  # change this as you need
+$ export VERSION=1.17.2 OS=linux ARCH=amd64  # change this as you need
 
 $ wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz && \
   sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz


### PR DESCRIPTION
Bump `go` version to 1.17.2 in CI config and installation documentation.