### PR TITLE
adding support for --sparse when creating ext3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,15 +37,18 @@ all your interactions with the project members and users.
 1. Make sure your code passes linting, by running `make check` before submitting
    the PR. We use `golangci-lint` as our linter. You may need to address linting
    errors by:
-   - Running `gofumpt .` to format all `.go` files. We use
-     [gofumpt](https://github.com/mvdan/gofumpt) instead of `gofmt` as it adds
-     additional formatting rules which are helpful for clarity.
+   - Running `gofumpt .` to format all `.go` files. To do this in place you can
+     do `gofumpt -w .`. We use [gofumpt](https://github.com/mvdan/gofumpt)
+     instead of `gofmt` as it adds additional formatting rules which are helpful
+     for clarity.
    - Leaving a function comment on **every** new exported function and package
      that your PR has introduced. To learn about how to properly comment Go
      code, read
      [this post on golang.org](https://golang.org/doc/effective_go.html#commentary)
 1. Make sure you have locally tested using `make -C builddir test` and that all
    tests succeed before submitting the PR.
+1. If you accidentally changed code in a submodule, you can undo it like
+   `git submodule foreach --recursive git reset --hard` before committing.
 1. If possible, run `make -C builddir testall` locally, after setting the
    environment variables `E2E_DOCKER_USERNAME` and `E2E_DOCKER_PASSWORD`
    appropriately for an authorized Docker Hub account. This is required as

--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -15,6 +15,7 @@ func init() {
 
 		cmdManager.RegisterFlagForCmd(&overlaySizeFlag, OverlayCreateCmd)
 		cmdManager.RegisterFlagForCmd(&overlayCreateDirFlag, OverlayCreateCmd)
+		cmdManager.RegisterFlagForCmd(&overlaySparseFlag, OverlayCreateCmd)
 	})
 }
 

--- a/cmd/internal/cli/overlay_create.go
+++ b/cmd/internal/cli/overlay_create.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	overlaySize int
-	overlayDirs []string
+	overlaySize   int
+	overlayDirs   []string
+	overlaySparse bool
 )
 
 // -s|--size
@@ -21,6 +22,17 @@ var overlaySizeFlag = cmdline.Flag{
 	Name:         "size",
 	ShortHand:    "s",
 	Usage:        "size of the EXT3 writable overlay in MiB",
+}
+
+// --sparse/-S
+var overlaySparseFlag = cmdline.Flag{
+	ID:           "overlaySparseFlag",
+	Value:        &overlaySparse,
+	DefaultValue: false,
+	Name:         "sparse",
+	ShortHand:    "S",
+	Usage:        "create a sparse overlay",
+	EnvKeys:      []string{"SPARSE"},
 }
 
 // --create-dir
@@ -36,7 +48,7 @@ var overlayCreateDirFlag = cmdline.Flag{
 var OverlayCreateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := singularity.OverlayCreate(overlaySize, args[0], overlayDirs...); err != nil {
+		if err := singularity.OverlayCreate(overlaySize, args[0], overlaySparse, overlayDirs...); err != nil {
 			sylog.Fatalf(err.Error())
 		}
 		return nil

--- a/docs/content.go
+++ b/docs/content.go
@@ -1077,7 +1077,10 @@ Enterprise Performance Computing (EPC)`
   $ singularity overlay create --size 1024 /tmp/image.sif
 
   To create a single EXT3 writable overlay image:
-  $ singularity overlay create --size 1024 /tmp/my_overlay.img`
+  $ singularity overlay create --size 1024 /tmp/my_overlay.img
+
+  To create a sparse overlay when creating a new ext3 file system image:
+  $ singularity overlay create --size 1024 --sparse /tmp/ext3_overlay.img`
 )
 
 // Documentation for sif/siftool command.

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -85,6 +85,13 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 			exit:    255,
 		},
 		{
+			name:    "create ext3 sparse overlay image",
+			profile: e2e.UserProfile,
+			command: "overlay",
+			args:    []string{"create", "--size", "128", "--sparse", ext3Image},
+			exit:    0,
+		},
+		{
 			name:    "create ext3 overlay image",
 			profile: e2e.UserProfile,
 			command: "overlay",


### PR DESCRIPTION
## Description of the Pull Request (PR):

this will close issue #610. We basically want to add support for a sparse overlay, and we can do that by using truncate -s (size) instead of dd. In the case the command is not found, an error is issued and the user can decide to install or not use it. I think it would be overkill to hard code information about all OS versions / support but if anyone has ideas for how to reasonably do this we can return a more specific error message. I am not running the e2e tests locally but will see how they do in the CI! :)

Signed-off-by: vsoch <vsoch@users.noreply.github.com>

### This fixes or addresses the following GitHub issues:

 - Fixes #610 

Question: are we still adding changes to the changelog? It looks like they are added after release (at least the top version is already released and there isn't space for develop changes above that)