### PR TITLE
fix: use correct args for nc in network_linux_test.go

### DIFF
--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -541,7 +541,7 @@ func TestAddDelNetworks(t *testing.T) {
 		{
 			name:    "TestHTTPPortmap",
 			command: "nc",
-			args:    []string{"-l", "80"},
+			args:    []string{"-l", "0.0.0.0", "80"},
 			runFunc: testHTTPPortmap,
 		},
 		{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes confusing error on EL9, Fedora etc. where IP address needs to be
given for the nc -l flag.


### This fixes or addresses the following GitHub issues:

 - Fixes #838


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
