### PR TITLE
deb: fix runtime libglib2.0-0 dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Vcs-Browser: https://github.com/sylabs/singularity
 
 Package: singularity-ce
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, cryptsetup-bin, libseccomp2, libglib2.0, squashfs-tools, runc
+Depends: ${misc:Depends}, ${shlibs:Depends}, cryptsetup-bin, libseccomp2, libglib2.0-0, squashfs-tools, runc
 Conflicts:
  singularity-container,
  apptainer,


### PR DESCRIPTION
## Description of the Pull Request (PR):

The binary package is `libglib2.0-0` even if the headers are in `libglib2.0-dev` without the `-0`.

Also, the deb package build doesn't validate the requires, so my local test build did not catch this one. :cry: 

### This fixes or addresses the following GitHub issues:

 - Fixes #768


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
