### PR TITLE
techdebt: remove support for old distros (3.10 targets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   seccomp headers at build time. Run `mconfig` using `--without-seccomp` and
   `--without-conmon` to disable seccomp support and building of `conmon`
   (which requires seccomp headers).
+- SingularityCE now requires squashfs-tools >=4.3, which is satisfied by
+  current EL / Ubuntu / Debian and other distributions.
 
 ### New features / functionalities
 

--- a/cmd/starter/c/include/capability.h
+++ b/cmd/starter/c/include/capability.h
@@ -19,11 +19,9 @@
 /* 37 is the latest cap since many kernel versions */
 #define CAPSET_MAX  37
 
-/* Support only 64 bits sets, since kernel 2.6.25 */
+/* Support only 64 bits sets, since kernel 2.6.26 */
 #ifdef _LINUX_CAPABILITY_VERSION_3
 #  define LINUX_CAPABILITY_VERSION  _LINUX_CAPABILITY_VERSION_3
-#elif defined(_LINUX_CAPABILITY_VERSION_2)
-#  define LINUX_CAPABILITY_VERSION  _LINUX_CAPABILITY_VERSION_2
 #else
 #  error Linux 64 bits capability set not supported
 #endif /* _LINUX_CAPABILITY_VERSION_3 */

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -75,12 +75,7 @@ func (c ctx) singularityInspect(t *testing.T) {
 	// it can't set system xattrs while rootless.
 	cmd := exec.Command("unsquashfs", "-user-xattrs", "-d", sandboxImage, squashImage)
 	if res := cmd.Run(t); res.Error != nil {
-		// If we failed, then try without -user-xattrs for older unsquashfs
-		// versions that don't have that flag.
-		cmd := exec.Command("unsquashfs", "-d", sandboxImage, squashImage)
-		if res := cmd.Run(t); res.Error != nil {
-			t.Fatalf("Unexpected error while running command.\n%s", res)
-		}
+		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}
 
 	compareLabel := func(label, out string, appName string) func(*testing.T, *inspect.Metadata) {

--- a/internal/pkg/image/unpacker/squashfs.go
+++ b/internal/pkg/image/unpacker/squashfs.go
@@ -7,7 +7,6 @@
 package unpacker
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -104,12 +103,11 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) (err e
 		}
 	}
 
-	// First we try unsquashfs with appropriate xattr options.
-	// If we are in rootless mode we need "-user-xattrs" so we don't try to set system xattrs that require root.
-	// However...
-	//  1. This isn't supported on unsquashfs 4.0 in RHEL6 so we have to fall back to not using that option on failure.
-	//  2. Must check (user) xattrs are supported on the FS as unsquashfs >=4.4 will give a non-zero error code if
-	//	   it cannot set them, e.g. on tmpfs (#5668)
+	// First we try unsquashfs with appropriate xattr options. If we are in
+	// rootless mode we need "-user-xattrs" so we don't try to set system xattrs
+	// that require root. However we must check (user) xattrs are supported on
+	// the FS as unsquashfs >=4.4 will give a non-zero error code if it cannot
+	// set them, e.g. on tmpfs (#5668)
 	opts := []string{}
 	hostuid, err := namespaces.HostUID()
 	if err != nil {
@@ -117,7 +115,7 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) (err e
 	}
 	rootless := hostuid != 0
 
-	// Do we support user xattrs?
+	// Does our target filesystem support user xattrs?
 	ok, err := TestUserXattr(filepath.Dir(dest))
 	if err != nil {
 		return err
@@ -167,33 +165,10 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) (err e
 		cmd.Stdin = reader
 	}
 
-	o, err := cmd.CombinedOutput()
-	if err == nil {
-		return nil
-	}
-
-	// Invalid options give output...
-	// SYNTAX: unsquashfs [options] filesystem [directories or files to extract]
-	if bytes.Contains(o, []byte("SYNTAX")) {
-		sylog.Warningf("unsquashfs does not support %v. Images with xattrs may fail to extract", opts)
-	} else {
-		// A different error is fatal
-		return fmt.Errorf("extract command failed: %s: %s", string(o), err)
-	}
-
-	// Now we fall back to running without additional xattr options - to do the best we can on old 4.0 squashfs that
-	// does not support them.
-	cmd, err = cmdFunc(s.UnsquashfsPath, dest, filter, filename)
-	if err != nil {
-		return fmt.Errorf("command error: %s", err)
-	}
-	cmd.Args = append(cmd.Args, files...)
-	if stdin {
-		cmd.Stdin = reader
-	}
 	if o, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("extract command failed: %s: %s", string(o), err)
 	}
+
 	return nil
 }
 

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -517,19 +517,6 @@ func testBadBridge(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout
 func TestAddDelNetworks(t *testing.T) {
 	test.EnsurePrivilege(t)
 
-	// centos 6 doesn't support bridge/veth, only macvlan
-	// just skip tests on centos 6, rhel 6
-	b, err := ioutil.ReadFile("/etc/system-release-cpe")
-	if err == nil {
-		fields := strings.Split(string(b), ":")
-		switch fields[2] {
-		case "centos", "redhat":
-			if strings.HasPrefix(fields[4], "6") {
-				t.Skipf("RHEL6/CentOS6 don't support CNI bridge/veth - skipping")
-			}
-		}
-	}
-
 	cniPath := &CNIPath{
 		Conf:   defaultCNIConfPath,
 		Plugin: defaultCNIPluginPath,


### PR DESCRIPTION
## Description of the Pull Request (PR):

[techdebt: Remove workaround for squashfs-tools <4.3](https://github.com/sylabs/singularity/commit/df23c0a087f4418060975f87686d0c7c4acf7f6b)
A workaround was in place for squashfs-tools <4.3 which does not support the `user-xattrs` flag. All our target distros use 4.3 or
later, so remove the conditionals to simplify the squashfs unpack logic.

[techdebt: remove pkg/network test conditional for EL6](https://github.com/sylabs/singularity/commit/8c919c9d99ad83f6b1d42dffbd404e4908483696)
We no longer support EL6 which has been EOL for some time.

[techdebt: drop _LINUX_CAPABILITY_VERSION_2 support](https://github.com/sylabs/singularity/commit/fe8da3c38c7ad44a0eae15f80ef3d6686eb094b4)

In starter we are currently allowing _LINUX_CAPABILITY_VERSION_2, but this was specific to kernel 2.6.25, and deprecated in 2.6.26, which is older than used by any system we target / test on.

See also:

https://github.com/torvalds/linux/blob/v2.6.26/include/linux/capability.h#L34

https://man7.org/linux/man-pages/man2/capset.2.html

> Kernels prior to 2.6.25 prefer 32-bit capabilities with version  _LINUX_CAPABILITY_VERSION_1.  Linux 2.6.25 added 64-bit  capability sets, with version _LINUX_CAPABILITY_VERSION_2.  There was, however, an API glitch, and Linux 2.6.26 added _LINUX_CAPABILITY_VERSION_3 to fix the problem.

### This fixes or addresses the following GitHub issues:

 - Fixes #82 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
