### PR TITLE
build: handle man pages with make install (release-3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Changed defaults / behaviours
+
+- `make install` now installs man pages. A separate `make man` is not
+  required.
+
+### Bug fixes
+
+- GitHub .deb packages correctly include man pages.
+
 ## v3.9.4 \[2022-01-19\]
 
 ### Bug fixes

--- a/debian/rules
+++ b/debian/rules
@@ -38,7 +38,7 @@ override_dh_auto_clean:
 override_dh_auto_configure:
 # Override the changelog file by adding an entry for our git-derived version number
 	dch -D unstable -v "$(srcver)-$(dist)" -M "See: https://github.com/sylabs/singularity/blob/master/CHANGELOG.md"
-	dch -r ""
+	dch -r "" -M
 
 	dh_auto_configure --builddirectory=_build
 # Reset permissions lost in the copy to _build/src on Ubuntu

--- a/debian/rules
+++ b/debian/rules
@@ -53,7 +53,8 @@ override_dh_auto_configure:
 	  --prefix=/usr \
 	  --sysconfdir=/etc \
 	  --libexecdir=/usr/lib/$(DEB_HOST_MULTIARCH) \
-	  --localstatedir=/var/lib
+	  --localstatedir=/var/lib \
+	  --mandir=/usr/share/man
 
 override_dh_auto_build:
 # build standard install

--- a/debian/singularity-ce.install
+++ b/debian/singularity-ce.install
@@ -13,3 +13,4 @@ etc/singularity/network/*
 etc/singularity/seccomp-profiles/*
 #etc/bash_completion.d/singularity/*
 var/lib/singularity/mnt/session
+usr/share/man/man1/singularity*

--- a/debian/singularity-ce.lintian-overrides
+++ b/debian/singularity-ce.lintian-overrides
@@ -1,0 +1,2 @@
+singularity-ce: binary-without-manpage usr/bin/run-singularity
+singularity-ce: setuid-binary usr/lib/x86_64-linux-gnu/singularity/bin/starter-suid 4755 root/root

--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -115,8 +115,7 @@ cd %{name}-%{version}
 export GOPATH=$PWD/gopath
 cd %{name}-@PACKAGE_VERSION@
 
-mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
-make -C builddir DESTDIR=$RPM_BUILD_ROOT install man
+make -C builddir DESTDIR=$RPM_BUILD_ROOT install
 
 %files
 %attr(4755, root, root) %{_libexecdir}/singularity/bin/starter-suid

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -7,6 +7,7 @@ all: $(ALL)
 
 .PHONY: man
 man: singularity
+	@printf " MAN\n"
 	mkdir -p $(DESTDIR)$(MANDIR)/man1
 	$(V)$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
 		$(SOURCEDIR)/cmd/docs/docs.go man --dir $(DESTDIR)$(MANDIR)/man1
@@ -128,7 +129,7 @@ clean:
 	$(V)rm -rf $(BUILDDIR)/mergeddeps cscope.* $(CLEANFILES)
 
 .PHONY: install
-install: $(INSTALLFILES)
+install: $(INSTALLFILES) man
 	@echo " DONE"
 
 -include $(BUILDDIR)/mergeddeps


### PR DESCRIPTION
## Description of the Pull Request (PR):

It's reasonable to expect that make install will install man pages,
but that hasn't been the case here... meaning we are somewhat unusual.

Have make install call the man target.

Ensure the resulting man pages are handled in the Debian package
properly.


### This fixes or addresses the following GitHub issues:

 - Fixes #512


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
