### PR TITLE
feat: support for multi-part concurrent library image download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # SingularityCE Changelog
 
+## Changes since last release
+
+### New features
+
+- Perform concurrent multi-part downloads for `library://` URIs. Uses 3
+  concurrent downloads by default, and is configurable in `singularity.conf` or
+  via environment variables.
+
 ## v3.9.0-rc.2 \[2021-10-28\]
 
 This is a _release candidate_ for SingularityCE 3.9.0

--- a/e2e/pull/concurrency.go
+++ b/e2e/pull/concurrency.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package pull
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+)
+
+func (c ctx) testDownloadConcurrencyConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		setting          string
+		value            string
+		expectedExitCode int
+	}{
+		{"DownloadConcurrency", "download concurrency", "5", 0},
+		{"InvalidDownloadConcurrency", "download concurrency", "-1", 255},
+		{"DownloadPartSize", "download part size", "32768", 0},
+		{"InvalidDownloadPartSize", "download part size", "-1", 255},
+		{"DownloadBufferSize", "download buffer size", "65536", 0},
+		{"InvalidDownloadBufferSize", "download buffer size", "-1", 255},
+	}
+
+	for _, tt := range tests {
+		defer func(t *testing.T) {
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(e2e.RootProfile),
+				e2e.WithCommand("config global"),
+				e2e.WithArgs("--reset", tt.setting),
+				e2e.ExpectExit(0),
+			)
+		}(t)
+
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.RootProfile),
+			e2e.WithCommand("config global"),
+			e2e.WithArgs("--set", tt.setting, tt.value),
+			e2e.ExpectExit(tt.expectedExitCode),
+		)
+	}
+}
+
+func (c ctx) testDownloadConcurrency(t *testing.T) {
+	c.testDownloadConcurrencyConfig(t)
+	c.testDownloads(t)
+}
+
+func (c ctx) testDownloads(t *testing.T) {
+	const srcURI = "library://alpine:3.11.5"
+
+	tests := []struct {
+		name             string
+		settings         map[string]string
+		envVars          []string
+		expectedExitCode int
+	}{
+		// test traditional sequential download
+		{"Concurrency1Cfg", map[string]string{"download concurrency": "1"}, nil, 0},
+		// test concurrency 3
+		{"Concurrency3Cfg", map[string]string{"download concurrency": "3"}, nil, 0},
+		// test concurrency 10
+		{"Concurrency10Cfg", map[string]string{"download concurrency": "10"}, nil, 0},
+
+		// test 1/3/10 goroutines (set via env vars)
+		{"Concurrency1Env", nil, []string{"SINGULARITY_DOWNLOAD_CONCURRENCY=1"}, 0},
+		{"Concurrency3Env", nil, []string{"SINGULARITY_DOWNLOAD_CONCURRENCY=3"}, 0},
+		{"Concurrency10Env", nil, []string{"SINGULARITY_DOWNLOAD_CONCURRENCY=10"}, 0},
+
+		// test concurrent download with 1 MiB and 8 MiB part size
+		{"PartSize1MCfg", map[string]string{"download part size": "1048576"}, nil, 0},
+		{"PartSize8MCfg", map[string]string{"download part size": "8388608"}, nil, 0},
+
+		// test concurrent download with 1 MiB and 8 MiB part size (via env vars)
+		{"PartSize1MEnv", nil, []string{"SINGULARITY_DOWNLOAD_PART_SIZE=1048576"}, 0},
+		{"PartSize8MEnv", nil, []string{"SINGULARITY_DOWNLOAD_PART_SIZE=8388608"}, 0},
+
+		// use 8 byte and 64 KiB buffer size for concurrent downloads
+		{"BufferSize1Cfg", map[string]string{"download buffer size": "8"}, nil, 0},
+		{"BufferSize65536Cfg", map[string]string{"download buffer size": "65536"}, nil, 0},
+
+		// use 8 byte and 64 KiB buffer size for concurrent downloads (via env vars)
+		{"BufferSize1Env", nil, []string{"SINGULARITY_DOWNLOAD_BUFFER_SIZE=8"}, 0},
+		{"BufferSize65536Env", nil, []string{"SINGULARITY_DOWNLOAD_BUFFER_SIZE=65536"}, 0},
+
+		// multiple settings (concurrency 1, download buffer size 64 KiB)
+		{"MultipleSettings", map[string]string{"download concurrency": "1", "download buffer size": "65536"}, nil, 0},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		tmpdir, err := ioutil.TempDir(c.env.TestDir, "pull_test.")
+		if err != nil {
+			t.Fatalf("Failed to create temporary directory for pull test: %+v", err)
+		}
+		defer os.RemoveAll(tmpdir)
+
+		cleanCfg := []string{}
+
+		if tt.settings != nil {
+			cfgCmdOps := []e2e.SingularityCmdOp{
+				e2e.WithProfile(e2e.RootProfile),
+				e2e.WithCommand("config global"),
+				e2e.ExpectExit(0),
+			}
+
+			for key, value := range tt.settings {
+				cfgCmd := append(cfgCmdOps, e2e.WithArgs("--set", key, value))
+
+				c.env.RunSingularity(t, cfgCmd...)
+
+				cleanCfg = append(cleanCfg, key)
+			}
+		}
+
+		ts := testStruct{
+			desc:             tt.name,
+			srcURI:           srcURI,
+			expectedExitCode: tt.expectedExitCode,
+			expectedImage:    getImageNameFromURI(srcURI),
+			envVars:          tt.envVars,
+		}
+
+		// reset config set via tests
+		defer func(t *testing.T) {
+			for _, cfg := range cleanCfg {
+				c.env.RunSingularity(
+					t,
+					e2e.WithProfile(e2e.RootProfile),
+					e2e.WithCommand("config global"),
+					e2e.WithArgs("--reset", cfg),
+					e2e.ExpectExit(0),
+				)
+			}
+		}(t)
+
+		// Since we are not passing an image name, change the current
+		// working directory to the temporary directory we just created so
+		// that we know it's clean. We don't do this for the other case in
+		// order to catch spurious files showing up. Maybe later we can
+		// examine the directory and assert that it only contains what we
+		// expect.
+		oldwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Failed to get working directory for pull test: %+v", err)
+		}
+		defer os.Chdir(oldwd)
+
+		os.Chdir(tmpdir)
+
+		// if there's a pullDir, that's where we expect to find the image
+		if ts.pullDir != "" {
+			os.Chdir(ts.pullDir)
+		}
+
+		ts.expectedImage = getImageNameFromURI(srcURI)
+
+		// pull image
+		c.imagePull(t, ts)
+	}
+}

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -44,6 +44,7 @@ type testStruct struct {
 	pullDir          string
 	imagePath        string
 	expectedImage    string
+	envVars          []string
 }
 
 var tests = []testStruct{
@@ -250,6 +251,7 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 		t,
 		e2e.AsSubtest(tt.desc),
 		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithEnv(tt.envVars),
 		e2e.WithCommand("pull"),
 		e2e.WithArgs(strings.Split(argv, " ")...),
 		e2e.ExpectExit(tt.expectedExitCode))
@@ -650,6 +652,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 
 			t.Run("pull", c.testPullCmd)
 			t.Run("pullDisableCache", c.testPullDisableCacheCmd)
+			t.Run("downloadConcurrency", c.testDownloadConcurrency)
 
 			// Regressions
 			t.Run("issue5808", c.issue5808)

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/sylabs/json-resp v0.8.0
 	github.com/sylabs/scs-build-client v0.2.1
 	github.com/sylabs/scs-key-client v0.7.1
-	github.com/sylabs/scs-library-client v1.1.2
+	github.com/sylabs/scs-library-client v1.2.0
 	github.com/sylabs/sif/v2 v2.2.1
 	github.com/urfave/cli v1.22.5 // indirect
 	github.com/vbauerster/mpb/v4 v4.12.2

--- a/go.sum
+++ b/go.sum
@@ -917,8 +917,8 @@ github.com/sylabs/scs-build-client v0.2.1 h1:/Hk9SI+hNPPjuacNk0aFvi6u7tFdNVtPzz+
 github.com/sylabs/scs-build-client v0.2.1/go.mod h1:/kuKpMv3JnFd2IXCmX1+OCYxBxv+zUUWv92Az3QvwfE=
 github.com/sylabs/scs-key-client v0.7.1 h1:m8w1fK5Ja/ahdgDRiAaFJ8CMOIOm8m37gKgSCwOgoeY=
 github.com/sylabs/scs-key-client v0.7.1/go.mod h1:/5RJxsW7iIKDD9FU2qfGvlCs+MfjigV7InUDE1SIR30=
-github.com/sylabs/scs-library-client v1.1.2 h1:fFc+ZVl0YFmwQImjYrUFJNNpgaTdQqOW+hdWzuyq/PY=
-github.com/sylabs/scs-library-client v1.1.2/go.mod h1:WddtCtL42AAsmCiUe8oxjHKbER5vbXtaO7Cxlmf+n0c=
+github.com/sylabs/scs-library-client v1.2.0 h1:Ee9fsnYy15pF1Y1RF/9gBUA7Up4XuEbOPPMPHMJr+zM=
+github.com/sylabs/scs-library-client v1.2.0/go.mod h1:WddtCtL42AAsmCiUe8oxjHKbER5vbXtaO7Cxlmf+n0c=
 github.com/sylabs/sif/v2 v2.2.1 h1:uFd6EfYF5oqs4EDsLuoFLo+VaILEkWo5CbhqSuWIACA=
 github.com/sylabs/sif/v2 v2.2.1/go.mod h1:WQa28qH0oIRsXiexugX3EuUFbeF5Twg2OF9MoU27hzs=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/internal/pkg/client/library/library.go
+++ b/internal/pkg/client/library/library.go
@@ -10,12 +10,14 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/util/singularityconf"
 
 	scslibrary "github.com/sylabs/scs-library-client/client"
-	"github.com/sylabs/singularity/internal/pkg/client"
 )
 
 const defaultTag = "latest"
@@ -53,8 +55,51 @@ func NormalizeLibraryRef(ref string) (*scslibrary.Ref, error) {
 	return &scslibrary.Ref{Host: host, Path: elem[0], Tags: tags}, nil
 }
 
+func getEnvInt(key string, defval int64) int64 {
+	if env := os.Getenv(key); env != "" {
+		if n, err := strconv.ParseInt(env, 10, 0); err == nil {
+			return n
+		}
+		sylog.Warningf("Error parsing %s; using default (%d)", key, defval)
+	}
+	return defval
+}
+
+func getDownloadConfig() (scslibrary.Downloader, error) {
+	// get downloader parameters from config
+	conf := singularityconf.GetCurrentConfig()
+	if conf == nil {
+		// sylog.Fatalf("Unable to get singularity configuration")
+		var err error
+		conf, err = singularityconf.Parse(buildcfg.SINGULARITY_CONF_FILE)
+		if err != nil {
+			sylog.Fatalf("unable to parse singularity.conf file: %s", err)
+		}
+	}
+
+	concurrency := int64(getEnvInt("SINGULARITY_DOWNLOAD_CONCURRENCY", int64(conf.DownloadConcurrency)))
+	partSize := int64(getEnvInt("SINGULARITY_DOWNLOAD_PART_SIZE", int64(conf.DownloadPartSize)))
+	bufferSize := int64(getEnvInt("SINGULARITY_DOWNLOAD_BUFFER_SIZE", int64(conf.DownloadBufferSize)))
+
+	if concurrency < 1 {
+		return scslibrary.Downloader{}, fmt.Errorf("invalid download concurrency value (%v)", concurrency)
+	}
+	if partSize < 1 {
+		return scslibrary.Downloader{}, fmt.Errorf("invalid concurrent download part size (%v)", partSize)
+	}
+	if bufferSize < 1 {
+		return scslibrary.Downloader{}, fmt.Errorf("invalid concurrent download buffer size (%v)", bufferSize)
+	}
+
+	return scslibrary.Downloader{
+		Concurrency: uint(concurrency),
+		PartSize:    partSize,
+		BufferSize:  bufferSize,
+	}, nil
+}
+
 // DownloadImage is a helper function to wrap library image download operation
-func DownloadImage(ctx context.Context, c *scslibrary.Client, imagePath, arch string, libraryRef *scslibrary.Ref, callback client.ProgressCallback) error {
+func DownloadImage(ctx context.Context, c *scslibrary.Client, imagePath, arch string, libraryRef *scslibrary.Ref, pb scslibrary.ProgressBar) error {
 	// open destination file for writing
 	f, err := os.OpenFile(imagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o777)
 	if err != nil {
@@ -67,9 +112,13 @@ func DownloadImage(ctx context.Context, c *scslibrary.Client, imagePath, arch st
 		tag = libraryRef.Tags[0]
 	}
 
-	// call library client to download image
-	err = c.DownloadImage(ctx, f, arch, libraryRef.Path, tag, callback)
+	spec, err := getDownloadConfig()
 	if err != nil {
+		return err
+	}
+
+	// call library client to download image
+	if err := c.ConcurrentDownloadImage(ctx, f, arch, libraryRef.Path, tag, &spec, pb); err != nil {
 		// Delete incomplete image file in the event of failure
 		// we get here e.g. if the context is canceled by Ctrl-C
 		sylog.Debugf("Cleaning up incomplete download: %s", imagePath)

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -26,8 +26,6 @@ var ErrLibraryPullUnsigned = errors.New("failed to verify container")
 
 // pull will pull a library image into the cache if directTo="", or a specific file if directTo is set.
 func pull(ctx context.Context, imgCache *cache.Handle, directTo string, imageRef *libclient.Ref, arch string, libraryConfig *libclient.Config) (imagePath string, err error) {
-	sylog.GetLevel()
-
 	c, err := libclient.NewClient(libraryConfig)
 	if err != nil {
 		return "", fmt.Errorf("unable to initialize client library: %v", err)
@@ -45,7 +43,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo string, imageRef
 
 	if directTo != "" {
 		sylog.Infof("Downloading library image")
-		if err = DownloadImage(ctx, c, directTo, arch, imageRef, client.ProgressBarCallback(ctx)); err != nil {
+		if err = DownloadImage(ctx, c, directTo, arch, imageRef, &client.DownloadProgressBar{}); err != nil {
 			return "", fmt.Errorf("unable to download image: %v", err)
 		}
 		imagePath = directTo
@@ -59,7 +57,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo string, imageRef
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading library image")
 
-			if err := DownloadImage(ctx, c, cacheEntry.TmpPath, arch, imageRef, client.ProgressBarCallback(ctx)); err != nil {
+			if err := DownloadImage(ctx, c, cacheEntry.TmpPath, arch, imageRef, &client.DownloadProgressBar{}); err != nil {
 				return "", fmt.Errorf("unable to download image: %v", err)
 			}
 

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -69,7 +69,7 @@ type File struct {
 	NvidiaContainerCliPath  string   `directive:"nvidia-container-cli path"`
 	UnsquashfsPath          string   `directive:"unsquashfs path"`
 	ImageDriver             string   `directive:"image driver"`
-	DownloadConcurrency     uint     `default:"1" directive:"download concurrency"`
+	DownloadConcurrency     uint     `default:"3" directive:"download concurrency"`
 	DownloadPartSize        uint     `default:"5242880" directive:"download part size"`
 	DownloadBufferSize      uint     `default:"32768" directive:"download buffer size"`
 }
@@ -439,20 +439,20 @@ shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }
 image driver = {{ .ImageDriver }}
 
 # DOWNLOAD CONCURRENCY: [UINT]
-# DEFAULT: 1
+# DEFAULT: 3
 # This option specifies how many concurrent streams when downloading (pulling)
 # an image from cloud library.
-# download concurrency = {{ .DownloadConcurrency }}
+download concurrency = {{ .DownloadConcurrency }}
 
 # DOWNLOAD PART SIZE: [UINT]
 # DEFAULT: 5242880
 # This option specifies the size of each part when concurrent downloads are
 # enabled.
-# download part size = {{ .DownloadPartSize }}
+download part size = {{ .DownloadPartSize }}
 
 # DOWNLOAD BUFFER SIZE: [UINT]
 # DEFAULT: 32768
 # This option specifies the transfer buffer size when concurrent downloads
 # are enabled.
-# download buffer size = {{ .DownloadBufferSize }}
+download buffer size = {{ .DownloadBufferSize }}
 `

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -69,6 +69,9 @@ type File struct {
 	NvidiaContainerCliPath  string   `directive:"nvidia-container-cli path"`
 	UnsquashfsPath          string   `directive:"unsquashfs path"`
 	ImageDriver             string   `directive:"image driver"`
+	DownloadConcurrency     uint     `default:"1" directive:"download concurrency"`
+	DownloadPartSize        uint     `default:"5242880" directive:"download part size"`
+	DownloadBufferSize      uint     `default:"32768" directive:"download buffer size"`
 }
 
 const TemplateAsset = `# SINGULARITY.CONF
@@ -434,4 +437,22 @@ shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }
 # If the driver name specified has not been registered via a plugin installation
 # the run-time will abort.
 image driver = {{ .ImageDriver }}
+
+# DOWNLOAD CONCURRENCY: [UINT]
+# DEFAULT: 1
+# This option specifies how many concurrent streams when downloading (pulling)
+# an image from cloud library.
+# download concurrency = {{ .DownloadConcurrency }}
+
+# DOWNLOAD PART SIZE: [UINT]
+# DEFAULT: 5242880
+# This option specifies the size of each part when concurrent downloads are
+# enabled.
+# download part size = {{ .DownloadPartSize }}
+
+# DOWNLOAD BUFFER SIZE: [UINT]
+# DEFAULT: 32768
+# This option specifies the transfer buffer size when concurrent downloads
+# are enabled.
+# download buffer size = {{ .DownloadBufferSize }}
 `

--- a/pkg/util/singularityconf/parser_test.go
+++ b/pkg/util/singularityconf/parser_test.go
@@ -119,6 +119,10 @@ func TestGetConfig(t *testing.T) {
 	directives["max loop devices"] = []string{"42"}
 	directives["bind path"] = []string{"/etc/hosts"}
 
+	directives["download concurrency"] = []string{"42"}
+	directives["download part size"] = []string{"1234"}
+	directives["download buffer size"] = []string{"4567"}
+
 	config, err := GetConfig(directives)
 	if err != nil {
 		t.Errorf("unexpected error while getting config: %s", err)
@@ -134,6 +138,15 @@ func TestGetConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(config.BindPath, directives["bind path"]) {
 		t.Errorf("bad value for BindPath: %v", config.BindPath)
+	}
+	if config.DownloadConcurrency != 42 {
+		t.Errorf("bad value for DownloadConcurrency: %v", config.DownloadConcurrency)
+	}
+	if config.DownloadPartSize != 1234 {
+		t.Errorf("bad value for DownloadPartSize: %v", config.DownloadPartSize)
+	}
+	if config.DownloadBufferSize != 4567 {
+		t.Errorf("bad value for DownloadBufferSize: %v", config.DownloadPartSize)
 	}
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

_Work performed by @EmmEff  - I've just cherry picked / squashed off his branch_

Adds singularity.conf and env var overrides:

`SINGULARITY_DOWNLOAD_CONCURRENCY` - number of concurrent requests for
multi-part download (default: 1)

`SINGULARITY_DOWNLOAD_PART_SIZE` - size (in bytes) of part for
multi-part download (default: 5242880)

`SINGULARITY_DOWNLOAD_BUFFER_SIZE` - size (in bytes) of xfer buffer
used to download part (default: 32768)

### This fixes or addresses the following GitHub issues:

 - Fixes #394 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
