### PR TITLE
Switch to containers/common from seccomp/containers-golang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### New features / functionalities
+
+- Updated seccomp support allows use of seccomp profiles that set an error
+  return code with `errnoRet` and `defaultErrnoRet`. Previously EPERM was hard
+  coded. The example `etc/seccomp-profiles/default.json` has been updated.
+
 ## v3.9.0 \[2021-11-16\]
 
 This is the first release of SingularityCE 3.9, the Community Edition of the

--- a/etc/seccomp-profiles/default.json
+++ b/etc/seccomp-profiles/default.json
@@ -1,5 +1,6 @@
 {
 	"defaultAction": "SCMP_ACT_ERRNO",
+	"defaultErrnoRet": 38,
 	"archMap": [
 		{
 			"architecture": "SCMP_ARCH_X86_64",
@@ -52,6 +53,46 @@
 	"syscalls": [
 		{
 			"names": [
+				"bdflush",
+				"io_pgetevents",
+				"kexec_file_load",
+				"kexec_load",
+				"migrate_pages",
+				"move_pages",
+				"nfsservctl",
+				"nice",
+				"oldfstat",
+				"oldlstat",
+				"oldolduname",
+				"oldstat",
+				"olduname",
+				"pciconfig_iobase",
+				"pciconfig_read",
+				"pciconfig_write",
+				"sgetmask",
+				"ssetmask",
+				"swapcontext",
+				"swapoff",
+				"swapon",
+				"sysfs",
+				"uselib",
+				"userfaultfd",
+				"ustat",
+				"vm86",
+				"vm86old",
+				"vmsplice"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {},
+			"errnoRet": 1
+		},
+		{
+			"names": [
+				"_llseek",
+				"_newselect",
 				"accept",
 				"accept4",
 				"access",
@@ -65,10 +106,18 @@
 				"chmod",
 				"chown",
 				"chown32",
+				"clock_adjtime",
+				"clock_adjtime64",
 				"clock_getres",
+				"clock_getres_time64",
 				"clock_gettime",
+				"clock_gettime64",
 				"clock_nanosleep",
+				"clock_nanosleep_time64",
+				"clone",
+				"clone3",
 				"close",
+				"close_range",
 				"connect",
 				"copy_file_range",
 				"creat",
@@ -80,6 +129,7 @@
 				"epoll_ctl",
 				"epoll_ctl_old",
 				"epoll_pwait",
+				"epoll_pwait2",
 				"epoll_wait",
 				"epoll_wait_old",
 				"eventfd",
@@ -89,6 +139,7 @@
 				"exit",
 				"exit_group",
 				"faccessat",
+				"faccessat2",
 				"fadvise64",
 				"fadvise64_64",
 				"fallocate",
@@ -107,7 +158,11 @@
 				"flock",
 				"fork",
 				"fremovexattr",
+				"fsconfig",
 				"fsetxattr",
+				"fsmount",
+				"fsopen",
+				"fspick",
 				"fstat",
 				"fstat64",
 				"fstatat64",
@@ -117,7 +172,10 @@
 				"ftruncate",
 				"ftruncate64",
 				"futex",
+				"futex_time64",
 				"futimesat",
+				"get_robust_list",
+				"get_thread_area",
 				"getcpu",
 				"getcwd",
 				"getdents",
@@ -131,6 +189,7 @@
 				"getgroups",
 				"getgroups32",
 				"getitimer",
+				"get_mempolicy",
 				"getpeername",
 				"getpgid",
 				"getpgrp",
@@ -143,12 +202,10 @@
 				"getresuid",
 				"getresuid32",
 				"getrlimit",
-				"get_robust_list",
 				"getrusage",
 				"getsid",
 				"getsockname",
 				"getsockopt",
-				"get_thread_area",
 				"gettid",
 				"gettimeofday",
 				"getuid",
@@ -159,14 +216,15 @@
 				"inotify_init1",
 				"inotify_rm_watch",
 				"io_cancel",
-				"ioctl",
 				"io_destroy",
 				"io_getevents",
-				"ioprio_get",
-				"ioprio_set",
 				"io_setup",
 				"io_submit",
+				"ioctl",
+				"ioprio_get",
+				"ioprio_set",
 				"ipc",
+				"keyctl",
 				"kill",
 				"lchown",
 				"lchown32",
@@ -176,16 +234,17 @@
 				"listen",
 				"listxattr",
 				"llistxattr",
-				"_llseek",
 				"lremovexattr",
 				"lseek",
 				"lsetxattr",
 				"lstat",
 				"lstat64",
 				"madvise",
+				"mbind",
 				"memfd_create",
+				"memfd_secret",
 				"mincore",
-                "mkdir",
+				"mkdir",
 				"mkdirat",
 				"mknod",
 				"mknodat",
@@ -194,12 +253,16 @@
 				"mlockall",
 				"mmap",
 				"mmap2",
+				"mount",
+				"move_mount",
 				"mprotect",
 				"mq_getsetattr",
 				"mq_notify",
 				"mq_open",
 				"mq_timedreceive",
+				"mq_timedreceive_time64",
 				"mq_timedsend",
+				"mq_timedsend_time64",
 				"mq_unlink",
 				"mremap",
 				"msgctl",
@@ -210,33 +273,47 @@
 				"munlock",
 				"munlockall",
 				"munmap",
+				"name_to_handle_at",
 				"nanosleep",
 				"newfstatat",
-				"_newselect",
 				"open",
 				"openat",
+				"openat2",
+				"open_tree",
 				"pause",
+				"pidfd_getfd",
+				"pidfd_open",
+				"pidfd_send_signal",
 				"pipe",
 				"pipe2",
+				"pivot_root",
+				"pkey_alloc",
+				"pkey_free",
+				"pkey_mprotect",
 				"poll",
 				"ppoll",
+				"ppoll_time64",
 				"prctl",
 				"pread64",
 				"preadv",
 				"preadv2",
 				"prlimit64",
 				"pselect6",
+				"pselect6_time64",
 				"pwrite64",
 				"pwritev",
 				"pwritev2",
 				"read",
 				"readahead",
+				"readdir",
 				"readlink",
 				"readlinkat",
 				"readv",
+				"reboot",
 				"recv",
 				"recvfrom",
 				"recvmmsg",
+				"recvmmsg_time64",
 				"recvmsg",
 				"remap_file_pages",
 				"removexattr",
@@ -245,6 +322,7 @@
 				"renameat2",
 				"restart_syscall",
 				"rmdir",
+				"rseq",
 				"rt_sigaction",
 				"rt_sigpending",
 				"rt_sigprocmask",
@@ -252,14 +330,16 @@
 				"rt_sigreturn",
 				"rt_sigsuspend",
 				"rt_sigtimedwait",
+				"rt_sigtimedwait_time64",
 				"rt_tgsigqueueinfo",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
 				"sched_getaffinity",
 				"sched_getattr",
 				"sched_getparam",
-				"sched_get_priority_max",
-				"sched_get_priority_min",
 				"sched_getscheduler",
 				"sched_rr_get_interval",
+				"sched_rr_get_interval_time64",
 				"sched_setaffinity",
 				"sched_setattr",
 				"sched_setparam",
@@ -271,12 +351,18 @@
 				"semget",
 				"semop",
 				"semtimedop",
+				"semtimedop_time64",
 				"send",
 				"sendfile",
 				"sendfile64",
 				"sendmmsg",
 				"sendmsg",
 				"sendto",
+				"setns",
+				"set_mempolicy",
+				"set_robust_list",
+				"set_thread_area",
+				"set_tid_address",
 				"setfsgid",
 				"setfsgid32",
 				"setfsuid",
@@ -297,11 +383,8 @@
 				"setreuid",
 				"setreuid32",
 				"setrlimit",
-				"set_robust_list",
 				"setsid",
 				"setsockopt",
-				"set_thread_area",
-				"set_tid_address",
 				"setuid",
 				"setuid32",
 				"setxattr",
@@ -314,7 +397,6 @@
 				"signalfd",
 				"signalfd4",
 				"sigreturn",
-				"socket",
 				"socketcall",
 				"socketpair",
 				"splice",
@@ -322,6 +404,7 @@
 				"stat64",
 				"statfs",
 				"statfs64",
+				"statx",
 				"symlink",
 				"symlinkat",
 				"sync",
@@ -334,36 +417,38 @@
 				"time",
 				"timer_create",
 				"timer_delete",
-				"timerfd_create",
-				"timerfd_gettime",
-				"timerfd_settime",
 				"timer_getoverrun",
 				"timer_gettime",
+				"timer_gettime64",
 				"timer_settime",
+				"timer_settime64",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_gettime64",
+				"timerfd_settime",
+				"timerfd_settime64",
 				"times",
 				"tkill",
 				"truncate",
 				"truncate64",
 				"ugetrlimit",
 				"umask",
+				"umount",
+				"umount2",
 				"uname",
 				"unlink",
 				"unlinkat",
+				"unshare",
 				"utime",
 				"utimensat",
+				"utimensat_time64",
 				"utimes",
 				"vfork",
-				"vmsplice",
 				"wait4",
 				"waitid",
 				"waitpid",
 				"write",
-				"writev",
-				"mount",
-				"umount2",
-				"reboot",
-				"name_to_handle_at",
-				"unshare"
+				"writev"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -554,20 +639,29 @@
 		},
 		{
 			"names": [
+				"open_by_handle_at"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_DAC_READ_SEARCH"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"bpf",
-				"clone",
 				"fanotify_init",
 				"lookup_dcookie",
-				"mount",
-				"name_to_handle_at",
 				"perf_event_open",
 				"quotactl",
 				"setdomainname",
 				"sethostname",
-				"setns",
-				"umount",
-				"umount2",
-				"unshare"
+				"setns"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -581,68 +675,25 @@
 		},
 		{
 			"names": [
-				"clone"
+				"bpf",
+				"fanotify_init",
+				"lookup_dcookie",
+				"perf_event_open",
+				"quotactl",
+				"setdomainname",
+				"sethostname",
+				"setns"
 			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 2080505856,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_MASKED_EQ"
-				}
-			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
 			"comment": "",
 			"includes": {},
 			"excludes": {
 				"caps": [
 					"CAP_SYS_ADMIN"
-				],
-				"arches": [
-					"s390",
-					"s390x"
-				]
-			}
-		},
-		{
-			"names": [
-				"clone"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 1,
-					"value": 2080505856,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_MASKED_EQ"
-				}
-			],
-			"comment": "s390 parameter ordering for clone is different",
-			"includes": {
-				"arches": [
-					"s390",
-					"s390x"
 				]
 			},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_ADMIN"
-				]
-			}
-		},
-		{
-			"names": [
-				"reboot"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_BOOT"
-				]
-			},
-			"excludes": {}
+			"errnoRet": 1
 		},
 		{
 			"names": [
@@ -657,6 +708,21 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"chroot"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_CHROOT"
+				]
+			},
+			"errnoRet": 1
 		},
 		{
 			"names": [
@@ -677,6 +743,24 @@
 		},
 		{
 			"names": [
+				"delete_module",
+				"init_module",
+				"finit_module",
+				"query_module"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_MODULE"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"acct"
 			],
 			"action": "SCMP_ACT_ALLOW",
@@ -691,7 +775,23 @@
 		},
 		{
 			"names": [
+				"acct"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_PACCT"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"kcmp",
+				"process_madvise",
 				"process_vm_readv",
 				"process_vm_writev",
 				"ptrace"
@@ -705,6 +805,25 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"kcmp",
+				"process_madvise",
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_PTRACE"
+				]
+			},
+			"errnoRet": 1
 		},
 		{
 			"names": [
@@ -723,9 +842,26 @@
 		},
 		{
 			"names": [
+				"iopl",
+				"ioperm"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_RAWIO"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"settimeofday",
 				"stime",
-				"clock_settime"
+				"clock_settime",
+				"clock_settime64"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -739,6 +875,24 @@
 		},
 		{
 			"names": [
+				"settimeofday",
+				"stime",
+				"clock_settime",
+				"clock_settime64"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_TIME"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
 				"vhangup"
 			],
 			"action": "SCMP_ACT_ALLOW",
@@ -747,6 +901,126 @@
 			"includes": {
 				"caps": [
 					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"vhangup"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"errnoRet": 1
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [
+				{
+					"index": 0,
+					"value": 16,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				},
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			},
+			"errnoRet": 22
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 16,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 2,
+					"value": 9,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_NE"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
+				]
+			}
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": null,
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_AUDIT_WRITE"
 				]
 			},
 			"excludes": {}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/containerd/containerd v1.5.8
 	github.com/containernetworking/cni v1.0.1
 	github.com/containernetworking/plugins v1.0.1
+	github.com/containers/common v0.44.3
 	github.com/containers/image/v5 v5.16.1
 	github.com/cyphar/filepath-securejoin v0.2.3
 	github.com/docker/docker v20.10.11+incompatible
@@ -37,8 +38,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4
 	github.com/pkg/errors v0.9.1
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/seccomp/containers-golang v0.6.0
-	github.com/seccomp/libseccomp-golang v0.9.1
+	github.com/seccomp/libseccomp-golang v0.9.2-0.20211028222634-77bddc247e72
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/sylabs/json-resp v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,7 @@ github.com/containerd/imgcrypt v1.1.1/go.mod h1:xpLnwiQmEUJPvQoAapeb2SNCxz7Xr6PJ
 github.com/containerd/nri v0.0.0-20201007170849-eb1350a75164/go.mod h1:+2wGSDGFYfE5+So4M5syatU0N0f0LbWpuqyMi4/BE8c=
 github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
+github.com/containerd/stargz-snapshotter/estargz v0.8.0/go.mod h1:mwIwuwb+D8FX2t45Trwi0hmWmZm5VW7zPP/rekwhWQU=
 github.com/containerd/stargz-snapshotter/estargz v0.9.0/go.mod h1:aE5PCyhFMwR8sbrErO5eM2GcvkyXTTJremG883D4qF0=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
@@ -277,6 +278,9 @@ github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHV
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containernetworking/plugins v1.0.1 h1:wwCfYbTCj5FC0EJgyzyjTXmqysOiJE9r712Z+2KVZAk=
 github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNBDZcxSOplJT5ico8/FLE=
+github.com/containers/common v0.44.3 h1:Wx+mJT+gH/ie86JdZUmVnZwTieXw86UE6JOYuCNTV1g=
+github.com/containers/common v0.44.3/go.mod h1:7sdP4vmI5Bm6FPFxb3lvAh1Iktb6tiO1MzjUzhxdoGo=
+github.com/containers/image/v5 v5.16.0/go.mod h1:XgTpfAPLRGOd1XYyCU5cISFr777bLmOerCSpt/v7+Q4=
 github.com/containers/image/v5 v5.16.1 h1:4786k48/af3dOkVf9EM+xB880ArkXalICsGC4AXC6to=
 github.com/containers/image/v5 v5.16.1/go.mod h1:mCvIFdzyyP1B0NBcZ80OIuaYqFn/OpFpaOMOMn1kU2M=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
@@ -286,6 +290,8 @@ github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgU
 github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/containers/ocicrypt v1.1.2 h1:Ez+GAMP/4GLix5Ywo/fL7O0nY771gsBIigiqUm1aXz0=
 github.com/containers/ocicrypt v1.1.2/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
+github.com/containers/storage v1.35.0/go.mod h1:qzYhasQP2/V9D9XdO+vRwkHBhsBO0oznMLzzRDQ8s20=
+github.com/containers/storage v1.36.0/go.mod h1:vbd3SKVQNHdmU5qQI6hTEcKPxnZkGqydG4f6uwrI5a8=
 github.com/containers/storage v1.37.0 h1:HVhDsur6sx889ZIZ1d1kEiOzv3gsr5q0diX2VZmOdSg=
 github.com/containers/storage v1.37.0/go.mod h1:kqeJeS0b7DO2ZT1nVWs0XufrmPFbgV3c+Q/45RlH6r4=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -312,6 +318,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.15 h1:cKRCLMj3Ddm54bKSpemfQ8AtYFBhAI2MPmdys22fBdc=
 github.com/creack/pty v1.1.15/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
@@ -332,6 +339,7 @@ github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8l
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/disiqueira/gotree/v3 v3.0.2/go.mod h1:ZuyjE4+mUQZlbpkI24AmruZKhg3VHEgPLDY8Qk+uUu8=
 github.com/distribution/distribution/v3 v3.0.0-20210926092439-1563384b69df h1:zafDqOsnugdrReF9Pe0wybnfFtEIaegSyHNIvnwKPVk=
 github.com/distribution/distribution/v3 v3.0.0-20210926092439-1563384b69df/go.mod h1:ZDZib/BOniVWcXcsy0voU8gR00znhe5VJm47d3H2Y5g=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
@@ -476,6 +484,7 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gomodule/redigo v1.8.2 h1:H5XSIre1MB5NbPYFp+i1NBbb5qN1W8Y8YAQoAYbkm8k=
 github.com/gomodule/redigo v1.8.2/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -554,7 +563,6 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
@@ -586,6 +594,7 @@ github.com/j-keck/arping v1.0.2 h1:hlLhuXgQkzIJTZuhMigvG/CuSkaspeaD9hRDk2zuiMI=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jinzhu/copier v0.3.2/go.mod h1:24xnZezI2Yqac9J61UC6/dG/k76ttpq0DdJI3QmUvro=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -612,6 +621,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
@@ -692,8 +703,9 @@ github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2J
 github.com/moby/sys/mountinfo v0.4.1 h1:1O+1cHA1aujwEwwVMa2Xm2l+gIpUHyd3+D+d7LZh1kM=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
-github.com/moby/term v0.0.0-20200312100748-672ec06f55cd h1:aY7OQNf2XqY/JQ6qREWamhI/81os/agb2BAGpcx5yWI=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
+github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 h1:rzf0wL0CHVc8CEsgyygG0Mn9CNCCPZqOPaz8RiiHYQk=
+github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -734,8 +746,9 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
-github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
+github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
+github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -758,7 +771,6 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.m
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/opencontainers/runtime-spec v1.0.3-0.20200710190001-3e4195d92445/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -769,6 +781,7 @@ github.com/opencontainers/runtime-tools v0.9.1-0.20210326182921-59cdde06764b/go.
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
+github.com/opencontainers/selinux v1.8.4/go.mod h1:HTvjPFoGMbpQsG886e3lQwnsRWtE4TC1OF3OUvG9FAo=
 github.com/opencontainers/selinux v1.8.5/go.mod h1:HTvjPFoGMbpQsG886e3lQwnsRWtE4TC1OF3OUvG9FAo=
 github.com/opencontainers/selinux v1.9.1 h1:b4VPEF3O5JLZgdTDBmGepaaIbAo0GqoF6EBRq5f/g3Y=
 github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
@@ -852,10 +865,10 @@ github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZ
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
 github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
-github.com/seccomp/containers-golang v0.6.0 h1:VWPMMIDr8pAtNjCX0WvLEEK9EQi5lAm4HtJbDtAtFvQ=
-github.com/seccomp/containers-golang v0.6.0/go.mod h1:Dd9mONHvW4YdbSzdm23yf2CFw0iqvqLhO0mEFvPIvm4=
-github.com/seccomp/libseccomp-golang v0.9.1 h1:NJjM5DNFOs0s3kYE1WUOr6G8V97sdt46rlXTMfXGWBo=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
+github.com/seccomp/libseccomp-golang v0.9.2-0.20200616122406-847368b35ebf/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+github.com/seccomp/libseccomp-golang v0.9.2-0.20211028222634-77bddc247e72 h1:Xo1J470k4DxyW4sVQNI1Uu21YJCLX15dgDZzpCb7Gso=
+github.com/seccomp/libseccomp-golang v0.9.2-0.20211028222634-77bddc247e72/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
@@ -958,6 +971,7 @@ github.com/vbauerster/mpb/v4 v4.12.2 h1:TsBs1nWRYF0m8cUH13pxNhOUqY6yKcOr2PeSYxp2
 github.com/vbauerster/mpb/v4 v4.12.2/go.mod h1:LVRGvMch8T4HQO3eg2pFPsACH9kO/O6fT/7vhGje3QE=
 github.com/vbauerster/mpb/v6 v6.0.4 h1:h6J5zM/2wimP5Hj00unQuV8qbo5EPcj6wbkCqgj7KcY=
 github.com/vbauerster/mpb/v6 v6.0.4/go.mod h1:a/+JT57gqh6Du0Ay5jSR+uBMfXGdlR7VQlGP52fJxLM=
+github.com/vbauerster/mpb/v7 v7.1.3/go.mod h1:X5GlohZw2fIpypMXWaKart+HGSAjpz49skxkDk+ZL7c=
 github.com/vbauerster/mpb/v7 v7.1.5 h1:vtUEUfQHmNeJETyF4AcRCOV6RC4wqFwNORy52UMXPbQ=
 github.com/vbauerster/mpb/v7 v7.1.5/go.mod h1:4M8+qAoQqV60WDNktBM5k05i1iTrXE7rjKOHEVkVlec=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
@@ -1218,10 +1232,10 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200817155316-9781c653f443/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/pkg/runtime/engine/config/oci/config.go
+++ b/internal/pkg/runtime/engine/config/oci/config.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 
 	"github.com/containerd/cgroups"
+	cseccomp "github.com/containers/common/pkg/seccomp"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	cseccomp "github.com/seccomp/containers-golang"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/sylabs/singularity/internal/pkg/security/seccomp"
 )

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -159,12 +159,15 @@ func (e *EngineOperations) CreateContainer(context.Context, int, net.Conn) error
 // set the return value to 0 for mknod and mknodat syscalls. It
 // allows build bootstrap like yum to work with fakeroot.
 func fakerootSeccompProfile() *specs.LinuxSeccomp {
+	zero := uint(0)
 	syscalls := []specs.LinuxSyscall{
 		{
-			Names:  []string{"mknod", "mknodat"},
-			Action: specs.ActErrno,
+			Names:    []string{"mknod", "mknodat"},
+			Action:   specs.ActErrno,
+			ErrnoRet: &zero,
 		},
 	}
+
 	return &specs.LinuxSeccomp{
 		DefaultAction: specs.ActAllow,
 		Syscalls:      syscalls,
@@ -234,7 +237,7 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 	}
 
 	if seccomp.Enabled() {
-		if err := seccomp.LoadSeccompConfig(fakerootSeccompProfile(), false, 0); err != nil {
+		if err := seccomp.LoadSeccompConfig(fakerootSeccompProfile(), false); err != nil {
 			sylog.Warningf("Could not apply seccomp filter, some bootstrap may not work correctly")
 		}
 	} else {

--- a/internal/pkg/security/seccomp/seccomp_supported.go
+++ b/internal/pkg/security/seccomp/seccomp_supported.go
@@ -9,16 +9,22 @@
 package seccomp
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"syscall"
 
+	cseccomp "github.com/containers/common/pkg/seccomp"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	cseccomp "github.com/seccomp/containers-golang"
 	lseccomp "github.com/seccomp/libseccomp-golang"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+var (
+	ErrInvalidAction    = errors.New("invalid action")
+	ErrUnsupportedErrno = errors.New("errno is not supported for action")
 )
 
 var scmpArchMap = map[specs.Arch]lseccomp.ScmpArch{
@@ -69,13 +75,64 @@ func hasConditionSupport() bool {
 	return (major > 2) || (major == 2 && minor >= 2) || (major == 2 && minor == 2 && micro >= 1)
 }
 
+// getDefaultErrno returns the default errNo that is specified by the specs
+//
+// https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#seccomp
+//
+// defaultErrnoRet (uint, OPTIONAL) - the errno return code to use. Some actions
+// like SCMP_ACT_ERRNO and SCMP_ACT_TRACE allow to specify the errno code to
+// return. When the action doesn't support an errno, the runtime MUST print and
+// error and fail. If not specified then its default value is EPERM
+//
+func getDefaultErrno(config *specs.LinuxSeccomp) (errnoRet *uint, err error) {
+	// If there is no attempt to explicitly set a defaultErrnoRet then a default
+	// or explicit ERRNO/TRACE action should return EPERM.
+	if config.DefaultErrnoRet == nil {
+		eperm := uint(syscall.EPERM)
+		return &eperm, nil
+	}
+
+	// defaultErrno is set with a defaultAction of ERRNO or TRACE
+	if config.DefaultAction == specs.ActErrno || config.DefaultAction == specs.ActTrace {
+		return config.DefaultErrnoRet, nil
+	}
+
+	// defaultErrno is set for a defaultAction that doesn't support it
+	return nil, fmt.Errorf("defaultAction: %w", ErrUnsupportedErrno)
+}
+
+// getAction returns the approriate libseccomp action for a given containers/common seccomp action
+func getAction(specAction specs.LinuxSeccompAction, errnoRet *uint, defaultErrNoRet uint) (scmpAction lseccomp.ScmpAction, err error) {
+	scmpAction, ok := scmpActionMap[specAction]
+	if !ok {
+		return lseccomp.ActInvalid, fmt.Errorf("%v: %w", specAction, ErrInvalidAction)
+	}
+
+	// Errno or Trace must set an Errno
+	if specAction == specs.ActErrno || specAction == specs.ActTrace {
+		// errnoRet override of the default
+		if errnoRet != nil {
+			return scmpAction.SetReturnCode(int16(*errnoRet)), nil
+		}
+		// defaultErrnoRet (which is EPERM if not specified)
+		return scmpAction.SetReturnCode(int16(defaultErrNoRet)), nil
+	}
+
+	// Other actions which don't take an errno
+	if errnoRet != nil {
+		return lseccomp.ActInvalid, fmt.Errorf("%v, %w", specAction, ErrUnsupportedErrno)
+	}
+
+	return scmpAction, nil
+}
+
 // Enabled returns whether seccomp is enabled.
 func Enabled() bool {
 	return true
 }
 
 // LoadSeccompConfig loads seccomp configuration filter for the current process.
-func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool, errNo int16) error {
+func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool) error {
 	if err := prctl(syscall.PR_GET_SECCOMP, 0, 0, 0, 0); err == syscall.EINVAL {
 		return fmt.Errorf("can't load seccomp filter: not supported by kernel")
 	}
@@ -97,15 +154,20 @@ func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool, errNo int16)
 		sylog.Warningf("seccomp rule conditions are not supported with libseccomp under 2.2.1")
 	}
 
-	scmpAction, ok := scmpActionMap[config.DefaultAction]
-	if !ok {
-		return fmt.Errorf("invalid action '%s' specified", config.DefaultAction)
+	defaultErrno, err := getDefaultErrno(config)
+	if err != nil {
+		return fmt.Errorf("can't load default action: %w", err)
 	}
-	if scmpAction == lseccomp.ActErrno {
-		scmpAction = scmpAction.SetReturnCode(errNo)
+	if defaultErrno == nil {
+		return fmt.Errorf("internal error - computed defaultErrno cannot be nil")
 	}
 
-	filter, err := lseccomp.NewFilter(scmpAction)
+	defaultAction, err := getAction(config.DefaultAction, nil, *defaultErrno)
+	if err != nil {
+		return fmt.Errorf("can't load default action: %w", err)
+	}
+
+	filter, err := lseccomp.NewFilter(defaultAction)
 	if err != nil {
 		return fmt.Errorf("error creating new filter: %s", err)
 	}
@@ -130,12 +192,16 @@ func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool, errNo int16)
 			return fmt.Errorf("no syscall specified for the rule")
 		}
 
-		scmpAction, ok = scmpActionMap[syscall.Action]
-		if !ok {
-			return fmt.Errorf("invalid action '%s' specified", syscall.Action)
+		scmpAction, err := getAction(syscall.Action, syscall.ErrnoRet, *defaultErrno)
+		if err != nil {
+			return fmt.Errorf("error adding action: %w", err)
 		}
-		if scmpAction == lseccomp.ActErrno {
-			scmpAction = scmpAction.SetReturnCode(errNo)
+
+		// If the action is equal to the default action we skip the rule
+		// silently, as it is redundant and AddRule will error inserting it.
+		if scmpAction == defaultAction {
+			sylog.Debugf("Skipping redundant seccomp rule for %v %v", syscall.Names, scmpAction)
+			continue
 		}
 
 		for _, sysName := range syscall.Names {

--- a/internal/pkg/security/seccomp/seccomp_supported_test.go
+++ b/internal/pkg/security/seccomp/seccomp_supported_test.go
@@ -9,12 +9,15 @@
 package seccomp
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"syscall"
 	"testing"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	lseccomp "github.com/seccomp/libseccomp-golang"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
@@ -68,10 +71,10 @@ func TestLoadSeccompConfig(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if err := LoadSeccompConfig(nil, false, 1); err == nil {
+	if err := LoadSeccompConfig(nil, false); err == nil {
 		t.Errorf("should have failed with an empty config")
 	}
-	if err := LoadSeccompConfig(defaultProfile(), true, 1); err != nil {
+	if err := LoadSeccompConfig(defaultProfile(), true); err != nil {
 		t.Errorf("%s", err)
 	}
 
@@ -92,9 +95,192 @@ func TestLoadProfileFromFile(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := LoadSeccompConfig(gen.Config.Linux.Seccomp, true, 1); err != nil {
+	if err := LoadSeccompConfig(gen.Config.Linux.Seccomp, true); err != nil {
 		t.Errorf("%s", err)
 	}
 
 	testFchmod(t)
+}
+
+func TestGetDefaultErrno(t *testing.T) {
+	eperm := uint(syscall.EPERM)
+	enosys := uint(syscall.ENOSYS)
+
+	tests := []struct {
+		name        string
+		specs       *specs.LinuxSeccomp
+		expectErrno *uint
+		expectError error
+	}{
+		{
+			name:        "EmptyDefaultEPERM",
+			specs:       &specs.LinuxSeccomp{},
+			expectErrno: &eperm,
+			expectError: nil,
+		},
+		{
+			name: "ActErrnoDefaultEPERM",
+			specs: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActErrno,
+			},
+			expectErrno: &eperm,
+			expectError: nil,
+		},
+		{
+			name: "ActTraceDefaultEPERM",
+			specs: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActTrace,
+			},
+			expectErrno: &eperm,
+			expectError: nil,
+		},
+		{
+			name: "ActKillDefaultEPERM",
+			specs: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActKill,
+			},
+			expectErrno: &eperm,
+			expectError: nil,
+		},
+		{
+			name: "ActErrnoENOSYS",
+			specs: &specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: &enosys,
+			},
+			expectErrno: &enosys,
+			expectError: nil,
+		},
+		{
+			name: "ActTraceENOSYS",
+			specs: &specs.LinuxSeccomp{
+				DefaultAction:   specs.ActTrace,
+				DefaultErrnoRet: &enosys,
+			},
+			expectErrno: &enosys,
+			expectError: nil,
+		},
+		{
+			name: "ActKillENOSYS",
+			specs: &specs.LinuxSeccomp{
+				DefaultAction:   specs.ActKill,
+				DefaultErrnoRet: &enosys,
+			},
+			expectErrno: nil,
+			expectError: ErrUnsupportedErrno,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errno, err := getDefaultErrno(tt.specs)
+
+			if err == nil {
+				if tt.expectError != nil {
+					t.Errorf("no error, expected %v", tt.expectError)
+				}
+			} else {
+				if !errors.Is(err, tt.expectError) {
+					t.Errorf("got err=%v, expected %v", err, tt.expectError)
+				}
+			}
+
+			if !reflect.DeepEqual(errno, tt.expectErrno) {
+				t.Errorf("got errno=%v, expected %v", errno, tt.expectErrno)
+			}
+		})
+	}
+}
+
+func TestGetAction(t *testing.T) {
+	eperm := uint(syscall.EPERM)
+	enosys := uint(syscall.ENOSYS)
+
+	errnoEPERM := lseccomp.ActErrno
+	errnoEPERM = errnoEPERM.SetReturnCode(int16(syscall.EPERM))
+	errnoENOSYS := lseccomp.ActErrno
+	errnoENOSYS = errnoENOSYS.SetReturnCode(int16(syscall.ENOSYS))
+	traceEPERM := lseccomp.ActTrace
+	traceEPERM = traceEPERM.SetReturnCode(int16(syscall.EPERM))
+	traceENOSYS := lseccomp.ActTrace
+	traceENOSYS = traceENOSYS.SetReturnCode(int16(syscall.ENOSYS))
+	kill := lseccomp.ActKill
+
+	tests := []struct {
+		name         string
+		action       specs.LinuxSeccompAction
+		errno        *uint
+		defaultErrno uint
+		expectAction lseccomp.ScmpAction
+		expectError  error
+	}{
+		{
+			name:         "KillOK",
+			action:       specs.ActKill,
+			errno:        nil,
+			defaultErrno: eperm,
+			expectAction: kill,
+			expectError:  nil,
+		},
+		{
+			name:         "KillUnsupportedErrno",
+			action:       specs.ActKill,
+			errno:        &enosys,
+			defaultErrno: eperm,
+			expectAction: lseccomp.ActInvalid,
+			expectError:  ErrUnsupportedErrno,
+		},
+		{
+			name:         "ErrnoDefaultEPERM",
+			action:       specs.ActErrno,
+			errno:        nil,
+			defaultErrno: eperm,
+			expectAction: errnoEPERM,
+			expectError:  nil,
+		},
+		{
+			name:         "ErrnoOverrideENOSYS",
+			action:       specs.ActErrno,
+			errno:        &enosys,
+			defaultErrno: eperm,
+			expectAction: errnoENOSYS,
+			expectError:  nil,
+		},
+		{
+			name:         "TraceDefaultEPERM",
+			action:       specs.ActTrace,
+			errno:        nil,
+			defaultErrno: eperm,
+			expectAction: traceEPERM,
+			expectError:  nil,
+		},
+		{
+			name:         "TraceOverrideENOSYS",
+			action:       specs.ActTrace,
+			errno:        &enosys,
+			defaultErrno: eperm,
+			expectAction: traceENOSYS,
+			expectError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action, err := getAction(tt.action, tt.errno, tt.defaultErrno)
+
+			if err == nil {
+				if tt.expectError != nil {
+					t.Errorf("no error, expected %v", tt.expectError)
+				}
+			} else {
+				if !errors.Is(err, tt.expectError) {
+					t.Errorf("got err=%v, expected %v", err, tt.expectError)
+				}
+			}
+
+			if action != tt.expectAction {
+				t.Errorf("got action=%v, expected %v", action, tt.expectAction)
+			}
+		})
+	}
 }

--- a/internal/pkg/security/seccomp/seccomp_unsupported.go
+++ b/internal/pkg/security/seccomp/seccomp_unsupported.go
@@ -21,7 +21,7 @@ func Enabled() bool {
 }
 
 // LoadSeccompConfig loads seccomp configuration filter for the current process.
-func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool, errNo int16) error {
+func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool) error {
 	return fmt.Errorf("can't load seccomp filter: not enabled at compilation time")
 }
 

--- a/internal/pkg/security/security.go
+++ b/internal/pkg/security/security.go
@@ -42,7 +42,7 @@ func Configure(config *specs.Spec) error {
 	}
 	if config.Linux != nil && config.Linux.Seccomp != nil {
 		if seccomp.Enabled() {
-			if err := seccomp.LoadSeccompConfig(config.Linux.Seccomp, config.Process.NoNewPrivileges, 1); err != nil {
+			if err := seccomp.LoadSeccompConfig(config.Linux.Seccomp, config.Process.NoNewPrivileges); err != nil {
 				return err
 			}
 		} else {


### PR DESCRIPTION
## Description of the Pull Request (PR):

seccomp/containers-golang has been archived and will not receive fixes,
so we need to transition to containers/common/pkg/seccomp.

Update our example seccomp profile to the output of `make seccomp.json`
on the new module.

Add handling of errnoRet & defaultErrnoRet in seccomp profiles, and use
this rather than passing the err number in function calls.

Skip over any seccomp rules that are redundant, i.e. the action is the
same as the default action. These now cause AddRule to error with our
updated dependencies.

I've opened #439 as an issue to improve unit and e2e testing here, so that we are checking the _effect_ of a broader variety of filters is as expected. I've added some tests in this PR that cover parts of the internal image-spec -> libseccomp translations, but a lot of paths here aren't well covered.


### This fixes or addresses the following GitHub issues:

 - Fixes #437 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
