### PR TITLE
fix: Show informative error for non-executable exec target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 - Support nvidia-container-cli v1.8.0 and above, via fix to capability set.
 - Do not truncate environment variables with commas
+- Show an informative error when `exec` target is not executable.
 
 ## v3.9.6 \[2022-03-10\]
 

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -157,7 +157,14 @@ sylog debug "Running action command ${__singularity_cmd__}"
 
 case "${__singularity_cmd__}" in
 exec)
-    exec "$@" ;;
+    # This uses the limited type -p behavior of mvdan.cc/sh and is *not* POSIX.
+    execbin=$(type -p "$1")
+    if test $? -ne 0 || test -z "${execbin}" ; then
+        sylog error "$1 is not an executable file in the container. Check it exists and has executable permissions."
+        exit 1
+    fi
+    exec "$@"   
+    ;;
 shell)
     if test -n "${SINGULARITY_SHELL:-}" -a -x "${SINGULARITY_SHELL:-}"; then
         exec "${SINGULARITY_SHELL:-}" "$@"


### PR DESCRIPTION
## Description of the Pull Request (PR):

When the target executable of `singularity exec` lacks `+x`
permissions, show a sensible error message rather than `permission
denied`.

Now...

```
$ singularity exec ~/ubuntu_latest.sif /etc/hosts
ERROR:   /etc/hosts is not executable, please check permissions. If it is a shell built-in, specify an executable instead. E.g. use /bin/echo instead of echo.
```

### This fixes or addresses the following GitHub issues:

 - Fixes #607


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
