### PR TITLE
fix: make seccomp a hard requirement in mconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - Plugins must be compiled from inside the SingularityCE source directory,
   and will use the main SingularityCE `go.mod` file. Required for Go 1.18
   support.
+- seccomp support is not disabled automatically in the absence of
+  seccomp headers at build time. Run `mconfig` using `--without-seccomp` and
+  `--without-conmon` to disable seccomp support and building of `conmon`
+  (which requires seccomp headers).
 
 ### New features / functionalities
 

--- a/mconfig
+++ b/mconfig
@@ -113,7 +113,7 @@ usage_args () {
 	echo "  Singularity options:"
 	echo "     --without-suid    do not install SUID binary (linux only)"
 	echo "     --without-network do not compile/install network plugins (linux only)"
-	echo "     --without-seccomp do not compile/install seccomp support even if available"
+	echo "     --without-seccomp do not compile/install seccomp support (linux only)"
   echo
   echo "  Third-party dependencies:"
   echo "     --without-conmon  do not build conmon, use distro provided version"
@@ -903,6 +903,11 @@ if [ "$with_network" = 0 ]; then
 	echo "    - Network plugins: no"
 else
 	echo "    - Network plugins: yes"
+fi
+if [ "$appsec" = 0 ]; then
+	echo "    - seccomp support: no"
+else
+	echo "    - seccomp support: yes"
 fi
 if [ "$with_conmon" = 0 ]; then
 	echo "    - Build conmon: no"

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -309,12 +309,22 @@ if [ "$with_seccomp_check" = "1" ]; then
     seccomp_iflags=`pkg-config --cflags-only-I libseccomp 2>/dev/null || true`
     if ! printf "#include <seccomp.h>\nint main() { seccomp_syscall_resolve_name(\"read\"); }" | \
        $tgtcc $user_cflags $ldflags $seccomp_iflags -x c -o /dev/null - -lseccomp >/dev/null 2>&1; then
-	tgtstatic=0
-	echo "no"
+      tgtstatic=0
+      echo "no"
+      if [ "$build_runtime" -eq 1 ]; then
+         echo
+         echo "seccomp headers are required to build Singularity with seccomp support."
+         echo "To disable seccomp support run mconfig using '--without-seccomp'."
+         echo
+         exit 2
+      fi
     else
-	echo "yes"
-	appsec=1
+      echo "yes"
+      appsec=1
     fi
+else
+   appsec=0
+   tgtstatic=0
 fi
 
 
@@ -322,13 +332,22 @@ fi
 # conmon deps
 ########################
 if [ "$with_conmon" = "1" ]; then
+
+   if [ "$appsec" = "0" ]; then
+      echo
+      echo "Cannot build conmon for OCI support without libseccomp headers."
+      echo "Use --without-conmon to disable build and use conmon on PATH if present."
+      echo
+      exit 2
+   fi
+
    printf " checking: conmon source... "
    if [ ! -f "$sourcedir/third_party/conmon/Makefile" ]; then
       echo "no"
       echo
       echo "conmon source not found"
       echo
-      echo "Unless you are building --without-conmon you must 'git clone recursive'"
+      echo "Unless you are building --without-conmon you must 'git clone --recurse-submodules'"
       echo "or 'git submodule update --init'."
       echo
       exit 2


### PR DESCRIPTION
## Description of the Pull Request (PR):

Make seccomp a hard requirement in `mconfig` unless `--without-seccomp` is used. Also check that seccomp is available unless `--without-conmon` is used to disable the build of conmon from source, which requires the seccomp headers.


### This fixes or addresses the following GitHub issues:

 - Fixes #673


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
