### PR TITLE
updating --env flags to be a map[string]string (release 3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   in the next minor release (3.10.x). Users utilizing plugins with
   SingularityCE 3.9.x should use version 1.17.x of the Go toolchain.
 
+## Changes Since Last Release
+
+### Bug fixes
+
+- Do not truncate environment variables with commas
+
 ## v3.9.7 \[2022-03-23\]
 
 ### Bug fixes

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -96,7 +96,7 @@ The following have contributed code and/or documentation to this repository.
 - Tim Wright <7im.Wright@protonmail.com>
 - Tru Huynh <tru@pasteur.fr>
 - Tyson Whitehead <twhitehead@gmail.com>
-- Vanessa Sochat <vsochat@stanford.edu>
+- Vanessa Sochat <vsoch@users.noreply.github.com>
 - Westley Kurtzer <westley@sylabs.io>, <westleyk@nym.hush.com>
 - Yannick Cote <y@sylabs.io>, <yhcote@gmail.com>
 - Yaroslav Halchenko <debian@onerussian.com>

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -33,7 +33,7 @@ var (
 	VMIP               string
 	ContainLibsPath    []string
 	FuseMount          []string
-	SingularityEnv     []string
+	SingularityEnv     map[string]string
 	SingularityEnvFile string
 	NoMount            []string
 
@@ -619,7 +619,7 @@ var actionAllowSetuidFlag = cmdline.Flag{
 var actionEnvFlag = cmdline.Flag{
 	ID:           "actionEnvFlag",
 	Value:        &SingularityEnv,
-	DefaultValue: []string{},
+	DefaultValue: map[string]string{},
 	Name:         "env",
 	Usage:        "pass environment variable to contained process",
 }

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -45,6 +45,9 @@ func (c ctx) singularityEnv(t *testing.T) {
 
 	// Overwrite the path with this one.
 	overwrittenPath := "/usr/bin:/bin"
+
+	// A path with a trailing comma
+	trailingCommaPath := "/usr/bin:/bin,"
 
 	tests := []struct {
 		name  string
@@ -99,6 +102,12 @@ func (c ctx) singularityEnv(t *testing.T) {
 			image: customImage,
 			path:  overwrittenPath,
 			env:   []string{"SINGULARITYENV_PATH=" + overwrittenPath},
+		},
+		{
+			name:  "OverwriteTrailingCommaPath",
+			image: defaultImage,
+			path:  trailingCommaPath,
+			env:   []string{"SINGULARITYENV_PATH=" + trailingCommaPath},
 		},
 	}
 
@@ -290,6 +299,13 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 			matchVal: singularityLibs,
 		},
 		{
+			name:     "TestCustomTrailingCommaPath",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"LD_LIBRARY_PATH=/foo,"},
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo,:" + singularityLibs,
+		},
+		{
 			name:     "TestCustomLdLibraryPath",
 			image:    c.env.ImagePath,
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo"},
@@ -405,6 +421,13 @@ func (c ctx) singularityEnvFile(t *testing.T) {
 			envFile:  "LD_LIBRARY_PATH=/foo",
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo:" + singularityLibs,
+		},
+		{
+			name:     "CustomTrailingCommaPath",
+			image:    c.env.ImagePath,
+			envFile:  "LD_LIBRARY_PATH=/foo,",
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo,:" + singularityLibs,
 		},
 	}
 

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -65,7 +65,6 @@ func (e *Config) GetURL() (string, error) {
 	} else {
 		u.Scheme = "https"
 	}
-
 	return u.String(), nil
 }
 

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -79,6 +79,8 @@ func (m *flagManager) registerFlagForCmd(flag *Flag, cmds ...*cobra.Command) err
 	switch t := flag.DefaultValue.(type) {
 	case string:
 		m.registerStringVar(flag, cmds)
+	case map[string]string:
+		m.registerStringMapVar(flag, cmds)
 	case []string:
 		if flag.StringArray {
 			m.registerStringArrayVar(flag, cmds)
@@ -128,6 +130,19 @@ func (m *flagManager) registerStringArrayVar(flag *Flag, cmds []*cobra.Command) 
 			c.Flags().StringArrayVarP(flag.Value.(*[]string), flag.Name, flag.ShortHand, flag.DefaultValue.([]string), flag.Usage)
 		} else {
 			c.Flags().StringArrayVar(flag.Value.(*[]string), flag.Name, flag.DefaultValue.([]string), flag.Usage)
+		}
+		m.setFlagOptions(flag, c)
+	}
+	return nil
+}
+
+// registerStringArrayCommas uses StringToStringVarP, a variant to allow commas (and a map of string/string)
+func (m *flagManager) registerStringMapVar(flag *Flag, cmds []*cobra.Command) error {
+	for _, c := range cmds {
+		if flag.ShortHand != "" {
+			c.Flags().StringToStringVarP(flag.Value.(*map[string]string), flag.Name, flag.ShortHand, flag.DefaultValue.(map[string]string), flag.Usage)
+		} else {
+			c.Flags().StringToStringVar(flag.Value.(*map[string]string), flag.Name, flag.DefaultValue.(map[string]string), flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}

--- a/pkg/cmdline/flag_test.go
+++ b/pkg/cmdline/flag_test.go
@@ -20,14 +20,17 @@ var (
 	testStringArray []string
 	testInt         int
 	testUint32      uint32
+	testStringMap   map[string]string
 )
 
 var ttData = []struct {
-	desc            string
-	flag            *Flag
-	cmd             *cobra.Command
-	envValue        string
-	matchValue      string
+	desc       string
+	flag       *Flag
+	cmd        *cobra.Command
+	envValue   string
+	matchValue string
+	// Alternative match to accommodate random map ordering
+	altMatchValue   string
 	expectedFailure bool
 }{
 	{
@@ -153,6 +156,21 @@ var ttData = []struct {
 		cmd: parentCmd,
 	},
 	{
+		desc: "string map flag",
+		flag: &Flag{
+			ID:           "testStringMapFlag",
+			Value:        &testStringMap,
+			DefaultValue: testStringMap,
+			Name:         "string-map",
+			Usage:        "a string map flag",
+			EnvKeys:      []string{"STRING_MAP"},
+		},
+		cmd:           parentCmd,
+		envValue:      "key1=arg1,key2=arg2",
+		matchValue:    "[key1=arg1,key2=arg2]",
+		altMatchValue: "[key2=arg2,key1=arg1]",
+	},
+	{
 		desc: "string array flag",
 		flag: &Flag{
 			ID:           "testStringArrayFlag",
@@ -274,7 +292,9 @@ func TestCmdFlag(t *testing.T) {
 		}
 		if d.envValue != "" {
 			v := d.cmd.Flags().Lookup(d.flag.Name).Value.String()
-			if v != d.matchValue {
+			// We allow matching against an optional altMatchValue, so that we can accommodate
+			// the string forms of both orderings of maps with 2 keys.
+			if v != d.matchValue && (d.altMatchValue == "" || v != d.altMatchValue) {
 				t.Errorf("unexpected value for %s, returned %s instead of %s", d.desc, v, d.matchValue)
 			}
 		}


### PR DESCRIPTION
Cherry pick #674 

Commit message:

the current flag using a splice type will truncate on commas. In order to better
support commas in --env variables we should have support for types of map[string]string.
This change will add this new option and fix the current --env bug described in slack
that splits name=val1,val2 into just name=val1 and outputs a warning. I saw some custom
parsing code in a different file that maybe was intended to handle this, but it never
gets called because the envar is skipped. If it is not skipped the comma would already
be truncated by the flag parser.

Apologies for mistakes - have not looked at Singularity source code in years it seems!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>

