### PR TITLE
Wire up Contexts in CLI Package (release-3.8)

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -48,9 +48,7 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 
 	os.Setenv("USER_PATH", userPath)
 
-	ctx := context.TODO()
-
-	replaceURIWithImage(ctx, cmd, args)
+	replaceURIWithImage(cmd.Context(), cmd, args)
 
 	// set PATH after pulling images to be able to find potential
 	// docker credential helpers outside of standard paths

--- a/cmd/internal/cli/build_darwin.go
+++ b/cmd/internal/cli/build_darwin.go
@@ -7,8 +7,6 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/internal/pkg/build/remotebuilder"
 	"github.com/sylabs/singularity/pkg/sylog"
@@ -63,7 +61,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Failed to create builder: %v", err)
 	}
 
-	err = b.Build(context.TODO())
+	err = b.Build(cmd.Context())
 	if err != nil {
 		sylog.Fatalf("While performing build: %v", err)
 	}

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -95,8 +95,6 @@ func fakerootExec(cmdArgs []string) {
 }
 
 func runBuild(cmd *cobra.Command, args []string) {
-	ctx := context.TODO()
-
 	if buildArgs.nvidia {
 		if buildArgs.remote {
 			sylog.Fatalf("--nv option is not supported for remote build")
@@ -129,9 +127,9 @@ func runBuild(cmd *cobra.Command, args []string) {
 	}
 
 	if buildArgs.remote {
-		runBuildRemote(ctx, cmd, dest, spec)
+		runBuildRemote(cmd.Context(), cmd, dest, spec)
 	} else {
-		runBuildLocal(ctx, cmd, dest, spec)
+		runBuildLocal(cmd.Context(), cmd, dest, spec)
 	}
 	sylog.Infof("Build complete: %s", dest)
 }

--- a/cmd/internal/cli/delete.go
+++ b/cmd/internal/cli/delete.go
@@ -126,7 +126,7 @@ var deleteImageCmd = &cobra.Command{
 			sylog.Fatalf("Error while getting library client config: %v", err)
 		}
 
-		ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(deleteImageTimeout)*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), time.Duration(deleteImageTimeout)*time.Second)
 		defer cancel()
 
 		if err := singularity.DeleteImage(ctx, libraryConfig, r, deleteImageArch); err != nil {

--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -7,7 +7,6 @@
 package cli
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -90,8 +89,6 @@ type keyNewPairOptions struct {
 }
 
 func runNewPairCmd(cmd *cobra.Command, args []string) {
-	ctx := context.TODO()
-
 	keyring := sypgp.NewHandle("")
 
 	opts, err := collectInput(cmd)
@@ -120,7 +117,7 @@ func runNewPairCmd(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Keyserver client failed: %s", err)
 	}
 
-	if err := sypgp.PushPubkey(ctx, key, co...); err != nil {
+	if err := sypgp.PushPubkey(cmd.Context(), key, co...); err != nil {
 		fmt.Printf("Failed to push newly created key to keystore: %s\n", err)
 	} else {
 		fmt.Println("Key successfully pushed to keystore")

--- a/cmd/internal/cli/key_pull.go
+++ b/cmd/internal/cli/key_pull.go
@@ -26,14 +26,12 @@ var KeyPullCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
 		co, err := getKeyserverClientOpts(keyServerURI, endpoint.KeyserverPullOp)
 		if err != nil {
 			sylog.Fatalf("Keyserver client failed: %s", err)
 		}
 
-		if err := doKeyPullCmd(ctx, args[0], co...); err != nil {
+		if err := doKeyPullCmd(cmd.Context(), args[0], co...); err != nil {
 			sylog.Errorf("pull failed: %s", err)
 			os.Exit(2)
 		}

--- a/cmd/internal/cli/key_push.go
+++ b/cmd/internal/cli/key_push.go
@@ -26,14 +26,12 @@ var KeyPushCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
 		co, err := getKeyserverClientOpts(keyServerURI, endpoint.KeyserverPushOp)
 		if err != nil {
 			sylog.Fatalf("Keyserver client failed: %s", err)
 		}
 
-		if err := doKeyPushCmd(ctx, args[0], co...); err != nil {
+		if err := doKeyPushCmd(cmd.Context(), args[0], co...); err != nil {
 			sylog.Errorf("push failed: %s", err)
 			os.Exit(2)
 		}

--- a/cmd/internal/cli/key_search.go
+++ b/cmd/internal/cli/key_search.go
@@ -23,14 +23,12 @@ var KeySearchCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
 		co, err := getKeyserverClientOpts(keyServerURI, endpoint.KeyserverSearchOp)
 		if err != nil {
 			sylog.Fatalf("Keyserver client failed: %s", err)
 		}
 
-		if err := doKeySearchCmd(ctx, args[0], co...); err != nil {
+		if err := doKeySearchCmd(cmd.Context(), args[0], co...); err != nil {
 			sylog.Errorf("search failed: %s", err)
 			os.Exit(2)
 		}

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -6,8 +6,6 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/app/singularity"
@@ -186,9 +184,7 @@ var OciRunCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
-		if err := singularity.OciRun(ctx, args[0], &ociArgs); err != nil {
+		if err := singularity.OciRun(cmd.Context(), args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -220,9 +216,7 @@ var OciDeleteCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
-		if err := singularity.OciDelete(ctx, args[0]); err != nil {
+		if err := singularity.OciDelete(cmd.Context(), args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -280,9 +274,7 @@ var OciAttachCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
-		if err := singularity.OciAttach(ctx, args[0]); err != nil {
+		if err := singularity.OciAttach(cmd.Context(), args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -7,7 +7,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -81,8 +80,6 @@ var PushCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
 		file, dest := args[0], args[1]
 
 		transport, ref := uri.Split(dest)
@@ -115,7 +112,7 @@ var PushCmd = &cobra.Command{
 				FrontendURI:   URI(),
 			}
 
-			err = singularity.LibraryPush(ctx, pushSpec, lc, co)
+			err = singularity.LibraryPush(cmd.Context(), pushSpec, lc, co)
 			if err == singularity.ErrLibraryUnsigned {
 				fmt.Printf("TIP: You can push unsigned images with 'singularity push -U %s'.\n", file)
 				fmt.Printf("TIP: Learn how to sign your own containers by using 'singularity help sign'\n\n")

--- a/cmd/internal/cli/search.go
+++ b/cmd/internal/cli/search.go
@@ -7,7 +7,6 @@
 package cli
 
 import (
-	"context"
 	"runtime"
 
 	"github.com/spf13/cobra"
@@ -72,8 +71,6 @@ var SearchCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
 		config, err := getLibraryClientConfig(SearchLibraryURI)
 		if err != nil {
 			sylog.Fatalf("Error while getting library client config: %v", err)
@@ -84,7 +81,7 @@ var SearchCmd = &cobra.Command{
 			sylog.Fatalf("Error initializing library client: %v", err)
 		}
 
-		if err := library.SearchLibrary(ctx, libraryClient, args[0], SearchArch, SearchSigned); err != nil {
+		if err := library.SearchLibrary(cmd.Context(), libraryClient, args[0], SearchArch, SearchSigned); err != nil {
 			sylog.Fatalf("Couldn't search library: %v", err)
 		}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Replace usage of `context.TODO` with command context `cmd/internal/cli`.

### This fixes or addresses the following GitHub issues:

 - Fixes #

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
