### PR TITLE
fix: do not require working keyserver config in local build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   return code with `errnoRet` and `defaultErrnoRet`. Previously EPERM was hard
   coded. The example `etc/seccomp-profiles/default.json` has been updated.
 
+### Bug Fixes
+
+- Ensure a local build does not fail unnecessarily if a keyserver
+  config cannot be retrieved from the remote endpoint.
+
 ## v3.9.1 \[2021-11-22\]
 
 This is a security release for SingularityCE 3.9, addressing a security issue in


### PR DESCRIPTION
## Description of the Pull Request (PR):

At the CLI level, local builds had a hard fail if a keyserver config
could not be retrieved.

1) Warn instead of fail. For builds that perform verification of a
   SIF, it may still be possbile to verify using the local keyring.

2) Don't attempt to get a keyserver config at all, unless build
   definition has a bootstrap that will, or may provide a SIF source
   image (library/localimage/oras/shub).

### This fixes or addresses the following GitHub issues:

 - Fixes #465


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
