### PR TITLE
'%files' Support for Remote Build (3.10)

### DIFF
--- a/internal/pkg/build/remotebuilder/remotebuilder.go
+++ b/internal/pkg/build/remotebuilder/remotebuilder.go
@@ -114,7 +114,11 @@ func (rb *RemoteBuilder) uploadBuildContext(ctx context.Context) (digest string,
 		return "", nil
 	}
 
-	return rb.BuildClient.UploadBuildContext(ctx, paths)
+	digest, err = rb.BuildClient.UploadBuildContext(ctx, paths)
+	if err != nil {
+		sylog.Infof("Build context upload failed. This build server may not support the `%%files` section for remote builds.")
+	}
+	return digest, err
 }
 
 // Build is responsible for making the request via scs-build-client to the builder

--- a/pkg/build/types/definition.go
+++ b/pkg/build/types/definition.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 )
 
@@ -64,10 +65,43 @@ type Files struct {
 	Files []FileTransport `json:"files"`
 }
 
+// Stage returns the build stage referenced by the files section f, or "" if no stage is
+// referenced.
+func (f Files) Stage() string {
+	// Trim comments from args.
+	cleanArgs := strings.SplitN(f.Args, "#", 2)[0]
+
+	// If "stage <name>", return "<name>".
+	if args := strings.Fields(cleanArgs); len(args) == 2 && args[0] != "stage" {
+		return args[1]
+	}
+
+	return ""
+}
+
 // FileTransport holds source and destination information of files to copy into the container.
 type FileTransport struct {
 	Src string `json:"source"`
 	Dst string `json:"destination"`
+}
+
+// SourcePath returns the source path in the format as specified by the io/fs package.
+func (ft FileTransport) SourcePath() (string, error) {
+	path, err := filepath.Abs(ft.Src)
+	if err != nil {
+		return "", err
+	}
+
+	// Paths are slash-separated.
+	path = filepath.ToSlash(path)
+
+	// Special case: the root directory is named ".".
+	if path == "/" {
+		return ".", nil
+	}
+
+	// Paths must not start with a slash.
+	return strings.TrimPrefix(path, "/"), nil
 }
 
 // Script describes any script section of a definition.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add support for `%files` section during a remote build. This requires a compatible remote. Add `(Files).Stage()` and `(FileTransport).SourcePath()` helpers.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)