### PR TITLE
feat: non-root, non --fakeroot builds with proot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,12 @@ commands:
       - run:
           name: Install dependencies
           command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin runc libglib2.0-dev squashfuse
+      - run:
+          name: Install proot
+          command: |-
+            <<# parameters.sudo >>sudo <</ parameters.sudo >>curl -L -o /usr/local/bin/proot https://proot.gitlab.io/proot/bin/proot
+            <<# parameters.sudo >>sudo <</ parameters.sudo >>chmod +x /usr/local/bin/proot
+
   configure-singularity:
     steps:
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,20 @@
 - Instances started by a non-root user can use `--apply-cgroups` to apply
   resource limits. Requires cgroups v2, and delegation configured via systemd.
 - Added EL9 package builds to CI for GitHub releases.
+- Non-root users can now build from a definition file, on systems that do not
+  support `--fakeroot`. This requires the statically built `proot` command
+  (<https://proot-me.github.io/>) to be available on the user `PATH`. These builds:
+  - Do not support `arch` / `debootstrap` / `yum` / `zypper` bootstraps. Use
+    `localimage`, `library`, `oras`, or one of the docker/oci sources.
+  - Do not support `%pre` and `%setup` sections.
+  - Run the `%post` sections of a build in the container as an emulated root
+    user.
+  - Run the `%test` section of a build as the non-root user, like `singularity
+    test`.
+  - Are subject to any restrictions imposed in `singularity.conf`.
+  - Incur a performance penalty due to `proot`'s `ptrace` based interception of syscalls.
+  - May fail if the `%post` script requires privileged operations that `proot`
+    cannot emulate.
 
 ### Bug Fixes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -36,6 +36,7 @@ var (
 	SingularityEnv     map[string]string
 	SingularityEnvFile string
 	NoMount            []string
+	Proot              string
 
 	IsBoot          bool
 	IsFakeroot      bool
@@ -788,6 +789,17 @@ var actionSIFFUSEFlag = cmdline.Flag{
 	EnvKeys:      []string{"SIF_FUSE"},
 }
 
+// --proot (hidden)
+var actionProotFlag = cmdline.Flag{
+	ID:           "actionProot",
+	Value:        &Proot,
+	DefaultValue: "",
+	Name:         "proot",
+	Usage:        "Bind proot from the host into /.singularity.d/libs",
+	EnvKeys:      []string{"PROOT"},
+	Hidden:       true,
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -880,5 +892,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionOomKillDisableFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPidsLimitFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionSIFFUSEFlag, actionsCmd...)
+		cmdManager.RegisterFlagForCmd(&actionProotFlag, actionsCmd...)
 	})
 }

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -499,6 +499,11 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		sylog.Fatalf("while setting GPU configuration: %s", err)
 	}
 
+	if Proot != "" && uid != 0 {
+		sylog.Debugf("Binding proot from %s", Proot)
+		engineConfig.AppendLibrariesPath(Proot)
+	}
+
 	engineConfig.SetAddCaps(AddCaps)
 	engineConfig.SetDropCaps(DropCaps)
 	engineConfig.SetConfigurationFile(configurationFile)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1472,6 +1472,67 @@ func (c imgBuildTests) buildLibraryHost(t *testing.T) {
 	)
 }
 
+// Limited tests to exercise non-root builds with proot and a %post and %test.
+// Does not support distro bootstraps. Build to SIF to ensure no issue,
+// (e.g. perms) when converting the temporary sandbox into SIF.
+func (c imgBuildTests) buildProot(t *testing.T) {
+	e2e.EnsureRegistry(t)
+	require.Command(t, "proot")
+
+	tt := []struct {
+		name      string
+		buildSpec string
+	}{
+		{
+			name:      "Alpine",
+			buildSpec: "testdata/proot_alpine.def",
+		},
+		{
+			name:      "CentOS",
+			buildSpec: "testdata/proot_centos.def",
+		},
+		{
+			name:      "Ubuntu",
+			buildSpec: "testdata/proot_ubuntu.def",
+		},
+	}
+
+	profiles := []e2e.Profile{e2e.UserProfile}
+	for _, profile := range profiles {
+		profile := profile
+
+		t.Run(profile.String(), func(t *testing.T) {
+			for _, tc := range tt {
+				dn, cleanup := c.tempDir(t, "build-proot")
+				defer cleanup()
+
+				imagePath := path.Join(dn, "image.sif")
+
+				// Pass --sandbox because sandboxes take less time to
+				// build by skipping the SIF creation step.
+				args := []string{"--force", imagePath, tc.buildSpec}
+
+				c.env.RunSingularity(
+					t,
+					e2e.AsSubtest(tc.name),
+					e2e.WithProfile(profile),
+					e2e.WithCommand("build"),
+					e2e.WithArgs(args...),
+					e2e.PostRun(func(t *testing.T) {
+						if t.Failed() {
+							return
+						}
+
+						defer os.RemoveAll(imagePath)
+						c.env.ImageVerify(t, imagePath, profile)
+					}),
+					e2e.ExpectExit(0),
+				)
+			}
+		})
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := imgBuildTests{
@@ -1492,6 +1553,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"build with bind mount":           c.buildBindMount,            // build image with bind mount
 		"test with writable tmpfs":        c.testWritableTmpfs,         // build image, using writable tmpfs in the test step
 		"library host":                    c.buildLibraryHost,          // build image with hostname in library URI
+		"proot":                           c.buildProot,                // build image as an unpriv user with proot
 		"issue 3848":                      c.issue3848,                 // https://github.com/hpcng/singularity/issues/3848
 		"issue 4203":                      c.issue4203,                 // https://github.com/sylabs/singularity/issues/4203
 		"issue 4407":                      c.issue4407,                 // https://github.com/sylabs/singularity/issues/4407

--- a/e2e/testdata/proot_alpine.def
+++ b/e2e/testdata/proot_alpine.def
@@ -1,0 +1,16 @@
+bootstrap: library
+from: alpine:3.11.5
+
+%post
+  echo "Running %post as $(id -u)"
+  # We should appear to be root
+  test $(id -u) -eq 0
+  # We should be able to install some software
+  apk add wget
+
+%test
+  echo "Running %post as $(id -u)"
+  # We should not appear to be root
+  test $(id -u) -ne 0
+  # wget was installed
+  wget --version

--- a/e2e/testdata/proot_centos.def
+++ b/e2e/testdata/proot_centos.def
@@ -1,0 +1,16 @@
+bootstrap: library
+from: centos:7
+
+%post
+  echo "Running %post as $(id -u)"
+  # We should appear to be root
+  test $(id -u) -eq 0
+  # We should be able to install some software
+  yum -y install wget
+
+%test
+  echo "Running %post as $(id -u)"
+  # We should not appear to be root
+  test $(id -u) -ne 0
+  # wget was installed
+  wget --version

--- a/e2e/testdata/proot_ubuntu.def
+++ b/e2e/testdata/proot_ubuntu.def
@@ -1,0 +1,17 @@
+bootstrap: library
+from: ubuntu:20.04
+
+%post
+  echo "Running %post as $(id -u)"
+  # We should appear to be root
+  test $(id -u) -eq 0
+  # We should be able to install some software
+  apt -y update
+  apt -y install wget
+
+%test
+  echo "Running %post as $(id -u)"
+  # We should not appear to be root
+  test $(id -u) -ne 0
+  # wget was installed
+  wget --version

--- a/examples/docker/Singularity
+++ b/examples/docker/Singularity
@@ -7,3 +7,7 @@ From: busybox:latest   # This is a comment
 %post
     echo "Hello from inside the container"
     echo "Install additional software here"
+
+%test
+    echo "Hello from the test script"
+

--- a/examples/library/Singularity
+++ b/examples/library/Singularity
@@ -7,3 +7,7 @@ From: alpine:3.11.5
 %post
     echo "Hello from inside the container"
     echo "Install additional software here"
+
+%test
+    echo "Hello from the test script"
+

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -452,6 +452,7 @@ func (b *Build) Full(ctx context.Context) error {
 		}
 
 		// write the build configuration used for %post and %test sections
+		// as a root or non-setuid user.
 		configFile := filepath.Join(stage.b.TmpDir, "singularity.conf")
 		if err := ioutil.WriteFile(configFile, configData, 0o644); err != nil {
 			return fmt.Errorf("while creating %s: %s", configFile, err)

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -26,7 +26,7 @@ func FindBin(name string) (path string, err error) {
 	case "true", "mkfs.ext3", "cp", "rm", "dd", "truncate":
 		return findOnPath(name)
 	// Bootstrap related executables that we assume are on PATH
-	case "mount", "mknod", "debootstrap", "pacstrap", "dnf", "yum", "rpm", "curl", "uname", "zypper", "SUSEConnect", "rpmkeys":
+	case "mount", "mknod", "debootstrap", "pacstrap", "dnf", "yum", "rpm", "curl", "uname", "zypper", "SUSEConnect", "rpmkeys", "proot":
 		return findOnPath(name)
 	// Configurable executables that are found at build time, can be overridden
 	// in singularity.conf. If config value is "" will look on PATH.
@@ -66,7 +66,7 @@ func findOnPath(name string) (path string, err error) {
 	os.Setenv("PATH", oldPath+":"+env.DefaultPath)
 
 	path, err = exec.LookPath(name)
-	if err != nil {
+	if err == nil {
 		sylog.Debugf("Found %q at %q", name, path)
 	}
 	return path, err


### PR DESCRIPTION
## Description of the Pull Request (PR):

Non-root users can now build from a definition file, on systems that do not support `--fakeroot`. This requires the statically built `proot` command (<https://proot-me.github.io/>) to be available on the user `PATH`. 

These builds:
  - Do not support `arch` / `debootstrap` / `yum` / `zypper` bootstraps. Use `localimage`, `library`, `oras`, or one of the docker/oci sources.
  - Do not support `%pre` and `%setup` sections.
  - Run the `%post` sections of a build in the container as an emulated root user.
  - Run the `%test` section of a build as the non-root user, like `singularity test`.
  - Are subject to any restrictions imposed in `singularity.conf`.
  - Incur a performance penalty due to `proot`'s `ptrace` based interception of syscalls.
  - May fail if the `%post` and `%test` scripts require privileged operations that `proot` cannot emulate.

### This fixes or addresses the following GitHub issues:

 - Fixes #880


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
