### PR TITLE
fix: bind libs to correct .so file for unsquashfs containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 
 - Don't prompt for y/n to overwrite an existing file when build is
   called from a non-interactive environment. Fail with an error.
+- Correct library bindings for `unsquashfs` containment. Fixes errors where
+  resolved library filename does not match library filename in binary (e.g. EL8,
+  POWER9 with glibc-hwcaps).
 
 ## v3.9.5 \[2022-02-04\]
 

--- a/internal/pkg/image/unpacker/squashfs_singularity.go
+++ b/internal/pkg/image/unpacker/squashfs_singularity.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -10,6 +10,7 @@
 package unpacker
 
 import (
+	"bufio"
 	"bytes"
 	"debug/elf"
 	"fmt"
@@ -18,7 +19,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
@@ -29,11 +29,18 @@ func init() {
 	cmdFunc = unsquashfsSandboxCmd
 }
 
-// getLibraries returns the libraries required by the elf binary,
-// the binary path must be absolute.
-func getLibraries(binary string) ([]string, error) {
-	libs := make([]string, 0)
+// libBind represents a library bind mount required by an elf binary
+// that will be run in a contained minimal filesystem.
+type libBind struct {
+	// source is the path to bind from, on the host.
+	source string
+	// dest is the path to bind to, inside the minimal filesystem.
+	dest string
+}
 
+// getLibraryBinds returns the library bind mounts required by an elf binary.
+// The binary path must be absolute.
+func getLibraryBinds(binary string) ([]libBind, error) {
 	exe, err := elf.Open(binary)
 	if err != nil {
 		return nil, err
@@ -61,7 +68,7 @@ func getLibraries(binary string) ([]string, error) {
 
 	// this is a static binary, nothing to do
 	if interp == "" {
-		return libs, nil
+		return []libBind{}, nil
 	}
 
 	// run interpreter to list library dependencies for the
@@ -85,25 +92,52 @@ func getLibraries(binary string) ([]string, error) {
 		return nil, fmt.Errorf("while getting library dependencies: %s\n%s", err, errBuf.String())
 	}
 
-	// parse the output to get matches for ' /an/absolute/path ('
-	re := regexp.MustCompile(`[[:blank:]]?(\/.*)[[:blank:]]\(`)
+	return parseLibraryBinds(buf)
+}
 
-	match := re.FindAllStringSubmatch(buf.String(), -1)
-	for _, m := range match {
-		if len(m) < 2 {
+// parseLibrary binds parses `ld-linux-x86-64.so.2 --list <binary>` output.
+// Returns a list of source->dest bind mounts required to run the binary
+// in a minimal contained filesystem.
+func parseLibraryBinds(buf io.Reader) ([]libBind, error) {
+	libs := make([]libBind, 0)
+	scanner := bufio.NewScanner(buf)
+
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
 			continue
 		}
-		lib := m[1]
-		has := false
-		for _, l := range libs {
-			if l == lib {
-				has = true
-				break
-			}
+		// /lib64/ld64.so.2 (0x00007fff96c60000)
+		// Absolute path in 1st field - bind directly dest=source
+		if filepath.IsAbs(fields[0]) {
+			libs = append(libs, libBind{
+				source: fields[0],
+				dest:   fields[0],
+			})
+			continue
 		}
-		if !has {
-			libs = append(libs, lib)
+		// libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fff96a20000)
+		//    .. or with glibc-hwcaps ..
+		// libpthread.so.0 => /lib64/glibc-hwcaps/power9/libpthread-2.28.so (0x00007fff96a20000)
+		//
+		// Bind resolved lib to same dir, but with .so filename from 1st field.
+		// e.g. source is: /lib64/glibc-hwcaps/power9/libpthread-2.28.so
+		//      dest is  : /lib64/glibc-hwcaps/power9/libpthread.so.0
+		if len(fields) >= 3 && fields[1] == "=>" {
+			destDir := filepath.Dir(fields[2])
+			dest := filepath.Join(destDir, fields[0])
+			libs = append(libs, libBind{
+				source: fields[2],
+				dest:   dest,
+			})
 		}
+		// linux-vdso64.so.1 (0x00007fff96c40000)
+		//   .. or anything else
+		// No absolute path = nothing to bind
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("while parsing library dependencies: %v", err)
 	}
 
 	return libs, nil
@@ -172,46 +206,58 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 		filename = filepath.Join(rootfsImageDir, filepath.Base(filename))
 	}
 
-	// get the library dependencies of unsquashfs
-	libs, err := getLibraries(unsquashfs)
-	if err != nil {
-		return nil, err
-	}
-	libraryPath := make([]string, 0)
-
 	roFiles := []string{
 		unsquashfs,
 	}
 
-	// add libraries for bind mount and also generate
-	// LD_LIBRARY_PATH
+	// get the library dependencies of unsquashfs
+	libs, err := getLibraryBinds(unsquashfs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle binding of files
+	for _, b := range roFiles {
+		// Ensure parent dir and file exist in container
+		rootfsFile := filepath.Join(rootfs, b)
+		rootfsDir := filepath.Dir(rootfsFile)
+		if err := os.MkdirAll(rootfsDir, 0o700); err != nil {
+			return nil, fmt.Errorf("while creating %s: %s", rootfsDir, err)
+		}
+		if err := ioutil.WriteFile(rootfsFile, []byte(""), 0o600); err != nil {
+			return nil, fmt.Errorf("while creating %s: %s", rootfsFile, err)
+		}
+		// Simple read-only bind, dest in container same as source on host
+		args = append(args, "-B", fmt.Sprintf("%s:%s:ro", b, b))
+	}
+
+	// Handle binding of libs and generate LD_LIBRARY_PATH
+	libraryPath := make([]string, 0)
 	for _, l := range libs {
-		dir := filepath.Dir(l)
-		roFiles = append(roFiles, l)
+		// Ensure parent dir and file exist in container
+		rootfsFile := filepath.Join(rootfs, l.dest)
+		rootfsDir := filepath.Dir(rootfsFile)
+		if err := os.MkdirAll(rootfsDir, 0o700); err != nil {
+			return nil, fmt.Errorf("while creating %s: %s", rootfsDir, err)
+		}
+		if err := ioutil.WriteFile(rootfsFile, []byte(""), 0o600); err != nil {
+			return nil, fmt.Errorf("while creating %s: %s", rootfsFile, err)
+		}
+		// Read only bind, dest in container may not match source on host due
+		// to .so symlinking (see getLibraryBinds comments).
+		args = append(args, "-B", fmt.Sprintf("%s:%s:ro", l.source, l.dest))
+		// If dir of lib not already in the LD_LIBRARY_PATH, add it.
 		has := false
+		libraryDir := filepath.Dir(l.dest)
 		for _, lp := range libraryPath {
-			if lp == dir {
+			if lp == libraryDir {
 				has = true
 				break
 			}
 		}
 		if !has {
-			libraryPath = append(libraryPath, dir)
+			libraryPath = append(libraryPath, libraryDir)
 		}
-	}
-
-	// create files and directories in the sandbox and
-	// add singularity bind mount options
-	for _, b := range roFiles {
-		file := filepath.Join(rootfs, b)
-		dir := filepath.Dir(file)
-		if err := os.MkdirAll(dir, 0o700); err != nil {
-			return nil, fmt.Errorf("while creating %s: %s", dir, err)
-		}
-		if err := ioutil.WriteFile(file, []byte(""), 0o600); err != nil {
-			return nil, fmt.Errorf("while creating %s: %s", file, err)
-		}
-		args = append(args, "-B", fmt.Sprintf("%s:%s:ro", b, b))
 	}
 
 	// singularity sandbox

--- a/internal/pkg/image/unpacker/squashfs_singularity_test.go
+++ b/internal/pkg/image/unpacker/squashfs_singularity_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build singularity_engine
+// +build singularity_engine
+
+package unpacker
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Library listing on Fedora 35 AMD64 - simple case
+// $ /lib64/ld-linux-x86-64.so.2 --list /usr/sbin/unsquashfs
+const ldListSimple = `        linux-vdso.so.1 (0x00007ffe9ebcb000)
+        libm.so.6 => /lib64/libm.so.6 (0x00007f5dd1e6a000)
+        libz.so.1 => /lib64/libz.so.1 (0x00007f5dd1e50000)
+        liblzma.so.5 => /lib64/liblzma.so.5 (0x00007f5dd1e24000)
+        liblzo2.so.2 => /lib64/liblzo2.so.2 (0x00007f5dd1e03000)
+        liblz4.so.1 => /lib64/liblz4.so.1 (0x00007f5dd1ddf000)
+        libzstd.so.1 => /lib64/libzstd.so.1 (0x00007f5dd1d30000)
+        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f5dd1d13000)
+        libc.so.6 => /lib64/libc.so.6 (0x00007f5dd1b09000)
+        /lib64/ld-linux-x86-64.so.2 (0x00007f5dd2104000)`
+
+// Library listing on EL8 POWER8 - complex case
+// glibc-hwcaps and dependency filename not matching resolved filename
+// $ /lib64/ld64.so.2 --list /usr/sbin/unsquashfs
+const ldListComplex = `        linux-vdso64.so.1 (0x00007fff80d70000)
+        libpthread.so.0 => /lib64/glibc-hwcaps/power9/libpthread-2.28.so (0x00007fff80b50000)
+        libm.so.6 => /lib64/glibc-hwcaps/power9/libm-2.28.so (0x00007fff80a20000)
+        libz.so.1 => /lib64/libz.so.1 (0x00007fff809e0000)
+        liblzma.so.5 => /lib64/liblzma.so.5 (0x00007fff80980000)
+        liblzo2.so.2 => /lib64/liblzo2.so.2 (0x00007fff80930000)
+        liblz4.so.1 => /lib64/liblz4.so.1 (0x00007fff808e0000)
+        libc.so.6 => /lib64/glibc-hwcaps/power9/libc-2.28.so (0x00007fff806d0000)
+        /lib64/ld64.so.2 (0x00007fff80d90000)`
+
+func Test_parseLibraryBinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		ldList  string
+		want    []libBind
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			ldList:  "",
+			want:    []libBind{},
+			wantErr: false,
+		},
+		{
+			name:   "simple",
+			ldList: ldListSimple,
+			want: []libBind{
+				{"/lib64/libm.so.6", "/lib64/libm.so.6"},
+				{"/lib64/libz.so.1", "/lib64/libz.so.1"},
+				{"/lib64/liblzma.so.5", "/lib64/liblzma.so.5"},
+				{"/lib64/liblzo2.so.2", "/lib64/liblzo2.so.2"},
+				{"/lib64/liblz4.so.1", "/lib64/liblz4.so.1"},
+				{"/lib64/libzstd.so.1", "/lib64/libzstd.so.1"},
+				{"/lib64/libgcc_s.so.1", "/lib64/libgcc_s.so.1"},
+				{"/lib64/libc.so.6", "/lib64/libc.so.6"},
+				{"/lib64/ld-linux-x86-64.so.2", "/lib64/ld-linux-x86-64.so.2"},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "complex",
+			ldList: ldListComplex,
+			want: []libBind{
+				{
+					"/lib64/glibc-hwcaps/power9/libpthread-2.28.so",
+					"/lib64/glibc-hwcaps/power9/libpthread.so.0",
+				},
+				{"/lib64/glibc-hwcaps/power9/libm-2.28.so", "/lib64/glibc-hwcaps/power9/libm.so.6"},
+				{"/lib64/libz.so.1", "/lib64/libz.so.1"},
+				{"/lib64/liblzma.so.5", "/lib64/liblzma.so.5"},
+				{"/lib64/liblzo2.so.2", "/lib64/liblzo2.so.2"},
+				{"/lib64/liblz4.so.1", "/lib64/liblz4.so.1"},
+				{"/lib64/glibc-hwcaps/power9/libc-2.28.so", "/lib64/glibc-hwcaps/power9/libc.so.6"},
+				{"/lib64/ld64.so.2", "/lib64/ld64.so.2"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := strings.NewReader(tt.ldList)
+			got, err := parseLibraryBinds(buf)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseLibraryBinds() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseLibraryBinds() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

When running `unsquashfs` in a minimal container, we need to bind in the libraries that it requires. In some circumstances, the filename of `.so` that the loader is looking for may not much the filename of the resolved library through symlinks etc.

E.g. on EL8, POWER9 with glibc-hwcaps we have:

```
libpthread.so.0 => /lib64/glibc-hwcaps/power9/libpthread-2.28.so (0x00007fff96a20000)
```

In this case we have to bind `libpthread-2.28.so` into the container as `libpthread.so.0` as we are not creating symlinks, and the loader is looking for `libpthread.so.0` and won't find `libpthread-2.28.so`.

### This fixes or addresses the following GitHub issues:

 - Fixes #571 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
