### PR TITLE
Fix TestFindOnPath

### DIFF
--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -19,6 +19,7 @@ type ctx struct {
 func (c ctx) testOverlayCreate(t *testing.T) {
 	require.Filesystem(t, "overlay")
 	require.MkfsExt3(t)
+	e2e.EnsureImage(t, c.env)
 
 	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "overlay", "")
 	defer cleanup(t)

--- a/internal/pkg/util/bin/bin_test.go
+++ b/internal/pkg/util/bin/bin_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/internal/pkg/util/env"
 	"github.com/sylabs/singularity/pkg/util/singularityconf"
 )
 
@@ -20,12 +21,19 @@ func TestFindOnPath(t *testing.T) {
 	// findOnPath should give same as exec.LookPath, but additionally work
 	// in the case where $PATH doesn't include default sensible directories
 	// as these are added to $PATH before the lookup.
+
+	// Find the true path of 'cp' under a sensible PATH=env.DefaultPath
+	// Forcing this avoid issues with PATH across sudo calls for the tests,
+	// differing orders, /usr/bin -> /bin symlinks etc.
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", env.DefaultPath)
+	defer os.Setenv("PATH", oldPath)
 	truePath, err := exec.LookPath("cp")
 	if err != nil {
 		t.Fatalf("exec.LookPath failed to find cp: %v", err)
 	}
 
-	t.Run("unmodified path", func(t *testing.T) {
+	t.Run("sensible path", func(t *testing.T) {
 		gotPath, err := findOnPath("cp")
 		if err != nil {
 			t.Errorf("unexpected error from findOnPath: %v", err)
@@ -35,9 +43,8 @@ func TestFindOnPath(t *testing.T) {
 		}
 	})
 
-	t.Run("modified path", func(t *testing.T) {
-		oldPath := os.Getenv("PATH")
-		defer os.Setenv("PATH", oldPath)
+	t.Run("bad path", func(t *testing.T) {
+		// Force a PATH that doesn't contain cp
 		os.Setenv("PATH", "/invalid/dir:/another/invalid/dir")
 
 		gotPath, err := findOnPath("cp")


### PR DESCRIPTION
## Description of the Pull Request (PR):

Unfortunately, on some distributions or user environments, variations
in `/bin` symlinking, PATH ordering and propagation / non propagation
across tests run under sudo lead to situations where TestFindOnPath
doesn't work, as the truth value may have the symlink path, while the
function under test returns the target path (or vice versa).

We can't resolve symlinks out in findOnPath to match the test, as the
symlink name can impact the function of the program. E.g. resolving
`mkfs.ext3` to `mke2fs` and calling that will result in an ext2
filesystem, rather than an ext3 filesystem being created.

The best approach here seems to be to force a specific PATH in the
test, instead.

Also add an ensureImage call to e2e overlay tests - found this was missing when running a subset of the e2e and it failed here.

### This fixes or addresses the following GitHub issues:

 - Fixes #392 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
