### PR TITLE
ci: reduce CI minutes / storage consumption

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,17 +153,6 @@ jobs:
           name: Check License Changes
           command: git diff --exit-code -- LICENSE_DEPENDENCIES.md
 
-  build-source-debian:
-    executor:
-      name: golang
-      variant: bullseye
-    steps:
-      - checkout
-      - install-deps-apt:
-          sudo: false
-      - update-submodules
-      - build-singularity
-
   build-source-alpine:
     executor:
       name: golang
@@ -312,7 +301,6 @@ workflows:
       - lint-markdown
       - check-go-mod
       - check-license-dependencies
-      - build-source-debian
       - build-source-alpine
       - lint-source
       - short-unit-tests
@@ -322,7 +310,18 @@ workflows:
           matrix:
             parameters:
               e: ["centos7", "almalinux8"]
+          filters:
+            branches:
+              only:
+                - master
+                - /release-.*/
+
       - build-deb:
           matrix:
             parameters:
               e: ["ubuntu1804", "ubuntu2004", "ubuntu2204"]
+          filters:
+            branches:
+              only:
+                - master
+                - /release-.*/


### PR DESCRIPTION
## Description of the Pull Request (PR):

Our CI tasks are using quite a lot of minutes and artifact storage for tasks that aren't particularly useful. This PR reduces CI resource
usage.

1) Remove the `build-source-debian` task. Our source is built on Ubuntu 20.04 in the test jobs. Ubuntu LTS is close enough to Debian
stable that I can't ever remember a failure on one, but not the other.

2) Limit package builds to commits to `master` and `release-` branches. This avoids building and storing 5 distro packages for every
PR commit etc. We still have artifacts available after a PR is merged, to point users to if they need a packaged version with a fix urgently. The cadence should be sufficient to show any rpm / deb build issues.


### This fixes or addresses the following GitHub issues:

 - Fixes #744 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
