### PR TITLE
fix: Close loopFd in transient error path (release-3.9)

### DIFF
--- a/pkg/util/loop/loop.go
+++ b/pkg/util/loop/loop.go
@@ -222,6 +222,7 @@ func (loop *Device) attachLoop(image *os.File, mode int, number *int) error {
 		}
 
 		if _, _, err := syscall.Syscall(syscall.SYS_FCNTL, uintptr(loopFd), syscall.F_SETFD, syscall.FD_CLOEXEC); err != 0 {
+			syscall.Close(loopFd)
 			return fmt.Errorf("failed to set close-on-exec on loop device %s: %s", path, err.Error())
 		}
 
@@ -230,6 +231,7 @@ func (loop *Device) attachLoop(image *os.File, mode int, number *int) error {
 			syscall.Syscall(syscall.SYS_IOCTL, uintptr(loopFd), CmdClrFd, 0)
 			// EAGAIN and EBUSY will likely clear themselves... so track we hit one and keep trying
 			if err == syscall.EAGAIN || err == syscall.EBUSY {
+				syscall.Close(loopFd)
 				sylog.Debugf("transient error %v for loop device %d, continuing", err, device)
 				transientError = err
 				continue


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a transient error is hit in attachLoop, make sure we close loopFd
before continuing, so that we don't leak an fd.

Add the close to another fatal error path for code consistency - it's an
exit path so it isn't a necessity.

### This fixes or addresses the following GitHub issues:

 - Fixes #482 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
