### PR TITLE
Split SIF/bare types w.r.t `allow container $type` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Changes since last release
 
+### Changed defaults / behaviours
+
+- The behaviour of the `allow container` directives in `singularity.conf` has
+  been modified, to support more intuitive limitations on the usage of SIF and non-SIF
+  container images. If you use these directives, _you may need to make changes
+  to singularity.conf to preserve behaviour_.
+  - A new `allow container sif` directive permits or denies usage of
+    _unencrypted_ SIF images, irrespective of the filesystem(s) inside the SIF.
+  - The `allow container encrypted` directive permits or denies usage of SIF
+    images with an encrypted root filesystem.
+  - The `allow container squashfs/extfs` directives in `singularity.conf`
+    permit or deny usage of bare SquashFS and EXT image files only.
+  - The effect of the `allow container dir` directive is unchanged.
+
 ### New features
 
 - Perform concurrent multi-part downloads for `library://` URIs. Uses 3

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -19,11 +21,83 @@ import (
 )
 
 type configTests struct {
-	env e2e.TestEnv
+	env            e2e.TestEnv
+	sifImage       string
+	encryptedImage string
+	squashfsImage  string
+	ext3Image      string
+	sandboxImage   string
+	pemPublic      string
+	pemPrivate     string
+}
+
+// prepImages creates containers covering all image formats to test the
+// `allow container xxx` directives.
+func (c *configTests) prepImages(t *testing.T) (cleanup func(t *testing.T)) {
+	require.MkfsExt3(t)
+	require.Command(t, "truncate")
+	require.Command(t, "mksquashfs")
+
+	tmpDir, cleanup := e2e.MakeTempDir(t, "", "config-", "CONFIG")
+
+	// An unencrypted SIF
+	e2e.EnsureImage(t, c.env)
+	c.sifImage = c.env.ImagePath
+
+	// An encrypted SIF
+	c.pemPublic, c.pemPrivate = e2e.GeneratePemFiles(t, tmpDir)
+	c.encryptedImage = filepath.Join(tmpDir, "encrypted.sif")
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("PrepareEncryptedSIF"),
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--encrypt", "--pem-path", c.pemPublic, c.encryptedImage, c.sifImage),
+		e2e.ExpectExit(0),
+	)
+
+	// A sandbox directory
+	c.sandboxImage = filepath.Join(tmpDir, "sandbox")
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("PrepareSandbox"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("-s", c.sandboxImage, c.sifImage),
+		e2e.ExpectExit(0),
+	)
+
+	// A bare ext3 image
+	t.Run("PrepareExt3", func(t *testing.T) {
+		c.ext3Image = filepath.Join(tmpDir, "ext3.img")
+		cmd := exec.Command("truncate", "-s", "16M", c.ext3Image)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			defer cleanup(t)
+			t.Fatalf("Error creating blank ext3 image: %v: %s", err, out)
+		}
+		cmd = exec.Command("mkfs.ext3", "-d", c.sandboxImage, c.ext3Image)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			defer cleanup(t)
+			t.Fatalf("Error creating populated ext3 image: %v: %s", err, out)
+		}
+	})
+
+	// A bare squashfs image
+	t.Run("PrepareSquashfs", func(t *testing.T) {
+		c.squashfsImage = filepath.Join(tmpDir, "squashfs.img")
+		cmd := exec.Command("mksquashfs", c.sandboxImage, c.squashfsImage)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			defer cleanup(t)
+			t.Fatalf("Error creating squashfs image: %v: %s", err, out)
+		}
+	})
+
+	return cleanup
 }
 
 func (c configTests) configGlobal(t *testing.T) {
-	e2e.EnsureImage(t, c.env)
+	cleanup := c.prepImages(t)
+	defer cleanup(t)
 
 	setDirective := func(t *testing.T, directive, value string) {
 		c.env.RunSingularity(
@@ -346,8 +420,40 @@ func (c configTests) configGlobal(t *testing.T) {
 			exit:           0,
 		},
 		{
+			name:           "AllowContainerSifNo",
+			argv:           []string{c.sifImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow container sif",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "AllowContainerSifYes",
+			argv:           []string{c.sifImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow container sif",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "AllowContainerEncryptedNo",
+			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow container encrypted",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "AllowContainerEncryptedYes",
+			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow container encrypted",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
 			name:           "AllowContainerSquashfsNo",
-			argv:           []string{c.env.ImagePath, "true"},
+			argv:           []string{c.squashfsImage, "true"},
 			profile:        e2e.UserProfile,
 			directive:      "allow container squashfs",
 			directiveValue: "no",
@@ -355,24 +461,40 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "AllowContainerSquashfsYes",
-			argv:           []string{c.env.ImagePath, "true"},
+			argv:           []string{c.squashfsImage, "true"},
 			profile:        e2e.UserProfile,
 			directive:      "allow container squashfs",
 			directiveValue: "yes",
 			exit:           0,
 		},
 		{
+			name:           "AllowContainerExfs3No",
+			argv:           []string{c.ext3Image, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow container extfs",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "AllowContainerExtfsYes",
+			argv:           []string{c.ext3Image, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow container extfs",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
 			name:           "AllowContainerDirNo",
-			argv:           []string{c.env.ImagePath, "true"},
-			profile:        e2e.UserNamespaceProfile,
+			argv:           []string{c.sandboxImage, "true"},
+			profile:        e2e.UserProfile,
 			directive:      "allow container dir",
 			directiveValue: "no",
 			exit:           255,
 		},
 		{
 			name:           "AllowContainerDirYes",
-			argv:           []string{c.env.ImagePath, "true"},
-			profile:        e2e.UserNamespaceProfile,
+			argv:           []string{c.sandboxImage, "true"},
+			profile:        e2e.UserProfile,
 			directive:      "allow container dir",
 			directiveValue: "yes",
 			exit:           0,

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -1375,25 +1375,41 @@ func (e *EngineOperations) loadImage(path string, writable bool) (*image.Image, 
 		}
 	}
 
-	for _, p := range imgObject.Partitions {
-		switch p.Type {
-		case image.SANDBOX:
-			if !e.EngineConfig.File.AllowContainerDir {
-				return nil, fmt.Errorf("configuration disallows users from running sandbox based containers")
-			}
-		case image.EXT3:
-			if !e.EngineConfig.File.AllowContainerExtfs {
-				return nil, fmt.Errorf("configuration disallows users from running extFS based containers")
-			}
-		case image.SQUASHFS:
-			if !e.EngineConfig.File.AllowContainerSquashfs {
-				return nil, fmt.Errorf("configuration disallows users from running squashFS based containers")
-			}
-		case image.ENCRYPTSQUASHFS:
-			if !e.EngineConfig.File.AllowContainerEncrypted {
-				return nil, fmt.Errorf("configuration disallows users from running encrypted containers")
-			}
+	switch imgObject.Type {
+	// Bare SquashFS
+	case image.SQUASHFS:
+		if !e.EngineConfig.File.AllowContainerSquashfs {
+			return nil, fmt.Errorf("configuration disallows users from running squashFS containers")
 		}
+	// Bare EXT3
+	case image.EXT3:
+		if !e.EngineConfig.File.AllowContainerExtfs {
+			return nil, fmt.Errorf("configuration disallows users from running extFS containers")
+		}
+	// Bare sandbox directory
+	case image.SANDBOX:
+		if !e.EngineConfig.File.AllowContainerDir {
+			return nil, fmt.Errorf("configuration disallows users from running sandbox containers")
+		}
+	// SIF
+	case image.SIF:
+		// Check if SIF contains an encrypted rootfs partition.
+		// We don't support encryption for other partitions at present.
+		encrypted, err := imgObject.HasEncryptedRootFs()
+		if err != nil {
+			return nil, fmt.Errorf("while checking for encrypted root FS: %v", err)
+		}
+		// SIF with encryption
+		if encrypted && !e.EngineConfig.File.AllowContainerEncrypted {
+			return nil, fmt.Errorf("configuration disallows users from running encrypted SIF containers")
+		}
+		// SIF without encryption - regardless of rootfs filesystem type
+		if !encrypted && !e.EngineConfig.File.AllowContainerSIF {
+			return nil, fmt.Errorf("configuration disallows users from running unencrypted SIF containers")
+		}
+	// We shouldn't be able to run anything else, but make sure we don't!
+	default:
+		return nil, fmt.Errorf("unknown image format %d", imgObject.Type)
 	}
 
 	return imgObject, imgErr

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -261,6 +261,23 @@ func (i *Image) GetDataPartitions() ([]Section, error) {
 	return i.getPartitions(DataUsage)
 }
 
+// HasEncryptedRootFs returns true if the image contains an encrypted
+// rootfs partition.
+func (i *Image) HasEncryptedRootFs() (encrypted bool, err error) {
+	rootFsParts, err := i.GetRootFsPartitions()
+	if err != nil {
+		return false, fmt.Errorf("while getting root FS partitions: %v", err)
+	}
+
+	for _, p := range rootFsParts {
+		if p.Type == ENCRYPTSQUASHFS {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // initFile ensures file descriptor is associated to a file handle.
 func (i *Image) initFile() error {
 	if i.File != nil {

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -37,10 +37,11 @@ type File struct {
 	EnableFusemount         bool     `default:"yes" authorized:"yes,no" directive:"enable fusemount"`
 	EnableUnderlay          bool     `default:"yes" authorized:"yes,no" directive:"enable underlay"`
 	MountSlave              bool     `default:"yes" authorized:"yes,no" directive:"mount slave"`
+	AllowContainerSIF       bool     `default:"yes" authorized:"yes,no" directive:"allow container sif"`
+	AllowContainerEncrypted bool     `default:"yes" authorized:"yes,no" directive:"allow container encrypted"`
 	AllowContainerSquashfs  bool     `default:"yes" authorized:"yes,no" directive:"allow container squashfs"`
 	AllowContainerExtfs     bool     `default:"yes" authorized:"yes,no" directive:"allow container extfs"`
 	AllowContainerDir       bool     `default:"yes" authorized:"yes,no" directive:"allow container dir"`
-	AllowContainerEncrypted bool     `default:"yes" authorized:"yes,no" directive:"allow container encrypted"`
 	AlwaysUseNv             bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
 	UseNvCCLI               bool     `default:"no" authorized:"yes,no" directive:"use nvidia-container-cli"`
 	AlwaysUseRocm           bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
@@ -268,10 +269,17 @@ sessiondir max size = {{ .SessiondirMaxSize }}
 # DEFAULT: yes
 # This feature limits what kind of containers that Singularity will allow
 # users to use (note this does not apply for root).
+#
+# Allow use of unencrypted SIF containers
+allow container sif = {{ if eq .AllowContainerSIF true}}yes{{ else }}no{{ end }}
+#
+# Allow use of encrypted SIF containers
+allow container encrypted = {{ if eq .AllowContainerEncrypted true }}yes{{ else }}no{{ end }}
+#
+# Allow use of non-SIF image formats
 allow container squashfs = {{ if eq .AllowContainerSquashfs true }}yes{{ else }}no{{ end }}
 allow container extfs = {{ if eq .AllowContainerExtfs true }}yes{{ else }}no{{ end }}
 allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }}
-allow container encrypted = {{ if eq .AllowContainerEncrypted true }}yes{{ else }}no{{ end }}
 
 # ALLOW NET USERS: [STRING]
 # DEFAULT: NULL


### PR DESCRIPTION
## Description of the Pull Request (PR):

The `allow container $type` directives are confusing as they allow
limiting use of SquashFS and EXT3 containers... but will also apply to
those filesystems inside of a SIF.

We commonly present SIF as a separate container format, and users
don't generally need to be aware that it's a wrapper format for other
filesystem types. We generally talk about a `SquashFS` image in the
context of a raw Singularity 2.x image, not the contents of a
SIF. With this in mind it makes more sense to separately allow /
disallow SIF or bare SquashFS etc.

This PR:

* Modifies the logic applying the `allow container
  squashfs/ext3` directive so they only apply to *bare* images
  in those formats, not SIFs using those formats internally.

* Modifies `allow container encrypted` so that it only controls use of
  SIF containers where the RootFS is an encrypted SquashFS
  filesystem.

* Adds a new `allow container sif` directive, controlling use of
  unencrypted SIF containers, with *any* internal FS, except an
  encrypted RootFS (see above).

### This fixes or addresses the following GitHub issues:

 - Fixes #398


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
