### PR TITLE
fix: Handle literal escaped newline \n in host environment vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Allow `newgidmap / newuidmap` that use capabilities instead of setuid root.
 - Corrected `key search` output for results from some servers, and keys
   with multiple names.
+- Pass through a literal `\n` in host environment variables to container.
 
 ## v3.9.9 \[2022-04-22\]
 

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -285,6 +285,13 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 			matchVal: "Hello\nWorld",
 		},
 		{
+			name:     "TestEscapedNewline",
+			image:    c.env.ImagePath,
+			hostEnv:  []string{"ESCAPED=Hello\\nWorld"},
+			matchEnv: "ESCAPED",
+			matchVal: "Hello\\nWorld",
+		},
+		{
 			name:  "TestInvalidKey",
 			image: c.env.ImagePath,
 			// We try to set an invalid env var... and make sure

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -720,11 +720,17 @@ func getAllEnvBuiltin(shell *interpreter.Shell) interpreter.ShellBuiltin {
 				sylog.Debugf("Not exporting %q to container environment: invalid key", key)
 				continue
 			}
-
-			// Because we are using IFS=\n we need to escape newlines
-			// here and unescape them in the action script when we
-			// export the var again.
-			env := strings.Replace(env, "\n", "\\n", -1)
+			// Because we are using IFS=\n we need to escape newlines here and
+			// unescape them in the action script when we export the var again.
+			//
+			// This is imperfect - it is not possible to represent a string
+			// containing a literal '\u000A' (unicode escaped newline) in it.
+			//
+			// Full escaping / unescaping requires iterative parsing of the
+			// string in the action script. This is too awkward and slow in
+			// shell code. If we can use `printf -v VAR "%b" ...` from mvdan.cc/sh
+			// in future, we may be able to revisit this.
+			env := strings.Replace(env, "\n", "\\u000A", -1)
 			fmt.Fprintf(hc.Stdout, "%s\n", env)
 		}
 		return nil

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -70,7 +70,7 @@ restore_env() {
     for e in ${__exported_env__}; do
         key=${e%%=*}
         if ! test -v "${key}"; then
-            export "${e//'\n'/$IFS}"
+            export "${e//'\u000A'/$IFS}"
         elif test -z "${!key}"; then
             unset "${key}"
         fi


### PR DESCRIPTION
## Description of the Pull Request (PR):

Since 3.6.0 we have been passing the entire host environment into the action script, it being stored with a single env var there. We use a newline as our IFS when processing this later on. This requires replacing newlines with some other char or string. To date we have been using the standard `\n` as the replacement. However, this means that any host env var containing a literal `\n` cannot be faithfully passed into the container.

There is no easy perfect solution to this at present.

We cannot do a full escaping of the host env vars, as reversing this in our action script requires either:

* Iterative processing on unescape, as look-ahead is important to understand the context of any `\`. This would be extremely messy and slow to implement in shell code, and impact maintainability in this area further.
* Support for `printf` into a var (`-v`), an perhaps with the POSIX `%b` format code. While suported by bash, `-v` and `%b`are not
  available in mvdan.cc/sh and using a subshell invocation of printf has significant performance problems.

On balance, I think a sensible strategy is to use the unicode escaping `\u000A`. This prevents verbatim use of a host env var that contains `\u000A`, but this is less likely to be seen that `\n` and we can document the limitation. Continuing to use something that really does represent a newline is also good for sanity's sake.

I considered changing the IFS, but that still doesn't buy us a complete solution. I don't think there are any great choices here really. We should address the issue properly when a solution is available. Perhaps this is via us contributing some more printf feature support to mvdan.cc/sh when resources allow, and if it would be accepted there.

### This fixes or addresses the following GitHub issues:

 - Fixes #752 (imperfectly)


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
