### PR TITLE
Adopt Go 1.18 (master)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.17.7'
+    default: '1.18'
 
 executors:
   node:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -51,7 +51,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.17.8 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.18 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz

--- a/cmd/starter/engines/fakeroot_linux.go
+++ b/cmd/starter/engines/fakeroot_linux.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build fakeroot_engine
-// +build fakeroot_engine
 
 package engines
 

--- a/cmd/starter/engines/singularity_linux.go
+++ b/cmd/starter/engines/singularity_linux.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build singularity_engine
-// +build singularity_engine
 
 package engines
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -4,7 +4,6 @@
 // rights to use or distribute this software.
 
 //go:build e2e_test
-// +build e2e_test
 
 package e2e
 

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,14 @@
 module github.com/sylabs/singularity
 
-go 1.16
+go 1.17
 
 require (
-	github.com/AdamKorcz/go-fuzz-headers v0.0.0-20210319161527-f761c2329661 // indirect
 	github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667
 	github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f
 	github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60
 	github.com/apex/log v1.9.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/buger/jsonparser v1.1.1
-	github.com/bugsnag/bugsnag-go v1.5.1 // indirect
-	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/containerd/containerd v1.6.2
 	github.com/containernetworking/cni v1.0.1
 	github.com/containernetworking/plugins v1.1.1
@@ -23,9 +20,6 @@ require (
 	github.com/go-log/log v0.2.0
 	github.com/google/uuid v1.3.0
 	github.com/gosimple/slug v1.12.0
-	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
-	github.com/kr/pty v1.1.8 // indirect
-	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20211202193544-a5463b7f9c84
@@ -44,18 +38,115 @@ require (
 	github.com/sylabs/scs-key-client v0.7.2
 	github.com/sylabs/scs-library-client v1.2.2
 	github.com/sylabs/sif/v2 v2.4.1
-	github.com/urfave/cli v1.22.5 // indirect
 	github.com/vbauerster/mpb/v4 v4.12.2
 	github.com/vbauerster/mpb/v6 v6.0.4
-	github.com/yvasiyarov/go-metrics v0.0.0-20150112132944-c25f46c4b940 // indirect
-	github.com/yvasiyarov/gorelic v0.0.6 // indirect
-	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.1.0
 	mvdan.cc/sh/v3 v3.4.3
 	oras.land/oras-go v1.1.0
+)
+
+require (
+	github.com/AdamKorcz/go-fuzz-headers v0.0.0-20210319161527-f761c2329661 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/BurntSushi/toml v1.0.0 // indirect
+	github.com/Microsoft/go-winio v0.5.1 // indirect
+	github.com/Microsoft/hcsshim v0.9.2 // indirect
+	github.com/VividCortex/ewma v1.2.0 // indirect
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
+	github.com/alexflint/go-filemutex v1.1.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/bugsnag/bugsnag-go v1.5.1 // indirect
+	github.com/bugsnag/panicwrap v1.2.0 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/cilium/ebpf v0.7.0 // indirect
+	github.com/containerd/cgroups v1.0.3 // indirect
+	github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a // indirect
+	github.com/containers/ocicrypt v1.1.2 // indirect
+	github.com/containers/storage v1.38.2 // indirect
+	github.com/coreos/go-iptables v0.6.0 // indirect
+	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/creack/pty v1.1.15 // indirect
+	github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c // indirect
+	github.com/d2g/dhcp4client v1.0.0 // indirect
+	github.com/docker/cli v20.10.11+incompatible // indirect
+	github.com/docker/distribution v2.8.0+incompatible // indirect
+	github.com/docker/docker-credential-helpers v0.6.4 // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-metrics v0.0.1 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/godbus/dbus/v5 v5.0.6 // indirect
+	github.com/gofrs/uuid v4.0.0+incompatible // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/gosimple/unidecode v1.0.1 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
+	github.com/klauspost/compress v1.14.4 // indirect
+	github.com/klauspost/pgzip v1.2.5 // indirect
+	github.com/kr/pty v1.1.8 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/miekg/pkcs11 v1.0.3 // indirect
+	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/sys/mount v0.2.0 // indirect
+	github.com/moby/sys/mountinfo v0.5.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/networkplumbing/go-nft v0.2.0 // indirect
+	github.com/proglottis/gpgme v0.1.1 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.30.0 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rootless-containers/proto v0.1.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 // indirect
+	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
+	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/urfave/cli v1.22.5 // indirect
+	github.com/vbatts/go-mtree v0.5.0 // indirect
+	github.com/vbatts/tar-split v0.11.2 // indirect
+	github.com/vbauerster/mpb/v7 v7.3.2 // indirect
+	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5 // indirect
+	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/yvasiyarov/go-metrics v0.0.0-20150112132944-c25f46c4b940 // indirect
+	github.com/yvasiyarov/gorelic v0.0.6 // indirect
+	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
+	go.etcd.io/bbolt v1.3.6 // indirect
+	go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
+	golang.org/x/net v0.0.0-20220107192237-5cfca573fb4d // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368 // indirect
+	google.golang.org/grpc v1.43.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )
 
 // Temporarily force an image-spec that has the main branch commits not in 1.0.2 which is being brought in by oras-go

--- a/internal/pkg/image/unpacker/squashfs_no_singularity.go
+++ b/internal/pkg/image/unpacker/squashfs_no_singularity.go
@@ -1,11 +1,10 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build !singularity_engine
-// +build !singularity_engine
 
 package unpacker
 

--- a/internal/pkg/image/unpacker/squashfs_singularity.go
+++ b/internal/pkg/image/unpacker/squashfs_singularity.go
@@ -5,7 +5,6 @@
 // rights to use or distribute this software.
 
 //go:build singularity_engine
-// +build singularity_engine
 
 package unpacker
 

--- a/internal/pkg/image/unpacker/squashfs_singularity_test.go
+++ b/internal/pkg/image/unpacker/squashfs_singularity_test.go
@@ -4,7 +4,6 @@
 // rights to use or distribute this software.
 
 //go:build singularity_engine
-// +build singularity_engine
 
 package unpacker
 

--- a/internal/pkg/runtime/engine/singularity/plugins_linux.go
+++ b/internal/pkg/runtime/engine/singularity/plugins_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -11,7 +11,6 @@
 // The build system will pick it up from here.
 
 //go:build cni_plugins
-// +build cni_plugins
 
 package singularity
 

--- a/internal/pkg/security/apparmor/apparmor_supported.go
+++ b/internal/pkg/security/apparmor/apparmor_supported.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build apparmor
-// +build apparmor
 
 package apparmor
 

--- a/internal/pkg/security/apparmor/apparmor_unsupported.go
+++ b/internal/pkg/security/apparmor/apparmor_unsupported.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build !apparmor
-// +build !apparmor
 
 package apparmor
 

--- a/internal/pkg/security/seccomp/seccomp_supported.go
+++ b/internal/pkg/security/seccomp/seccomp_supported.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build seccomp
-// +build seccomp
 
 package seccomp
 

--- a/internal/pkg/security/seccomp/seccomp_supported_test.go
+++ b/internal/pkg/security/seccomp/seccomp_supported_test.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build seccomp
-// +build seccomp
 
 package seccomp
 

--- a/internal/pkg/security/seccomp/seccomp_unsupported.go
+++ b/internal/pkg/security/seccomp/seccomp_unsupported.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build !seccomp
-// +build !seccomp
 
 package seccomp
 

--- a/internal/pkg/security/selinux/selinux_supported.go
+++ b/internal/pkg/security/selinux/selinux_supported.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build selinux
-// +build selinux
 
 package selinux
 

--- a/internal/pkg/security/selinux/selinux_unsupported.go
+++ b/internal/pkg/security/selinux/selinux_unsupported.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build !selinux
-// +build !selinux
 
 package selinux
 

--- a/internal/pkg/util/gpu/paths_test.go
+++ b/internal/pkg/util/gpu/paths_test.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build linux
-// +build linux
 
 package gpu
 

--- a/internal/pkg/util/user/cgo_lookup_unix.go
+++ b/internal/pkg/util/user/cgo_lookup_unix.go
@@ -3,11 +3,8 @@
 // license that can be found in the LICENSE file.
 
 //go:build (aix || darwin || dragonfly || freebsd || (!android && linux) || netbsd || openbsd || solaris) && cgo && !osusergo
-// +build aix darwin dragonfly freebsd !android,linux netbsd openbsd solaris
-// +build cgo
-// +build !osusergo
 
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build integration_test
-// +build integration_test
 
 package network
 

--- a/pkg/sylog/sylog.go
+++ b/pkg/sylog/sylog.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build sylog
-// +build sylog
 
 package sylog
 

--- a/pkg/sylog/sylog_dummy.go
+++ b/pkg/sylog/sylog_dummy.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build !sylog
-// +build !sylog
 
 package sylog
 

--- a/pkg/sylog/sylog_dummy_test.go
+++ b/pkg/sylog/sylog_dummy_test.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build !sylog
-// +build !sylog
 
 package sylog
 

--- a/pkg/sylog/sylog_test.go
+++ b/pkg/sylog/sylog_test.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build sylog
-// +build sylog
 
 package sylog
 

--- a/pkg/util/fs/lock/var_linux_32bit.go
+++ b/pkg/util/fs/lock/var_linux_32bit.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build (linux && 386) || (linux && arm) || (linux && mips) || (linux && mipsle)
-// +build linux,386 linux,arm linux,mips linux,mipsle
 
 package lock
 

--- a/pkg/util/loop/loop_no_singularity.go
+++ b/pkg/util/loop/loop_no_singularity.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build !singularity_engine
-// +build !singularity_engine
 
 package loop
 

--- a/pkg/util/loop/loop_singularity.go
+++ b/pkg/util/loop/loop_singularity.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build singularity_engine
-// +build singularity_engine
 
 package loop
 

--- a/pkg/util/namespaces/setns_linux.go
+++ b/pkg/util/namespaces/setns_linux.go
@@ -1,10 +1,7 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
-
-//go:build go1.10
-// +build go1.10
 
 package namespaces
 


### PR DESCRIPTION
Bump Go versions used in CI to 1.17 and 1.18. Remove deprecated build constraint format.