### PR TITLE
fix: ensure wrapped unsquashfs error is displayed to user

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -127,14 +127,15 @@ func handleImage(ctx context.Context, filename string, tryFUSE bool) (isFUSE boo
 	}
 
 	// Fall back to extraction to directory
-	if err := extractImage(img, imageDir); err == nil {
+	err = extractImage(img, imageDir)
+	if err == nil {
 		return false, tempDir, imageDir, nil
 	}
 
 	if err2 := os.RemoveAll(tempDir); err2 != nil {
 		sylog.Errorf("Couldn't remove temporary directory %s: %s", tempDir, err2)
 	}
-	return false, "", "", fmt.Errorf("while extracting image: %w", err)
+	return false, "", "", fmt.Errorf("while extracting image: %v", err)
 }
 
 // extractImage extracts img to directory dir within a temporary directory


### PR DESCRIPTION
## Description of the Pull Request (PR):

`if err :=` was incorrectly used in #711, resulting in a nil error return.

### This fixes or addresses the following GitHub issues:

 - Fixes #897 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
