### PR TITLE
fix: Don't prompt y/n to overwrite output in noninteractive build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   return code with `errnoRet` and `defaultErrnoRet`. Previously EPERM was hard
   coded. The example `etc/seccomp-profiles/default.json` has been updated.
 
+### Bug fixes
+
+- Don't prompt for y/n to overwrite an existing file when build is
+  called from a non-interactive environment. Fail with an error.
+
 ## v3.9.4 \[2022-01-19\]
 
 ### Bug fixes

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime"
+	"syscall"
 
 	ocitypes "github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
@@ -26,6 +27,7 @@ import (
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/image"
 	"github.com/sylabs/singularity/pkg/sylog"
+	"golang.org/x/term"
 )
 
 var buildArgs struct {
@@ -379,6 +381,10 @@ func checkBuildTarget(path string) error {
 			}
 		}
 		if !buildArgs.update && !forceOverwrite {
+			// If non-interactive, die... don't try to prompt the user y/n
+			if !term.IsTerminal(syscall.Stdin) {
+				return fmt.Errorf("build target '%s' already exists. Use --force if you want to overwrite it", f.Name())
+			}
 
 			question := fmt.Sprintf("Build target '%s' already exists and will be deleted during the build process. Do you want to continue? [N/y] ", f.Name())
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

If a `singularity build` is run without a terminal Stdin (i.e. non-interactive), fail quickly if the output file already exists. Don't get stuck trying to ask for a y/n that won't come.

This is a quick fix addressing this specific common location where a non-interactive build can get hung up... and there is a `--force` flag to be employed so nobody needs to pipe in a 'y'. 

Really there should be a proper review of where the interactive package is used, and sensible behavior of the functions for these types of uses. We maybe should have variant functions that e.g. fail or fall to a default if Stdin isn't a terminal. However we also need to consider usage that pipes in to answer a prompt (e.g. provide encryption passphrase) from another tool.

Will open a tech-debt issue for the above.

### This fixes or addresses the following GitHub issues:

 - Fixes #521 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
