### PR TITLE
fix: do not require working keyserver config in local build (3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Ensure `gengodep` in build uses vendor dir when present.
 - Fix `source` of a script on `PATH` and scoping of environment variables in
   definition files (via dependency update).
+- Ensure a local build does not fail unnecessarily if a keyserver
+  config cannot be retrieved from the remote endpoint.
 
 ## v3.9.1 \[2021-11-22\]
 


### PR DESCRIPTION
Cherry-pick of #466 

## Description of the Pull Request (PR):

At the CLI level, local builds had a hard fail if a keyserver config
could not be retrieved.

1) Warn instead of fail. For builds that perform verification of a
   SIF it may still be possbile to verify using the local keyring.

2) Don't attempt to get a keyserver config at all, unless build
   definition has a bootstrap that will, or may provide a SIF source
   image (library/localimage/oras/shub).

### This fixes or addresses the following GitHub issues:

 - Fixes #465


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
