### PR TITLE
feat: enable cgroups for non-root instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Debug output can now be enabled by setting the `SINGULARITY_DEBUG` env var.
 - Debug output is now shown for nested `singularity` calls, in wrapped
   `unsquashfs` image extraction, and build stages.
+- Instances started by a non-root user can use `--apply-cgroups` to apply
+  resource limits. Requires cgroups v2, and delegation configured via systemd.
 
 ### Bug Fixes
 

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -62,11 +62,6 @@ func (c *ctx) instanceStats(t *testing.T, profile e2e.Profile) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// stats only for privileged atm
-			if !profile.Privileged() {
-				t.Skip()
-			}
-
 			// We always expect stats output, not create
 			createExitFunc := []e2e.SingularityCmdResultOp{}
 			instanceName := randomName(t)
@@ -152,6 +147,7 @@ func (c *ctx) instanceApply(t *testing.T, profile e2e.Profile) {
 			createArgs: []string{"--apply-cgroups", "testdata/cgroups/memory_limit.toml", c.env.ImagePath},
 			// We get a CLI 255 error code, not the 137 that the starter receives for an OOM kill
 			startErrorCode: 255,
+			startErrorOut:  "signal: killed",
 			rootfull:       true,
 			rootless:       true,
 		},
@@ -177,56 +173,60 @@ func (c *ctx) instanceApply(t *testing.T, profile e2e.Profile) {
 	}
 
 	for _, tt := range tests {
-		if profile.Privileged() && !tt.rootfull {
-			t.Skip()
-		}
-		if !profile.Privileged() && !tt.rootless {
-			t.Skip()
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if profile.Privileged() && !tt.rootfull {
+				t.Skip()
+			}
+			if !profile.Privileged() && !tt.rootless {
+				t.Skip()
+			}
 
-		createExitFunc := []e2e.SingularityCmdResultOp{}
-		if tt.startErrorOut != "" {
-			createExitFunc = []e2e.SingularityCmdResultOp{e2e.ExpectError(e2e.ContainMatch, tt.startErrorOut)}
-		}
-		execExitFunc := []e2e.SingularityCmdResultOp{}
-		if tt.execErrorOut != "" {
-			execExitFunc = []e2e.SingularityCmdResultOp{e2e.ExpectError(e2e.ContainMatch, tt.execErrorOut)}
-		}
-		// pick up a random name
-		instanceName := randomName(t)
-		joinName := fmt.Sprintf("instance://%s", instanceName)
+			createExitFunc := []e2e.SingularityCmdResultOp{}
+			if tt.startErrorOut != "" {
+				createExitFunc = []e2e.SingularityCmdResultOp{e2e.ExpectError(e2e.ContainMatch, tt.startErrorOut)}
+			}
+			execExitFunc := []e2e.SingularityCmdResultOp{}
+			if tt.execErrorOut != "" {
+				execExitFunc = []e2e.SingularityCmdResultOp{e2e.ExpectError(e2e.ContainMatch, tt.execErrorOut)}
+			}
+			// pick up a random name
+			instanceName := randomName(t)
+			joinName := fmt.Sprintf("instance://%s", instanceName)
 
-		createArgs := append(tt.createArgs, instanceName)
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name+"/start"),
-			e2e.WithProfile(profile),
-			e2e.WithCommand("instance start"),
-			e2e.WithArgs(createArgs...),
-			e2e.ExpectExit(tt.startErrorCode, createExitFunc...),
-		)
-		if tt.startErrorCode != 0 {
-			continue
-		}
+			createArgs := append(tt.createArgs, instanceName)
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest("start"),
+				e2e.WithProfile(profile),
+				e2e.WithCommand("instance start"),
+				e2e.WithArgs(createArgs...),
+				e2e.ExpectExit(tt.startErrorCode, createExitFunc...),
+			)
+			if tt.startErrorCode != 0 {
+				return
+			}
 
-		execArgs := append([]string{joinName}, tt.execArgs...)
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name+"/exec"),
-			e2e.WithProfile(profile),
-			e2e.WithCommand("exec"),
-			e2e.WithArgs(execArgs...),
-			e2e.ExpectExit(tt.execErrorCode, execExitFunc...),
-		)
+			execArgs := append([]string{joinName}, tt.execArgs...)
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest("exec"),
+				e2e.WithProfile(profile),
+				e2e.WithGlobalOptions("-d"),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs(execArgs...),
+				e2e.WithDir(profile.HostUser(t).Dir),
+				e2e.ExpectExit(tt.execErrorCode, execExitFunc...),
+			)
 
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name+"/stop"),
-			e2e.WithProfile(profile),
-			e2e.WithCommand("instance stop"),
-			e2e.WithArgs(instanceName),
-			e2e.ExpectExit(0),
-		)
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest("stop"),
+				e2e.WithProfile(profile),
+				e2e.WithCommand("instance stop"),
+				e2e.WithArgs(instanceName),
+				e2e.ExpectExit(0),
+			)
+		})
 	}
 }
 
@@ -234,26 +234,16 @@ func (c *ctx) instanceApplyRoot(t *testing.T) {
 	c.instanceApply(t, e2e.RootProfile)
 }
 
+func (c *ctx) instanceApplyRootless(t *testing.T) {
+	c.instanceApply(t, e2e.UserProfile)
+}
+
 func (c *ctx) instanceStatsRoot(t *testing.T) {
 	c.instanceStats(t, e2e.RootProfile)
 }
 
-// TODO - when instance support for rootless cgroups is ready, this
-// should instead call instanceApply over the user profiles.
-func (c *ctx) instanceApplyRootless(t *testing.T) {
-	e2e.EnsureImage(t, c.env)
-	// pick up a random name
-	instanceName := randomName(t)
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithRootlessEnv(),
-		e2e.WithCommand("instance start"),
-		e2e.WithArgs("--apply-cgroups", "testdata/cgroups/memory_limit.toml", c.env.ImagePath, instanceName),
-		e2e.ExpectExit(255,
-			e2e.ExpectError(e2e.ContainMatch, "Instances do not currently support rootless cgroups")),
-	)
+func (c *ctx) instanceStatsRootless(t *testing.T) {
+	c.instanceStats(t, e2e.UserProfile)
 }
 
 func (c *ctx) actionApply(t *testing.T, profile e2e.Profile) {
@@ -321,31 +311,32 @@ func (c *ctx) actionApply(t *testing.T, profile e2e.Profile) {
 			name:            "device ignored",
 			args:            []string{"--apply-cgroups", "testdata/cgroups/deny_device.toml", c.env.ImagePath, "cat", "/dev/null"},
 			expectErrorCode: 0,
-			expectErrorOut:  "Operation not permitted",
+			expectErrorOut:  "Device limits will not be applied with rootless cgroups",
 			rootfull:        false,
 			rootless:        true,
 		},
 	}
 
 	for _, tt := range tests {
-		if profile.Privileged() && !tt.rootfull {
-			t.Skip()
-		}
-		if !profile.Privileged() && !tt.rootless {
-			t.Skip()
-		}
-		exitFunc := []e2e.SingularityCmdResultOp{}
-		if tt.expectErrorOut != "" {
-			exitFunc = []e2e.SingularityCmdResultOp{e2e.ExpectError(e2e.ContainMatch, tt.expectErrorOut)}
-		}
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(profile),
-			e2e.WithCommand("exec"),
-			e2e.WithArgs(tt.args...),
-			e2e.ExpectExit(tt.expectErrorCode, exitFunc...),
-		)
+		t.Run(tt.name, func(t *testing.T) {
+			if profile.Privileged() && !tt.rootfull {
+				t.Skip()
+			}
+			if !profile.Privileged() && !tt.rootless {
+				t.Skip()
+			}
+			exitFunc := []e2e.SingularityCmdResultOp{}
+			if tt.expectErrorOut != "" {
+				exitFunc = []e2e.SingularityCmdResultOp{e2e.ExpectError(e2e.ContainMatch, tt.expectErrorOut)}
+			}
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(profile),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs(tt.args...),
+				e2e.ExpectExit(tt.expectErrorCode, exitFunc...),
+			)
+		})
 	}
 }
 
@@ -590,7 +581,8 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	np := testhelper.NoParallel
 
 	return testhelper.Tests{
-		"instance stats":                np(env.WithRootManagers(c.instanceStatsRoot)),
+		"instance stats root":           np(env.WithRootManagers(c.instanceStatsRoot)),
+		"instance stats rootless":       np(env.WithRootlessManagers(c.instanceStatsRootless)),
 		"instance root cgroups":         np(env.WithRootManagers(c.instanceApplyRoot)),
 		"instance rootless cgroups":     np(env.WithRootlessManagers(c.instanceApplyRootless)),
 		"action root cgroups":           np(env.WithRootManagers(c.actionApplyRoot)),

--- a/e2e/testdata/cgroups/cpu_success.toml
+++ b/e2e/testdata/cgroups/cpu_success.toml
@@ -1,4 +1,4 @@
 [cpu]
-  cpus = "0"
-  mems = "0"
+  shares = 512
+
 

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -903,6 +903,10 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 		e.EngineConfig.OciConfig.Linux.Seccomp = instanceEngineConfig.OciConfig.Linux.Seccomp
 	}
 
+	// Note - in non-root flow without userns the CLI process joined the cgroup
+	// early in execStarter because we don't have permission to move a parent
+	// process into the cgroup here. In that case, this code is a no-op that
+	// just enforces that actually happened.
 	if file.Cgroup {
 		sylog.Debugf("Adding process to instance cgroup")
 		ppid := os.Getppid()

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -117,23 +117,24 @@ func New(r io.Reader, name string, args []string, envs []string, runnerOptions .
 		name:   name,
 	}
 
+	dir, err := os.Getwd()
+	if err != nil {
+		dir = "/"
+	}
+
 	opts := []interp.RunnerOption{
 		interp.StdIO(os.Stdin, os.Stdout, os.Stderr),
 		interp.ExecHandler(s.internalExecHandler()),
 		interp.OpenHandler(s.internalOpenHandler()),
 		interp.Params("--"),
 		interp.Env(expand.ListEnviron(envs...)),
+		interp.Dir(dir),
 	}
 	opts = append(opts, runnerOptions...)
 	s.runner, err = interp.New(opts...)
 
 	if err != nil {
 		return nil, fmt.Errorf("while creating shell interpreter: %s", err)
-	}
-
-	s.runner.Dir, err = os.Getwd()
-	if err != nil {
-		s.runner.Dir = "/"
 	}
 
 	s.runner.Params = append(s.runner.Params, args...)

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs, Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license.  Please
 // consult LICENSE.md file distributed with the sources of this project regarding
 // your rights to use or distribute this software.


### PR DESCRIPTION
## Description of the Pull Request (PR):

**feat: enable cgroups for non-root instances**

Our existing method for joining an instance cgroup with an action on an `instance://` does not work for non-root instances, without a
usernamepace - so we blocked non-root instances with cgroups. The existing code attempts to move its parent ID (the starter main process), into the instance cgroup. This will receive an operation not permitted error.

We can work around by having the CLI process directly join the cgroup, so that everything is spawned within the instance cgroup.

Also modify e2e cgroups tests to verify this functionality, and correct unintentional test skips in rootless flow.

**e2e: use cpu controller instead of cpuset for cgroups test**
    
The cpuset controller may not be delegated by default on many distributions.

**fix: handle invalid wd before shell interp.New**

### This fixes or addresses the following GitHub issues:

 - Fixes #816


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
