### PR TITLE
fix: key search results for keys.openpgp.org and multiple names on a key (apptainer 99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
 - Support nvidia-container-cli v1.8.0 and above, via fix to capability set.
 - Do not truncate environment variables with commas.
 - Allow `newgidmap / newuidmap` that use capabilities instead of setuid root.
+- Corrected `key search` output for results from some servers, and keys
+  with multiple names.
 
 ## v3.9.9 \[2022-04-22\]
 

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -108,8 +108,28 @@ func (c *ctx) singularityKeySearch(t *testing.T) {
 			stdout: "^Showing 1 results",
 		},
 		{
+			name:   "key search -u https://keys.openpgp.org 0x<key fingerprint>",
+			args:   []string{"search", "-u", "https://keys.openpgp.org", "0x7605BC2716168DF057D6C600ACEEC62C8BD91BEE"},
+			stdout: "^Showing 1 results",
+		},
+		{
+			name:   "key search -u https://keys.openpgp.org <key fingerprint>",
+			args:   []string{"search", "-u", "https://keys.openpgp.org", "7605BC2716168DF057D6C600ACEEC62C8BD91BEE"},
+			stdout: "^Showing 1 results",
+		},
+		{
+			name:   "key search <key with at least two emails>",
+			args:   []string{"search", "-u", "https://keys.openpgp.org", "dwd@fnal.gov"},
+			stdout: "\n  .*@",
+		},
+		{
+			name:   "key search -l <key with at least two emails>",
+			args:   []string{"search", "-u", "https://keys.openpgp.org", "-l", "dwd@fnal.gov"},
+			stdout: "\n  .*@",
+		},
+		{
 			name:   "key search <name>",
-			args:   []string{"search", "westley"},
+			args:   []string{"search", "Library"},
 			stdout: "^Showing",
 		},
 		{

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -599,45 +600,66 @@ func SelectPrivKey(el openpgp.EntityList) (*openpgp.Entity, error) {
 // in []bytes, and a error if one occurs.
 func formatMROutput(mrString string) (int, []byte, error) {
 	count := 0
-	keyNum := 0
+	numKeys := 0
 	listLine := "%s\t%s\t%s\n"
 
 	retList := bytes.NewBuffer(nil)
 	tw := tabwriter.NewWriter(retList, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(tw, listLine, "KEY ID", "BITS", "NAME/EMAIL")
 
-	key := strings.Split(mrString, "\n")
+	lines := strings.Split(mrString, "\n")
 
-	for _, k := range key {
-		nk := strings.Split(k, ":")
-		for _, n := range nk {
-			if n == "info" {
-				var err error
-				keyNum, err = strconv.Atoi(nk[2])
-				if err != nil {
-					return -1, nil, fmt.Errorf("unable to check key number")
+	first := true
+	gotName := false
+	for _, l := range lines {
+		fields := strings.Split(strings.TrimSpace(l), ":")
+		if fields[0] == "info" {
+			var err error
+			numKeys, err = strconv.Atoi(fields[2])
+			if err != nil {
+				return -1, nil, fmt.Errorf("unable to check number of keys")
+			}
+		} else if fields[0] == "pub" {
+			if !first {
+				if !gotName {
+					// there was a pub without uid; end line
+					fmt.Fprintf(tw, "\n")
 				}
+				// put a blank line between each key
+				fmt.Fprintf(tw, "\n")
 			}
-			if n == "pub" {
-				// The fingerprint is located at nk[1], and we only want the last 8 chars
-				fmt.Fprintf(tw, "%s\t", nk[1][len(nk[1])-8:])
-				// The key size (bits) is located at nk[3]
-				fmt.Fprintf(tw, "%s\t", nk[3])
-				count++
+			first = false
+			gotName = false
+			// The fingerprint is located at fields[1], and we only want the last 8 chars
+			fmt.Fprintf(tw, "%s\t", fields[1][len(fields[1])-8:])
+			// The key size (bits) is located at fields[3]
+			fmt.Fprintf(tw, "%s\t", fields[3])
+			count++
+		} else if fields[0] == "uid" {
+			// And the key name/email is on fields[1]
+			// There may be more than one of these for each pub
+			if !gotName {
+				gotName = true
+			} else {
+				// indent as far as the pub line
+				fmt.Fprintf(tw, "%s\t%s\t", "", "")
 			}
-			if n == "uid" {
-				// And the key name/email is on nk[1]
-				fmt.Fprintf(tw, "%s\t\n\n", nk[1])
-			}
+			name := fields[1]
+			name, _ = url.QueryUnescape(name)
+			fmt.Fprintf(tw, "%s\t\n", name)
 		}
+	}
+	if numKeys > 0 && !gotName {
+		// no name was printed with last key
+		fmt.Fprintf(tw, "\n")
 	}
 	tw.Flush()
 
-	sylog.Debugf("key count=%d; expect=%d\n", count, keyNum)
+	sylog.Debugf("key count=%d; expect=%d\n", count, numKeys)
 
 	// Simple check to ensure the conversion was successful
-	if count != keyNum {
-		sylog.Debugf("expecting %d, got %d\n", keyNum, count)
+	if count != numKeys {
+		sylog.Debugf("expecting %d, got %d\n", numKeys, count)
 		return -1, retList.Bytes(), fmt.Errorf("failed to convert machine readable to human readable output correctly")
 	}
 
@@ -743,37 +765,37 @@ func date(s string) string {
 	return ret
 }
 
-// getKeyInfoFromList takes the lines, from strings.Split(), and a index of lines. Appends
-// the output into keyList. Returns a error if one occurs.
-func getKeyInfoFromList(keyList *mrKeyList, lines []string, index string) error {
+// getKeyInfoFromLine extracts information from the fields coming from each
+// line of output from a key search.  Returns a error if one occurs.
+func getKeyInfoFromLine(keyList *mrKeyList, fields []string) error {
 	var errRet error
 
-	if index == "pub" {
+	if fields[0] == "pub" {
 		// Get the fingerprint for the key
-		keyList.keyFingerprint = lines[1]
+		keyList.keyFingerprint = fields[1]
 
 		// Get the bit length for the key
-		keyList.keyBit = lines[3]
+		keyList.keyBit = fields[3]
 
 		var err error
 		// Get the key type
-		keyList.keyType, err = getEncryptionAlgorithmName(lines[2])
+		keyList.keyType, err = getEncryptionAlgorithmName(fields[2])
 		if err != nil {
 			errRet = err
 		}
 
 		// Get the date created for the key
-		keyList.keyDateCreated = date(lines[4])
+		keyList.keyDateCreated = date(fields[4])
 
 		// Get the expiration date for the key
-		keyList.keyDateExpired = date(lines[5])
+		keyList.keyDateExpired = date(fields[5])
 
 		// Get the key status
-		if lines[6] == "r" {
+		if fields[6] == "r" {
 			keyList.keyStatus = "[revoked]"
-		} else if lines[6] == "d" {
+		} else if fields[6] == "d" {
 			keyList.keyStatus = "[disabled]"
-		} else if lines[6] == "e" {
+		} else if fields[6] == "e" {
 			keyList.keyStatus = "[expired]"
 		} else {
 			keyList.keyStatus = "[enabled]"
@@ -782,13 +804,12 @@ func getKeyInfoFromList(keyList *mrKeyList, lines []string, index string) error 
 		// Only count the key if it has a fingerprint. Otherwise
 		// dont count it.
 		keyList.keyCount++
-	}
-	if index == "uid" {
-		// Get the name of the key
-		keyList.keyName = lines[1]
+	} else if fields[0] == "uid" {
+		// Note that there can be more than one of these for each pub
 
-		// After we get the name, the key is ready to print!
-		keyList.keyReady = true
+		// Get the name of the key
+		keyList.keyName = fields[1]
+		keyList.keyName, _ = url.QueryUnescape(keyList.keyName)
 	}
 
 	return errRet
@@ -797,44 +818,67 @@ func getKeyInfoFromList(keyList *mrKeyList, lines []string, index string) error 
 // formatMROutputLongList reformats the key search output that is in machine readable format
 // see the output format in: https://tools.ietf.org/html/draft-shaw-openpgp-hkp-00#section-5.2
 func formatMROutputLongList(mrString string) (int, []byte, error) {
-	listLine := "%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
+	pubFmt := "%s\t%s\t%s\t%s\t%s\t%s\t"
+	nameFmt := "%s\n"
 
 	retList := bytes.NewBuffer(nil)
 	tw := tabwriter.NewWriter(retList, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, listLine, "FINGERPRINT", "ALGORITHM", "BITS", "CREATION DATE", "EXPIRATION DATE", "STATUS", "NAME/EMAIL")
+	fmt.Fprintf(tw, pubFmt+nameFmt, "FINGERPRINT", "ALGORITHM", "BITS", "CREATION DATE", "EXPIRATION DATE", "STATUS", "NAME/EMAIL")
 
-	keyNum := 0
-	key := strings.Split(mrString, "\n")
+	numKeys := 0
+	lines := strings.Split(mrString, "\n")
 	var keyList mrKeyList
 
-	for _, k := range key {
-		nk := strings.Split(k, ":")
-		for _, n := range nk {
-			if n == "info" {
-				var err error
-				keyNum, err = strconv.Atoi(nk[2])
-				if err != nil {
-					return -1, nil, fmt.Errorf("unable to check key number")
-				}
-			}
-			err := getKeyInfoFromList(&keyList, nk, n)
+	first := true
+	gotName := false
+	for _, l := range lines {
+		fields := strings.Split(strings.TrimSpace(l), ":")
+		if fields[0] == "info" {
+			var err error
+			numKeys, err = strconv.Atoi(fields[2])
 			if err != nil {
-				return -1, nil, fmt.Errorf("failed to get entity from list: %s", err)
+				return -1, nil, fmt.Errorf("unable to check key number")
+			}
+		} else {
+			err := getKeyInfoFromLine(&keyList, fields)
+			if err != nil {
+				return -1, nil, fmt.Errorf("failed to get key entity from line: %s", err)
+			}
+			if fields[0] == "pub" {
+				if !first {
+					if !gotName {
+						// there was a pub without uid; end line
+						fmt.Fprintf(tw, "\n")
+					}
+					// put blank line between each key
+					fmt.Fprintf(tw, "\n")
+				}
+				first = false
+				gotName = false
+				fmt.Fprintf(tw, pubFmt, keyList.keyFingerprint, keyList.keyType, keyList.keyBit, keyList.keyDateCreated, keyList.keyDateExpired, keyList.keyStatus)
+			}
+			if fields[0] == "uid" {
+				if gotName {
+					// an extra name, indent it
+					fmt.Fprintf(tw, pubFmt, "", "", "", "", "", "")
+				} else {
+					gotName = true
+				}
+				fmt.Fprintf(tw, nameFmt, keyList.keyName)
 			}
 		}
-		if keyList.keyReady {
-			fmt.Fprintf(tw, listLine, keyList.keyFingerprint, keyList.keyType, keyList.keyBit, keyList.keyDateCreated, keyList.keyDateExpired, keyList.keyStatus, keyList.keyName)
-			fmt.Fprintf(tw, "\t\t\t\t\t\t\n")
-			keyList = mrKeyList{keyCount: keyList.keyCount}
-		}
+	}
+	if numKeys > 0 && !gotName {
+		// no name was printed with last key
+		fmt.Fprintf(tw, "\n")
 	}
 	tw.Flush()
 
-	sylog.Debugf("key count=%d; expect=%d\n", keyList.keyCount, keyNum)
+	sylog.Debugf("key count=%d; expect=%d\n", keyList.keyCount, numKeys)
 
 	// Simple check to ensure the conversion was successful
-	if keyList.keyCount != keyNum {
-		sylog.Debugf("expecting %d, got %d\n", keyNum, keyList.keyCount)
+	if keyList.keyCount != numKeys {
+		sylog.Debugf("expecting %d, got %d\n", numKeys, keyList.keyCount)
 		return -1, retList.Bytes(), fmt.Errorf("failed to convert machine readable to human readable output correctly")
 	}
 

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -85,20 +85,6 @@ type GenKeyPairOptions struct {
 	KeyLength int
 }
 
-// mrKeyList contains all the key info, used for decoding
-// the MR output from 'key search'
-type mrKeyList struct {
-	keyFingerprint string
-	keyBit         string
-	keyName        string
-	keyType        string
-	keyDateCreated string
-	keyDateExpired string
-	keyStatus      string
-	keyCount       int
-	keyReady       bool
-}
-
 func (e *KeyExistsError) Error() string {
 	return fmt.Sprintf("the key with fingerprint %X already belongs to the keyring", e.fingerprint)
 }
@@ -595,17 +581,27 @@ func SelectPrivKey(el openpgp.EntityList) (*openpgp.Entity, error) {
 	return el[n], nil
 }
 
-// formatMROutput will take a machine readable input, and convert it to fit
-// on a 80x24 terminal. Returns the number of keys(int), the formated string
-// in []bytes, and a error if one occurs.
-func formatMROutput(mrString string) (int, []byte, error) {
+// formatMROutput formats the key search output that is in machine readable
+// format into something readable by people.  If longOutput is set, more
+// detail is included.  See the input format in:
+// https://tools.ietf.org/html/draft-shaw-openpgp-hkp-00#section-5.2
+// Returns the number of keys(int), the formated string
+// in []bytes, and an error if one occurs.
+func formatMROutput(mrString string, longOutput bool) (int, []byte, error) {
 	count := 0
 	numKeys := 0
-	listLine := "%s\t%s\t%s\n"
+	longFmt := "%s\t%s\t%s\t%s\t%s\t%s\t"
+	shortFmt := "%s\t%s\t"
+	nameFmt := "%s\n"
 
 	retList := bytes.NewBuffer(nil)
 	tw := tabwriter.NewWriter(retList, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, listLine, "KEY ID", "BITS", "NAME/EMAIL")
+	if longOutput {
+		fmt.Fprintf(tw, longFmt, "FINGERPRINT", "ALGORITHM", "BITS", "CREATION DATE", "EXPIRATION DATE", "STATUS")
+	} else {
+		fmt.Fprintf(tw, shortFmt, "KEY ID", "BITS")
+	}
+	fmt.Fprintf(tw, nameFmt, "NAME/EMAIL")
 
 	lines := strings.Split(mrString, "\n")
 
@@ -630,10 +626,34 @@ func formatMROutput(mrString string) (int, []byte, error) {
 			}
 			first = false
 			gotName = false
-			// The fingerprint is located at fields[1], and we only want the last 8 chars
-			fmt.Fprintf(tw, "%s\t", fields[1][len(fields[1])-8:])
-			// The key size (bits) is located at fields[3]
-			fmt.Fprintf(tw, "%s\t", fields[3])
+			keyFingerprint := fields[1]
+			keyBits := fields[3]
+			if longOutput {
+				keyType, err := getEncryptionAlgorithmName(fields[2])
+				if err != nil {
+					return -1, nil, err
+				}
+				keyDateCreated := date(fields[4])
+				keyDateExpired := date(fields[5])
+
+				keyStatus := ""
+				if fields[6] == "r" {
+					keyStatus = "[revoked]"
+				} else if fields[6] == "d" {
+					keyStatus = "[disabled]"
+				} else if fields[6] == "e" {
+					keyStatus = "[expired]"
+				} else {
+					keyStatus = "[enabled]"
+				}
+
+				fmt.Fprintf(tw, longFmt, keyFingerprint, keyType, keyBits, keyDateCreated, keyDateExpired, keyStatus)
+
+			} else {
+				// Short output
+				// take only last 8 chars of fingerprint
+				fmt.Fprintf(tw, shortFmt, keyFingerprint[len(fields[1])-8:], keyBits)
+			}
 			count++
 		} else if fields[0] == "uid" {
 			// And the key name/email is on fields[1]
@@ -642,11 +662,18 @@ func formatMROutput(mrString string) (int, []byte, error) {
 				gotName = true
 			} else {
 				// indent as far as the pub line
-				fmt.Fprintf(tw, "%s\t%s\t", "", "")
+				if longOutput {
+					fmt.Fprintf(tw, longFmt, "", "", "", "", "", "")
+				} else {
+					fmt.Fprintf(tw, shortFmt, "", "")
+				}
 			}
-			name := fields[1]
-			name, _ = url.QueryUnescape(name)
-			fmt.Fprintf(tw, "%s\t\n", name)
+			name, err := url.QueryUnescape(fields[1])
+			if err != nil {
+				sylog.Debugf("using undecoded name because url decode didn't work: %v", err)
+				name = fields[1]
+			}
+			fmt.Fprintf(tw, nameFmt, name)
 		}
 	}
 	if numKeys > 0 && !gotName {
@@ -704,18 +731,10 @@ func SearchPubkey(ctx context.Context, search string, longOutput bool, opts ...c
 		}
 	}
 
-	if longOutput {
-		kcount, keyList, err := formatMROutputLongList(keyText)
-		fmt.Printf("Showing %d results\n\n%s", kcount, keyList)
-		if err != nil {
-			return fmt.Errorf("could not reformat key output")
-		}
-	} else {
-		kcount, keyList, err := formatMROutput(keyText)
-		fmt.Printf("Showing %d results\n\n%s", kcount, keyList)
-		if err != nil {
-			return err
-		}
+	kcount, keyList, err := formatMROutput(keyText, longOutput)
+	fmt.Printf("Showing %d results\n\n%s", kcount, keyList)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -763,126 +782,6 @@ func date(s string) string {
 	ret := time.Unix(c, 0).String()
 
 	return ret
-}
-
-// getKeyInfoFromLine extracts information from the fields coming from each
-// line of output from a key search.  Returns a error if one occurs.
-func getKeyInfoFromLine(keyList *mrKeyList, fields []string) error {
-	var errRet error
-
-	if fields[0] == "pub" {
-		// Get the fingerprint for the key
-		keyList.keyFingerprint = fields[1]
-
-		// Get the bit length for the key
-		keyList.keyBit = fields[3]
-
-		var err error
-		// Get the key type
-		keyList.keyType, err = getEncryptionAlgorithmName(fields[2])
-		if err != nil {
-			errRet = err
-		}
-
-		// Get the date created for the key
-		keyList.keyDateCreated = date(fields[4])
-
-		// Get the expiration date for the key
-		keyList.keyDateExpired = date(fields[5])
-
-		// Get the key status
-		if fields[6] == "r" {
-			keyList.keyStatus = "[revoked]"
-		} else if fields[6] == "d" {
-			keyList.keyStatus = "[disabled]"
-		} else if fields[6] == "e" {
-			keyList.keyStatus = "[expired]"
-		} else {
-			keyList.keyStatus = "[enabled]"
-		}
-
-		// Only count the key if it has a fingerprint. Otherwise
-		// dont count it.
-		keyList.keyCount++
-	} else if fields[0] == "uid" {
-		// Note that there can be more than one of these for each pub
-
-		// Get the name of the key
-		keyList.keyName = fields[1]
-		keyList.keyName, _ = url.QueryUnescape(keyList.keyName)
-	}
-
-	return errRet
-}
-
-// formatMROutputLongList reformats the key search output that is in machine readable format
-// see the output format in: https://tools.ietf.org/html/draft-shaw-openpgp-hkp-00#section-5.2
-func formatMROutputLongList(mrString string) (int, []byte, error) {
-	pubFmt := "%s\t%s\t%s\t%s\t%s\t%s\t"
-	nameFmt := "%s\n"
-
-	retList := bytes.NewBuffer(nil)
-	tw := tabwriter.NewWriter(retList, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, pubFmt+nameFmt, "FINGERPRINT", "ALGORITHM", "BITS", "CREATION DATE", "EXPIRATION DATE", "STATUS", "NAME/EMAIL")
-
-	numKeys := 0
-	lines := strings.Split(mrString, "\n")
-	var keyList mrKeyList
-
-	first := true
-	gotName := false
-	for _, l := range lines {
-		fields := strings.Split(strings.TrimSpace(l), ":")
-		if fields[0] == "info" {
-			var err error
-			numKeys, err = strconv.Atoi(fields[2])
-			if err != nil {
-				return -1, nil, fmt.Errorf("unable to check key number")
-			}
-		} else {
-			err := getKeyInfoFromLine(&keyList, fields)
-			if err != nil {
-				return -1, nil, fmt.Errorf("failed to get key entity from line: %s", err)
-			}
-			if fields[0] == "pub" {
-				if !first {
-					if !gotName {
-						// there was a pub without uid; end line
-						fmt.Fprintf(tw, "\n")
-					}
-					// put blank line between each key
-					fmt.Fprintf(tw, "\n")
-				}
-				first = false
-				gotName = false
-				fmt.Fprintf(tw, pubFmt, keyList.keyFingerprint, keyList.keyType, keyList.keyBit, keyList.keyDateCreated, keyList.keyDateExpired, keyList.keyStatus)
-			}
-			if fields[0] == "uid" {
-				if gotName {
-					// an extra name, indent it
-					fmt.Fprintf(tw, pubFmt, "", "", "", "", "", "")
-				} else {
-					gotName = true
-				}
-				fmt.Fprintf(tw, nameFmt, keyList.keyName)
-			}
-		}
-	}
-	if numKeys > 0 && !gotName {
-		// no name was printed with last key
-		fmt.Fprintf(tw, "\n")
-	}
-	tw.Flush()
-
-	sylog.Debugf("key count=%d; expect=%d\n", keyList.keyCount, numKeys)
-
-	// Simple check to ensure the conversion was successful
-	if keyList.keyCount != numKeys {
-		sylog.Debugf("expecting %d, got %d\n", numKeys, keyList.keyCount)
-		return -1, retList.Bytes(), fmt.Errorf("failed to convert machine readable to human readable output correctly")
-	}
-
-	return keyList.keyCount, retList.Bytes(), nil
 }
 
 // FetchPubkey pulls a public key from the Key Service.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Cherry pick https://github.com/apptainer/apptainer/pull/99 - except keep reliance on default Sylabs key server in tests.

Original PR description:

This fixes a few problems with searching on the https://keys.openpg.org/ key server:

- Lines read needed trimming because of a trailing carriage return.
- The name/email portion needed to be url-decoded.
- There is not always exactly one name/email/uid; sometimes there are zero (if no email addresses have been confirmed), one as normal, or more than one if there are multiple uids associated with a key.

In addition, this renames several variables which had misleading names, and consolidates duplicate code in the formatting functions.

### This fixes or addresses the following GitHub issues:

 - Fixes #495 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
