### PR TITLE
CI Updates (release-3.9)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ executors:
       - image: ubuntu:20.04
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.43
+      - image: golangci/golangci-lint:v1.44
   ubuntu-machine:
     machine:
       image: ubuntu-2004:202111-02

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.17.6'
+    default: '1.17.7'
 
 executors:
   node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ parameters:
 executors:
   node:
     docker:
-      - image: node:16-slim
+      - image: node:17-slim
   golang:
     parameters:
       variant:
@@ -288,7 +288,6 @@ jobs:
           command: singularity version
       - store_artifacts:
           path: ~/deb
-
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ executors:
       - image: golangci/golangci-lint:v1.43
   ubuntu-machine:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:202111-02
 
 commands:
   check-changes:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
   disable-all: true
   enable-all: false
   enable:
+    - containedctx
     - contextcheck
     - deadcode
     - decorder

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - govet
     - grouper
     - ineffassign
+    - maintidx
     - misspell
     - nakedret
     - revive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,11 +17,13 @@ linters:
   enable:
     - contextcheck
     - deadcode
+    - decorder
     - dupl
     - gofumpt
     - goimports
     - gosimple
     - govet
+    - grouper
     - ineffassign
     - misspell
     - nakedret

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,7 +49,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.17.6 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.17.7 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -167,6 +167,7 @@ func setNoMountFlags(c *singularityConfig.EngineConfig) {
 }
 
 // TODO: Let's stick this in another file so that that CLI is just CLI
+//nolint:maintidx
 func execStarter(cobraCmd *cobra.Command, image string, args []string, name string) {
 	var err error
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -1053,6 +1053,7 @@ func (c actionTests) actionNetwork(t *testing.T) {
 	}
 }
 
+//nolint:maintidx
 func (c actionTests) actionBinds(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
@@ -1761,6 +1762,7 @@ func (c actionTests) fuseMount(t *testing.T) {
 	}
 }
 
+//nolint:maintidx
 func (c actionTests) bindImage(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -95,6 +95,7 @@ func (c *configTests) prepImages(t *testing.T) (cleanup func(t *testing.T)) {
 	return cleanup
 }
 
+//nolint:maintidx
 func (c configTests) configGlobal(t *testing.T) {
 	cleanup := c.prepImages(t)
 	defer cleanup(t)

--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -26,6 +26,7 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
+//nolint:maintidx
 func (c *ctx) eclConfig(t *testing.T) {
 	tmpDir, remove := e2e.MakeTempDir(t, "", "ecl-", "ECL")
 	pgpDir, _ := e2e.MakeSyPGPDir(t, tmpDir)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -540,6 +540,7 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 	}
 }
 
+//nolint:maintidx
 func (c imgBuildTests) buildDefinition(t *testing.T) {
 	tmpfile, err := e2e.WriteTempFile(c.env.TestDir, "testFile-", testFileContent)
 	if err != nil {

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -30,6 +30,7 @@ const (
 	containerTesterDEF = "testdata/inspecter_container.def"
 )
 
+//nolint:maintidx
 func (c ctx) singularityInspect(t *testing.T) {
 	testDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "inspect-", "")
 	defer cleanup(t)

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -465,6 +465,7 @@ func ExpectExit(code int, resultOps ...SingularityCmdResultOp) SingularityCmdOp 
 // cmdPath specifies the path to the singularity binary and cmdOps
 // provides a list of operations to be executed before or after running
 // the command.
+//nolint:maintidx
 func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 	t.Helper()
 

--- a/internal/app/singularity/remote_add_test.go
+++ b/internal/app/singularity/remote_add_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -88,6 +88,7 @@ func createValidCfgFile(t *testing.T) string {
 	return path
 }
 
+//nolint:maintidx
 func TestRemoteAdd(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -82,6 +82,7 @@ func TestMakeParentDir(t *testing.T) {
 
 // TestCopyFromHost tests that copying non-nested source dirs, files, links to various
 // destinations works. CopyFromHost should always resolve symlinks.
+//nolint:maintidx
 func TestCopyFromHost(t *testing.T) {
 	// create tmpdir
 	dir, err := ioutil.TempDir("", "copy-test-src-")
@@ -480,6 +481,7 @@ func TestCopyFromHostNested(t *testing.T) {
 // TestCopyFromStage tests that copying non-nested source dirs, files, links to various
 // destinations works. CopyFromStage should resolve top-level symlinks for sources it is
 // called against.
+//nolint:maintidx
 func TestCopyFromStage(t *testing.T) {
 	// create tmpdir
 	srcRoot, err := ioutil.TempDir("", "copy-test-src-")

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -380,7 +380,7 @@ func TestNewImageSource(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		ctx       context.Context
+		ctx       context.Context //nolint:containedctx
 		sys       *types.SystemContext
 		shallPass bool
 	}{

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -50,6 +50,7 @@ func machine() (string, error) {
 }
 
 // Get downloads container information from the specified source
+//nolint:maintidx
 func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err error) {
 	var suseconnectProduct, suseconnectModver string
 	var suseconnectPath string

--- a/internal/pkg/runtime/engine/config/oci/generate/generate_test.go
+++ b/internal/pkg/runtime/engine/config/oci/generate/generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -18,6 +18,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
+//nolint:maintidx
 func TestGenerate(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/internal/pkg/runtime/engine/oci/create_linux.go
+++ b/internal/pkg/runtime/engine/oci/create_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -156,6 +156,7 @@ var statusChan = make(chan string, 1)
 //
 // However, most likely this still will be executed as root since `singularity oci`
 // command set requires privileged execution.
+//nolint:maintidx
 func (e *EngineOperations) CreateContainer(ctx context.Context, pid int, rpcConn net.Conn) error {
 	var err error
 

--- a/internal/pkg/runtime/engine/oci/prepare_linux.go
+++ b/internal/pkg/runtime/engine/oci/prepare_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -33,6 +33,7 @@ var (
 // dropped by the time PrepareConfig is called. However, most likely this
 // still will be executed as root since `singularity oci` command set
 // requires privileged execution.
+//nolint:maintidx
 func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	if e.CommonConfig.EngineName != Name {
 		return fmt.Errorf("incorrect engine")

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -86,6 +86,7 @@ type container struct {
 	devSourcePath string
 }
 
+//nolint:maintidx
 func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 	var err error
 
@@ -1291,6 +1292,7 @@ func (c *container) addSessionDevMount(system *mount.System) error {
 	return nil
 }
 
+//nolint:maintidx
 func (c *container) addDevMount(system *mount.System) error {
 	sylog.Debugf("Checking configuration file for 'mount dev'")
 

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -644,6 +644,7 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 
 // prepareInstanceJoinConfig is responsible for getting and
 // applying configuration to join a running instance.
+//nolint:maintidx
 func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Config) error {
 	name := instance.ExtractName(e.EngineConfig.GetImage())
 	file, err := instance.Get(name, instance.SingSubDir)

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -56,6 +56,7 @@ const defaultShell = "/bin/sh"
 // No additional privileges can be gained during this call (unless container
 // is executed as root intentionally) as starter will set uid/euid/suid
 // to the targetUID (PrepareConfig will set it by calling starter.Config.SetTargetUID).
+//nolint:maintidx
 func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 	// Manage all signals.
 	// Queue them until they're ready to be handled below.

--- a/internal/pkg/util/fs/mount/mount_linux_test.go
+++ b/internal/pkg/util/fs/mount/mount_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -313,6 +313,7 @@ func TestAddPropagation(t *testing.T) {
 	points.RemoveAll()
 }
 
+//nolint:maintidx
 func TestImport(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/pkg/sypgp/keyring.go
+++ b/pkg/sypgp/keyring.go
@@ -27,7 +27,7 @@ func PublicKeyRing() (openpgp.KeyRing, error) {
 // the openpgp.KeyRing interface.
 type hybridKeyRing struct {
 	local openpgp.KeyRing // Local keyring.
-	ctx   context.Context // Context, for use when retrieving keys remotely.
+	ctx   context.Context //nolint:containedctx // Context, for use when retrieving keys remotely.
 	c     *client.Client  // Keyserver client.
 }
 


### PR DESCRIPTION
Bump Go to 1.17.7. Use latest `ubuntu-machine` image. Bump Node to 17.x. Bump `golangci-lint` to 1.44, and enable `containedctx`, `decorder`, `grouper` and `maintidx` linters.