### PR TITLE
mipsel build failure fix: Cast Rdev to uint64 in call to unix.Minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Fix compilation on `mipsel`.
+
 ## 3.10.0 \[2022-05-17\]
 
 ### Changed defaults / behaviours

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,6 +76,7 @@ The following have contributed code and/or documentation to this repository.
 - Mike Gray <mike@sylabs.io>
 - Nathan Chou <nathan.chou@sylabs.io>, <choun@berkeley.edu>
 - Nathan Lin <nathan.lin@yale.edu>
+- Nilesh Patra <nilesh@nileshpatra.info>
 - Oleksandr Moskalenko <om@rc.ufl.edu>
 - Oliver Breitwieser <obreitwi@kip.uni-heidelberg.de>, <oliver@breitwieser.eu>
 - Oliver Freyermuth <freyermuth@physik.uni-bonn.de>

--- a/cmd/internal/cli/cgroups.go
+++ b/cmd/internal/cli/cgroups.go
@@ -299,5 +299,7 @@ func deviceMajorMinor(path string) (major, minor int64, err error) {
 		return -1, -1, fmt.Errorf("%s is not a device", path)
 	}
 
-	return int64(unix.Major(stat.Rdev)), int64(unix.Minor(stat.Rdev)), nil
+	// Extra casting to uint64 for stat.Rdev to make sure correct type is set correctly on all archs
+	// and avoid failures on mips
+	return int64(unix.Major(uint64(stat.Rdev))), int64(unix.Minor(uint64(stat.Rdev))), nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Singularity fails to build from source on mips archs and chokes with: 

```
# github.com/sylabs/singularity/cmd/internal/cli
../cmd/internal/cli/cgroups.go:302:26: cannot use stat.Rdev (variable of type uint32) as type uint64 in argument to unix.Major
../cmd/internal/cli/cgroups.go:302:56: cannot use stat.Rdev (variable of type uint32) as type uint64 in argument to unix.Minor
make[2]: *** [Makefile:178: singularity] Error 2
```

Full log [here](https://buildd.debian.org/status/fetch.php?pkg=singularity-container&arch=mips64el&ver=3.10.0%2Bds2-1&stamp=1655166544&raw=0)

It seems to stem from Rdev being defined as uint32 on mipsel, relevant discussion on go forum [here](https://forum.golangbridge.org/t/the-argument-rdev-is-defined-as-type-uint32-in-mips-arch-and-uint64-in-others/21179/6)

This patch fixes the build on mips64el and mipsel.