### PR TITLE
feat: squashfuse unpriv SIF image mount (experimental)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ commands:
           command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q update
       - run:
           name: Install dependencies
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin runc libglib2.0-dev
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin runc libglib2.0-dev squashfuse
   configure-singularity:
     steps:
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
   manager.
 - Added `--cpu*`, `--blkio*`, `--memory*`, `--pids-limit` flags to apply cgroups
   resource limits to a container directly.
+- Allow direct mount of SIF images with `squashfuse` in user-namespace / no-setuid
+  mode.
 
 ### Bug Fixes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -45,6 +45,7 @@ var (
 	IsContainAll    bool
 	IsWritable      bool
 	IsWritableTmpfs bool
+	SIFFUSE         bool
 	Nvidia          bool
 	NvCCLI          bool
 	Rocm            bool
@@ -777,6 +778,16 @@ var actionPidsLimitFlag = cmdline.Flag{
 	EnvKeys:      []string{"PIDS_LIMIT"},
 }
 
+// --sif-fuse
+var actionSIFFUSEFlag = cmdline.Flag{
+	ID:           "actionSIFFUSE",
+	Value:        &SIFFUSE,
+	DefaultValue: false,
+	Name:         "sif-fuse",
+	Usage:        "attempt FUSE mount of SIF (unprivileged / user namespace only) (experimental)",
+	EnvKeys:      []string{"SIF_FUSE"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -867,5 +878,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionMemorySwapFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionOomKillDisableFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPidsLimitFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionSIFFUSEFlag, actionsCmd...)
 	})
 }

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	sifuser "github.com/sylabs/sif/v2/pkg/user"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/image/unpacker"
 	"github.com/sylabs/singularity/internal/pkg/instance"
@@ -31,6 +33,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/shell/interpreter"
 	"github.com/sylabs/singularity/internal/pkg/util/starter"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
+	"github.com/sylabs/singularity/pkg/image"
 	imgutil "github.com/sylabs/singularity/pkg/image"
 	clicallback "github.com/sylabs/singularity/pkg/plugin/callback/cli"
 	singularitycallback "github.com/sylabs/singularity/pkg/plugin/callback/runtime/engine/singularity"
@@ -46,44 +49,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// convertImage extracts the image found at filename to directory dir within a temporary directory
-// tempDir. If the unsquashfs binary is not located, the binary at unsquashfsPath is used. It is
-// the caller's responsibility to remove tempDir when no longer needed.
-func convertImage(filename string, unsquashfsPath string) (tempDir, imageDir string, err error) {
-	img, err := imgutil.Init(filename, false)
-	if err != nil {
-		return "", "", fmt.Errorf("could not open image %s: %s", filename, err)
-	}
-	defer img.File.Close()
-
-	part, err := img.GetRootFsPartition()
-	if err != nil {
-		return "", "", fmt.Errorf("while getting root filesystem in %s: %s", filename, err)
-	}
-
-	// Nice message if we have been given an older ext3 image, which cannot be extracted due to lack of privilege
-	// to loopback mount.
-	if part.Type == imgutil.EXT3 {
-		sylog.Errorf("File %q is an ext3 format continer image.", filename)
-		sylog.Errorf("Only SIF and squashfs images can be extracted in unprivileged mode.")
-		sylog.Errorf("Use `singularity build` to convert this image to a SIF file using a setuid install of Singularity.")
-	}
-
-	// Only squashfs can be extracted
-	if part.Type != imgutil.SQUASHFS {
-		return "", "", fmt.Errorf("not a squashfs root filesystem")
-	}
-
-	// create a reader for rootfs partition
-	reader, err := imgutil.NewPartitionReader(img, "", 0)
-	if err != nil {
-		return "", "", fmt.Errorf("could not extract root filesystem: %s", err)
-	}
-	s := unpacker.NewSquashfs()
-	if !s.HasUnsquashfs() && unsquashfsPath != "" {
-		s.UnsquashfsPath = unsquashfsPath
-	}
-
+// mkContainerDirs creates a tempDir, with a nested 'root' imageDir that an image can be placed into.
+// The directory nesting is required so that extraction of an image doesn't apply permissions that
+// cause the tempDir to be accessible to others.
+func mkContainerDirs() (tempDir, imageDir string, err error) {
 	// keep compatibility with v2
 	tmpdir := os.Getenv("SINGULARITY_TMPDIR")
 	if tmpdir == "" {
@@ -93,10 +62,10 @@ func convertImage(filename string, unsquashfsPath string) (tempDir, imageDir str
 		}
 	}
 
-	// create temporary sandbox
+	// create temporary dir
 	tempDir, err = ioutil.TempDir(tmpdir, "rootfs-")
 	if err != nil {
-		return "", "", fmt.Errorf("could not create temporary sandbox: %s", err)
+		return "", "", fmt.Errorf("could not create temporary directory: %s", err)
 	}
 	defer func() {
 		if err != nil {
@@ -110,12 +79,119 @@ func convertImage(filename string, unsquashfsPath string) (tempDir, imageDir str
 		return "", "", fmt.Errorf("could not create root directory: %s", err)
 	}
 
-	// extract root filesystem
-	if err := s.ExtractAll(reader, imageDir); err != nil {
-		return "", "", fmt.Errorf("root filesystem extraction failed: %s", err)
+	return tempDir, imageDir, nil
+}
+
+// handleImage makes the image at filename available at directory dir within a
+// temporary directory tempDir, by extraction or squashfuse mount. It is the
+// caller's responsibility to remove tempDir when no longer needed. If isFUSE is
+// returned true, then the imageDir is a FUSE mount, and must be unmounted
+// during cleanup.
+func handleImage(filename string, tryFUSE bool) (isFUSE bool, tempDir, imageDir string, err error) {
+	img, err := imgutil.Init(filename, false)
+	if err != nil {
+		return false, "", "", fmt.Errorf("could not open image %s: %s", filename, err)
+	}
+	defer img.File.Close()
+
+	part, err := img.GetRootFsPartition()
+	if err != nil {
+		return false, "", "", fmt.Errorf("while getting root filesystem in %s: %s", filename, err)
 	}
 
-	return tempDir, imageDir, err
+	// Nice message if we have been given an older ext3 image, which cannot be extracted due to lack of privilege
+	// to loopback mount.
+	if part.Type == imgutil.EXT3 {
+		sylog.Errorf("File %q is an ext3 format container image.", filename)
+		sylog.Errorf("Only SIF and squashfs images can be extracted in unprivileged mode.")
+		sylog.Errorf("Use `singularity build` to convert this image to a SIF file using a setuid install of Singularity.")
+	}
+
+	// Only squashfs can be extracted
+	if part.Type != imgutil.SQUASHFS {
+		return false, "", "", fmt.Errorf("not a squashfs root filesystem")
+	}
+
+	tempDir, imageDir, err = mkContainerDirs()
+	if err != nil {
+		return false, "", "", err
+	}
+
+	// Attempt squashfuse mount
+	if tryFUSE {
+		err := squashfuseMount(img, imageDir)
+		if err == nil {
+			return true, tempDir, imageDir, nil
+		}
+		sylog.Warningf("SIF squashfuse mount failed, falling back to extraction: %v", err)
+	}
+
+	// Fall back to extraction to directory
+	if err := extractImage(img, imageDir); err == nil {
+		return false, tempDir, imageDir, nil
+	}
+
+	if err2 := os.RemoveAll(tempDir); err2 != nil {
+		sylog.Errorf("Couldn't remove temporary directory %s: %s", tempDir, err2)
+	}
+	return false, "", "", fmt.Errorf("while extracting image: %w", err)
+}
+
+// extractImage extracts img to directory dir within a temporary directory
+// tempDir. It is the caller's responsibility to remove tempDir
+// when no longer needed.
+func extractImage(img *imgutil.Image, imageDir string) error {
+	sylog.Infof("Converting SIF file to temporary sandbox...")
+	unsquashfsPath, err := bin.FindBin("unsquashfs")
+	if err != nil {
+		return err
+	}
+
+	// create a reader for rootfs partition
+	reader, err := imgutil.NewPartitionReader(img, "", 0)
+	if err != nil {
+		return fmt.Errorf("could not extract root filesystem: %s", err)
+	}
+	s := unpacker.NewSquashfs()
+	if !s.HasUnsquashfs() && unsquashfsPath != "" {
+		s.UnsquashfsPath = unsquashfsPath
+	}
+
+	// extract root filesystem
+	if err := s.ExtractAll(reader, imageDir); err != nil {
+		return fmt.Errorf("root filesystem extraction failed: %s", err)
+	}
+
+	return nil
+}
+
+// squashfuseMount mounts img using squashfuse to directory imageDir. It is the
+// caller's responsibility to umount imageDir when no longer needed.
+func squashfuseMount(img *imgutil.Image, imageDir string) (err error) {
+	part, err := img.GetRootFsPartition()
+	if err != nil {
+		return fmt.Errorf("while getting root filesystem : %s", err)
+	}
+	if img.Type != image.SIF && part.Type != image.SQUASHFS {
+		return fmt.Errorf("only SIF images are supported")
+	}
+	if IsFakeroot {
+		return fmt.Errorf("fakeroot is not currently supported")
+	}
+	sylog.Infof("Mounting SIF with FUSE...")
+
+	squashfusePath, err := bin.FindBin("squashfuse")
+	if err != nil {
+		return fmt.Errorf("squashfuse is required: %w", err)
+	}
+	if _, err := bin.FindBin("fusermount"); err != nil {
+		return fmt.Errorf("fusermount is required: %w", err)
+	}
+
+	return sifuser.Mount(context.TODO(), img.Path, imageDir,
+		sifuser.OptMountStdout(os.Stdout),
+		sifuser.OptMountStderr(os.Stderr),
+		sifuser.OptMountSquashfusePath(squashfusePath))
 }
 
 // checkHidepid checks if hidepid is set on /proc mount point, when this
@@ -694,17 +770,12 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		}
 
 		if convert {
-			unsquashfsPath, err := bin.FindBin("unsquashfs")
+			fuse, tempDir, imageDir, err := handleImage(image, SIFFUSE)
 			if err != nil {
-				sylog.Fatalf("while extracting %s: %s", image, err)
-			}
-			sylog.Verbosef("User namespace requested, convert image %s to sandbox", image)
-			sylog.Infof("Converting SIF file to temporary sandbox...")
-			tempDir, imageDir, err := convertImage(image, unsquashfsPath)
-			if err != nil {
-				sylog.Fatalf("while extracting %s: %s", image, err)
+				sylog.Fatalf("while handling %s: %s", image, err)
 			}
 			engineConfig.SetImage(imageDir)
+			engineConfig.SetImageFuse(fuse)
 			engineConfig.SetDeleteTempDir(tempDir)
 			generator.AddProcessEnv("SINGULARITY_CONTAINER", imageDir)
 

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -770,7 +770,8 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		}
 
 		if convert {
-			fuse, tempDir, imageDir, err := handleImage(image, SIFFUSE)
+			tryFUSE := SIFFUSE || engineConfig.File.SIFFUSE
+			fuse, tempDir, imageDir, err := handleImage(image, tryFUSE)
 			if err != nil {
 				sylog.Fatalf("while handling %s: %s", image, err)
 			}

--- a/cmd/starter/c/include/starter.h
+++ b/cmd/starter/c/include/starter.h
@@ -38,10 +38,11 @@
 #define ENTER_NAMESPACE     1
 
 enum goexec {
-    STAGE1      = 1,
-    STAGE2      = 2,
-    MASTER      = 3,
-    RPC_SERVER  = 4
+    STAGE1             = 1,
+    STAGE2             = 2,
+    MASTER             = 3,
+    RPC_SERVER         = 4,
+    CLEANUP_HOST       = 5
 };
 
 #ifndef NS_CLONE_NEWPID
@@ -144,6 +145,9 @@ struct starter {
     /* control starter working directory from a file descriptor */
     int workingDirectoryFd;
 
+    /* image FD that we need to close on cleanup if it's FUSE mounted */
+    int imageFd;
+
     /* hold file descriptors that need to be remains open after stage 1 */
     int fds[MAX_STARTER_FDS];
     int numfds;
@@ -157,6 +161,9 @@ struct starter {
 
     /* bounding capability set will include caps needed by nvidia-container-cli */
     bool nvCCLICaps;
+
+    /* is a CLEANUP_HOST process require outside of namespaces for SIF FUSE cleanup */
+    bool cleanupHost;
 };
 
 /* engine configuration */

--- a/cmd/starter/main_linux.go
+++ b/cmd/starter/main_linux.go
@@ -66,12 +66,13 @@ func startup() {
 		sylog.Verbosef("Execute master process\n")
 
 		pid := sconfig.GetContainerPid()
+		imageFd := sconfig.GetImageFd()
 
 		if err := sconfig.Release(); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 
-		starter.Master(int(C.rpc_socket[0]), int(C.master_socket[0]), pid, e)
+		starter.Master(int(C.rpc_socket[0]), int(C.master_socket[0]), int(C.cleanup_socket[0]), pid, imageFd, e)
 	case C.RPC_SERVER:
 		sylog.Verbosef("Serve RPC requests\n")
 
@@ -80,7 +81,14 @@ func startup() {
 		}
 
 		starter.RPCServer(int(C.rpc_socket[1]), e)
+	case C.CLEANUP_HOST:
+		sylog.Verbosef("Execute Cleanup Host Process")
+		if err := sconfig.Release(); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+		starter.CleanupHost(int(C.cleanup_socket[1]), e)
 	}
+
 	sylog.Fatalf("You should not be there\n")
 }
 

--- a/internal/app/starter/cleanup_host.go
+++ b/internal/app/starter/cleanup_host.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package starter
+
+import (
+	"net"
+	"os"
+
+	"github.com/sylabs/singularity/internal/pkg/runtime/engine"
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+func CleanupHost(cleanupSocket int, e *engine.Engine) {
+	sylog.Debugf("Entering CleanupHost\n")
+	comm := os.NewFile(uintptr(cleanupSocket), "unix")
+	conn, err := net.FileConn(comm)
+	if err != nil {
+		sylog.Fatalf("socket communication error: %s\n", err)
+	}
+	comm.Close()
+	defer conn.Close()
+
+	// Wait for a write into the socket from master to trigger cleanup
+	data := make([]byte, 1)
+	if _, err := conn.Read(data); err != nil {
+		sylog.Fatalf("While reading from cleanup socket: %s", err)
+	}
+
+	if err := e.CleanupHost(); err != nil {
+		if _, err := conn.Write([]byte{'f'}); err != nil {
+			sylog.Fatalf("Could not write to master: %s", err)
+		}
+		sylog.Fatalf("While cleaning up: %s", err)
+	}
+
+	if _, err := conn.Write([]byte{'c'}); err != nil {
+		sylog.Fatalf("Could not write to master: %s", err)
+	}
+	os.Exit(0)
+}

--- a/internal/app/starter/cleanup_host.go
+++ b/internal/app/starter/cleanup_host.go
@@ -6,6 +6,7 @@
 package starter
 
 import (
+	"context"
 	"net"
 	"os"
 
@@ -23,13 +24,15 @@ func CleanupHost(cleanupSocket int, e *engine.Engine) {
 	comm.Close()
 	defer conn.Close()
 
+	ctx := context.TODO()
+
 	// Wait for a write into the socket from master to trigger cleanup
 	data := make([]byte, 1)
 	if _, err := conn.Read(data); err != nil {
 		sylog.Fatalf("While reading from cleanup socket: %s", err)
 	}
 
-	if err := e.CleanupHost(); err != nil {
+	if err := e.CleanupHost(ctx); err != nil {
 		if _, err := conn.Write([]byte{'f'}); err != nil {
 			sylog.Fatalf("Could not write to master: %s", err)
 		}

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -144,6 +144,16 @@ func (c *Config) SetWorkingDirectoryFd(fd int) {
 	c.config.starter.workingDirectoryFd = C.int(fd)
 }
 
+// SetImageFd changes starter config and sets fd for the image in use.
+func (c *Config) SetImageFd(fd int) {
+	c.config.starter.imageFd = C.int(fd)
+}
+
+// GetImageFd returns the fd for the image in use.
+func (c *Config) GetImageFd() int {
+	return int(c.config.starter.imageFd)
+}
+
 // KeepFileDescriptor adds a file descriptor to an array of file
 // descriptors that starter will keep open. All files opened during
 // stage 1 will be shared with starter process. Once stage 1 returns,
@@ -187,6 +197,17 @@ func (c *Config) SetAllowSetgroups(allow bool) {
 		c.config.container.privileges.allowSetgroups = C.true
 	} else {
 		c.config.container.privileges.allowSetgroups = C.false
+	}
+}
+
+// SetCleanupHost sets the flag to tell starter container setup
+// to spawn a cleanup process for SIF FUSE mounts early, in the
+// original host namespaces.
+func (c *Config) SetCleanupHost(enabled bool) {
+	if enabled {
+		c.config.starter.cleanupHost = C.true
+	} else {
+		c.config.starter.cleanupHost = C.false
 	}
 }
 

--- a/internal/pkg/runtime/engine/engine_linux.go
+++ b/internal/pkg/runtime/engine/engine_linux.go
@@ -94,7 +94,7 @@ type Operations interface {
 	//
 	// No additional privileges can be gained during this call, as privileges are
 	// dropped permanently after forking in starter.
-	CleanupHost() error
+	CleanupHost(context.Context) error
 }
 
 // getName returns the engine name set in JSON []byte configuration.

--- a/internal/pkg/runtime/engine/engine_linux.go
+++ b/internal/pkg/runtime/engine/engine_linux.go
@@ -88,6 +88,13 @@ type Operations interface {
 	// a hybrid workflow (e.g. fakeroot), then there is no privileged saved uid
 	// and thus no additional privileges can be gained.
 	CleanupContainer(context.Context, error, syscall.WaitStatus) error
+	// CleanupHost is called after CleanupContainer, before master exits.
+	// It is run in the process forked from starter before namespace setup etc. and
+	// will perform any cleanup in the host mount namespace at time of CLI execution.
+	//
+	// No additional privileges can be gained during this call, as privileges are
+	// dropped permanently after forking in starter.
+	CleanupHost() error
 }
 
 // getName returns the engine name set in JSON []byte configuration.

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -287,7 +287,7 @@ func (e *EngineOperations) CleanupContainer(context.Context, error, syscall.Wait
 }
 
 // CleanupHost does nothing for the fakeroot engine.
-func (e *EngineOperations) CleanupHost() error {
+func (e *EngineOperations) CleanupHost(ctx context.Context) error {
 	return nil
 }
 

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -286,6 +286,11 @@ func (e *EngineOperations) CleanupContainer(context.Context, error, syscall.Wait
 	return nil
 }
 
+// CleanupHost does nothing for the fakeroot engine.
+func (e *EngineOperations) CleanupHost() error {
+	return nil
+}
+
 // PostStartProcess does nothing for the fakeroot engine.
 func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error {
 	return nil

--- a/internal/pkg/runtime/engine/singularity/cleanup_host_linux.go
+++ b/internal/pkg/runtime/engine/singularity/cleanup_host_linux.go
@@ -17,7 +17,7 @@ import (
 
 // CleanupHost cleans up a SIF FUSE mount and temporary directory. It is called
 // from a HOST_CLEANUP process that exists in the original host namespaces.
-func (e *EngineOperations) CleanupHost() (err error) {
+func (e *EngineOperations) CleanupHost(ctx context.Context) (err error) {
 	if e.EngineConfig.GetImageFuse() {
 		sylog.Infof("Unmounting SIF with FUSE...")
 		fusermountPath, err := bin.FindBin("fusermount")
@@ -25,7 +25,7 @@ func (e *EngineOperations) CleanupHost() (err error) {
 			return fmt.Errorf("while unmounting fuse directory: %s: %w", e.EngineConfig.GetImage(), err)
 		}
 
-		err = sifuser.Unmount(context.TODO(), e.EngineConfig.GetImage(),
+		err = sifuser.Unmount(ctx, e.EngineConfig.GetImage(),
 			sifuser.OptUnmountStdout(os.Stdout),
 			sifuser.OptUnmountStderr(os.Stderr),
 			sifuser.OptUnmountFusermountPath(fusermountPath))

--- a/internal/pkg/runtime/engine/singularity/cleanup_host_linux.go
+++ b/internal/pkg/runtime/engine/singularity/cleanup_host_linux.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	sifuser "github.com/sylabs/sif/v2/pkg/user"
+	"github.com/sylabs/singularity/internal/pkg/util/bin"
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+// CleanupHost cleans up a SIF FUSE mount and temporary directory. It is called
+// from a HOST_CLEANUP process that exists in the original host namespaces.
+func (e *EngineOperations) CleanupHost() (err error) {
+	if e.EngineConfig.GetImageFuse() {
+		sylog.Infof("Unmounting SIF with FUSE...")
+		fusermountPath, err := bin.FindBin("fusermount")
+		if err != nil {
+			return fmt.Errorf("while unmounting fuse directory: %s: %w", e.EngineConfig.GetImage(), err)
+		}
+
+		err = sifuser.Unmount(context.TODO(), e.EngineConfig.GetImage(),
+			sifuser.OptUnmountStdout(os.Stdout),
+			sifuser.OptUnmountStderr(os.Stderr),
+			sifuser.OptUnmountFusermountPath(fusermountPath))
+		if err != nil {
+			return fmt.Errorf("while unmounting fuse directory: %s: %w", e.EngineConfig.GetImage(), err)
+		}
+
+		if tempDir := e.EngineConfig.GetDeleteTempDir(); tempDir != "" {
+			sylog.Infof("Removing image tempDir %s", tempDir)
+			err := os.RemoveAll(tempDir)
+			if err != nil {
+				return fmt.Errorf("failed to delete container image tempDir %s: %w", tempDir, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -50,6 +50,9 @@ func FindBin(name string) (path string, err error) {
 	// ldconfig is invoked by nvidia-container-cli, so must be trusted also.
 	case "cryptsetup", "ldconfig", "nvidia-container-cli":
 		return findFromConfigOnly(name)
+	// distro provided squashfuse & fusermount for unpriv SIF mount
+	case "squashfuse", "fusermount":
+		return findOnPath(name)
 	}
 	return "", fmt.Errorf("unknown executable name %q", name)
 }

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -121,6 +121,7 @@ type JSONConfig struct {
 	SignalPropagation     bool              `json:"signalPropagation,omitempty"`
 	RestoreUmask          bool              `json:"restoreUmask,omitempty"`
 	DeleteTempDir         string            `json:"deleteTempDir,omitempty"`
+	ImageFuse             bool              `json:"imageFuse,omitempty"`
 	Umask                 int               `json:"umask,omitempty"`
 	XdgRuntimeDir         string            `json:"xdgRuntimeDir,omitempty"`
 	DbusSessionBusAddress string            `json:"dbusSessionBusAddress,omitempty"`
@@ -660,6 +661,16 @@ func (e *EngineConfig) GetDeleteTempDir() string {
 // which must be deleted after use.
 func (e *EngineConfig) SetDeleteTempDir(dir string) {
 	e.JSON.DeleteTempDir = dir
+}
+
+// SetImageFuse sets whether the ImageDir is a FUSE mount.
+func (e *EngineConfig) SetImageFuse(fuse bool) {
+	e.JSON.ImageFuse = fuse
+}
+
+// GetFakeroot returns if the ImageDir is a FUSE mount or not.
+func (e *EngineConfig) GetImageFuse() bool {
+	return e.JSON.ImageFuse
 }
 
 // SetSignalPropagation sets if engine must propagate signals from

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -74,6 +74,7 @@ type File struct {
 	DownloadPartSize        uint     `default:"5242880" directive:"download part size"`
 	DownloadBufferSize      uint     `default:"32768" directive:"download buffer size"`
 	SystemdCgroups          bool     `default:"yes" authorized:"yes,no" directive:"systemd cgroups"`
+	SIFFUSE                 bool     `default:"no" authorized:"yes,no" directive:"sif fuse"`
 }
 
 const TemplateAsset = `# SINGULARITY.CONF
@@ -470,4 +471,12 @@ download buffer size = {{ .DownloadBufferSize }}
 # Whether to use systemd to manage container cgroups. Required for rootless cgroups
 # functionality. 'no' will manage cgroups directly via cgroupfs.
 systemd cgroups = {{ if eq .SystemdCgroups true }}yes{{ else }}no{{ end }}
+
+# SIF FUSE: [BOOL]
+# DEFAULT: no
+# EXPERIMENTAL
+# Whether to try mounting SIF images with Squashfuse by default.
+# Applies only to unprivileged / user namespace flows. Requires squashfuse and
+# fusermount on PATH. Will fall back to extracting the SIF on failure.
+sif fuse = {{ if eq .SIFFUSE true }}yes{{ else }}no{{ end }}
 `


### PR DESCRIPTION
Allow SIF images to be mounted with `squashfuse` in the unpriv / user-namespace flow.

The approach take here is to:

* Leverage the `MountFUSE` / `UnmountFUSE` functionality from sylabs/sif, rather than duplicating code.
* Perform the mount onto a temporary directory in the CLI layer, at the point where the SIF would otherwise be extracted. The singularity runtime then sees a sandbox.
* Add a 'CLEANUP_HOST' process that is forked from `starter` early, before any namespace manipulation. This process is able to unmount the SIF at cleanup time. A socket from the host cleanup process to the master process is used for coordination.

Mount at the CLI layer, rather than inside of the runtime engine, is used so that we can adopt a similar approach across `singularity oci` commands, and general use of runc in future.

`--fakeroot` is not currently supported.

`instance start` is not currently supported.

Fixes https://github.com/sylabs/singularity/issues/718

**Unsolved questions?**

* Should we have a `singularity.conf` to always try? It  *is* experimental, and there's a flag + env-var... but other experimental features have had a conf option in the past.

```
$ singularity run -u --sif-fuse ubuntu_latest.sif 
INFO:    Mounting SIF with FUSE...
Singularity> echo "HELLO!"
HELLO!
Singularity> 
exit
INFO:    Unmounting SIF with FUSE...
INFO:    Removing image tempDir /tmp/rootfs-949762240
```