### PR TITLE
Switch centos:8 to almalinux:8 (release-3.9)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ executors:
   centos7:
     docker:
       - image: centos:7
-  centos8:
+  almalinux8:
     docker:
-      - image: centos:8
+      - image: almalinux:8
   ubuntu1804:
     docker:
       - image: ubuntu:18.04
@@ -294,7 +294,7 @@ workflows:
       - build-rpm:
           matrix:
             parameters:
-              e: ["centos7", "centos8"]
+              e: ["centos7", "almalinux8"]
       - build-deb:
           matrix:
             parameters:

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -285,9 +285,9 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 			from:                "centos:7",
 		},
 		{
-			name:                "CentOS_8",
+			name:                "AlmaLinux_8",
 			kernelMajorRequired: 3,
-			from:                "centos:8",
+			from:                "almalinux:8",
 		},
 		{
 			name:                "Ubuntu_1604",

--- a/examples/build-singularity/build-singularity.def
+++ b/examples/build-singularity/build-singularity.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: centos:8
+From: almalinux:8
 
 %post
     # Set build time env variable


### PR DESCRIPTION
## Description of the Pull Request (PR):

CentOS 8 is EOL. Switching to AlmaLinux as an EL compatible rebuild.

Cherry pick of #536 to release-3.9

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
