### PR TITLE
fix: gpu: support nvidia-container-cli >=1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
   container resource usage on a system using cgroups v2 and the systemd cgroups
   manager.
 
+### Bug Fixes
+
+- Support nvidia-container-cli v1.8.0 and above, via fix to capability set.
+
 ## v3.9.6 \[2022-03-10\]
 
 ### New features / functionalities

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -394,6 +394,7 @@ static void set_rpc_privileges(void) {
         priv->capabilities.bounding |= capflag(CAP_FOWNER);
         priv->capabilities.bounding |= capflag(CAP_KILL);
         priv->capabilities.bounding |= capflag(CAP_MKNOD);
+        priv->capabilities.bounding |= capflag(CAP_NET_ADMIN);
         priv->capabilities.bounding |= capflag(CAP_SETGID);
         priv->capabilities.bounding |= capflag(CAP_SETPCAP);
         priv->capabilities.bounding |= capflag(CAP_SETUID);


### PR DESCRIPTION
## Description of the Pull Request (PR):

nvidia-container-cli v1.8.0+ requires CAP_NET_ADMIN due to cgroups
v2 (eBPF) related functionality in libnvidia-container.

### This fixes or addresses the following GitHub issues:

 - Fixes #641


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
