### PR TITLE
feat: `bind-paths` option for `--no-mount` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   specified instance, running within a cgroup.
 - Add `--sparse` flag to `overlay create` command to allow generation of a
   sparse ext3 overlay image.
+- The `--no-mount` flag now accepts the value `bind-paths` to disable mounting of
+  all `bind path` entries in `singularity.conf.
 
 ### Bug Fixes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -460,7 +460,7 @@ var actionNoMountFlag = cmdline.Flag{
 	Value:        &NoMount,
 	DefaultValue: []string{},
 	Name:         "no-mount",
-	Usage:        "disable one or more 'mount xxx' options set in singularity.conf, specify absolute destination path to disable a 'bind path' entry",
+	Usage:        "disable one or more 'mount xxx' options set in singularity.conf, specify absolute destination path to disable a bind path entry, or 'bind-paths' to disable all bind path entries.",
 	EnvKeys:      []string{"NO_MOUNT"},
 }
 

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -237,7 +237,11 @@ func setNoMountFlags(c *singularityConfig.EngineConfig) {
 			c.SetNoHostfs(true)
 		case "cwd":
 			c.SetNoCwd(true)
+		// All bind path singularity.conf entries
+		case "bind-paths":
+			skipBinds = append(skipBinds, "*")
 		default:
+			// Single bind path singularity.conf entry by abs path
 			if filepath.IsAbs(v) {
 				skipBinds = append(skipBinds, v)
 				continue

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2239,6 +2239,23 @@ func (c actionTests) actionNoMount(t *testing.T) {
 			testContained: true,
 			exit:          0,
 		},
+		// bind-paths should disable all of the bind path mounts - including both defaults
+		{
+			name:          "binds-paths-hosts",
+			noMount:       "bind-paths",
+			noMatch:       "on /etc/hosts",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
+		{
+			name:          "bind-paths-localtime",
+			noMount:       "bind-paths",
+			noMatch:       "on /etc/localtime",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1527,7 +1527,8 @@ func (c *container) addBindsMount(system *mount.System) error {
 		localtimePath = "/etc/localtime"
 	)
 
-	noBinds := c.engine.EngineConfig.GetNoBinds()
+	skipBinds := c.engine.EngineConfig.GetSkipBinds()
+	skipAllBinds := slice.ContainsString(skipBinds, "*")
 
 	if c.engine.EngineConfig.GetContain() {
 		hosts := hostsPath
@@ -1548,7 +1549,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 			hosts, _ = c.session.GetPath(hostsPath)
 		}
 
-		if !slice.ContainsString(noBinds, hostsPath) {
+		if !skipAllBinds && !slice.ContainsString(skipBinds, hostsPath) {
 			// #5465 If hosts/localtime mount fails, it should not be fatal so skip-on-error
 			if err := system.Points.AddBind(mount.BindsTag, hosts, hostsPath, flags, "skip-on-error"); err != nil {
 				return fmt.Errorf("unable to add %s to mount list: %s", hosts, err)
@@ -1557,7 +1558,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 				return fmt.Errorf("unable to add %s for remount: %s", hostsPath, err)
 			}
 		}
-		if !slice.ContainsString(noBinds, localtimePath) {
+		if !skipAllBinds && !slice.ContainsString(skipBinds, localtimePath) {
 			if err := system.Points.AddBind(mount.BindsTag, localtimePath, localtimePath, flags, "skip-on-error"); err != nil {
 				return fmt.Errorf("unable to add %s to mount list: %s", localtimePath, err)
 			}
@@ -1580,7 +1581,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 
 		sylog.Verbosef("Found 'bind path' = %s, %s", src, dst)
 
-		if slice.ContainsString(noBinds, dst) {
+		if skipAllBinds || slice.ContainsString(skipBinds, dst) {
 			sylog.Debugf("Skipping bind to %s at user request", dst)
 			continue
 		}

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -484,7 +484,7 @@ func (e *EngineConfig) SetSkipBinds(val []string) {
 }
 
 // GetSkipBinds gets bind paths to skip
-func (e *EngineConfig) GetNoBinds() []string {
+func (e *EngineConfig) GetSkipBinds() []string {
 	return e.JSON.SkipBinds
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add `bind-paths` option for the `--no-mount` flag. This will disable mounting all of the `bind path` entries set in `singularity.conf`.

Previously, `bind path` entries could only be disabled one-by-one by specifying their absolute path.


### This fixes or addresses the following GitHub issues:

 - Fixes #883


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
