### PR TITLE
e2e: Add E2E_GROUPS & E2E_TESTS to filter e2e test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Changes Since Last Release
 
+### Development / Testing
+
+- The `e2e-test` makefile target now accepts an argument `E2E_GROUPS` to only
+  run specified groups of end to end tests. E.g. `make -C builddir e2e-test
+  E2E_GROUPS=VERSION,HELP` will run end to end tests in the `VERSION` and `HELP`
+  groups only.
+- The `e2e-test` makefile target now accepts an argument `E2E_TESTS` which is a
+  regular expression specifying the names of (top level) end to end tests that
+  should be run. E.g. `make -C builddir e2e-test E2E_TESTS=^semantic` will only
+  run end to end tests with a name that begins with `semantic`.
+
 ### Bug Fixes
 
 - Fix compilation on `mipsel`.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,141 +1,179 @@
 # End-to-End Testing
 
-This package contains the end-to-end tests for `singularity`.
+This package contains the end-to-end (e2e) tests for `singularity`.
 
 ## Contributing
 
-For this example, we're going to use a topic of `env` or
-`environment variable tests`.
+The e2e tests are split into *groups*, which gather tests that exercise a
+specific area of functionality.
 
-- Add your topic as a runtime-hook in `suite.go`.
+For this example, we're going to use a a group called `ENV` which would hold
+tests relevant to environment variable handling.
+
+- Add your group into the `e2eGroups` or `e2eGroupsNoPIDNS` struct in
+  `suite.go`. This is a map from the name of the group (in upper case), to the
+  `E2ETests` function declared in the group's package.
+
+  You should generally use `e2eGroups`. The `e2eGroupsNoPIDNS`
+  struct is only for groups that cannot be run within a PID namespace -
+  specifically tests that involve systemd cgroups handling.
 
 ```go
-// RunE2ETests by functionality
-t.Run("BUILD", imgbuild.RunE2ETests)
-t.Run("ACTIONS", actions.RunE2ETests)
-t.Run("ENV", env.RunE2ETests)
+var e2eGroups = map[string]testhelper.Group{
+    ...
+    "ENV":        env.E2ETests,
 ```
 
-- Create a directory for your topic.
+- Now create a directory for your group.
 
 ```sh
 mkdir -p e2e/env
 ```
 
-- Create a source file to include your topic's tests.
+- Create a source file that will hold your groups's tests.
 
 ```sh
 touch e2e/env/env.go
 ```
 
-- Optionally create a source file to include helpers for your topic's test.
+- Optionally create a source file to include helpers for your group's test.
 
 ```sh
 touch e2e/env/env_utils.go
 ```
 
-- Add a package declaration to your topic's test file that matches what you put
-  in `suite.go`
+- Add a package declaration to the test file (e2e/env/env.go) that matches what
+  you put in `suite.go`
 
 ```go
 package env
 ```
 
-- Add a variable to store the testing settings in your topic's test file.
+- Declare a ctx struct that holds the `e2e.TestEnv` structure, and can be
+  extended with any other group-specific variables.
 
 ```go
-import (
-        "github.com/kelseyhightower/envconfig"
-)
-
-type testingEnv struct {
-	// base env for running tests
-	CmdPath     string `split_words:"true"`
-	TestDir     string `split_words:"true"`
-	RunDisabled bool   `default:"false"`
-}
-
-var testenv testingEnv
-```
-
-- Add a entry-point to your topic's test file that matches what you put in
-  `suite.go`
-
-```go
-//RunE2ETests is the main func to trigger the test suite
-func RunE2ETests(t *testing.T) {
-	err := envconfig.Process("E2E", &testenv)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+type ctx struct {
+    env e2e.TestEnv
 }
 ```
 
-- Create a test in your topic's test file as you normally would in `go`.
+- Add tests, which are member functions of the `ctx`. The following example
+  tests that when an environment variable is set, it can be echoed from a
+  `singularity exec`.
 
 ```go
-func TestEnv(t *Testing.T) {
-	...
+func (c ctx) echoEnv(t *testing.T) {
+    e2e.EnsureImage(t, c.env)
+
+    env := []string{`FOO=BAR`}
+    c.env.RunSingularity(
+        t,
+        e2e.WithProfile(e2e.UserProfile),
+        e2e.WithCommand("exec"),
+        e2e.WithEnv(env),
+        e2e.WithArgs("/bin/sh", "-c" "echo $FOO"),
+        e2e.ExpectExit(
+            0,
+            e2e.ExpectOutput(e2e.ExactMatch, "BAR"),
+        ),
+    )
+}
+
+```
+
+Note that we use a helper function `e2e.EnsureImage` to make sure the test image
+that we will run has been created. We use the `c.env.RunSingularity` function to
+actually execute `singularity`, and specify arguments, expected output etc.
+
+- Now add a public `E2ETests` function to the package, which returns a
+  `testhelper.Tests` struct, holding the test we want to run:
+
+```go
+func E2ETests(env e2e.TestEnv) testhelper.Tests {
+    c := ctx{
+        env: env,
+    }
+
+    return testhelper.Tests{
+        "environment echo": c.echoEnv,
+    }
 }
 ```
 
-- Run your test from your entry-point function using a `go` sub-test.
-
-```go
-//RunE2ETests is the main func to trigger the test suite
-func RunE2ETests(t *testing.T) {
-	err := envconfig.Process("E2E", &testenv)
-        if err != nil {
-        	t.Fatal(err.Error())
-        }
-        
-	// Add tests
-	t.Run("TestEnv", TestEnv)
-}
-```
-
-- Example of what your topic's test file might look like:
+- Putting this altogether, the `e2e/env/env.go` will look like:
 
 ```go
 package env 
 
 import (
-	"github.com/kelseyhightower/envconfig"
+    "testing"
+
+    "github.com/sylabs/singularity/e2e/internal/e2e"
+    "github.com/sylabs/singularity/e2e/internal/testhelper"
 )
 
-type testingEnv struct {
-	// base env for running tests
-	CmdPath     string `split_words:"true"`
-	TestDir     string `split_words:"true"`
-	RunDisabled bool   `default:"false"`
+type ctx struct {
+    env e2e.TestEnv
 }
 
-var testenv testingEnv
+func (c ctx) echoEnv(t *testing.T) {
+    e2e.EnsureImage(t, c.env)
 
-func TestEnv(t *testing.T) {
-	...
+    env := []string{`FOO=BAR`}
+    c.env.RunSingularity(
+        t,
+        e2e.WithProfile(e2e.UserProfile),
+        e2e.WithCommand("exec"),
+        e2e.WithEnv(env),
+        e2e.WithArgs("/bin/sh", "-c" "echo $FOO"),
+        e2e.ExpectExit(
+            0,
+            e2e.ExpectOutput(e2e.ExactMatch, "BAR"),
+        ),
+    )
 }
 
-//RunE2ETests is the main func to trigger the test suite
-func RunE2ETests(t *testing.T) {
-	err := envconfig.Process("E2E", &testenv)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+func E2ETests(env e2e.TestEnv) testhelper.Tests {
+    c := ctx{
+        env: env,
+    }
 
-	t.Run("TestEnv", TestEnv)
+    return testhelper.Tests{
+        "environment echo": c.echoEnv,
+    }
 }
 ```
 
 ## Running
 
-Test your topic using the `e2e` target in the `Makefile`. To avoid skipping
-these tests (default), make sure you set the environment variable
-`SINGULARITY_E2E` to `1`.
+To run all end to end tests, use the `e2e-tests` make target:
 
 ```sh
-SINGULARITY_E2E=1 make -C builddir e2e-test
+make -C builddir e2e-test
 ```
 
-- Verify that your test was run by modifying the `Makefile` to add a verbose
-  flag (`go test -v`) and re-running the previous `make` step.
+To run all tests in a specific group, or groups, specify the group names (comma
+seperated) in an `E2E_GROUPS=` argument to the make target:
+
+```sh
+# Only run tests in the VERSION and HELP groups
+make -C builddir e2e-test E2E_GROUPS=VERSION,HELP
+```
+
+To run specific top-level tests (as defined in the `testhelper.Tests` struct
+returned by eache group's `E2ETests` function) supply a regular expression in an
+`E2E_TESTS` argument to the make target:
+
+```sh
+# Only run e2e tests with a name that begins with 'semantic'
+make -C builddir e2e-test E2E_TESTS=^semantic
+```
+
+You can combine the `E2E_GROUPS` and `E2E_TESTS` arguments to limit the tests
+that are run:
+
+```sh
+# Only run e2e tests in the VERSION group that have a name that begins with 'semantic'
+make -C builddir e2e-test E2E_GROUP=VERSION E2E_TESTS=^semantic
+```

--- a/e2e/internal/testhelper/testhelper.go
+++ b/e2e/internal/testhelper/testhelper.go
@@ -7,6 +7,7 @@ package testhelper
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -45,7 +46,20 @@ func (s *Suite) AddGroup(name string, group Group) {
 	s.groups[name] = group
 }
 
-func (s *Suite) Run() {
+// Run will run top-level tests matching the regex filter, or all tests if
+// filter is the empty string.
+func (s *Suite) Run(filter *string) {
+	var filterMatch *regexp.Regexp
+	var err error
+
+	if filter != nil && *filter != "" {
+		s.t.Logf("Running top level tests matching: %s", *filter)
+		filterMatch, err = regexp.Compile(*filter)
+		if err != nil {
+			s.t.Fatalf("error in filter regexp: %v", err)
+		}
+	}
+
 	tests := make(map[string]Tests)
 
 	for name, gr := range s.groups {
@@ -65,6 +79,12 @@ func (s *Suite) Run() {
 				for testName, fn := range tests[name] {
 					fn := fn
 					testName := testName
+
+					if filterMatch != nil {
+						if !filterMatch.MatchString(testName) {
+							continue
+						}
+					}
 
 					pc := reflect.ValueOf(fn).Pointer()
 					if _, ok := npTests[pc]; ok {
@@ -86,6 +106,13 @@ func (s *Suite) Run() {
 
 			t.Run(name, func(t *testing.T) {
 				for testName, fn := range tests[name] {
+
+					if filterMatch != nil {
+						if !filterMatch.MatchString(testName) {
+							continue
+						}
+					}
+
 					pc := reflect.ValueOf(fn).Pointer()
 					if _, ok := npTests[pc]; !ok {
 						continue

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -68,19 +68,23 @@ short-integration-test:
 		./pkg/network
 	@echo "       PASS"
 
+
 .PHONY: e2e-test
+
+e2e-test: GROUPS_FLAG := $(if $(E2E_GROUPS),-e2e_groups $(E2E_GROUPS))
+e2e-test: TESTS_FLAG := $(if $(E2E_TESTS),-e2e_tests $(E2E_TESTS))
 e2e-test: EXTRA_FLAGS := $(if $(filter yes,$(strip $(JUNIT_OUTPUT))),-junit $(BUILDDIR_ABSPATH)/e2e-test.xml)
 e2e-test:
 	# Run the majority of e2e tests, which will use a separate pid and mount namespace
 	@echo " TEST sudo go test [e2e pid+mount ns]"
 	$(V)cd $(SOURCEDIR) && \
-		scripts/e2e-test -v $(GO_RACE) $(EXTRA_FLAGS)
+		scripts/e2e-test -v $(GO_RACE) $(EXTRA_FLAGS) $(GROUPS_FLAG) $(TESTS_FLAG)
 	@echo "       PASS"
 	# Run the remaining e2e tests, which need to be in the host pid namespace
 	@echo " TEST sudo go test [e2e mount ns only]"
 	$(V)cd $(SOURCEDIR) && \
 		SINGULARITY_E2E_NO_PID_NS=1 \
-		scripts/e2e-test -v $(GO_RACE) $(EXTRA_FLAGS)
+		scripts/e2e-test -v $(GO_RACE) $(EXTRA_FLAGS) $(GROUPS_FLAG) $(TESTS_FLAG)
 	@echo "       PASS"
 
 # test runs only those tests that do not need any docker auth setup etc.

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set +x
+
 if test ! -e scripts/go-test ; then
 	echo 'E: Cannot find scripts/go-test. Abort.'
 	exit 1

--- a/scripts/go-test.in
+++ b/scripts/go-test.in
@@ -109,6 +109,16 @@ for arg in "$@" ; do
 			set -- "$@" -v
 			;;
 
+		-e2e_groups)
+		    e2e_groups="${1}"
+			skip=true
+			;;
+
+		-e2e_tests)
+			e2e_tests="${1}"
+			skip=true
+			;;
+
 		*)
 			set -- "$@" "${arg}"
 			;;
@@ -119,6 +129,22 @@ if ${use_gotestsum} ; then
 	if ${verbose} ; then
 		gotestrunner_format=standard-verbose
 	fi
+fi
+
+if ${use_gotestsum} ; then
+	if ${verbose} ; then
+		gotestrunner_format=standard-verbose
+	fi
+fi
+
+if  [ -n "${e2e_groups}" ] ; then
+	set -- "$@" "-e2e_groups"
+	set -- "$@" "${e2e_groups}"
+fi
+
+if  [ -n "${e2e_tests}" ] ; then
+	set -- "$@" "-e2e_tests"
+	set -- "$@" "${e2e_tests}"
 fi
 
 # capture exit code


### PR DESCRIPTION
## Description of the Pull Request (PR):

The e2e test suite is cumbersome for developers. To date it has not
been possible to run a subset of tests without commenting out portions
of the `suite.go` and group specific test code.

Add an `E2E_GROUPS` argument to the `make e2e-test` target that will
allow developers to run only the specificed groups of e2e tests.

Add an `E2E_TESTS` argument to the `make e2e-test` target that takes a
regexp to filter the top-level test names that will be run.

    # Only run tests in the VERSION and HELP groups
    make -C builddir e2e-test E2E_GROUPS=VERSION,HELP

To run specific top-level tests (as defined in the `testhelper.Tests`
struct returned by each group's `E2ETests` function) supply a regular
expression in an `E2E_TESTS` argument to the make target:

    # Only run e2e tests with a name that begins with 'semantic'
    make -C builddir e2e-test E2E_TESTS=^semantic

You can combine the `E2E_GROUPS` and `E2E_TESTS` arguments to limit
the tests that are run:

    # Only run e2e tests in the VERSION group that have a name that begins with 'semantic'
    make -C builddir e2e-test E2E_GROUP=VERSION E2E_TESTS=^semantic

Also tidied up the docs, minimally.

### This fixes or addresses the following GitHub issues:

 - Fixes #820 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
