### PR TITLE
fix: Use HEAD request to check remote OCI image digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@
 - Support nvidia-container-cli v1.8.0 and above, via fix to capability set.
 - Do not truncate environment variables with commas.
 - Allow `newgidmap / newuidmap` that use capabilities instead of setuid root.
+- Use HEAD request when checking digest of remote OCI image sources, instead
+  of GET. Greatly reduces Singularity's impact on Docker Hub API limits.
 
 ## v3.9.6 \[2022-03-10\]
 

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -14,11 +14,11 @@ import (
 	"strings"
 
 	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/internal/pkg/cache"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
@@ -38,7 +38,7 @@ func ConvertReference(ctx context.Context, imgCache *cache.Handle, src types.Ima
 	// Our cache dir is an OCI directory. We are using this as a 'blob pool'
 	// storing all incoming containers under unique tags, which are a hash of
 	// their source URI.
-	cacheTag, err := calculateRefHash(ctx, src, sys)
+	cacheTag, err := getRefDigest(ctx, src, sys)
 	if err != nil {
 		return nil, err
 	}
@@ -108,24 +108,31 @@ func parseURI(uri string) (types.ImageReference, error) {
 	return transport.ParseReference(split[1])
 }
 
-// ImageSHA calculates the SHA of a uri's manifest
-func ImageSHA(ctx context.Context, uri string, sys *types.SystemContext) (string, error) {
+// ImageDigest obtains the digest of a uri's manifest
+func ImageDigest(ctx context.Context, uri string, sys *types.SystemContext) (string, error) {
 	ref, err := parseURI(uri)
 	if err != nil {
 		return "", fmt.Errorf("unable to parse image name %v: %v", uri, err)
 	}
 
-	return calculateRefHash(ctx, ref, sys)
+	return getRefDigest(ctx, ref, sys)
 }
 
-func calculateRefHash(ctx context.Context, ref types.ImageReference, sys *types.SystemContext) (hash string, err error) {
+// getRefDigest obtains the manifest digest for a ref.
+func getRefDigest(ctx context.Context, ref types.ImageReference, sys *types.SystemContext) (digest string, err error) {
+	// Handle docker references specially, using a HEAD request to ensure we don't hit API limits
+	if ref.Transport().Name() == "docker" {
+		return getDockerRefDigest(ctx, ref, sys)
+	}
+
+	// Otherwise get the manifest and calculate sha256 over it
 	source, err := ref.NewImageSource(ctx, sys)
 	if err != nil {
 		return "", err
 	}
 	defer func() {
 		if closeErr := source.Close(); closeErr != nil {
-			err = errors.Wrapf(err, " (src: %v)", closeErr)
+			err = fmt.Errorf("%w (src: %v)", err, closeErr)
 		}
 	}()
 
@@ -133,7 +140,24 @@ func calculateRefHash(ctx context.Context, ref types.ImageReference, sys *types.
 	if err != nil {
 		return "", err
 	}
+	// Match the sha256.<digest> format we are using in the library cache also.
+	// Previously we didn't include the algorithm, but we should, in case
+	// alternatives are introduced.
+	digest = fmt.Sprintf("sha256.%x", sha256.Sum256(man))
+	sylog.Debugf("Digest for %s is %s", transports.ImageName(ref), digest)
+	return digest, nil
+}
 
-	hash = fmt.Sprintf("%x", sha256.Sum256(man))
-	return hash, nil
+// getDockerRefDigest obtains the manifest digest for a docker ref.
+func getDockerRefDigest(ctx context.Context, ref types.ImageReference, sys *types.SystemContext) (digest string, err error) {
+	d, err := docker.GetDigest(ctx, sys, ref)
+	if err != nil {
+		return "", err
+	}
+	// Match the sha256.<digest> format we are using in the library cache also.
+	// Previously we didn't include the algorithm, but we should, in case
+	// alternatives are introduced.
+	digest = d.Algorithm().String() + "." + d.Encoded()
+	sylog.Debugf("Digest for %s is %s", transports.ImageName(ref), digest)
+	return digest, nil
 }

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -358,7 +358,7 @@ func TestImageNameAndImageSHA(t *testing.T) {
 
 		testName = "ImageSHA - " + tt.name
 		t.Run(testName, func(t *testing.T) {
-			_, err := ImageSHA(context.Background(), tt.uri, tt.ctx)
+			_, err := ImageDigest(context.Background(), tt.uri, tt.ctx)
 			if tt.shouldPass == true && err != nil {
 				t.Fatal("test expected to succeeded but failed")
 			}

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -39,7 +39,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDi
 		sysCtx.DockerInsecureSkipTLSVerify = ocitypes.NewOptionalBool(true)
 	}
 
-	hash, err := oci.ImageSHA(ctx, pullFrom, sysCtx)
+	hash, err := oci.ImageDigest(ctx, pullFrom, sysCtx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get checksum for %s: %s", pullFrom, err)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use a HEAD request when checking digest of remote OCI image sources, via the `docker.GetDigest` function in containers/image.

Previously we were using `GetManifest` and computing the hash ourselves. This is a complete GET, and counts against Docker Hub  API limits even if the cached image is up-to-date.

Note - filename of generated SIF in cache is now `<alg>.<digest>`, previously `<digest>`. Storing the algorithm in the filename prevents conflicts if there is a switch from `sha256` to something else.


Example requests pulling an image that's already cached:

**Before this PR**
One GET against `/v2/` to check API availability (no impact on API limits)
One GET against manifest URL (**counts against API limits**)

```
172.17.0.1 - - [21/Apr/2022:23:16:38 +0000] "GET /v2/ HTTP/1.1" 200 2 "" "Singularity-Ce/3.9.1+239 (Linux amd64) Go/1.17.8"
172.17.0.1 - - [21/Apr/2022:23:16:38 +0000] "GET /v2/ubuntu/manifests/latest HTTP/1.1" 200 529 "" "Singularity-Ce/3.9.1+239 (Linux amd64) Go/1.17.8"
```

**With this PR**

One GET against `/v2/` to check API availability (no impact on API limits)
One HEAD against manifest URL (no impact on API limits)

```
172.17.0.1 - - [21/Apr/2022:23:19:13 +0000] "GET /v2/ HTTP/1.1" 200 2 "" "Singularity-Ce/3.9.1+240 (Linux amd64) Go/1.17.8"
172.17.0.1 - - [21/Apr/2022:23:19:13 +0000] "HEAD /v2/ubuntu/manifests/latest HTTP/1.1" 200 529 "" "Singularity-Ce/3.9.1+240 (Linux amd64) Go/1.17.8"
```


### This fixes or addresses the following GitHub issues:

 - Fixes #722


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
