### PR TITLE
e2e: use rsa-sha2 ssh-key in sshfs test

### DIFF
--- a/e2e/testdata/sshfs.def
+++ b/e2e/testdata/sshfs.def
@@ -1,5 +1,5 @@
 bootstrap: docker
-from: alpine:3.11
+from: alpine:3.16
 
 %post
     apk update
@@ -7,7 +7,7 @@ from: alpine:3.11
     loader=`strings /bin/sh | head -n1`
 
     mkdir /etc/dropbear
-    ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa
+    ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa-sha2-512
     mkdir /root/.ssh
     chmod 0600 /root/.ssh
     cp /etc/ssh/ssh_host_rsa_key.pub /root/.ssh/authorized_keys


### PR DESCRIPTION
## Description of the Pull Request (PR):

Our sshfs tests must use an image where the ssh key is rsa-sha2, so
that it is compatible with the EL9 default crypto policy.

### This fixes or addresses the following GitHub issues:

 - Fixes #839 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
