### PR TITLE
Clarify source of key index

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,6 +85,7 @@ The following have contributed code and/or documentation to this repository.
 - Rafal Gumienny <rafal.gumienny@gmail.com>
 - Ralph Castain <rhc@open-mpi.org>
 - Rémy Dernat <remy.dernat@umontpellier.fr>
+- Richard Hattersley <richard.hattersley@metoffice.gov.uk>
 - Richard Neuboeck <hawk@tbi.univie.ac.at>
 - Sasha Yakovtseva <sasha@sylabs.io>, <sashayakovtseva@gmail.com>
 - Satish Chebrolu  <satish@sylabs.io>

--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	privKey int // -k encryption key (index from 'keys list') specification
+	privKey int // -k encryption key (index from 'key list --secret') specification
 	signAll bool
 )
 
@@ -68,7 +68,7 @@ var signKeyIdxFlag = cmdline.Flag{
 	DefaultValue: 0,
 	Name:         "keyidx",
 	ShortHand:    "k",
-	Usage:        "private key to use (index from 'key list')",
+	Usage:        "private key to use (index from 'key list --secret')",
 }
 
 // -a|--all (deprecated)


### PR DESCRIPTION
## Description of the Pull Request (PR):

This is purely a change to the documentation to clarify that the `--keyidx` key index parameter for the `singularity sign ...` command relates to the _private_ keys, so the `--secret` argument is necessary when obtaining the index from `singularity key list`.

### This fixes or addresses the following GitHub issues:

 - N/A


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
