### PR TITLE
fix: split man generation and install

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -5,13 +5,6 @@
 
 all: $(ALL)
 
-.PHONY: man
-man: singularity
-	@printf " MAN\n"
-	mkdir -p $(DESTDIR)$(MANDIR)/man1
-	$(V)$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
-		$(SOURCEDIR)/cmd/docs/docs.go man --dir $(DESTDIR)$(MANDIR)/man1
-
 .PHONY: collect
 collect:
 	@printf " DEPENDS\n"
@@ -129,7 +122,7 @@ clean:
 	$(V)rm -rf $(BUILDDIR)/mergeddeps cscope.* $(CLEANFILES)
 
 .PHONY: install
-install: $(INSTALLFILES) man
+install: $(INSTALLFILES)
 	@echo " DONE"
 
 -include $(BUILDDIR)/mergeddeps

--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -85,3 +85,19 @@ $(remote_config_INSTALL): $(remote_config)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(remote_config_INSTALL)
+
+man_pages := $(BUILDDIR)$(MANDIR)/man1
+$(man_pages): singularity
+	@echo " MAN" $@
+	mkdir -p $@
+	$(V)$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
+		$(SOURCEDIR)/cmd/docs/docs.go man --dir $@
+
+man_pages_INSTALL := $(DESTDIR)$(MANDIR)/man1
+$(man_pages_INSTALL): $(man_pages)
+	@echo " INSTALL" $@
+	$(V)umask 0022 && mkdir -p $@
+	$(V)install -m 0644 -t $@ $(man_pages)/*
+
+INSTALLFILES += $(man_pages_INSTALL)
+ALL += $(man_pages)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Make man page generation part of the `build_cli.mk` fragment, so that man pages are built under `make` and installed with `make install`.

What I should have originally done in #524 instead!

### This fixes or addresses the following GitHub issues:

 - Fixes #555

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
