### PR TITLE
Build / packaging cleanup (go check & conflicts / obsoletes/ deps)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,9 +17,10 @@ Vcs-Browser: https://github.com/sylabs/singularity
 
 Package: singularity-ce
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, cryptsetup-bin, squashfs-tools
+Depends: ${misc:Depends}, ${shlibs:Depends}, cryptsetup-bin, libseccomp2, squashfs-tools
 Conflicts:
  singularity-container,
+ apptainer,
  singularitypro24,
  singularitypro25,
  singularitypro26,

--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -45,8 +45,10 @@ BuildRequires: libseccomp-devel
 BuildRequires: glib2-devel
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
+Requires: libseccomp2
 %else
 Requires: squashfs-tools
+Requires: libseccomp
 %endif
 BuildRequires: cryptsetup
 
@@ -54,14 +56,15 @@ BuildRequires: cryptsetup
 ExcludeArch: ppc64
 
 Provides: %{name}-runtime
-Obsoletes: %{name}-runtime
+
+# Conflicts with non-CE packages
 Conflicts: singularity
+# Conflicts with Apptainer, which installs the `/usr/bin/singularity` compatibility executable
+Conflicts: apptainer
+# Conflicts with SingularityPRO basic packaging (not other variants).
 Conflicts: singularitypro24
-Conflicts: singularitypro24-runtime
 Conflicts: singularitypro25
-Conflicts: singularitypro25-runtime
 Conflicts: singularitypro26
-Conflicts: singularitypro26-runtime
 Conflicts: singularitypro31
 Conflicts: singularitypro35
 Conflicts: singularitypro37

--- a/mconfig
+++ b/mconfig
@@ -20,7 +20,7 @@ hstld=
 hstranlib=
 hstobjcopy=
 hstgo=
-hstgo_version="1.16"
+hstgo_version="1.17"
 hstgo_opts="go"
 
 tgtcc=


### PR DESCRIPTION
## Description of the Pull Request (PR):

* [fix: Match mconfig min go version to go.mod](https://github.com/sylabs/singularity/commit/d684010ac96cb26481f8b0bda7dbe4b3cbf10353)
 * [rpm: Tidy Requires / Conflicts etc.](https://github.com/sylabs/singularity/commit/3c096b131505d5476b17d31a061ab3585a4d2033)
    * Add runtime libeccomp / libseccomp2 dependency.
    * Remove `Obsoletes` for `singularity-ce-runtime`... we didn't ever
      have any 2.x packaging with a of CE, so there wasn't a split runtime
      package.
    * Add conflicts for Apptainer (which has a /usr/bin/singularity). 
* [deb: Tidy Requires / Conflicts etc.](https://github.com/sylabs/singularity/commit/4284f9b2945b6a8d93094c27e5498e7dc25148eb)
    * Add libseccomp2 runtime dependency.
    * Add conflicts with apptainer that provides /usr/bin/singularity.

### This fixes or addresses the following GitHub issues:

 - Fixes #714 
 - Fixes #715 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
