### PR TITLE
feat: --no-mount for 'bind path' entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   coded. The example `etc/seccomp-profiles/default.json` has been updated.
 - Native cgroups v2 resource limits can be specified using the `[unified]` key
   in a cgroups toml file applied via `--apply-cgroups`.
+- The `--no-mount` flag & `SINGULARITY_NO_MOUNT` env var can now be used to
+  disable a `bind path` entry from `singularity.conf` by specifying the
+  absolute path to the destination of the bind.
 
 ### Bug fixes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -446,7 +446,7 @@ var actionNoMountFlag = cmdline.Flag{
 	Value:        &NoMount,
 	DefaultValue: []string{},
 	Name:         "no-mount",
-	Usage:        "disable one or more mount xxx options set in singularity.conf",
+	Usage:        "disable one or more 'mount xxx' options set in singularity.conf, specify absolute destination path to disable a 'bind path' entry",
 	EnvKeys:      []string{"NO_MOUNT"},
 }
 

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -142,6 +142,7 @@ func hidepidProc() bool {
 // Set engine flags to disable mounts, to allow overriding them if they are set true
 // in the singularity.conf
 func setNoMountFlags(c *singularityConfig.EngineConfig) {
+	skipBinds := []string{}
 	for _, v := range NoMount {
 		switch v {
 		case "proc":
@@ -161,9 +162,14 @@ func setNoMountFlags(c *singularityConfig.EngineConfig) {
 		case "cwd":
 			c.SetNoCwd(true)
 		default:
+			if filepath.IsAbs(v) {
+				skipBinds = append(skipBinds, v)
+				continue
+			}
 			sylog.Warningf("Ignoring unknown mount type '%s'", v)
 		}
 	}
+	c.SetSkipBinds(skipBinds)
 }
 
 // TODO: Let's stick this in another file so that that CLI is just CLI

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2216,6 +2216,27 @@ func (c actionTests) actionNoMount(t *testing.T) {
 			cwd:           "/srv",
 			exit:          0,
 		},
+		// /etc/hosts & /etc/localtime are default 'bind path' entries we should
+		// be able to disable by abs path. Although other 'bind path' entries
+		// are ignored under '--contain' these two are handled specially in
+		// addBindsMount(), so make sure that `--no-mount` applies properly
+		// under contain also.
+		{
+			name:          "/etc/hosts",
+			noMount:       "/etc/hosts",
+			noMatch:       "on /etc/hosts",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
+		{
+			name:          "/etc/localtime",
+			noMount:       "/etc/localtime",
+			noMatch:       "on /etc/localtime",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1519,6 +1519,8 @@ func (c *container) addBindsMount(system *mount.System) error {
 		localtimePath = "/etc/localtime"
 	)
 
+	noBinds := c.engine.EngineConfig.GetNoBinds()
+
 	if c.engine.EngineConfig.GetContain() {
 		hosts := hostsPath
 
@@ -1538,18 +1540,22 @@ func (c *container) addBindsMount(system *mount.System) error {
 			hosts, _ = c.session.GetPath(hostsPath)
 		}
 
-		// #5465 If hosts/localtime mount fails, it should not be fatal so skip-on-error
-		if err := system.Points.AddBind(mount.BindsTag, hosts, hostsPath, flags, "skip-on-error"); err != nil {
-			return fmt.Errorf("unable to add %s to mount list: %s", hosts, err)
+		if !slice.ContainsString(noBinds, hostsPath) {
+			// #5465 If hosts/localtime mount fails, it should not be fatal so skip-on-error
+			if err := system.Points.AddBind(mount.BindsTag, hosts, hostsPath, flags, "skip-on-error"); err != nil {
+				return fmt.Errorf("unable to add %s to mount list: %s", hosts, err)
+			}
+			if err := system.Points.AddRemount(mount.BindsTag, hostsPath, flags); err != nil {
+				return fmt.Errorf("unable to add %s for remount: %s", hostsPath, err)
+			}
 		}
-		if err := system.Points.AddRemount(mount.BindsTag, hostsPath, flags); err != nil {
-			return fmt.Errorf("unable to add %s for remount: %s", hostsPath, err)
-		}
-		if err := system.Points.AddBind(mount.BindsTag, localtimePath, localtimePath, flags, "skip-on-error"); err != nil {
-			return fmt.Errorf("unable to add %s to mount list: %s", localtimePath, err)
-		}
-		if err := system.Points.AddRemount(mount.BindsTag, localtimePath, flags); err != nil {
-			return fmt.Errorf("unable to add %s for remount: %s", localtimePath, err)
+		if !slice.ContainsString(noBinds, localtimePath) {
+			if err := system.Points.AddBind(mount.BindsTag, localtimePath, localtimePath, flags, "skip-on-error"); err != nil {
+				return fmt.Errorf("unable to add %s to mount list: %s", localtimePath, err)
+			}
+			if err := system.Points.AddRemount(mount.BindsTag, localtimePath, flags); err != nil {
+				return fmt.Errorf("unable to add %s for remount: %s", localtimePath, err)
+			}
 		}
 		return nil
 	}
@@ -1565,6 +1571,11 @@ func (c *container) addBindsMount(system *mount.System) error {
 		}
 
 		sylog.Verbosef("Found 'bind path' = %s, %s", src, dst)
+
+		if slice.ContainsString(noBinds, dst) {
+			sylog.Debugf("Skipping bind to %s at user request", dst)
+			continue
+		}
 
 		// #5465 If hosts/localtime mount fails, it should not be fatal so skip-on-error
 		bindOpt := ""

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -115,6 +115,7 @@ type JSONConfig struct {
 	NoTmp             bool              `json:"noTmp,omitempty"`
 	NoHostfs          bool              `json:"noHostfs,omitempty"`
 	NoCwd             bool              `json:"noCwd,omitempty"`
+	SkipBinds         []string          `json:"skipBinds,omitempty"`
 	NoInit            bool              `json:"noInit,omitempty"`
 	Fakeroot          bool              `json:"fakeroot,omitempty"`
 	SignalPropagation bool              `json:"signalPropagation,omitempty"`
@@ -471,6 +472,16 @@ func (e *EngineConfig) SetNoCwd(val bool) {
 // GetNoCwd returns if no-cwd flag is set or not.
 func (e *EngineConfig) GetNoCwd() bool {
 	return e.JSON.NoCwd
+}
+
+// SetSkipBinds sets bind paths to skip
+func (e *EngineConfig) SetSkipBinds(val []string) {
+	e.JSON.SkipBinds = val
+}
+
+// GetSkipBinds gets bind paths to skip
+func (e *EngineConfig) GetNoBinds() []string {
+	return e.JSON.SkipBinds
 }
 
 // SetNoInit set noinit flag to not start shim init process.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow one or more `bind path` entries in `singularity.conf` to be
ignored by specifying the absolute path of the destination as a
`--no-mount` or `SINGULARITY_NO_MOUNT` value.

This allows finer-grained control of bind mounts than `--contain`,
which will disable all.

It is useful in situations where e.g. a directory `/project` in a
container clashes with a `bind path = /project` entry, but other
default binds from the host are still required.

Note that `/etc/hosts` and `/etc/localtime` were always specially
injected with `--contain`, but the new `--no-mount` handling now
allows this to be overridden also.

### This fixes or addresses the following GitHub issues:

 - Fixes #625 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
