### PR TITLE
fix: Don't truncate config file until we have valid output to write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ This is a _release candidate_ for SingularityCE 3.9.0
   concurrent downloads by default, and is configurable in `singularity.conf` or
   via environment variables.
 
+### Bug fixes
+
+- Ensure invalid values passed to `config global --set` cannot lead to an empty
+  configuration file being written.
+
 ## v3.9.0-rc.2 \[2021-10-28\]
 
 This is a _release candidate_ for SingularityCE 3.9.0


### PR DESCRIPTION
## Description of the Pull Request (PR):

When using `config global --set` an invalid directive value could previously
lead to an empty `singularity.conf`, as the file was opened with
`O_TRUNC` before the new config was generated/validated.

Generate the config output to an in memory buffer, and only create /
truncate the `singularity.conf` file once we have generated known valid
output.

### This fixes or addresses the following GitHub issues:

 - Fixes #409


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
