### PR TITLE
fix: Allow newuidmap/newgidmap using caps, not setuid root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@
 ### Bug Fixes
 
 - Support nvidia-container-cli v1.8.0 and above, via fix to capability set.
-- Do not truncate environment variables with commas
+- Do not truncate environment variables with commas.
+- Allow `newgidmap / newuidmap` that use capabilities instead of setuid root.
 
 ## v3.9.6 \[2022-03-10\]
 

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -621,8 +621,9 @@ static void set_mappings_external(const char *name, char *cmdpath, pid_t pid, ch
     }
 
     /* scary !? it's fine as it's never called by setuid context */
-    if ( system(cmd) < 0 ) {
-        fatalf("'%s' execution failed", cmd);
+    debugf("Executing '%s'", cmd);
+    if ( system(cmd) != 0 ) {
+        fatalf("'%s' execution failed. Check that '%s' is setuid root, or has required capabilities.\n", name, name);
     }
 
     free(cmd);

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -277,10 +277,6 @@ func setNewIDMapPath(command string, pathPointer unsafe.Pointer) error {
 		return fmt.Errorf("%s must be owned by the root user to setup fakeroot ID mappings in an unprivileged installation", path)
 	}
 
-	if !fs.IsSuid(path) {
-		return fmt.Errorf("%s must be setuid root to setup fakeroot ID mappings in an unprivileged installation", path)
-	}
-
 	lpath := len(path)
 	size := C.size_t(lpath)
 	if lpath >= C.MAX_PATH_SIZE-1 {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fedora 35 (and maybe other distros) uses file capabilities for `newuidmap` and `newgidmap`. We were previously checking these were setuid root. Drop the check and instead output an informative message on execution failure.

Error message is not the tidiest, due to where in the started flow any failure will occur, but is informative:

```
$ singularity run -u --fakeroot docker://alpine
INFO:    Using cached SIF image
INFO:    Converting SIF file to temporary sandbox...
newgidmap: write to gid_map failed: Operation not permitted
ERROR  : 'newgidmap' execution failed. Check that 'newgidmap' is setuid root, or has required capabilities.
ERROR  : Error while waiting event for user namespace mappings: Bad file descriptor
```

With caps per Fedora 35 default, now works:

```
$ singularity run -u --fakeroot docker://alpine
INFO:    Using cached SIF image
INFO:    Converting SIF file to temporary sandbox...
WARNING: Skipping mount /etc/localtime [binds]: /etc/localtime doesn't exist in container
Singularity> 
```



### This fixes or addresses the following GitHub issues:

 - Fixes #709

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
