### PR TITLE
fix: Handle old EL7 library list format

### DIFF
--- a/internal/pkg/image/unpacker/squashfs_singularity.go
+++ b/internal/pkg/image/unpacker/squashfs_singularity.go
@@ -123,7 +123,7 @@ func parseLibraryBinds(buf io.Reader) ([]libBind, error) {
 		// Bind resolved lib to same dir, but with .so filename from 1st field.
 		// e.g. source is: /lib64/glibc-hwcaps/power9/libpthread-2.28.so
 		//      dest is  : /lib64/glibc-hwcaps/power9/libpthread.so.0
-		if len(fields) >= 3 && fields[1] == "=>" {
+		if len(fields) >= 3 && fields[1] == "=>" && filepath.IsAbs(fields[2]) {
 			destDir := filepath.Dir(fields[2])
 			dest := filepath.Join(destDir, fields[0])
 			libs = append(libs, libBind{
@@ -132,6 +132,7 @@ func parseLibraryBinds(buf io.Reader) ([]libBind, error) {
 			})
 		}
 		// linux-vdso64.so.1 (0x00007fff96c40000)
+		// linux-vdso64.so.1 =>  (0x00007fff96c40000)
 		//   .. or anything else
 		// No absolute path = nothing to bind
 	}

--- a/internal/pkg/image/unpacker/squashfs_singularity_test.go
+++ b/internal/pkg/image/unpacker/squashfs_singularity_test.go
@@ -40,6 +40,18 @@ const ldListComplex = `        linux-vdso64.so.1 (0x00007fff80d70000)
         libc.so.6 => /lib64/glibc-hwcaps/power9/libc-2.28.so (0x00007fff806d0000)
         /lib64/ld64.so.2 (0x00007fff80d90000)`
 
+// Library listing on EL7 - old case
+// The linux-vdso.so.1 line has a => field that doesn't point to an absolute path
+const ldListOld = `        linux-vdso.so.1 =>  (0x00007ffccf1de000)
+        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f5ab0e3d000)
+        libm.so.6 => /lib64/libm.so.6 (0x00007f5ab0b3b000)
+        libz.so.1 => /lib64/libz.so.1 (0x00007f5ab0925000)
+        liblzma.so.5 => /lib64/liblzma.so.5 (0x00007f5ab06ff000)
+        liblzo2.so.2 => /lib64/liblzo2.so.2 (0x00007f5ab04de000)
+        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f5ab02c8000)
+        libc.so.6 => /lib64/libc.so.6 (0x00007f5aafefa000)
+        /lib64/ld-linux-x86-64.so.2 (0x00007f5ab1059000)`
+
 func Test_parseLibraryBinds(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -84,6 +96,21 @@ func Test_parseLibraryBinds(t *testing.T) {
 				{"/lib64/liblz4.so.1", "/lib64/liblz4.so.1"},
 				{"/lib64/glibc-hwcaps/power9/libc-2.28.so", "/lib64/glibc-hwcaps/power9/libc.so.6"},
 				{"/lib64/ld64.so.2", "/lib64/ld64.so.2"},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "old",
+			ldList: ldListOld,
+			want: []libBind{
+				{"/lib64/libpthread.so.0", "/lib64/libpthread.so.0"},
+				{"/lib64/libm.so.6", "/lib64/libm.so.6"},
+				{"/lib64/libz.so.1", "/lib64/libz.so.1"},
+				{"/lib64/liblzma.so.5", "/lib64/liblzma.so.5"},
+				{"/lib64/liblzo2.so.2", "/lib64/liblzo2.so.2"},
+				{"/lib64/libgcc_s.so.1", "/lib64/libgcc_s.so.1"},
+				{"/lib64/libc.so.6", "/lib64/libc.so.6"},
+				{"/lib64/ld-linux-x86-64.so.2", "/lib64/ld-linux-x86-64.so.2"},
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
## Description of the Pull Request (PR):

Refine the unsquashfs library discovery to accommodate the output of the loader --list on EL7, where it outputs a `=>` field even when the arrow isn't going to point to a path.

### This fixes or addresses the following GitHub issues:

 - Fixes #582 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
