### PR TITLE
Bump golangci-lint to 1.43

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ executors:
       - image: centos:8
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.42
+      - image: golangci/golangci-lint:v1.43
   ubuntu-machine:
     machine:
       image: ubuntu-2004:202107-02

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
   enable:
     - contextcheck
     - deadcode
+    - dupl
     - gofumpt
     - goimports
     - gosimple
@@ -26,8 +27,6 @@ linters:
     - nakedret
     - revive
     - staticcheck
-    # we would like to add these
-    # - dupl
 
 linters-settings:
   misspell:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
   disable-all: true
   enable-all: false
   enable:
+    - contextcheck
     - deadcode
     - gofumpt
     - goimports

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -271,6 +271,7 @@ func (c ctx) testRocm(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func (c ctx) testBuildNvidiaLegacy(t *testing.T) {
 	require.Nvidia(t)
 
@@ -430,6 +431,7 @@ func (c ctx) testBuildNvCCLI(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func (c ctx) testBuildRocm(t *testing.T) {
 	require.Rocm(t)
 

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -59,6 +59,7 @@ func (c *ctx) prepareImage(t *testing.T) (string, func(*testing.T)) {
 	}
 }
 
+//nolint:dupl
 func (c ctx) singularitySignIDOption(t *testing.T) {
 	imgPath, cleanup := c.prepareImage(t)
 	defer cleanup(t)
@@ -139,6 +140,7 @@ func (c ctx) singularitySignAllOption(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func (c ctx) singularitySignGroupIDOption(t *testing.T) {
 	imgPath, cleanup := c.prepareImage(t)
 	defer cleanup(t)

--- a/internal/app/starter/master_linux_test.go
+++ b/internal/app/starter/master_linux_test.go
@@ -20,6 +20,7 @@ import (
 // cover case with bad socket file descriptors or non socket file
 // file descriptor (stderr).
 
+//nolint:dupl
 func TestCreateContainer(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
@@ -67,6 +68,7 @@ func TestCreateContainer(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func TestStartContainer(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -302,6 +302,7 @@ func (c *YumConveyor) importGPGKey() (err error) {
 	return nil
 }
 
+//nolint:dupl
 func (c *YumConveyor) makePseudoDevices() (err error) {
 	devPath := filepath.Join(c.b.RootfsPath, "dev")
 	err = os.Mkdir(devPath, 0o775)

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -399,6 +399,7 @@ func (cp *ZypperConveyorPacker) genZypperConfig() (err error) {
 	return nil
 }
 
+//nolint:dupl
 func (cp *ZypperConveyorPacker) copyPseudoDevices() (err error) {
 	devPath := filepath.Join(cp.b.RootfsPath, "dev")
 	err = os.Mkdir(devPath, 0o775)

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -57,7 +57,7 @@ const (
 
 var sifLayerMediaTypes = []string{SifLayerMediaTypeV1, SifLayerMediaTypeProto}
 
-func getResolver(ociAuth *ocitypes.DockerAuthConfig) (remotes.Resolver, error) {
+func getResolver(ctx context.Context, ociAuth *ocitypes.DockerAuthConfig) (remotes.Resolver, error) {
 	opts := docker.ResolverOptions{Credentials: genCredfn(ociAuth)}
 	if ociAuth != nil && (ociAuth.Username != "" || ociAuth.Password != "") {
 		return docker.NewResolver(opts), nil
@@ -69,7 +69,7 @@ func getResolver(ociAuth *ocitypes.DockerAuthConfig) (remotes.Resolver, error) {
 		return docker.NewResolver(opts), nil
 	}
 
-	return cli.Resolver(context.Background(), &http.Client{}, false)
+	return cli.Resolver(ctx, &http.Client{}, false)
 }
 
 // DownloadImage downloads a SIF image specified by an oci reference to a file using the included credentials
@@ -88,7 +88,7 @@ func DownloadImage(ctx context.Context, imagePath, ref string, ociAuth *ocitypes
 		sylog.Infof("No tag or digest found, using default: %s", SifDefaultTag)
 	}
 
-	resolver, err := getResolver(ociAuth)
+	resolver, err := getResolver(ctx, ociAuth)
 	if err != nil {
 		return fmt.Errorf("while getting resolver: %s", err)
 	}
@@ -173,7 +173,7 @@ func UploadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.Docker
 		sylog.Infof("No tag or digest found, using default: %s", SifDefaultTag)
 	}
 
-	resolver, err := getResolver(ociAuth)
+	resolver, err := getResolver(ctx, ociAuth)
 	if err != nil {
 		return fmt.Errorf("while getting resolver: %s", err)
 	}
@@ -233,7 +233,7 @@ func ImageSHA(ctx context.Context, uri string, ociAuth *ocitypes.DockerAuthConfi
 	ref := strings.TrimPrefix(uri, "oras://")
 	ref = strings.TrimPrefix(ref, "//")
 
-	resolver, err := getResolver(ociAuth)
+	resolver, err := getResolver(ctx, ociAuth)
 	if err != nil {
 		return "", fmt.Errorf("while getting resolver: %s", err)
 	}

--- a/internal/pkg/remote/endpoint/client_test.go
+++ b/internal/pkg/remote/endpoint/client_test.go
@@ -130,6 +130,7 @@ func TestKeyserverClientOpts(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func TestLibraryClientConfig(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -199,6 +200,7 @@ func TestLibraryClientConfig(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func TestBuilderClientConfig(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/pkg/util/bin/bin_test.go
+++ b/internal/pkg/util/bin/bin_test.go
@@ -58,6 +58,7 @@ func TestFindOnPath(t *testing.T) {
 }
 
 func TestFindFromConfigOrPath(t *testing.T) {
+	//nolint:dupl
 	cases := []struct {
 		name          string
 		bin           string
@@ -200,6 +201,7 @@ func TestFindFromConfigOrPath(t *testing.T) {
 }
 
 func TestFindFromConfigOnly(t *testing.T) {
+	//nolint:dupl
 	cases := []struct {
 		name          string
 		bin           string

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -303,6 +303,7 @@ func TestRootAuthorizedOwner(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func TestAuthorizedOwner(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -410,6 +411,7 @@ func TestPrivilegedAuthorizedGroup(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func TestAuthorizedGroup(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()

--- a/pkg/util/capabilities/config.go
+++ b/pkg/util/capabilities/config.go
@@ -126,6 +126,7 @@ func (c *Config) AddGroupCaps(group string, caps []string) error {
 }
 
 // DropUserCaps drops a set of capabilities for user
+//nolint:dupl
 func (c *Config) DropUserCaps(user string, caps []string) error {
 	if err := c.checkCaps(caps); err != nil {
 		return err
@@ -153,6 +154,7 @@ func (c *Config) DropUserCaps(user string, caps []string) error {
 }
 
 // DropGroupCaps drops a set of capabilities for group
+//nolint:dupl
 func (c *Config) DropGroupCaps(group string, caps []string) error {
 	if err := c.checkCaps(caps); err != nil {
 		return err

--- a/pkg/util/capabilities/config_test.go
+++ b/pkg/util/capabilities/config_test.go
@@ -75,6 +75,7 @@ type capTest struct {
 	caps []string
 }
 
+//nolint:dupl
 func TestAddUserCaps(t *testing.T) {
 	testsPass := []capTest{
 		{
@@ -175,6 +176,7 @@ func TestAddUserCaps(t *testing.T) {
 	})
 }
 
+//nolint:dupl
 func TestAddGroupCaps(t *testing.T) {
 	testsPass := []capTest{
 		{
@@ -275,6 +277,7 @@ func TestAddGroupCaps(t *testing.T) {
 	})
 }
 
+//nolint:dupl
 func TestDropUserCaps(t *testing.T) {
 	testsPass := []capTest{
 		{
@@ -391,6 +394,7 @@ func TestDropUserCaps(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func TestDropGroupCaps(t *testing.T) {
 	testsPass := []capTest{
 		{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump `golangci-lint` to 1.43. Enable `contextcheck` and `dupl` linters. Wire up context in ORAS `getResolver`, which is caught by the `contextlint` trap.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
