### PR TITLE
feat: SINGULARITY_DEBUG env var, and nested debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `SINGULARITY_` prefix.
 - The `--no-mount` flag now accepts the value `bind-paths` to disable mounting of
   all `bind path` entries in `singularity.conf.
+- Debug output can now be enabled by setting the `SINGULARITY_DEBUG` env var.
+- Debug output is now shown for nested `singularity` calls, in wrapped
+  `unsquashfs` image extraction, and build stages.
 
 ### Bug Fixes
 

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -82,6 +82,7 @@ var singDebugFlag = cmdline.Flag{
 	Name:         "debug",
 	ShortHand:    "d",
 	Usage:        "print debugging information (highest verbosity)",
+	EnvKeys:      []string{"DEBUG"},
 }
 
 // --nocolor
@@ -256,6 +257,8 @@ func setSylogMessageLevel() {
 
 	if debug {
 		level = 5
+		// Propagate debug flag to nested `singularity` calls.
+		os.Setenv("SINGULARITY_DEBUG", "1")
 	} else if verbose {
 		level = 4
 	} else if quiet {
@@ -276,25 +279,26 @@ func setSylogMessageLevel() {
 
 // handleRemoteConf will make sure your 'remote.yaml' config file
 // has the correct permission.
-func handleRemoteConf(remoteConfFile string) {
+func handleRemoteConf(remoteConfFile string) error {
 	// Only check the permission if it exists.
 	if fs.IsFile(remoteConfFile) {
 		sylog.Debugf("Ensuring file permission of 0600 on %s", remoteConfFile)
 		if err := fs.EnsureFileWithPermission(remoteConfFile, 0o600); err != nil {
-			sylog.Fatalf("Unable to correct the permission on %s: %s", remoteConfFile, err)
+			return fmt.Errorf("unable to correct the permission on %s: %w", remoteConfFile, err)
 		}
 	}
+	return nil
 }
 
 // handleConfDir tries to create the user's configuration directory and handles
 // messages and/or errors.
-func handleConfDir(confDir string) {
+func handleConfDir(confDir string) error {
 	if err := fs.Mkdir(confDir, 0o700); err != nil {
 		if os.IsExist(err) {
 			sylog.Debugf("%s already exists. Not creating.", confDir)
 			fi, err := os.Stat(confDir)
 			if err != nil {
-				sylog.Fatalf("Failed to retrieve information for %s: %s", confDir, err)
+				return fmt.Errorf("failed to retrieve information for %s: %s", confDir, err)
 			}
 			if fi.Mode().Perm() != 0o700 {
 				sylog.Debugf("Enforce permission 0700 on %s", confDir)
@@ -310,29 +314,35 @@ func handleConfDir(confDir string) {
 	} else {
 		sylog.Debugf("Created %s", confDir)
 	}
+	return nil
 }
 
-func persistentPreRun(*cobra.Command, []string) {
+func persistentPreRun(*cobra.Command, []string) error {
 	setSylogMessageLevel()
 	sylog.Debugf("Singularity version: %s", buildcfg.PACKAGE_VERSION)
 
 	if os.Geteuid() != 0 && buildcfg.SINGULARITY_SUID_INSTALL == 1 {
 		if configurationFile != singConfigFileFlag.DefaultValue {
-			sylog.Fatalf("--config requires to be root or an unprivileged installation")
+			return fmt.Errorf("--config requires to be root or an unprivileged installation")
 		}
 	}
 
 	sylog.Debugf("Parsing configuration file %s", configurationFile)
 	config, err := singularityconf.Parse(configurationFile)
 	if err != nil {
-		sylog.Fatalf("Couldn't not parse configuration file %s: %s", configurationFile, err)
+		return fmt.Errorf("couldn't parse configuration file %s: %s", configurationFile, err)
 	}
 	singularityconf.SetCurrentConfig(config)
 
 	// Handle the config dir (~/.singularity),
 	// then check the remove conf file permission.
-	handleConfDir(syfs.ConfigDir())
-	handleRemoteConf(syfs.RemoteConf())
+	if err := handleConfDir(syfs.ConfigDir()); err != nil {
+		return fmt.Errorf("while handling config dir: %w", err)
+	}
+	if err := handleRemoteConf(syfs.RemoteConf()); err != nil {
+		return fmt.Errorf("while handling remote config: %w", err)
+	}
+	return nil
 }
 
 // Init initializes and registers all singularity commands.
@@ -355,8 +365,16 @@ func Init(loadPlugins bool) {
 
 	// set persistent pre run function here to avoid initialization loop error
 	singularityCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		persistentPreRun(cmd, args)
-		return cmdManager.UpdateCmdFlagFromEnv(cmd, envPrefix)
+		if err := cmdManager.UpdateCmdFlagFromEnv(singularityCmd, envPrefix); err != nil {
+			sylog.Fatalf("While parsing global environment variables: %s", err)
+		}
+		if err := cmdManager.UpdateCmdFlagFromEnv(cmd, envPrefix); err != nil {
+			sylog.Fatalf("While parsing environment variables: %s", err)
+		}
+		if err := persistentPreRun(cmd, args); err != nil {
+			sylog.Fatalf("While initializing: %s", err)
+		}
+		return nil
 	}
 
 	cmdManager.RegisterFlagForCmd(&singDebugFlag, singularityCmd)

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -108,7 +108,7 @@ func (s *stage) runPostScript(configFile, sessionResolv, sessionHosts string) er
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = "/"
-		cmd.Env = currentEnvNoSingularity([]string{"NV", "NVCCLI", "ROCM", "BINDPATH", "MOUNT"})
+		cmd.Env = currentEnvNoSingularity([]string{"DEBUG", "NV", "NVCCLI", "ROCM", "BINDPATH", "MOUNT"})
 
 		sylog.Infof("Running post scriptlet")
 		return cmd.Run()
@@ -134,7 +134,7 @@ func (s *stage) runTestScript(configFile, sessionResolv, sessionHosts string) er
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = "/"
-		cmd.Env = currentEnvNoSingularity([]string{"NV", "NVCCLI", "ROCM", "BINDPATH", "MOUNT", "WRITABLE_TMPFS"})
+		cmd.Env = currentEnvNoSingularity([]string{"DEBUG", "NV", "NVCCLI", "ROCM", "BINDPATH", "MOUNT", "WRITABLE_TMPFS"})
 
 		sylog.Infof("Running testscript")
 		return cmd.Run()

--- a/internal/pkg/image/unpacker/squashfs.go
+++ b/internal/pkg/image/unpacker/squashfs.go
@@ -165,7 +165,15 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) (err e
 		cmd.Stdin = reader
 	}
 
-	if o, err := cmd.CombinedOutput(); err != nil {
+	o, err := cmd.CombinedOutput()
+
+	if os.Getenv("SINGULARITY_DEBUG") != "" {
+		sylog.Debugf("*** BEGIN WRAPPED UNSQUASHFS OUTPUT ***")
+		sylog.Debugf(string(o))
+		sylog.Debugf("*** END WRAPPED UNSQUASHFS OUTPUT ***")
+	}
+
+	if err != nil {
 		return fmt.Errorf("extract command failed: %s: %s", string(o), err)
 	}
 

--- a/internal/pkg/image/unpacker/squashfs_singularity.go
+++ b/internal/pkg/image/unpacker/squashfs_singularity.go
@@ -191,7 +191,6 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 	// which will detect automatically depending of the configuration
 	// what workflow it could use
 	args := []string{
-		"-q",
 		"exec",
 		"--no-home",
 		"--no-nv",
@@ -282,6 +281,7 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 	cmd.Dir = "/"
 	cmd.Env = []string{
 		fmt.Sprintf("LD_LIBRARY_PATH=%s", strings.Join(libraryPath, string(os.PathListSeparator))),
+		fmt.Sprintf("SINGULARITY_DEBUG=%s", os.Getenv("SINGULARITY_DEBUG")),
 	}
 
 	return cmd, nil

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -209,7 +209,6 @@ func (m *flagManager) updateCmdFlagFromEnv(cmd *cobra.Command, prefix string) er
 			return
 		}
 		for _, key := range envKeys {
-
 			// First priority goes to prefixed variable
 			val, set := os.LookupEnv(prefix + key)
 			if !set {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow debug output to be turned on from a `SINGULARITY_DEBUG` env var.

Pass debug env var down through nested calls to `singularity` in
wrapped unsquashfs and build stages so that we can see the full debug
output for those.

### This fixes or addresses the following GitHub issues:

 - Fixes #884

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
