### PR TITLE
fix: remove subshell overhead in environment processing (release-3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 - GitHub .deb packages correctly include man pages.
 - Update dependency to correctly unset variables in container startup
   environment processing. Fixes regression in v3.9.2.
-
+- Remove subshell overhead when processing large environments on container
+  startup.
+  
 ## v3.9.4 \[2022-01-19\]
 
 ### Bug fixes

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,6 +1,6 @@
 # Copyright
 
-Copyright (c) 2017-2021, Sylabs, Inc. All rights reserved.
+Copyright (c) 2017-2022, Sylabs, Inc. All rights reserved.
 
 Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
 

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -696,27 +696,6 @@ func sylogBuiltin(ctx context.Context, argv []string) error {
 	return nil
 }
 
-// unescapeBuiltin returns a string, unescaping \n to a newline
-// Used to return newlines when we export a var in the action script
-func unescapeBuiltin(ctx context.Context, argv []string) error {
-	if len(argv) < 1 {
-		return fmt.Errorf("unescape builtin requires one argument")
-	}
-	hc := interp.HandlerCtx(ctx)
-	fmt.Fprintf(hc.Stdout, "%s", strings.Replace(argv[0], "\\n", "\n", -1))
-	return nil
-}
-
-// getEnvKeyBuiltin returns the KEY part of an environment variable.
-func getEnvKeyBuiltin(ctx context.Context, argv []string) error {
-	if len(argv) < 1 {
-		return fmt.Errorf("getenvkey builtin requires one argument")
-	}
-	hc := interp.HandlerCtx(ctx)
-	fmt.Fprintf(hc.Stdout, "%s\n", strings.SplitN(argv[0], "=", 2)[0])
-	return nil
-}
-
 // getAllEnvBuiltin display all exported variables in the form KEY=VALUE.
 func getAllEnvBuiltin(shell *interpreter.Shell) interpreter.ShellBuiltin {
 	return func(ctx context.Context, argv []string) error {
@@ -826,11 +805,9 @@ func runActionScript(engineConfig *singularityConfig.EngineConfig) ([]string, []
 
 	// register few builtin
 	shell.RegisterShellBuiltin("getallenv", getAllEnvBuiltin(shell))
-	shell.RegisterShellBuiltin("getenvkey", getEnvKeyBuiltin)
 	shell.RegisterShellBuiltin("sylog", sylogBuiltin)
 	shell.RegisterShellBuiltin("fixpath", fixPathBuiltin)
 	shell.RegisterShellBuiltin("hash", hashBuiltin)
-	shell.RegisterShellBuiltin("unescape", unescapeBuiltin)
 	shell.RegisterShellBuiltin("umask_builtin", umaskBuiltin)
 
 	// exec builtin won't execute the command but instead

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -38,7 +38,7 @@ clear_env() {
     set -o noglob
 
     for e in ${__exported_env__}; do
-        key=$(getenvkey "${e}")
+        key=${e%%=*}
         case "${key}" in
         PWD|HOME|OPTIND|UID|SINGULARITY_APPNAME|SINGULARITY_SHELL)
             ;;
@@ -68,9 +68,9 @@ restore_env() {
     # defined by docker or virtual file above, empty
     # variables are also unset
     for e in ${__exported_env__}; do
-        key=$(getenvkey "${e}")
+        key=${e%%=*}
         if ! test -v "${key}"; then
-            export "$(unescape ${e})"
+            export "${e//'\n'/$IFS}"
         elif test -z "${!key}"; then
             unset "${key}"
         fi


### PR DESCRIPTION
## Description of the Pull Request (PR):

The action script environment processing was calling out to
`getenvkey` and `unescape` go functions via subshell. This is
expensive, especially with large environments, as the environment
etc. must be duplicated for each subshell and other subshell setup
performed.

Replace these two go functions with shell var substitution syntax.

### This fixes or addresses the following GitHub issues:

 - Fixes #544


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
