### PR TITLE
Flip RunAsRoot->UserNS in RPC for NvCCLI

### DIFF
--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -134,7 +134,7 @@ type WriteFileArgs struct {
 type NvCCLIArgs struct {
 	Flags      []string
 	RootFsPath string
-	RunAsRoot  bool
+	UserNS     bool
 }
 
 // FileInfo returns FileInfo interface to be passed as RPC argument.

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -237,11 +237,11 @@ func (t *RPC) WriteFile(filename string, data []byte, perm os.FileMode) error {
 }
 
 // NvCCLI will call nvidia-container-cli to configure GPU(s) for the container.
-func (t *RPC) NvCCLI(flags []string, rootFsPath string, runAsRoot bool) error {
+func (t *RPC) NvCCLI(flags []string, rootFsPath string, userNS bool) error {
 	arguments := &args.NvCCLIArgs{
 		Flags:      flags,
 		RootFsPath: rootFsPath,
-		RunAsRoot:  runAsRoot,
+		UserNS:     userNS,
 	}
 	return t.Client.Call(t.Name+".NvCCLI", arguments, nil)
 }

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -424,7 +424,7 @@ func (t *Methods) NvCCLI(arguments *args.NvCCLIArgs, reply *int) (err error) {
 	// In the setuid flow we need CAP_CHOWN here to be able to start
 	// nvidia-container-cli successfully as root.
 	caps := defaultEffective
-	if arguments.RunAsRoot {
+	if !arguments.UserNS {
 		caps |= uint64(1 << capabilities.Map["CAP_CHOWN"].Value)
 	}
 	oldEffective, err := capabilities.SetProcessEffective(caps)
@@ -438,5 +438,5 @@ func (t *Methods) NvCCLI(arguments *args.NvCCLIArgs, reply *int) (err error) {
 		}
 	}()
 
-	return gpu.NVCLIConfigure(arguments.Flags, arguments.RootFsPath, arguments.RunAsRoot)
+	return gpu.NVCLIConfigure(arguments.Flags, arguments.RootFsPath, arguments.UserNS)
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

The previous nvccli PR flipped the 3rd variable in our NVCLI related
functions from RunAsRoot, to UserNS (which has opposite meaning). The RPC
functions signatures were not modified correctly at the same time.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
