### PR TITLE
fix: Pass CleanupHost boolean to starter correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Correctly launch CleanupHost process only when needed in `--sif-fuse` flow.
+
 ## 3.10.0-rc.1 \[2022-05-04\]
 
 This is the first release candidate for the upcoming SingularityCE 3.10 release.

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -791,6 +791,10 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		}
 	}
 
+	if SIFFUSE && !(UserNamespace || insideUserNs) {
+		sylog.Warningf("--sif-fuse is not supported without user namespace, ignoring.")
+	}
+
 	// setuid workflow set RLIMIT_STACK to its default value,
 	// get the original value to restore it before executing
 	// container process
@@ -835,6 +839,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 			starter.WithStdout(stdout),
 			starter.WithStderr(stderr),
 			starter.LoadOverlayModule(loadOverlay),
+			starter.CleanupHost(engineConfig.GetImageFuse()),
 		)
 
 		if sylog.GetLevel() != 0 {
@@ -866,6 +871,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 			cfg,
 			starter.UseSuid(useSuid),
 			starter.LoadOverlayModule(loadOverlay),
+			starter.CleanupHost(engineConfig.GetImageFuse()),
 		)
 		sylog.Fatalf("%s", err)
 	}

--- a/cmd/starter/c/include/starter.h
+++ b/cmd/starter/c/include/starter.h
@@ -161,9 +161,6 @@ struct starter {
 
     /* bounding capability set will include caps needed by nvidia-container-cli */
     bool nvCCLICaps;
-
-    /* is a CLEANUP_HOST process require outside of namespaces for SIF FUSE cleanup */
-    bool cleanupHost;
 };
 
 /* engine configuration */

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -200,17 +200,6 @@ func (c *Config) SetAllowSetgroups(allow bool) {
 	}
 }
 
-// SetCleanupHost sets the flag to tell starter container setup
-// to spawn a cleanup process for SIF FUSE mounts early, in the
-// original host namespaces.
-func (c *Config) SetCleanupHost(enabled bool) {
-	if enabled {
-		c.config.starter.cleanupHost = C.true
-	} else {
-		c.config.starter.cleanupHost = C.false
-	}
-}
-
 // GetJSONConfig returns pointer to the engine's JSON configuration.
 // A copy of the original bytes allocated on C heap is returned.
 func (c *Config) GetJSONConfig() []byte {

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -195,10 +195,6 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	if e.EngineConfig.GetNvCCLI() {
 		starterConfig.SetNvCCLICaps(true)
 	}
-	// If using a SIF FUSE mount, we need to cleanup in host namespaces.
-	if e.EngineConfig.GetImageFuse() {
-		starterConfig.SetCleanupHost(true)
-	}
 
 	return nil
 }

--- a/internal/pkg/util/starter/starter.go
+++ b/internal/pkg/util/starter/starter.go
@@ -74,6 +74,16 @@ func LoadOverlayModule(load bool) CommandOp {
 	}
 }
 
+// CleanupHost sets CLEANUP_HOST environment variable
+// which telsl starter to spawn the unprivileged host cleanup process.
+func CleanupHost(spawn bool) CommandOp {
+	return func(c *Command) {
+		if spawn {
+			c.env = append(c.env, "CLEANUP_HOST=1")
+		}
+	}
+}
+
 // Command a starter command to execute.
 type Command struct {
 	path   string


### PR DESCRIPTION
## Description of the Pull Request (PR):

The experimental `--sif-fuse` code was attempting to pass the boolean that controls whether starter spawns the CleanupHost process, for unmounting the FUSE SIF mount, in the starter config structure.

The starter config structure is setup from the Go engine 'prepare' code, which runs in stage1 *after* the point at which CleanupHost is
spawned from the starter C code... so the boolean was never true.

Unfortunately, all the tests we have were passing, because due to a bad negation in an if statement, the `CleanupHost` process
was *always* executed.

Switch to using an env var (`CLEANUP_HOST`) to control whether the `CleanupHost` process is spawned by starter. This is the right way to control starter behavior that needs to occur before 'prepare' in stage1. It's the same approach used to control whether the overlay module is loaded via `LOAD_OVERLAY_MODULE`.

While we are at it, ensure a `CleanupHost` process is never run in setuid mode. We don't support this yet, and if support is added we need to pay attention to permanent priv drop etc.

Add a bit more debug logging so it's easier to see what's going on.

### This fixes or addresses the following GitHub issues:

 - Fixes #777

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
