### PR TITLE
Add registerStringMapVar to handle --env with commas!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 ### Bug Fixes
 
 - Support nvidia-container-cli v1.8.0 and above, via fix to capability set.
+- Do not truncate environment variables with commas
 
 ## v3.9.6 \[2022-03-10\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -96,7 +96,7 @@ The following have contributed code and/or documentation to this repository.
 - Tim Wright <7im.Wright@protonmail.com>
 - Tru Huynh <tru@pasteur.fr>
 - Tyson Whitehead <twhitehead@gmail.com>
-- Vanessa Sochat <vsochat@stanford.edu>
+- Vanessa Sochat <vsoch@users.noreply.github.com>
 - Westley Kurtzer <westley@sylabs.io>, <westleyk@nym.hush.com>
 - Yannick Cote <y@sylabs.io>, <yhcote@gmail.com>
 - Yaroslav Halchenko <debian@onerussian.com>

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -33,7 +33,7 @@ var (
 	VMIP               string
 	ContainLibsPath    []string
 	FuseMount          []string
-	SingularityEnv     []string
+	SingularityEnv     map[string]string
 	SingularityEnvFile string
 	NoMount            []string
 
@@ -619,7 +619,7 @@ var actionAllowSetuidFlag = cmdline.Flag{
 var actionEnvFlag = cmdline.Flag{
 	ID:           "actionEnvFlag",
 	Value:        &SingularityEnv,
-	DefaultValue: []string{},
+	DefaultValue: map[string]string{},
 	Name:         "env",
 	Usage:        "pass environment variable to contained process",
 }

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -597,18 +597,34 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		// --env variables will take precedence over variables
 		// defined by the environment file
 		sylog.Debugf("Setting environment variables from file %s", SingularityEnvFile)
-		SingularityEnv = append(env, SingularityEnv...)
+
+		// Update SingularityEnv with those from file
+		for _, envar := range env {
+			e := strings.SplitN(envar, "=", 2)
+			if len(e) != 2 {
+				sylog.Warningf("Ignore environment variable %q: '=' is missing", envar)
+				continue
+			}
+
+			// Ensure we don't overwrite --env variables with environment file
+			if _, ok := SingularityEnv[e[0]]; ok {
+				sylog.Warningf("Ignore environment variable %s from %s: override from --env", e[0], SingularityEnvFile)
+			} else {
+				SingularityEnv[e[0]] = e[1]
+			}
+		}
 	}
 
 	// process --env and --env-file variables for injection
 	// into the environment by prefixing them with SINGULARITYENV_
-	for _, env := range SingularityEnv {
-		e := strings.SplitN(env, "=", 2)
-		if len(e) != 2 {
-			sylog.Warningf("Ignore environment variable %q: '=' is missing", env)
+	for envName, envValue := range SingularityEnv {
+
+		// We can allow envValue to be empty (explicit set to empty) but not name!
+		if envName == "" {
+			sylog.Warningf("Ignore environment variable %s=%s: variable name missing", envName, envValue)
 			continue
 		}
-		os.Setenv("SINGULARITYENV_"+e[0], e[1])
+		os.Setenv("SINGULARITYENV_"+envName, envValue)
 	}
 
 	// Copy and cache environment

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -45,6 +45,9 @@ func (c ctx) singularityEnv(t *testing.T) {
 
 	// Overwrite the path with this one.
 	overwrittenPath := "/usr/bin:/bin"
+
+	// A path with a trailing comma
+	trailingCommaPath := "/usr/bin:/bin,"
 
 	tests := []struct {
 		name  string
@@ -99,6 +102,12 @@ func (c ctx) singularityEnv(t *testing.T) {
 			image: customImage,
 			path:  overwrittenPath,
 			env:   []string{"SINGULARITYENV_PATH=" + overwrittenPath},
+		},
+		{
+			name:  "OverwriteTrailingCommaPath",
+			image: defaultImage,
+			path:  trailingCommaPath,
+			env:   []string{"SINGULARITYENV_PATH=" + trailingCommaPath},
 		},
 	}
 
@@ -290,6 +299,13 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 			matchVal: singularityLibs,
 		},
 		{
+			name:     "TestCustomTrailingCommaPath",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"LD_LIBRARY_PATH=/foo,"},
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo,:" + singularityLibs,
+		},
+		{
 			name:     "TestCustomLdLibraryPath",
 			image:    c.env.ImagePath,
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo"},
@@ -405,6 +421,13 @@ func (c ctx) singularityEnvFile(t *testing.T) {
 			envFile:  "LD_LIBRARY_PATH=/foo",
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo:" + singularityLibs,
+		},
+		{
+			name:     "CustomTrailingCommaPath",
+			image:    c.env.ImagePath,
+			envFile:  "LD_LIBRARY_PATH=/foo,",
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo,:" + singularityLibs,
 		},
 	}
 

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -65,7 +65,6 @@ func (e *Config) GetURL() (string, error) {
 	} else {
 		u.Scheme = "https"
 	}
-
 	return u.String(), nil
 }
 

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -79,6 +79,8 @@ func (m *flagManager) registerFlagForCmd(flag *Flag, cmds ...*cobra.Command) err
 	switch t := flag.DefaultValue.(type) {
 	case string:
 		m.registerStringVar(flag, cmds)
+	case map[string]string:
+		m.registerStringMapVar(flag, cmds)
 	case []string:
 		if flag.StringArray {
 			m.registerStringArrayVar(flag, cmds)
@@ -128,6 +130,19 @@ func (m *flagManager) registerStringArrayVar(flag *Flag, cmds []*cobra.Command) 
 			c.Flags().StringArrayVarP(flag.Value.(*[]string), flag.Name, flag.ShortHand, flag.DefaultValue.([]string), flag.Usage)
 		} else {
 			c.Flags().StringArrayVar(flag.Value.(*[]string), flag.Name, flag.DefaultValue.([]string), flag.Usage)
+		}
+		m.setFlagOptions(flag, c)
+	}
+	return nil
+}
+
+// registerStringArrayCommas uses StringToStringVarP, a variant to allow commas (and a map of string/string)
+func (m *flagManager) registerStringMapVar(flag *Flag, cmds []*cobra.Command) error {
+	for _, c := range cmds {
+		if flag.ShortHand != "" {
+			c.Flags().StringToStringVarP(flag.Value.(*map[string]string), flag.Name, flag.ShortHand, flag.DefaultValue.(map[string]string), flag.Usage)
+		} else {
+			c.Flags().StringToStringVar(flag.Value.(*map[string]string), flag.Name, flag.DefaultValue.(map[string]string), flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}

--- a/pkg/cmdline/flag_test.go
+++ b/pkg/cmdline/flag_test.go
@@ -20,14 +20,17 @@ var (
 	testStringArray []string
 	testInt         int
 	testUint32      uint32
+	testStringMap   map[string]string
 )
 
 var ttData = []struct {
-	desc            string
-	flag            *Flag
-	cmd             *cobra.Command
-	envValue        string
-	matchValue      string
+	desc       string
+	flag       *Flag
+	cmd        *cobra.Command
+	envValue   string
+	matchValue string
+	// Alternative match to accommodate random map ordering
+	altMatchValue   string
 	expectedFailure bool
 }{
 	{
@@ -153,6 +156,21 @@ var ttData = []struct {
 		cmd: parentCmd,
 	},
 	{
+		desc: "string map flag",
+		flag: &Flag{
+			ID:           "testStringMapFlag",
+			Value:        &testStringMap,
+			DefaultValue: testStringMap,
+			Name:         "string-map",
+			Usage:        "a string map flag",
+			EnvKeys:      []string{"STRING_MAP"},
+		},
+		cmd:           parentCmd,
+		envValue:      "key1=arg1,key2=arg2",
+		matchValue:    "[key1=arg1,key2=arg2]",
+		altMatchValue: "[key2=arg2,key1=arg1]",
+	},
+	{
 		desc: "string array flag",
 		flag: &Flag{
 			ID:           "testStringArrayFlag",
@@ -274,7 +292,9 @@ func TestCmdFlag(t *testing.T) {
 		}
 		if d.envValue != "" {
 			v := d.cmd.Flags().Lookup(d.flag.Name).Value.String()
-			if v != d.matchValue {
+			// We allow matching against an optional altMatchValue, so that we can accommodate
+			// the string forms of both orderings of maps with 2 keys.
+			if v != d.matchValue && (d.altMatchValue == "" || v != d.altMatchValue) {
 				t.Errorf("unexpected value for %s, returned %s instead of %s", d.desc, v, d.matchValue)
 			}
 		}


### PR DESCRIPTION
## Description of the Pull Request (PR):

There was a bug reported in slack that `--env` is truncating variables at commas:

> Hello, I am trying to use --env to specify an environment variable (--env clustering_threshold='100,97') but I am running into an issue with 

```WARNING: Ignore environment variable "97": '=' is missing .```

> I have tried to use a backslash to escape the comma but that doesn't seem to work.
> I am currently using singularity-ce version 3.9.0

And I think I've seen this before? https://github.com/google/go-containerregistry/pull/1178. So because I love Go and don't get to work on enough Go projects (and this seemed like maybe a good way to engage with Singularity again) I decided to try for a fix! The bug looks to be the same here - there are just a few more layers added on top of it with the custom cmdline package provided here. To go through the changes:

- we ultimately need to use StringToStringVarP/StringToStringVar that can handle taking a `varA=varB` and parsing into `map[string]string`. We need to do this because `StringArrayVarP` considers a comma an ending delimiter to separate something out into a different string. There could be a way to tweak this particular parsing, but for other projects I've found a more straight forward fix is to use a map[string]string.
- This means that we cannot just parse the SIngularityEnvFile into SingularityEnv by appending to the list. Instead we parse the list of env directly from the file, and then check if it's already defined (by `--env`) or not. We issue a warning if the flag is also provided with `--env` and do not overwrite (`--env` takes precedence!)
- Finally, when we go over the list we only skip a variable when the envName is not defined. We can technically allow an empty value for envValue because the user might be trying to unset something.

This same type can be used for any other variables that might come up to truncate on commas! 

Apologies in advance for anything I did wrong - I'll fix things as the CI brings up errors!