### PR TITLE
feat: enable native v2 unified cgroups config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Updated seccomp support allows use of seccomp profiles that set an error
   return code with `errnoRet` and `defaultErrnoRet`. Previously EPERM was hard
   coded. The example `etc/seccomp-profiles/default.json` has been updated.
+- Native cgroups v2 resource limits can be specified using the `[unified]` key
+  in a cgroups toml file applied via `--apply-cgroups`.
 
 ### Bug fixes
 

--- a/internal/pkg/cgroups/config_linux.go
+++ b/internal/pkg/cgroups/config_linux.go
@@ -167,8 +167,8 @@ type Config struct {
 	// Limits are a set of key value pairs that define RDMA resource limits,
 	// where the key is device name and value is resource limits.
 	Rdma map[string]LinuxRdma `toml:"rdma" json:"rdma,omitempty"`
-	// TODO: Enable support for native cgroup v2 resource specifications
-	// Unified map[string]string `toml:"unified" json:"unified,omitempty"`
+	// Native cgroups v2 unified hierarchy resource limits.
+	Unified map[string]string `toml:"unified" json:"unified,omitempty"`
 }
 
 // LoadConfig loads a cgroups config file into our native cgroups.Config struct

--- a/internal/pkg/cgroups/example/cgroups-unified.toml
+++ b/internal/pkg/cgroups/example/cgroups-unified.toml
@@ -1,0 +1,6 @@
+#
+# Cgroups configuration file example using unified key for cgroups v2 only
+#
+
+[unified]
+    "pids.max" = "512"

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -67,8 +67,7 @@ func (m *Manager) GetCgroupRootPath() (rootPath string, err error) {
 }
 
 // UpdateFromSpec updates the existing managed cgroup using configuration from
-// an OCI LinuxResources spec struct. The `Unified` key for native v2 cgroup
-// specifications is not yet supported.
+// an OCI LinuxResources spec struct.
 func (m *Manager) UpdateFromSpec(resources *specs.LinuxResources) (err error) {
 	if m.group == "" || m.cgroup == nil {
 		return ErrUnitialized
@@ -106,7 +105,7 @@ func (m *Manager) UpdateFromSpec(resources *specs.LinuxResources) (err error) {
 func (m *Manager) UpdateFromFile(path string) error {
 	spec, err := LoadResources(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("while loading cgroups file %s: %w", path, err)
 	}
 	return m.UpdateFromSpec(&spec)
 }

--- a/internal/pkg/cgroups/manager_linux_v2_test.go
+++ b/internal/pkg/cgroups/manager_linux_v2_test.go
@@ -25,6 +25,7 @@ func TestCgroupsV2(t *testing.T) {
 	require.CgroupsV2Unified(t)
 	t.Run("GetCgroupRootPath", testGetCgroupRootPathV2)
 	t.Run("NewUpdate", testNewUpdateV2)
+	t.Run("UpdateUnified", testUpdateUnifiedV2)
 	t.Run("AddProc", testAddProcV2)
 	t.Run("FreezeThaw", testFreezeThawV2)
 }
@@ -87,6 +88,27 @@ func testNewUpdateV2(t *testing.T) {
 	ensureInt(t, pidsMax, 512)
 }
 
+//nolint:dupl
+func testUpdateUnifiedV2(t *testing.T) {
+	test.EnsurePrivilege(t)
+	require.CgroupsV2Unified(t)
+
+	// Apply a 1024 pids.max limit using the v1 style config that sets [pids] limit
+	_, manager, cleanup := testManager(t)
+	defer cleanup()
+	pidsMax := filepath.Join("/sys/fs/cgroup", manager.group, "pids.max")
+	ensureInt(t, pidsMax, 1024)
+
+	// Update existing cgroup from unified style config setting [Unified] pids.max directly
+	if err := manager.UpdateFromFile("example/cgroups-unified.toml"); err != nil {
+		t.Fatalf("While updating cgroup: %v", err)
+	}
+
+	// Check pids.max is now 512
+	ensureInt(t, pidsMax, 512)
+}
+
+//nolint:dupl
 func testAddProcV2(t *testing.T) {
 	test.EnsurePrivilege(t)
 	require.CgroupsV2Unified(t)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow the `unified` key to be used in a cgroups config toml file, to directly apply resource limits using the v2 unified hierarchy, rather than v1 -> v2 translation.

### This fixes or addresses the following GitHub issues:

 - Fixes #538 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
