### PR TITLE
tests: allow for cgroups freeze/thaw that isn't instant

### DIFF
--- a/internal/pkg/cgroups/manager_linux_test.go
+++ b/internal/pkg/cgroups/manager_linux_test.go
@@ -8,12 +8,14 @@ package cgroups
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sylabs/singularity/internal/pkg/test"
 	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
@@ -134,31 +136,49 @@ func ensureContainsInt(t *testing.T, path string, wantInt int64) {
 	t.Fatalf("%s did not contain expected value %d", path, wantInt)
 }
 
-// ensureState asserts that a process pid has the required state
-func ensureState(t *testing.T, pid int, wantStates string) {
+// ensureStateBecomes asserts that a process pid has any of the wanted
+// states, or reaches one of these states in a 5 second window.
+func ensureStateBecomes(t *testing.T, pid int, wantStates string) {
+	const retries = 5
+	const delay = time.Second
+
 	file, err := os.Open(fmt.Sprintf("/proc/%d/status", pid))
 	if err != nil {
 		t.Error(err)
 	}
 	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
 	procState := ""
 
-	for scanner.Scan() {
-		// State:	R (running)
-		if strings.HasPrefix(scanner.Text(), "State:\t") {
-			f := strings.Fields(scanner.Text())
-			if len(f) < 2 {
-				t.Errorf("Could not check process state - not enough fields: %s", scanner.Text())
+	for r := 0; r <= retries; r++ {
+		if r > 0 {
+			t.Logf("Process %d has state %q, need %q - retrying %d/%d", pid, procState, wantStates, r, retries)
+			time.Sleep(delay)
+		}
+
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			t.Fatalf("Could not seek to start of /proc/%d/status", pid)
+		}
+
+		scanner := bufio.NewScanner(file)
+
+		for scanner.Scan() {
+			// State:	R (running)
+			if strings.HasPrefix(scanner.Text(), "State:\t") {
+				f := strings.Fields(scanner.Text())
+				if len(f) < 2 {
+					t.Errorf("Could not check process state - not enough fields: %s", scanner.Text())
+				}
+				procState = f[1]
 			}
-			procState = f[1]
+		}
+
+		if strings.ContainsAny(procState, wantStates) {
+			return
 		}
 	}
 
-	if !strings.ContainsAny(procState, wantStates) {
-		t.Errorf("Process %d had state %q, expected state %q", pid, procState, wantStates)
-	}
+	t.Errorf("Process %d did not reach expected state %q", pid, wantStates)
 }
 
 // testManager returns a cgroup manager, that has created a cgroup with a `cat /dev/zero` process,

--- a/internal/pkg/cgroups/manager_linux_v1_test.go
+++ b/internal/pkg/cgroups/manager_linux_v1_test.go
@@ -191,8 +191,8 @@ func testFreezeThawV1(t *testing.T, systemd bool) {
 
 	manager.Freeze()
 	// cgroups v1 freeze is to uninterruptible sleep
-	ensureState(t, pid, "D")
+	ensureStateBecomes(t, pid, "D")
 
 	manager.Thaw()
-	ensureState(t, pid, "RS")
+	ensureStateBecomes(t, pid, "RS")
 }

--- a/internal/pkg/cgroups/manager_linux_v2_test.go
+++ b/internal/pkg/cgroups/manager_linux_v2_test.go
@@ -191,11 +191,11 @@ func testFreezeThawV2(t *testing.T, systemd bool) {
 	// cgroups v2 freeze is to interruptible sleep, which could actually occur
 	// for our cat /dev/zero while it's running, so check freeze marker as well
 	// as the process state here.
-	ensureState(t, pid, "S")
+	ensureStateBecomes(t, pid, "S")
 	freezePath := path.Join(manager.cgroup.Path(""), "cgroup.freeze")
 	ensureInt(t, freezePath, 1)
 
 	manager.Thaw()
-	ensureState(t, pid, "RS")
+	ensureStateBecomes(t, pid, "RS")
 	ensureInt(t, freezePath, 0)
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Freezing a cgroup is almost always instant for our trivial test cases... except when it isn't due to system load, slow qemu emulation of alternate architectures etc.

The Linux docs explicitly show this in their example :-)

    to freeze all tasks in the container :
       # echo FROZEN > /sys/fs/cgroup/freezer/0/freezer.state
       # cat /sys/fs/cgroup/freezer/0/freezer.state
       FREEZING
       # cat /sys/fs/cgroup/freezer/0/freezer.state
       FROZEN

Allow up to 5 retries, separated by 1 second for processes to be suspended in our tests.

Verified by running the tests in a hard loop on a loaded and slow constrained system, and observing behaviour.

### This fixes or addresses the following GitHub issues:

 - Fixes #565


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
