### PR TITLE
fix: set OCI Process.Terminal: true in oci mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `make install` now installs man pages. A separate `make man` is not
   required.
+- `oci mount` sets `Process.Terminal: true` when creating an OCI `config.json`,
+  so that `oci run` provides expected interactive behavior by default.
+- Default hostname for `oci mount` containers is now `singularity` instead of
+  `mrsdalloway`.
 
 ### New features / functionalities
 

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -8,8 +8,6 @@ package oci
 import (
 	"encoding/json"
 	"io/ioutil"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/google/uuid"
@@ -17,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
-	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci"
 	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 	"github.com/sylabs/singularity/pkg/ociruntime"
 )
@@ -67,31 +64,11 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 		err = errors.Wrapf(err, "creating temporary bundle directory at %q", c.env.TestDir)
 		t.Fatalf("failed to create bundle directory: %+v", err)
 	}
-	ociConfig := filepath.Join(bundleDir, "config.json")
-
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci mount"),
 		e2e.WithArgs(c.env.ImagePath, bundleDir),
-		e2e.PostRun(func(t *testing.T) {
-			if t.Failed() {
-				t.Fatalf("failed to mount OCI bundle image")
-			}
-
-			g, err := oci.DefaultConfig()
-			if err != nil {
-				err = errors.Wrapf(err, "generating default OCI config for %q", runtime.GOOS)
-				t.Fatalf("failed to generate default OCI config: %+v", err)
-			}
-			g.SetProcessTerminal(true)
-
-			err = g.SaveToFile(ociConfig)
-			if err != nil {
-				err = errors.Wrapf(err, "saving OCI config at %q", ociConfig)
-				t.Fatalf("failed to save OCI config: %+v", err)
-			}
-		}),
 		e2e.ExpectExit(0),
 	)
 
@@ -125,7 +102,7 @@ func (c ctx) testOciRun(t *testing.T) {
 		e2e.WithArgs("-b", bundleDir, containerID),
 		e2e.ConsoleRun(
 			e2e.ConsoleSendLine("hostname"),
-			e2e.ConsoleExpect("mrsdalloway"),
+			e2e.ConsoleExpect("singularity"),
 			e2e.ConsoleSendLine("id -un"),
 			e2e.ConsoleExpect("root"),
 			e2e.ConsoleSendLine("exit"),
@@ -190,7 +167,7 @@ func (c ctx) testOciAttach(t *testing.T) {
 		e2e.WithArgs(containerID),
 		e2e.ConsoleRun(
 			e2e.ConsoleSendLine("hostname"),
-			e2e.ConsoleExpect("mrsdalloway"),
+			e2e.ConsoleExpect("singularity"),
 			e2e.ConsoleSendLine("exit"),
 		),
 		e2e.PostRun(func(t *testing.T) {

--- a/internal/pkg/runtime/engine/config/oci/config.go
+++ b/internal/pkg/runtime/engine/config/oci/config.go
@@ -52,7 +52,7 @@ func DefaultConfigV1() (*generate.Generator, error) {
 
 	config := specs.Spec{
 		Version:  specs.Version,
-		Hostname: "mrsdalloway",
+		Hostname: "singularity",
 	}
 
 	config.Root = &specs.Root{
@@ -60,7 +60,7 @@ func DefaultConfigV1() (*generate.Generator, error) {
 		Readonly: false,
 	}
 	config.Process = &specs.Process{
-		Terminal: false,
+		Terminal: true,
 		Args: []string{
 			"sh",
 		},


### PR DESCRIPTION
## Description of the Pull Request (PR):

When OCI mount creates a bundle it adds a default `config.json`. In this file, `Process.Terminal` was set to `false`. This means that an `oci run` of a container will not result in sensible interactive behavior, and the user's terminal will be broken.

`runc spec` and `crun spec` both set `Process.Terminal` to `true`, when creating a default config for a rootfs. I believe we should do the same so that sensible interactive behavior is the default.

Note that our e2e tests were already overriding the default config in this manner.

Also change the `mrsdalloway` default hostname to `singularity`.

### This fixes or addresses the following GitHub issues:

 - Fixes #532 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
