### PR TITLE
fix: cgroups: ensure cgroups device limits are default allow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Correctly launch CleanupHost process only when needed in `--sif-fuse` flow.
 - Add specific error for unreadable image / overlay file.
+- Ensure cgroups device limits are default allow per past behavior.
 
 ## 3.10.0-rc.1 \[2022-05-04\]
 

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -303,6 +303,14 @@ func (c *ctx) actionApply(t *testing.T, profile e2e.Profile) {
 			// Reason is believed to be: https://github.com/opencontainers/runc/issues/3026
 			rootless: false,
 		},
+		// Device access is allowed by default.
+		{
+			name:            "device allow default",
+			args:            []string{"--apply-cgroups", "testdata/cgroups/null.toml", c.env.ImagePath, "cat", "/dev/null"},
+			expectErrorCode: 0,
+			rootfull:        true,
+			rootless:        true,
+		},
 		// Device limits are properly applied only in rootful mode. Rootless will ignore them with a warning.
 		{
 			name:            "device deny",

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -141,6 +141,14 @@ func (m *Manager) UpdateFromSpec(resources *specs.LinuxResources) (err error) {
 		return fmt.Errorf("could not create cgroup config: %w", err)
 	}
 
+	// runc/libcontainer/cgroups for v2 defaults to a deny-all policy, while
+	// singularity has always allowed access to devices by default. If no device
+	// rules are provided in the spec, then skip setting them so the deny-all is
+	// not applied.
+	if len(resources.Devices) == 0 {
+		lcConfig.SkipDevices = true
+	}
+
 	err = m.cgroup.Set(lcConfig.Resources)
 	if err != nil {
 		return fmt.Errorf("while setting cgroup limits: %w", err)
@@ -289,6 +297,14 @@ func newManager(resources *specs.LinuxResources, group string, systemd bool) (ma
 	lcConfig, err := lcspecconv.CreateCgroupConfig(opts, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not create cgroup config: %w", err)
+	}
+
+	// runc/libcontainer/cgroups for v2 defaults to a deny-all policy, while
+	// singularity has always allowed access to devices by default. If no device
+	// rules are provided in the spec, then skip setting them so the deny-all is
+	// not applied.
+	if len(resources.Devices) == 0 {
+		lcConfig.SkipDevices = true
 	}
 
 	cgroup, err := lcmanager.New(lcConfig)


### PR DESCRIPTION
## Description of the Pull Request (PR):

In singularity, cgroups device limits have always defaulted to allow-all. When a cgroups config is provided with no explicit device rules, no cgroups mediated device limits have applied.

We recently switched to runc/libcontainer/cgroups as our cgroups manager (from containerd/cgroups), and this applies a default deny rule for devices.

Revert to previous behavior by asking runc/libcontainer/cgroups to skip application of device limits if no limits are provided in the spec that has been passed.

### This fixes or addresses the following GitHub issues:

 - Fixes #787

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
