### PR TITLE
no longer set python=3 for conda

### DIFF
--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -144,7 +144,7 @@ From: continuumio/miniconda3:latest
 %post
 
 	. /opt/conda/etc/profile.d/conda.sh
-	conda create -n env python=3
+	conda create -n env
 
 %environment
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick https://github.com/hpcng/singularity/pull/6282

No longer set python=3 for e2e test that uses conda

### This fixes or addresses the following GitHub issues:

 - Fixes #421 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
