### PR TITLE
feat: Add --no-eval for OCI compatible argument and env var handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@
   (which requires seccomp headers).
 - SingularityCE now requires squashfs-tools >=4.3, which is satisfied by
   current EL / Ubuntu / Debian and other distributions.
+- New action flag `--no-eval` which:
+  - Prevents shell evaluation of `SINGULARITYENV_ / --env / --env-file`
+    environment variables as they are injected in the container, to match OCI
+    behavior. *Applies to all containers*.
+  - Prevents shell evaluation of the values of `CMD / ENTRYPOINT` and command
+    line arguments for containers run or built directly from an OCI/Docker
+    source. *Applies to newly built containers only, use `singularity inspect`
+    to check version that container was built with*.
+- Added `--no-eval` to the list of flags set by the OCI/Docker `--compat` mode.
 
 ### New features / functionalities
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -48,6 +48,7 @@ var (
 	Nvidia          bool
 	NvCCLI          bool
 	Rocm            bool
+	NoEval          bool
 	NoHome          bool
 	NoInit          bool
 	NoNvidia        bool
@@ -353,7 +354,7 @@ var actionCompatFlag = cmdline.Flag{
 	Value:        &IsCompat,
 	DefaultValue: false,
 	Name:         "compat",
-	Usage:        "apply settings for increased OCI/Docker compatibility. Infers --containall, --no-init, --no-umask, --writable-tmpfs.",
+	Usage:        "apply settings for increased OCI/Docker compatibility. Infers --containall, --no-init, --no-umask, --no-eval, --writable-tmpfs.",
 	EnvKeys:      []string{"COMPAT"},
 }
 
@@ -636,12 +637,22 @@ var actionEnvFileFlag = cmdline.Flag{
 
 // --no-umask
 var actionNoUmaskFlag = cmdline.Flag{
-	ID:           " actionNoUmask",
+	ID:           "actionNoUmask",
 	Value:        &NoUmask,
 	DefaultValue: false,
 	Name:         "no-umask",
 	Usage:        "do not propagate umask to the container, set default 0022 umask",
 	EnvKeys:      []string{"NO_UMASK"},
+}
+
+// --no-eval
+var actionNoEvalFlag = cmdline.Flag{
+	ID:           "actionNoEval",
+	Value:        &NoEval,
+	DefaultValue: false,
+	Name:         "no-eval",
+	Usage:        "do not shell evaluate env vars or OCI container CMD/ENTRYPOINT/ARGS",
+	EnvKeys:      []string{"NO_EVAL"},
 }
 
 func init() {
@@ -722,5 +733,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionEnvFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionEnvFileFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoUmaskFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoEvalFlag, actionsInstanceCmd...)
 	})
 }

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -59,6 +59,7 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 		IsWritableTmpfs = true
 		NoInit = true
 		NoUmask = true
+		NoEval = true
 	}
 }
 

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -223,6 +223,11 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		engineConfig.SetRestoreUmask(true)
 	}
 
+	if NoEval {
+		engineConfig.SetNoEval(true)
+		generator.AddProcessEnv("SINGULARITY_NO_EVAL", "1")
+	}
+
 	uidParam := security.GetParam(Security, "uid")
 	gidParam := security.GetParam(Security, "gid")
 

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -437,7 +437,106 @@ func (c ctx) testDockerLabels(t *testing.T) {
 	)
 }
 
+func (c ctx) testDockerCMD(t *testing.T) {
+	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
+	defer cleanup(t)
+	imagePath := filepath.Join(imageDir, "container")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("while getting $HOME: %s", err)
+	}
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull"),
+		e2e.WithArgs(imagePath, "docker://sylabsio/docker-cmd"),
+		e2e.ExpectExit(0),
+	)
+
+	tests := []struct {
+		name         string
+		args         []string
+		noeval       bool
+		expectOutput string
+	}{
+		// Singularity historic behavior (without --no-eval)
+		// These do not all match Docker, due to evaluation, consumption of quoting.
+		{
+			name:         "default",
+			args:         []string{},
+			noeval:       false,
+			expectOutput: `CMD 'quotes' "quotes" $DOLLAR s p a c e s`,
+		},
+		{
+			name:         "override",
+			args:         []string{"echo", "test"},
+			noeval:       false,
+			expectOutput: `test`,
+		},
+		{
+			name:         "override env var",
+			args:         []string{"echo", "$HOME"},
+			noeval:       false,
+			expectOutput: home,
+		},
+		// This looks very wrong, but is historic behavior
+		{
+			name:         "override sh echo",
+			args:         []string{"sh", "-c", `echo "hello there"`},
+			noeval:       false,
+			expectOutput: "hello",
+		},
+		// Docker/OCI behavior (with --no-eval)
+		{
+			name:         "no-eval/default",
+			args:         []string{},
+			noeval:       false,
+			expectOutput: `CMD 'quotes' "quotes" $DOLLAR s p a c e s`,
+		},
+		{
+			name:         "no-eval/override",
+			args:         []string{"echo", "test"},
+			noeval:       true,
+			expectOutput: `test`,
+		},
+		{
+			name:         "no-eval/override env var",
+			noeval:       true,
+			args:         []string{"echo", "$HOME"},
+			expectOutput: "$HOME",
+		},
+		{
+			name:         "no-eval/override sh echo",
+			noeval:       true,
+			args:         []string{"sh", "-c", `echo "hello there"`},
+			expectOutput: "hello there",
+		},
+	}
+
+	for _, tt := range tests {
+		cmdArgs := []string{}
+		if tt.noeval {
+			cmdArgs = append(cmdArgs, "--no-eval")
+		}
+		cmdArgs = append(cmdArgs, imagePath)
+		cmdArgs = append(cmdArgs, tt.args...)
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("run"),
+			e2e.WithArgs(cmdArgs...),
+			e2e.ExpectExit(0,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.expectOutput),
+			),
+		)
+	}
+}
+
 // https://github.com/sylabs/singularity/issues/233
+// This tests quotes in the CMD shell form, not the [ .. ] exec form.
 func (c ctx) testDockerCMDQuotes(t *testing.T) {
 	c.env.RunSingularity(
 		t,
@@ -464,6 +563,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"registry":         c.testDockerRegistry,
 		"whiteout symlink": c.testDockerWhiteoutSymlink,
 		"labels":           c.testDockerLabels,
+		"cmd":              c.testDockerCMD,
 		"cmd quotes":       c.testDockerCMDQuotes,
 	}
 }

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -9,6 +9,7 @@ package sources
 import (
 	"archive/tar"
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -19,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/docker"
@@ -37,6 +39,82 @@ import (
 	"github.com/sylabs/singularity/pkg/sylog"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
+
+type ociRunscriptData struct {
+	PrependCmd        string
+	PrependEntrypoint string
+}
+
+const ociRunscript = `
+# When SINGULARITY_NO_EVAL set, use OCI compatible behavior that does
+# not evaluate resolved CMD / ENTRYPOINT / ARGS through the shell, and
+# does not modify expected quoting behavior of args.
+if [ -n "$SINGULARITY_NO_EVAL" ]; then
+	# ENTRYPOINT only - run entrypoint plus args
+	if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
+		{{.PrependEntrypoint}}
+		exec "$@"
+	fi
+
+	# CMD only - run CMD or override with args
+	if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
+		if [ $# -eq 0 ]; then
+			{{.PrependCmd}}
+		fi
+		exec "$@"
+	fi
+
+	# ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
+	# override with user provided args
+	if [ $# -gt 0 ]; then
+		{{.PrependEntrypoint}}
+	else
+		{{.PrependCmd}}
+		{{.PrependEntrypoint}}
+	fi
+	exec "$@"
+fi
+
+# Standard Singularity behavior evaluates CMD / ENTRYPOINT / ARGS
+# combination through shell before exec, and requires special quoting
+# due to concatenation of CMDLINE_ARGS.
+CMDLINE_ARGS=""
+# prepare command line arguments for evaluation
+for arg in "$@"; do
+		CMDLINE_ARGS="${CMDLINE_ARGS} \"$arg\""
+done
+
+# ENTRYPOINT only - run entrypoint plus args
+if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
+	if [ $# -gt 0 ]; then
+		SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${CMDLINE_ARGS}"
+	else
+		SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT}"
+	fi
+fi
+
+# CMD only - run CMD or override with args
+if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
+	if [ $# -gt 0 ]; then
+		SINGULARITY_OCI_RUN="${CMDLINE_ARGS}"
+	else
+		SINGULARITY_OCI_RUN="${OCI_CMD}"
+	fi
+fi
+
+# ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
+# override with user provided args
+if [ $# -gt 0 ]; then
+	SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${CMDLINE_ARGS}"
+else
+	SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
+fi
+
+# Evaluate shell expressions first and set arguments accordingly,
+# then execute final command as first container process
+eval "set ${SINGULARITY_OCI_RUN}"
+exec "$@"
+`
 
 // OCIConveyorPacker holds stuff that needs to be packed into the bundle
 type OCIConveyorPacker struct {
@@ -354,44 +432,34 @@ func (cp *OCIConveyorPacker) insertRunScript() (err error) {
 		}
 	}
 
-	_, err = f.WriteString(`CMDLINE_ARGS=""
-# prepare command line arguments for evaluation
-for arg in "$@"; do
-    CMDLINE_ARGS="${CMDLINE_ARGS} \"$arg\""
-done
+	// prependCmd is a set of shell commands necessary to prepend each CMD entry to $@
+	prependCmd := ""
+	for i := len(cp.imgConfig.Cmd) - 1; i >= 0; i-- {
+		prependCmd = prependCmd + fmt.Sprintf("set -- '%s' \"$@\"\n", shell.EscapeSingleQuotes(cp.imgConfig.Cmd[i]))
+	}
+	// prependCmd is a set of shell commands necessary to prepend each ENTRYPOINT entry to $@
+	prependEP := ""
+	for i := len(cp.imgConfig.Entrypoint) - 1; i >= 0; i-- {
+		prependEP = prependEP + fmt.Sprintf("set -- '%s' \"$@\"\n", shell.EscapeSingleQuotes(cp.imgConfig.Entrypoint[i]))
+	}
 
-# ENTRYPOINT only - run entrypoint plus args
-if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
-    if [ $# -gt 0 ]; then
-        SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${CMDLINE_ARGS}"
-    else
-        SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT}"
-    fi
-fi
+	data := ociRunscriptData{
+		PrependCmd:        prependCmd,
+		PrependEntrypoint: prependEP,
+	}
 
-# CMD only - run CMD or override with args
-if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
-    if [ $# -gt 0 ]; then
-        SINGULARITY_OCI_RUN="${CMDLINE_ARGS}"
-    else
-        SINGULARITY_OCI_RUN="${OCI_CMD}"
-    fi
-fi
+	tmpl, err := template.New("runscript").Parse(ociRunscript)
+	if err != nil {
+		return fmt.Errorf("while parsing runscript template: %w", err)
+	}
 
-# ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
-# override with user provided args
-if [ $# -gt 0 ]; then
-    SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${CMDLINE_ARGS}"
-else
-    SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
-fi
+	var runscript bytes.Buffer
+	err = tmpl.Execute(&runscript, data)
+	if err != nil {
+		return fmt.Errorf("while generating runscript template: %w", err)
+	}
 
-# Evaluate shell expressions first and set arguments accordingly,
-# then execute final command as first container process
-eval "set ${SINGULARITY_OCI_RUN}"
-exec "$@"
-
-`)
+	_, err = f.WriteString(runscript.String())
 	if err != nil {
 		return
 	}

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -124,6 +124,7 @@ type JSONConfig struct {
 	Umask                 int               `json:"umask,omitempty"`
 	XdgRuntimeDir         string            `json:"xdgRuntimeDir,omitempty"`
 	DbusSessionBusAddress string            `json:"dbusSessionBusAddress,omitempty"`
+	NoEval                bool              `json:"noEval,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -808,4 +809,16 @@ func (e *EngineConfig) SetDbusSessionBusAddress(address string) {
 // GetDbusSessionBusAddress gets the DBUS_SESSION_BUS_ADDRESS value for rootless operations
 func (e *EngineConfig) GetDbusSessionBusAddress() string {
 	return e.JSON.DbusSessionBusAddress
+}
+
+// SetNoEval sets whether to avoid a shell eval on SINGULARITYENV_ and in
+// runscripts generated from OCI containers CMD/ENTRYPOINT.
+func (e *EngineConfig) SetNoEval(noEval bool) {
+	e.JSON.NoEval = noEval
+}
+
+// GetNoEval sets whether to avoid a shell eval on SINGULARITYENV_ and in
+// runscripts generated from OCI containers CMD/ENTRYPOINT.
+func (e *EngineConfig) GetNoEval() bool {
+	return e.JSON.NoEval
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Address #487 by adding a `--no-eval` actions flag, which does the following:

1) Quotes environment variable values in the `inject-singularity-env.sh` generated script using single quotes to
ensure the values are not evaluated when the injection script is sourced.

    _This behavior applies to existing and newly created images._

2) Uses an alternate path in the generated runscript for images built from OCI sources, that avoids evaluating CMD / ENTRYPOINT parts, and args in the shell.

    _This behavior only applies to newly created images, that contain the new form of the generated OCI runscript._

The `--no-eval` flag is implictly added by the Docker/OCI `--compat` mode.

Also adds test cases that cover this new functionality, the historic behavior, and general handling of CMD / ENTRYPOINT/ CMD+ENTRYPOINT handling and overrides in Docker/OCI images. This should help us a lot in catching any changes to the 'historic' behaviour, that has been modified inadvertently in the past.

There is no change to the historic behavior of Singularity (run without `--no-eval` or `--compat`) at this time. OCI / Docker compatible handling by default may be considered for a future release.

### This fixes or addresses the following GitHub issues:

 - Fixes #487

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
