### PR TITLE
ci: add release-3.10 branch to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     schedule:
       interval: "daily"
     target-branch: release-3.9
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: release-3.10

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -28,13 +28,17 @@ When a new 3.Y.0 minor version of SingularityCE is issued the release process
 begins by branching, and then issuing a release candidate for broader testing.
 
 When a new 3.Y.Z patch release is issued, the branch will already be present,
-and steps 1-2 should be skipped.
+and steps 1-4 should be skipped.
 
 1. From a repository that is up-to-date with master, create a release branch
    e.g. `git checkout upstream/master -b release-3.8`.
 1. Push the release branch to GitHub via `git push upstream release-3.8`.
 1. Examine the GitHub branch protection rules, to extend them to the new release
    branch if needed.
+1. Update the `.github/dependabot.yml` configuration so that dependabot is
+   tracking the new stable release branch. Do not remove the previous stable
+   release branch from the configuration yet, as it should be monitored until
+   the final release of a new 3.Y.0 version.
 1. Modify the `README.md`, `INSTALL.md`, `CHANGELOG.md` via PR against the
    release branch, so that they reflect the version to be released.
 1. Apply an annotated tag via
@@ -81,7 +85,7 @@ covered by tests.
    history from the RC process etc. is captured on `master`.
 1. If the release is a new major/minor version, move the prior `release-3.x`
    branch to `vault/release-3.x`.
-1. If the release is a new major/minor version, update the
-   `.github/dependabot.yml` configuration so that dependabot is tracking the new
-   stable release branch.
+1. If the release is a new final major/minor version, update the
+   `.github/dependabot.yml` configuration to remove the prior stable release
+   branch.
 1. Start scheduling / setting up milestones etc. to track the next release!


### PR DESCRIPTION
## Description of the Pull Request (PR):

Ensure `release-3.10` branch is monitored by Dependabot. Leaving `release-3.9` branch for now until 3.10 ships.


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
