### PR TITLE
fix: gpu: ensure MIGs available with --nvccli and no --contain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   return code with `errnoRet` and `defaultErrnoRet`. Previously EPERM was hard
   coded. The example `etc/seccomp-profiles/default.json` has been updated.
 
+### Bug fixes
+
+- Ensure MIGs are visible with `--nvccli` in non-contained mode, to match the
+  legacy GPU binding behaviour.
+
 ## v3.9.2 \[2021-12-10\]
 
 ### Bug fixes

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -800,11 +800,18 @@ func setNvCCLIConfig(engineConfig *singularityConfig.EngineConfig) (err error) {
 	sylog.Debugf("Using nvidia-container-cli for GPU setup")
 	engineConfig.SetNvCCLI(true)
 
-	// When we use --contain we don't mount the NV devices by default in the nvidia-container-cli flow,
-	// they must be mounted via specifying with`NVIDIA_VISIBLE_DEVICES`. This differs from the legacy
-	// flow which mounts all GPU devices, always.
-	if (IsContained || IsContainAll) && os.Getenv("NVIDIA_VISIBLE_DEVICES") == "" {
-		sylog.Warningf("When using nvidia-container-cli with --contain NVIDIA_VISIBLE_DEVICES must be set or no GPUs will be available in container.")
+	if os.Getenv("NVIDIA_VISIBLE_DEVICES") == "" {
+		if IsContained || IsContainAll {
+			// When we use --contain we don't mount the NV devices by default in the nvidia-container-cli flow,
+			// they must be mounted via specifying with`NVIDIA_VISIBLE_DEVICES`. This differs from the legacy
+			// flow which mounts all GPU devices, always... so warn the user.
+			sylog.Warningf("When using nvidia-container-cli with --contain NVIDIA_VISIBLE_DEVICES must be set or no GPUs will be available in container.")
+		} else {
+			// In non-contained mode set NVIDIA_VISIBLE_DEVICES="all" by default, so MIGs are available.
+			// Otherwise there is a difference vs legacy GPU binding. See Issue #471.
+			sylog.Infof("Setting 'NVIDIA_VISIBLE_DEVICES=all' to emulate legacy GPU binding.")
+			os.Setenv("NVIDIA_VISIBLE_DEVICES", "all")
+		}
 	}
 
 	// Pass NVIDIA_ env vars that will be converted to nvidia-container-cli options


### PR DESCRIPTION
## Description of the Pull Request (PR):

When using nvidia-container-cli to setup the GPUs in the container, we
need to force NVIDIA_VISIBLE_DEVICES=all to have an exact match to the
legacy GPU binding behaviour, where MIGs are available as well as
physical GPUs.

### This fixes or addresses the following GitHub issues:

 - Fixes #471 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
