### PR TITLE
fix: Add fall-through for missing Docker-Content-Digest (release-3.9)

### DIFF
--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -122,7 +122,13 @@ func ImageDigest(ctx context.Context, uri string, sys *types.SystemContext) (str
 func getRefDigest(ctx context.Context, ref types.ImageReference, sys *types.SystemContext) (digest string, err error) {
 	// Handle docker references specially, using a HEAD request to ensure we don't hit API limits
 	if ref.Transport().Name() == "docker" {
-		return getDockerRefDigest(ctx, ref, sys)
+		digest, err := getDockerRefDigest(ctx, ref, sys)
+		if err == nil {
+			return digest, err
+		}
+		// Need to have a fallback path, as the Docker-Content-Digest header is
+		// not required in oci-distribution-spec.
+		sylog.Debugf("Falling back to GetManifest digest: %s", err)
 	}
 
 	// Otherwise get the manifest and calculate sha256 over it
@@ -141,7 +147,7 @@ func getRefDigest(ctx context.Context, ref types.ImageReference, sys *types.Syst
 		return "", err
 	}
 	digest = fmt.Sprintf("%x", sha256.Sum256(man))
-	sylog.Debugf("Digest for %s is %s", transports.ImageName(ref), digest)
+	sylog.Debugf("GetManifest digest for %s is %s", transports.ImageName(ref), digest)
 	return digest, nil
 }
 
@@ -152,6 +158,6 @@ func getDockerRefDigest(ctx context.Context, ref types.ImageReference, sys *type
 		return "", err
 	}
 	digest = d.Encoded()
-	sylog.Debugf("Digest for %s is %s", transports.ImageName(ref), digest)
+	sylog.Debugf("docker.GetDigest digest for %s is %s", transports.ImageName(ref), digest)
 	return digest, nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

PR #727 was written while reviewing the Docker registry API v2 spec, in which it is stated a manifest HEAD request does include
`Docker-Content-Digest`.

I had not considered potential differences in the oci-distribution-spec. This makes it clear that `Docker-Content-Digest` is a SHOULD header, and lists it as a field clients should not depend on.

The `containers/image` `docker.GetDigest` function doesn't handle the lack of a `Docker-Content-Digest` header, so we should fall-through to the old `GetManifest` approach on error.

### This fixes or addresses the following GitHub issues:

 - Fixes #733

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
