### PR TITLE
Wire up Contexts in ORAS Push/Pull (release-3.8)

### DIFF
--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -130,7 +130,7 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 			}
 
-			if err := oras.UploadImage(file, ref, ociAuth); err != nil {
+			if err := oras.UploadImage(cmd.Context(), file, ref, ociAuth); err != nil {
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
 			sylog.Infof("Upload complete")

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -25,7 +25,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 
 	if directTo != "" {
 		sylog.Infof("Downloading oras image")
-		if err := DownloadImage(directTo, pullFrom, ociAuth); err != nil {
+		if err := DownloadImage(ctx, directTo, pullFrom, ociAuth); err != nil {
 			return "", fmt.Errorf("unable to Download Image: %v", err)
 		}
 		imagePath = directTo
@@ -39,7 +39,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading oras image")
 
-			if err := DownloadImage(cacheEntry.TmpPath, pullFrom, ociAuth); err != nil {
+			if err := DownloadImage(ctx, cacheEntry.TmpPath, pullFrom, ociAuth); err != nil {
 				return "", fmt.Errorf("unable to Download Image: %v", err)
 			}
 			if cacheFileHash, err := ImageHash(cacheEntry.TmpPath); err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Wire up contexts in `oras.DownloadImage` and `oras.UploadImage`. I believe this is a possible fix for #113, at least in that a user interrupt should cause a push/pull to give up.

We could consider a timeout as well for push/pull, although defining a single, sensible timeout value probably isn't possible. A push/pull of a large SIF will always take a long time in certain environments.

### This fixes or addresses the following GitHub issues:

 - Potential fix for #113

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
