### PR TITLE
e2e: ensure GPU tests use intended profile

### DIFF
--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -93,7 +93,7 @@ func (c ctx) testNvidiaLegacy(t *testing.T) {
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithProfile(tt.profile),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.args...),
 			e2e.WithEnv(tt.env),
@@ -183,7 +183,7 @@ func (c ctx) testNvCCLI(t *testing.T) {
 		{
 			name:    "UserNamespace",
 			profile: e2e.UserNamespaceProfile,
-			args:    []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
+			args:    []string{"--nv", "--nvccli", "--writable", imagePath, "nvidia-smi"},
 		},
 		{
 			name:    "Root",
@@ -196,7 +196,7 @@ func (c ctx) testNvCCLI(t *testing.T) {
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithProfile(tt.profile),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.args...),
 			e2e.WithEnv(tt.env),
@@ -263,7 +263,7 @@ func (c ctx) testRocm(t *testing.T) {
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithProfile(tt.profile),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.args...),
 			e2e.ExpectExit(0),


### PR DESCRIPTION
## Description of the Pull Request (PR):

As pointed out in #416 the GPU tests weren't using the profile indicated on the `tt` test structures, but instead always the UserProfile.

PR corrects this.

Note... this won't be tested in CI as there is no GPU. See the output of a local run below:

<details>
  <summary>e2e GPU output</summary>
<pre>
=== RUN   TestE2E/PAR
=== RUN   TestE2E/PAR/GPU
=== PAUSE TestE2E/PAR/GPU
=== CONT  TestE2E/PAR/GPU
=== RUN   TestE2E/PAR/GPU/rocm
=== PAUSE TestE2E/PAR/GPU/rocm
=== RUN   TestE2E/PAR/GPU/build_nvidia
=== PAUSE TestE2E/PAR/GPU/build_nvidia
=== RUN   TestE2E/PAR/GPU/build_nvccli
=== PAUSE TestE2E/PAR/GPU/build_nvccli
=== RUN   TestE2E/PAR/GPU/build_rocm
=== PAUSE TestE2E/PAR/GPU/build_rocm
=== RUN   TestE2E/PAR/GPU/nvidia
=== PAUSE TestE2E/PAR/GPU/nvidia
=== RUN   TestE2E/PAR/GPU/nvccli
=== PAUSE TestE2E/PAR/GPU/nvccli
=== CONT  TestE2E/PAR/GPU/rocm
=== CONT  TestE2E/PAR/GPU/build_rocm
=== CONT  TestE2E/PAR/GPU/build_nvidia
=== CONT  TestE2E/PAR/GPU/nvidia
=== CONT  TestE2E/PAR/GPU/build_nvccli
=== CONT  TestE2E/PAR/GPU/build_rocm
    require.go:196: rocminfo not found on PATH: exec: "rocminfo": executable file not found in $PATH
=== CONT  TestE2E/PAR/GPU/nvccli
=== CONT  TestE2E/PAR/GPU/rocm
    require.go:196: rocminfo not found on PATH: exec: "rocminfo": executable file not found in $PATH
=== CONT  TestE2E/PAR/GPU/build_nvidia
    singularitycmd.go:683: Running command "/usr/local/bin/singularity build --force --sandbox /tmp/stest.963332759/build-nvidia-legacy916765592/source docker://ubuntu:20.04"
=== CONT  TestE2E/PAR/GPU/nvccli
    singularitycmd.go:683: Running command "/usr/local/bin/singularity pull --force /tmp/test-nvccli-4195741845 docker://ubuntu:20.04"
=== CONT  TestE2E/PAR/GPU/nvidia
    singularitycmd.go:683: Running command "/usr/local/bin/singularity pull --force /tmp/test-nvidia-legacy-1026766337 docker://ubuntu:20.04"
=== CONT  TestE2E/PAR/GPU/build_nvccli
    singularitycmd.go:683: Running command "/usr/local/bin/singularity build --force --sandbox /tmp/stest.963332759/build-nvccli2199663200/source docker://ubuntu:20.04"
=== RUN   TestE2E/PAR/GPU/build_nvccli/WithNvccliRoot
    gpu.go:417: Running command "/usr/local/bin/singularity build --nv --nvccli -F --sandbox /tmp/stest.963332759/build-nvccli2199663200/sandbox-WithNvccliRoot /tmp/stest.963332759/build-nvccli2199663200/raw-deffile1387274849"
=== RUN   TestE2E/PAR/GPU/build_nvidia/WithNvRoot
    gpu.go:343: Running command "/usr/local/bin/singularity build --nv -F --sandbox /tmp/stest.963332759/build-nvidia-legacy916765592/sandbox-WithNvRoot /tmp/stest.963332759/build-nvidia-legacy916765592/raw-deffile3447870755"
=== RUN   TestE2E/PAR/GPU/build_nvccli/WithoutNvccliRoot
    gpu.go:417: Running command "/usr/local/bin/singularity build -F --sandbox /tmp/stest.963332759/build-nvccli2199663200/sandbox-WithoutNvccliRoot /tmp/stest.963332759/build-nvccli2199663200/raw-deffile161907786"
=== RUN   TestE2E/PAR/GPU/build_nvidia/WithNvFakeroot
    gpu.go:343: Running command "/usr/local/bin/singularity build --fakeroot --nv -F --sandbox /tmp/stest.963332759/build-nvidia-legacy916765592/sandbox-WithNvFakeroot /tmp/stest.963332759/build-nvidia-legacy916765592/raw-deffile2476828233"
=== RUN   TestE2E/PAR/GPU/nvccli/User
    gpu.go:196: Running command "/usr/local/bin/singularity exec --nv --nvccli /tmp/test-nvccli-4195741845 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/nvidia/User
    gpu.go:93: Running command "/usr/local/bin/singularity exec --nv /tmp/test-nvidia-legacy-1026766337 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/build_nvidia/WithoutNvRoot
    gpu.go:343: Running command "/usr/local/bin/singularity build -F --sandbox /tmp/stest.963332759/build-nvidia-legacy916765592/sandbox-WithoutNvRoot /tmp/stest.963332759/build-nvidia-legacy916765592/raw-deffile2012551931"
=== RUN   TestE2E/PAR/GPU/nvidia/UserContain
    gpu.go:93: Running command "/usr/local/bin/singularity exec --contain --nv /tmp/test-nvidia-legacy-1026766337 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/nvccli/UserContainNoDevices
    gpu.go:196: Running command "/usr/local/bin/singularity exec --contain --nv --nvccli /tmp/test-nvccli-4195741845 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/nvidia/UserNamespace
    gpu.go:93: Running command "/usr/local/bin/singularity exec --userns --nv /tmp/test-nvidia-legacy-1026766337 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/nvccli/UserContainAllDevices
    gpu.go:196: Running command "/usr/local/bin/singularity exec --contain --nv --nvccli /tmp/test-nvccli-4195741845 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/nvccli/UserNoUtility
    gpu.go:196: Running command "/usr/local/bin/singularity exec --nv --nvccli /tmp/test-nvccli-4195741845 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/build_nvidia/WithoutNvFakeroot
    gpu.go:343: Running command "/usr/local/bin/singularity build --fakeroot -F --sandbox /tmp/stest.963332759/build-nvidia-legacy916765592/sandbox-WithoutNvFakeroot /tmp/stest.963332759/build-nvidia-legacy916765592/raw-deffile3224921860"
=== RUN   TestE2E/PAR/GPU/nvidia/Fakeroot
    gpu.go:93: Running command "/usr/local/bin/singularity exec --fakeroot --nv /tmp/test-nvidia-legacy-1026766337 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/nvccli/UserValidRequire
    gpu.go:196: Running command "/usr/local/bin/singularity exec --nv --nvccli /tmp/test-nvccli-4195741845 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/nvccli/UserInvalidRequire
    gpu.go:196: Running command "/usr/local/bin/singularity exec --nv --nvccli /tmp/test-nvccli-4195741845 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/nvccli/UserNamespace
    gpu.go:196: Running command "/usr/local/bin/singularity exec --userns --nv --nvccli --writable /tmp/test-nvccli-4195741845 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/nvidia/Root
    gpu.go:93: Running command "/usr/local/bin/singularity exec --nv /tmp/test-nvidia-legacy-1026766337 nvidia-smi"
=== RUN   TestE2E/PAR/GPU/nvccli/Root
    gpu.go:196: Running command "/usr/local/bin/singularity exec --nv --nvccli /tmp/test-nvccli-4195741845 nvidia-smi"
=== RUN   TestE2E/SEQ
=== RUN   TestE2E/SEQ/GPU
--- PASS: TestE2E (13.41s)
    --- PASS: TestE2E/PrepRegistry (0.00s)
    --- PASS: TestE2E/PAR (0.00s)
        --- PASS: TestE2E/PAR/GPU (0.00s)
            --- SKIP: TestE2E/PAR/GPU/build_rocm (0.00s)
            --- SKIP: TestE2E/PAR/GPU/rocm (0.00s)
            --- PASS: TestE2E/PAR/GPU/build_nvccli (9.93s)
                --- PASS: TestE2E/PAR/GPU/build_nvccli/WithNvccliRoot (1.42s)
                --- PASS: TestE2E/PAR/GPU/build_nvccli/WithoutNvccliRoot (0.97s)
            --- PASS: TestE2E/PAR/GPU/nvidia (12.70s)
                --- PASS: TestE2E/PAR/GPU/nvidia/User (0.30s)
                --- PASS: TestE2E/PAR/GPU/nvidia/UserContain (0.32s)
                --- PASS: TestE2E/PAR/GPU/nvidia/UserNamespace (0.72s)
                --- PASS: TestE2E/PAR/GPU/nvidia/Fakeroot (0.78s)
                --- PASS: TestE2E/PAR/GPU/nvidia/Root (0.28s)
            --- PASS: TestE2E/PAR/GPU/build_nvidia (12.70s)
                --- PASS: TestE2E/PAR/GPU/build_nvidia/WithNvRoot (1.31s)
                --- PASS: TestE2E/PAR/GPU/build_nvidia/WithNvFakeroot (1.44s)
                --- PASS: TestE2E/PAR/GPU/build_nvidia/WithoutNvRoot (1.04s)
                --- PASS: TestE2E/PAR/GPU/build_nvidia/WithoutNvFakeroot (1.15s)
            --- PASS: TestE2E/PAR/GPU/nvccli (13.38s)
                --- PASS: TestE2E/PAR/GPU/nvccli/User (0.42s)
                --- PASS: TestE2E/PAR/GPU/nvccli/UserContainNoDevices (0.37s)
                --- PASS: TestE2E/PAR/GPU/nvccli/UserContainAllDevices (0.40s)
                --- PASS: TestE2E/PAR/GPU/nvccli/UserNoUtility (0.32s)
                --- PASS: TestE2E/PAR/GPU/nvccli/UserValidRequire (0.38s)
                --- PASS: TestE2E/PAR/GPU/nvccli/UserInvalidRequire (0.14s)
                --- PASS: TestE2E/PAR/GPU/nvccli/UserNamespace (0.73s)
                --- PASS: TestE2E/PAR/GPU/nvccli/Root (0.38s)
</pre>
</details>



### This fixes or addresses the following GitHub issues:

 - Fixes #416 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
