### PR TITLE
AttachFromFile: rewrite retry loop

### DIFF
--- a/pkg/util/loop/loop.go
+++ b/pkg/util/loop/loop.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021, Genomics plc.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -77,11 +78,41 @@ type Info64 struct {
 	Init           [2]uint64
 }
 
-// AttachFromFile finds a free loop device, opens it, and stores file descriptor
-// provided by image file pointer
+// Error returned when attachFromFile failed to find a valid loop device,
+// but EAGAIN or EBUSY was returned. Will be used in AttachFromFile to determine
+// whether we should abort or continue to try finding a loop device.
+type TransientAttachError struct {
+	message string
+}
+
+func (tae *TransientAttachError) Error() string {
+	return tae.message
+}
+
 func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error {
+	maxRetries := 5
+
+	for i := 0; i < maxRetries; i++ {
+		err := loop.attachFromFile(image, mode, number)
+		if err != nil {
+			_, transient := err.(*TransientAttachError)
+			if !transient {
+				return err
+			}
+			time.Sleep(250 * time.Millisecond)
+		} else {
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to attach to loop device")
+}
+
+// attachFromFile finds a free loop device, opens it, and stores file descriptor
+// provided by image file pointer
+func (loop *Device) attachFromFile(image *os.File, mode int, number *int) error {
 	var path string
 	var loopFd int
+	var transientErrorFound bool
 
 	if image == nil {
 		return fmt.Errorf("empty file pointer")
@@ -114,6 +145,9 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 					device = freeDevice
 					continue
 				}
+			}
+			if transientErrorFound {
+				return &TransientAttachError{"failed to successfully allocate a loop device (please retry)"}
 			}
 			return fmt.Errorf("no loop devices available")
 		}
@@ -160,41 +194,34 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 				return nil
 			}
 			syscall.Close(loopFd)
-		} else {
-			_, _, esys := syscall.Syscall(syscall.SYS_IOCTL, uintptr(loopFd), CmdSetFd, image.Fd())
-			if esys != 0 {
-				syscall.Close(loopFd)
-				continue
-			}
-			break
+			continue
 		}
-	}
 
-	if _, _, err := syscall.Syscall(syscall.SYS_FCNTL, uintptr(loopFd), syscall.F_SETFD, syscall.FD_CLOEXEC); err != 0 {
-		return fmt.Errorf("failed to set close-on-exec on loop device %s: %s", path, err.Error())
-	}
+		_, _, esys := syscall.Syscall(syscall.SYS_IOCTL, uintptr(loopFd), CmdSetFd, image.Fd())
+		if esys != 0 {
+			syscall.Close(loopFd)
+			continue
+		}
 
-	maxRetries := 5
-	for i := 0; i < maxRetries; i++ {
+		if _, _, err := syscall.Syscall(syscall.SYS_FCNTL, uintptr(loopFd), syscall.F_SETFD, syscall.FD_CLOEXEC); err != 0 {
+			return fmt.Errorf("failed to set close-on-exec on loop device %s: %s", path, err.Error())
+		}
+
 		if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(loopFd), CmdSetStatus64, uintptr(unsafe.Pointer(loop.Info))); err != 0 {
-			if err == syscall.EAGAIN && i < maxRetries-1 {
-				// with changes introduces in https://github.com/torvalds/linux/commit/5db470e229e22b7eda6e23b5566e532c96fb5bc3
-				// loop_set_status() can temporarily fail with EAGAIN -> sleep and try again
-				// (cf. https://github.com/karelzak/util-linux/blob/dab1303287b7ebe30b57ccc78591070dad0a85ea/lib/loopdev.c#L1355)
-				time.Sleep(250 * time.Millisecond)
+			// clear associated file descriptor to release the loop device
+			syscall.Syscall(syscall.SYS_IOCTL, uintptr(loopFd), CmdClrFd, 0)
+			if err == syscall.EAGAIN || err == syscall.EBUSY {
+				transientErrorFound = true
 				continue
 			}
-			// clear associated file descriptor to release the loop device,
-			// best-effort here without error checking because we need the
-			// error from previous ioctl call
-			syscall.Syscall(syscall.SYS_IOCTL, uintptr(loopFd), CmdClrFd, 0)
 			return fmt.Errorf("failed to set loop flags on loop device: %s", syscall.Errno(err))
 		}
-		break
+
+		loop.fd = new(int)
+		*loop.fd = loopFd
+		return nil
 	}
 
-	loop.fd = new(int)
-	*loop.fd = loopFd
 	return nil
 }
 

--- a/pkg/util/loop/loop.go
+++ b/pkg/util/loop/loop.go
@@ -7,6 +7,7 @@
 package loop
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -78,33 +79,25 @@ type Info64 struct {
 	Init           [2]uint64
 }
 
-// Error returned when attachFromFile failed to find a valid loop device,
-// but EAGAIN or EBUSY was returned. Will be used in AttachFromFile to determine
-// whether we should abort or continue to try finding a loop device.
-type TransientAttachError struct {
-	message string
-}
-
-func (tae *TransientAttachError) Error() string {
-	return tae.message
-}
+var errTransientAttach = errors.New("failed to successfully allocate a loop device (please retry)")
 
 func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error {
 	maxRetries := 5
+	var err error
 
 	for i := 0; i < maxRetries; i++ {
 		err := loop.attachFromFile(image, mode, number)
 		if err != nil {
-			_, transient := err.(*TransientAttachError)
-			if !transient {
+			if !errors.Is(err, errTransientAttach) {
 				return err
 			}
+			sylog.Debugf("Transient error detected: %s", err)
 			time.Sleep(250 * time.Millisecond)
 		} else {
 			return nil
 		}
 	}
-	return fmt.Errorf("failed to attach to loop device")
+	return fmt.Errorf("failed to set loop flags: %s", err)
 }
 
 // attachFromFile finds a free loop device, opens it, and stores file descriptor
@@ -147,7 +140,7 @@ func (loop *Device) attachFromFile(image *os.File, mode int, number *int) error 
 				}
 			}
 			if transientErrorFound {
-				return &TransientAttachError{"failed to successfully allocate a loop device (please retry)"}
+				return fmt.Errorf("%w", errTransientAttach)
 			}
 			return fmt.Errorf("no loop devices available")
 		}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Recently an issue was discovered when using the Singularity container runtime in Arvados Crunch where certain Slurm jobs would start failing with an error message:

```
2021-11-26T18:57:12.918958066Z ERROR [container bcftools_convert_10] (arvc1-xvhdp-ffcjthyczz8gqol) error log:
2021-11-26T18:57:12.918958066Z 
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:45.272198441Z crunch-run Not starting a gateway server (GatewayAuthSecret was not provided by dispatcher)
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:45.272309584Z crunch-run crunch-run 2.3.1 (go1.17.1) started
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:45.272331939Z crunch-run Executing container 'arvc1-dz642-tlt1uw3hyppd06g' using singularity runtime
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:45.272354161Z crunch-run Executing on host 'slurm-worker-blue-4'
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:45.433328942Z crunch-run container token "token-obfuscated" 
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:45.433798736Z crunch-run Running [arv-mount --foreground --read-write --storage-classes default --crunchstat-interval=10 --file-cache 268435456 --mount-by-pdh by_id --disable-event-listening --mount-by-id by_uuid /tmp/crunch-run.arvc1-dz642-tlt1uw3hyppd06g.1063908694/keep2883686336]
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:49.241177040Z crunch-run Fetching Docker image from collection '3126bcd60bc91b04916bae8dfadede7d+177'
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:49.372828520Z crunch-run Using Docker image id "sha256:c74eb4247d8550fa2df0c5275a9dd3b34cb105347cc0fcefdf5a05749faaf0a1" 
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:49.372958779Z crunch-run Loading Docker image from keep
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:50.079531206Z crunch-run Starting container
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:50.080267548Z crunch-run Waiting for container to finish
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:52.939218932Z stderr FATAL:   container creation failed: mount /proc/self/fd/3->/usr/local/var/singularity/mnt/session/rootfs error: while mounting image /proc/self/fd/3: failed to find loop device: could not attach image file to loop device: failed to set loop flags on loop device: resource temporarily unavailable
2021-11-26T18:57:12.918958066Z   2021-11-26T18:56:53.365279723Z crunch-run Complete
2021-11-26T18:57:13.026434934Z ERROR [container bcftools_convert_10] unable to collect output from d41d8cd98f00b204e9800998ecf8427e+0:

```
with version 3.7.4 and 3.9.1 of Singularity. After reporting this issue on the [Arvados bug tracker](https://dev.arvados.org/issues/18489), its developers suggested that the issue is due to Singularity choosing the first `/dev/loopN` device that meets nearly all (but not all) of the criteria it needs:
* exists or can be created
* not already in use
* can be configured with the desired parameters (offset, size limit, flags, etc)

Once it has chosen a device that meets the first two criteria, it waits 1.5s for it to meet the third criterion, then gives up.

The Arvados developers (thanks @tomclegg) have analyzed the underlying issue, and based on their observations we have come up with a patch that does the following:

1. Move the `F_SETFD` and `CmdSetStatus64` syscalls into the "try each /dev/loopN" loop
2. If `CmdSetStatus64` returns `EAGAIN` or `EBUSY`, set `transientErrorFound` to `true`, and move on to try the next loop device
3. When all loop devices have been tried, return a `TransientAttachError`.
4. `AttachFromFile` was renamed to `attachFromFile`, and a new `AttachFromFile` method was written that loops for up to 5 times over `attachFromFile`, while it continues to return a `TransientAttachError`.

We have not managed to come up with a reproducer for this issue outside of Arvados Crunch, as its occurrence appears to be tied to the fact that the Singularity images are accessed through a Fuse mount (using the `arv-mount` command).


### This fixes or addresses the following GitHub issues:

 No issue was opened.


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)

CC @jrandall