### PR TITLE
e2e: fix: correctly test `%post -c` for regression 4967

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Bug Fixes
 
 - Fix compilation on `mipsel`.
+- Fix test code that implied `%test -c <shell>` was supported - it is not.
 
 ## 3.10.0 \[2022-05-17\]
 

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -219,7 +219,9 @@ func (c *imgBuildTests) issue4943(t *testing.T) {
 	)
 }
 
-// Test -c section parameter is correctly handled.
+// Test %post -c section parameter is correctly handled. We use `-c /bin/busybox
+// sh` for this test, and can observe the `/proc/$$/cmdline` to check that was
+// used to invoke the post script.
 func (c *imgBuildTests) issue4967(t *testing.T) {
 	image := filepath.Join(c.env.TestDir, "issue_4967.sif")
 
@@ -233,7 +235,7 @@ func (c *imgBuildTests) issue4967(t *testing.T) {
 		}),
 		e2e.ExpectExit(
 			0,
-			e2e.ExpectOutput(e2e.ContainMatch, "function foo"),
+			e2e.ExpectOutput(e2e.ContainMatch, "/bin/busybox sh /.post.script"),
 		),
 	)
 }

--- a/e2e/testdata/regressions/issue_4967.def
+++ b/e2e/testdata/regressions/issue_4967.def
@@ -1,9 +1,5 @@
-bootstrap: docker
-from: alpine:3.10
+bootstrap: library
+from: alpine:3.11.5
 
-%post
-    apk add --update-cache bash
-
-%test -c /bin/bash
-    function foo { echo "function foo"; }
-    foo
+%post -c /bin/busybox sh
+    cat /proc/$$/cmdline | tr '\000' ' '

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -373,7 +373,7 @@ func (b *Build) Full(ctx context.Context) error {
 
 	// build each stage one after the other
 	for i, stage := range b.stages {
-		if err := stage.runSectionScript("pre", stage.b.Recipe.BuildData.Pre); err != nil {
+		if err := stage.runHostScript("pre", stage.b.Recipe.BuildData.Pre); err != nil {
 			return err
 		}
 
@@ -426,7 +426,7 @@ func (b *Build) Full(ctx context.Context) error {
 			}
 		}
 
-		if err := stage.runSectionScript("setup", stage.b.Recipe.BuildData.Setup); err != nil {
+		if err := stage.runHostScript("setup", stage.b.Recipe.BuildData.Setup); err != nil {
 			return err
 		}
 

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -41,8 +41,8 @@ func (s *stage) Assemble(path string) error {
 	return s.a.Assemble(s.b, path)
 }
 
-// runSetupScript executes the stage's pre script on host.
-func (s *stage) runSectionScript(name string, script types.Script) error {
+// runHostScript executes the stage's pre or setup script on host.
+func (s *stage) runHostScript(name string, script types.Script) error {
 	if s.b.RunSection(name) && script.Script != "" {
 		if syscall.Getuid() != 0 {
 			return fmt.Errorf("attempted to build with scripts as non-root user or without --fakeroot")


### PR DESCRIPTION
## Description of the Pull Request (PR):

The issue_4967 build regression test was attempting to verify `-c` handling on `%post` and `%test` through `%test -c /bin/bash`.

Handling of `-c` on `%test` is not actually implemented, but the test was passing as the `%test` script passed okay.

Modify the test so that it is actually checking a `%post` script with `-c ...` is invoked as expected. We can leverage the fact that `/bin/sh` on busybox can also be called with `/bin/busybox sh`, which we can then observe on the `/proc/$$/cmdline` in the `%post` block.

While we are here, make the comment and function name for execution of `%pre` and `%setup` scripts on the *host* consistent and more obvious.

### This fixes or addresses the following GitHub issues:

 - Fixes #871


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
