### PR TITLE
fix: ensure gengodep uses vendor dir if present

### DIFF
--- a/makeit/gengodep
+++ b/makeit/gengodep
@@ -28,15 +28,9 @@ shift 4
 # get propagated down to go list.
 export GOPROXY
 
-if test -e "${srcdir}/vendor/modules.txt" ; then
-	mod_mode=vendor
-else
-	mod_mode=readonly
-fi
-
 template='{{ with $d := . }}{{ if not $d.Standard }}{{ range $d.GoFiles }}{{ printf "%s/%s\n" $d.Dir . }}{{ end }}{{ range $d.CgoFiles }}{{ printf "%s/%s\n" $d.Dir . }}{{ end }}{{ end }}{{ end }}'
 
-godeps=`${go} list -mod=${mod_mode} -deps -f "${template}" -tags "${gotags}" "$@" | sort -u`
+godeps=`${go} list -deps -f "${template}" -tags "${gotags}" "$@" | sort -u`
 
 for m in ${godeps}; do
     echo "$var += $m" >> ${depfile}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In a previous PR, initialization of the `srcdir` varible was removed from `makeit/gengodep`. However, the `gengodep` script was still using `srcdir` when checking for a `${srcdir}/vendor/modules.txt`.

Ref: https://github.com/sylabs/singularity/commit/48e7fab83e11a698adbd506d60e13fb375b00fec#

As a result, the vendor dir is never found, and `go` was run with `-mod=readonly`, which would lead to downloads.

Since go 1.14 the presence of a vendor dir infers `-mod=vendor` automatically, so we can just remove the handling here.

### This fixes or addresses the following GitHub issues:

 - Fixes #461 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
