### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@ The following have contributed code and/or documentation to this repository.
 - Divya Cote <divya.cote@gmail.com>
 - Eduardo Arango <eduardo@sylabs.io>, <arangogutierrez@gmail.com>
 - Egbert Eich <eich@suse.com>
+- Eng Zer Jun <engzerjun@gmail.com>
 - Eric Müller <mueller@kip.uni-heidelberg.de>
 - Felix Abecassis <fabecassis@nvidia.com>
 - Geoffroy Vallee <geoffroy@sylabs.io>, <geoffroy.vallee@gmail.com>

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -44,11 +44,7 @@ func TestMakeParentDir(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// create tmpdir for each test
-			dir, err := ioutil.TempDir("", "parent-dir-test-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			// concatenate test path with directory, do not use a join function so that we do not remove a trailing slash
 			path := dir + "/" + tt.path
@@ -85,11 +81,7 @@ func TestMakeParentDir(t *testing.T) {
 //nolint:maintidx
 func TestCopyFromHost(t *testing.T) {
 	// create tmpdir
-	dir, err := ioutil.TempDir("", "copy-test-src-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Source Files
 	srcFile := filepath.Join(dir, "srcFile")
@@ -334,11 +326,7 @@ func TestCopyFromHost(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create outer destination dir
-			dstRoot, err := ioutil.TempDir("", "copy-test-dst-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dstRoot)
+			dstRoot := t.TempDir()
 
 			if err := CopyFromHost(tt.src, tt.dst, dstRoot); err != nil {
 				t.Errorf("unexpected failure running %s test: %s", t.Name(), err)
@@ -346,7 +334,7 @@ func TestCopyFromHost(t *testing.T) {
 
 			dstFinal := filepath.Join(dstRoot, tt.expectPath)
 			// verify file was copied
-			_, err = os.Stat(dstFinal)
+			_, err := os.Stat(dstFinal)
 			if err != nil && !os.IsNotExist(err) {
 				t.Fatalf("while checking for destination file: %s", err)
 			}
@@ -374,11 +362,8 @@ func TestCopyFromHost(t *testing.T) {
 // works. CopyFromHost should always resolve symlinks, even those nested inside a source dir.
 func TestCopyFromHostNested(t *testing.T) {
 	// create tmpdir
-	dir, err := ioutil.TempDir("", "copy-test-src-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
+	t.Logf("src dir location: %s\n", dir)
 
 	// All our test files/dirs/links will be nested inside innerDir
 	innerDir := filepath.Join(dir, "innerDir")
@@ -414,11 +399,8 @@ func TestCopyFromHostNested(t *testing.T) {
 	}
 
 	// Create outer destination dir
-	dstDir, err := ioutil.TempDir("", "copy-test-dst-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dstDir)
+	dstDir := t.TempDir()
+	t.Logf("dstDir location: %s\n", dstDir)
 
 	// Copy our source innerDir over into the destination dir
 	if err := CopyFromHost(innerDir, "innerDir", dstDir); err != nil {
@@ -484,11 +466,8 @@ func TestCopyFromHostNested(t *testing.T) {
 //nolint:maintidx
 func TestCopyFromStage(t *testing.T) {
 	// create tmpdir
-	srcRoot, err := ioutil.TempDir("", "copy-test-src-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(srcRoot)
+	srcRoot := t.TempDir()
+	t.Logf("srcRoot location: %s\n", srcRoot)
 
 	// Source Files
 	srcFile := filepath.Join(srcRoot, "srcFile")
@@ -745,11 +724,8 @@ func TestCopyFromStage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create outer destination dir
-			dstRoot, err := ioutil.TempDir("", "copy-test-dst-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dstRoot)
+			dstRoot := t.TempDir()
+			t.Logf("dstRoot location: %s\n", dstRoot)
 
 			// Manually concatenating because we need to preserve any trailing slash that is
 			// stripped by Join.
@@ -759,7 +735,7 @@ func TestCopyFromStage(t *testing.T) {
 
 			dstFinal := filepath.Join(dstRoot, tt.expectPath)
 			// verify file was copied
-			_, err = os.Stat(dstFinal)
+			_, err := os.Stat(dstFinal)
 			if err != nil && !os.IsNotExist(err) {
 				t.Fatalf("while checking for destination file: %s", err)
 			}
@@ -787,11 +763,8 @@ func TestCopyFromStage(t *testing.T) {
 // works. CopyFromStage should *not* resolve the symlinks that are nested in the dir.
 func TestCopyFromStageNested(t *testing.T) {
 	// create tmpdir
-	srcRoot, err := ioutil.TempDir("", "copy-test-src-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(srcRoot)
+	srcRoot := t.TempDir()
+	t.Logf("srcRoot location: %s\n", srcRoot)
 
 	// All our test files/dirs/links will be nested inside innerDir
 	innerDir := filepath.Join(srcRoot, "innerDir")
@@ -827,11 +800,8 @@ func TestCopyFromStageNested(t *testing.T) {
 	}
 
 	// Create outer destination dir
-	dstRoot, err := ioutil.TempDir("", "copy-test-dst-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dstRoot)
+	dstRoot := t.TempDir()
+	t.Logf("dstRoot location: %s\n", dstRoot)
 
 	// Copy our source innerDir over into the destination dir
 	if err := CopyFromStage("innerDir", "", srcRoot, dstRoot); err != nil {

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -108,10 +108,7 @@ func createIndexFile(t *testing.T, dir string, sum string) {
 // and a SHA256 hash associated to the unique entry in the OCI cache.
 func createDummyOCICache(t *testing.T) (string, string) {
 	// Temporary directory that will serve as root of the OCI cache
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("cannot create temporary directory: %s\n", err)
-	}
+	dir := t.TempDir()
 
 	// Create the directory structure.
 	blobPath := filepath.Join(dir, "blobs")
@@ -119,16 +116,14 @@ func createDummyOCICache(t *testing.T) (string, string) {
 	sum := sha256.New()
 	sumFilename := hex.EncodeToString(sum.Sum(nil))
 	path := filepath.Join(shaPath, sumFilename)
-	err = os.MkdirAll(shaPath, 0o755)
+	err := os.MkdirAll(shaPath, 0o755)
 	if err != nil {
-		os.RemoveAll(dir)
 		t.Fatalf("cannot create cache directory: %s\n", err)
 	}
 
 	// Create the SHA256 file
 	f, err := os.Create(path)
 	if err != nil {
-		os.RemoveAll(dir)
 		t.Fatalf("cannot create file: %s\n", err)
 	}
 	defer f.Close()
@@ -157,8 +152,7 @@ func TestParseURI(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	cacheDir, _, ref := getTestCacheInfo(t)
-	defer os.RemoveAll(cacheDir)
+	_, _, ref := getTestCacheInfo(t)
 
 	tests := []struct {
 		name       string
@@ -235,7 +229,6 @@ func TestConvertReference(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	cacheDir, _, ref := getTestCacheInfo(t)
-	defer os.RemoveAll(cacheDir)
 	imgCache, err := cache.New(cache.Config{ParentDir: cacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle")
@@ -293,7 +286,6 @@ func TestImageNameAndImageSHA(t *testing.T) {
 
 	// We create a dummy OCI cache to run all our tests
 	cacheDir, _, _ := getTestCacheInfo(t)
-	defer os.RemoveAll(cacheDir)
 	imgCache, err := cache.New(cache.Config{ParentDir: cacheDir})
 	if imgCache == nil || err != nil {
 		t.Fatal("failed to create an image cache handle")
@@ -408,7 +400,6 @@ func TestNewImageSource(t *testing.T) {
 
 	// We create a minimalistic image reference that is valid enough for testing
 	cacheDir, _, ref := getTestCacheInfo(t)
-	defer os.RemoveAll(cacheDir)
 	imgCache, err := cache.New(cache.Config{ParentDir: cacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle: %s", err)

--- a/internal/pkg/build/sources/base_environment_test.go
+++ b/internal/pkg/build/sources/base_environment_test.go
@@ -6,8 +6,6 @@
 package sources
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -16,13 +14,7 @@ import (
 )
 
 func testWithGoodDir(t *testing.T, f func(d string) error) {
-	d, err := ioutil.TempDir(os.TempDir(), "test")
-	if err != nil {
-		t.Fatalf("Failed to make temporary directory: %v", err)
-	}
-	defer os.RemoveAll(d)
-
-	if err := f(d); err != nil {
+	if err := f(t.TempDir()); err != nil {
 		t.Fatalf("Unexpected failure: %v", err)
 	}
 }

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -210,11 +210,7 @@ func TestOCIConveyorOCILayout(t *testing.T) {
 
 	// We need to extract the oci archive to a directory
 	// Don't want to implement untar routines here, so use system tar
-	dir, err := ioutil.TempDir("", "oci-test")
-	if err != nil {
-		t.Fatalf("Could not create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	cmd := exec.Command("tar", "-C", dir, "-xf", archive)
 	err = cmd.Run()
 	if err != nil {

--- a/internal/pkg/image/packer/squashfs_test.go
+++ b/internal/pkg/image/packer/squashfs_test.go
@@ -19,11 +19,7 @@ func checkArchive(t *testing.T, path string, files []string) {
 		t.SkipNow()
 	}
 
-	dir, err := ioutil.TempDir("", "extracted-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cmd := exec.Command(un, "-f", "-d", dir, path)
 	if err := cmd.Run(); err != nil {

--- a/internal/pkg/image/unpacker/squashfs_test.go
+++ b/internal/pkg/image/unpacker/squashfs_test.go
@@ -57,11 +57,7 @@ func testSquashfs(t *testing.T, tmpParent string) {
 		t.Skip("unsquashfs not found")
 	}
 
-	dir, err := ioutil.TempDir(tmpParent, "unpacker-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// create archive with files present in this directory
 	archive := createArchive(t)

--- a/internal/pkg/util/crypt/crypt_dev_test.go
+++ b/internal/pkg/util/crypt/crypt_dev_test.go
@@ -34,11 +34,7 @@ func TestEncrypt(t *testing.T) {
 	defer os.Remove(emptyFile.Name())
 
 	// Create a dummy squashfs file
-	dummyDir, err := ioutil.TempDir("", "dummy-fs-")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory: %s", err)
-	}
-	defer os.RemoveAll(dummyDir) // This is delete the directory and all its sub-directories
+	dummyDir := t.TempDir()
 
 	// We create a few more sub-directories; note that they will be
 	// removed when the top-directory (dummyDir) will be removed.

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -20,10 +20,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	tmpDir, err := ioutil.TempDir("", "ensure_file_perm-")
-	if err != nil {
-		t.Errorf("Unable to make tmpdir %s", err)
-	}
+	tmpDir := t.TempDir()
 
 	//
 	// First test: Ensure a already-existing file is the
@@ -133,12 +130,6 @@ func TestEnsureFileWithPermission(t *testing.T) {
 	if currentMode := einfo.Mode(); currentMode != 0o544 {
 		t.Errorf("Unexpected file permission: expecting 544, got %o", currentMode)
 	}
-
-	// Cleanup.
-	err = os.RemoveAll(tmpDir)
-	if err != nil {
-		t.Errorf("Unable to remove tmpdir: %s", err)
-	}
 }
 
 func TestIsFile(t *testing.T) {
@@ -229,11 +220,7 @@ func TestMkdirAll(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	tmpdir, err := ioutil.TempDir("", "mkdir")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	if err := MkdirAll(filepath.Join(tmpdir, "test"), 0o777); err != nil {
 		t.Error(err)
@@ -257,13 +244,7 @@ func TestMkdir(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	tmpdir, err := ioutil.TempDir("", "mkdir")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-
-	test := filepath.Join(tmpdir, "test")
+	test := filepath.Join(t.TempDir(), "test")
 	if err := Mkdir(test, 0o777); err != nil {
 		t.Error(err)
 	}
@@ -280,11 +261,7 @@ func TestEvalRelative(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	tmpdir, err := ioutil.TempDir("", "evalrelative")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// test layout
 	// - /bin -> usr/bin
@@ -359,11 +336,7 @@ func TestTouch(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	tmpdir, err := ioutil.TempDir("", "evalrelative")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	if err := Touch(tmpdir); err == nil {
 		t.Errorf("touch can't take a directory")
@@ -491,14 +464,10 @@ func testCopyFileFunc(t *testing.T, fn copyFileFunc) {
 
 	testData := []byte("Hello, Singularity!")
 
-	tmpDir, err := ioutil.TempDir("", "copy-file")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	source := filepath.Join(tmpDir, "source")
-	err = ioutil.WriteFile(source, testData, 0o644)
+	err := ioutil.WriteFile(source, testData, 0o644)
 	if err != nil {
 		t.Fatalf("failed to create test source file: %v", err)
 	}
@@ -600,11 +569,7 @@ func TestIsWritable(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	// We make a temporary directory where all the different cases will be tested.
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory: %s", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// All the directory that we are about to create will be deleted when the temporary
 	// directory will be removed.

--- a/internal/pkg/util/fs/layout/manager_test.go
+++ b/internal/pkg/util/fs/layout/manager_test.go
@@ -6,7 +6,6 @@
 package layout
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -34,11 +33,7 @@ func TestLayout(t *testing.T) {
 		}
 	}
 
-	dir, err := ioutil.TempDir("", "session")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := session.AddDir("/etc"); err == nil {
 		t.Errorf("should have failed with uninitialized root path")

--- a/internal/pkg/util/gpu/paths_test.go
+++ b/internal/pkg/util/gpu/paths_test.go
@@ -70,10 +70,7 @@ func TestSoLinks(t *testing.T) {
 	//   - soLinks(a.so) should give both of these symlinks
 	// a.so.2 -> b.so
 	//   - this should *not* get included, as it doesn't resolve back to a.so
-	tmpDir, err := ioutil.TempDir("", "test-solinks")
-	if err != nil {
-		t.Fatalf("Could not create tempDir: %v", err)
-	}
+	tmpDir := t.TempDir()
 	aFile := filepath.Join(tmpDir, "a.so")
 	a1Link := filepath.Join(tmpDir, "a.so.1")
 	a12Link := filepath.Join(tmpDir, "a.so.1.2")
@@ -87,7 +84,7 @@ func TestSoLinks(t *testing.T) {
 		t.Fatalf("Could not symlink: %v", err)
 	}
 	bFile := filepath.Join(tmpDir, "b.so")
-	err = ioutil.WriteFile(bFile, nil, 0o644)
+	err := ioutil.WriteFile(bFile, nil, 0o644)
 	if err != nil {
 		t.Fatalf("Could not create file: %v", err)
 	}

--- a/pkg/build/types/bundle_test.go
+++ b/pkg/build/types/bundle_test.go
@@ -6,7 +6,6 @@
 package types
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,11 +13,7 @@ import (
 )
 
 func TestNewBundle(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "bundleTest-")
-	if err != nil {
-		t.Fatal("Could not create temporary directory", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	tt := []struct {
 		name        string

--- a/pkg/image/ext3_test.go
+++ b/pkg/image/ext3_test.go
@@ -105,13 +105,7 @@ func TestCheckExt3Header(t *testing.T) {
 	b := make([]byte, bufferSize)
 
 	// Create a fake ext3 file
-	dir, err := ioutil.TempDir("", "headerTesting-")
-	if err != nil {
-		t.Fatalf("impossible to create temporary directory: %s\n", err)
-	}
-	defer os.RemoveAll(dir)
-
-	path := dir + "ext3.fs"
+	path := t.TempDir() + "ext3.fs"
 
 	createFullVirtualBlockDevice(t, path, "ext3")
 
@@ -221,11 +215,7 @@ func TestInitializer(t *testing.T) {
 	}
 
 	// Error case when a directory is passed in to initializer()
-	path, err = ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Cannot create a temporary directory: %s\n", err)
-	}
-	defer os.RemoveAll(path)
+	path = t.TempDir()
 	resolvedPath, err = ResolvePath(path)
 	if err != nil {
 		t.Fatalf("failed to retrieve path for %s: %s\n", resolvedPath, err)

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -58,13 +58,9 @@ func copyImage(t *testing.T) string {
 	return name
 }
 
-func checkPartition(reader io.Reader) error {
+func checkPartition(t *testing.T, reader io.Reader) error {
 	extracted := "/bin/busybox"
-	dir, err := ioutil.TempDir("", "extract-")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s := unpacker.NewSquashfs()
 	if s.HasUnsquashfs() {
@@ -78,7 +74,7 @@ func checkPartition(reader io.Reader) error {
 	return nil
 }
 
-func checkSection(reader io.Reader) error {
+func checkSection(_ *testing.T, reader io.Reader) error {
 	dec := json.NewDecoder(reader)
 	imgSpec := &imageSpecs.ImageConfig{}
 	if err := dec.Decode(imgSpec); err != nil {
@@ -106,7 +102,7 @@ func TestReader(t *testing.T) {
 
 	for _, e := range []struct {
 		fn       func(*Image, string, int) (io.Reader, error)
-		fnCheck  func(io.Reader) error
+		fnCheck  func(*testing.T, io.Reader) error
 		errCheck error
 		name     string
 		index    int
@@ -169,7 +165,7 @@ func TestReader(t *testing.T) {
 		if r, err := e.fn(img, e.name, e.index); err == e.errCheck {
 			t.Error(err)
 		} else {
-			if err := e.fnCheck(r); err != nil {
+			if err := e.fnCheck(t, r); err != nil {
 				t.Error(err)
 			}
 		}

--- a/pkg/image/sandbox_test.go
+++ b/pkg/image/sandbox_test.go
@@ -42,18 +42,14 @@ func runSandboxInitializerTest(t *testing.T, img *Image, path string) error {
 
 func TestSandboxInitializer(t *testing.T) {
 	// Valid case using a directory
-	path, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("cannot create a temporary directory: %s\n", err)
-	}
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	img := &Image{
 		Path: path,
 		Name: "test",
 	}
 
-	err = runSandboxInitializerTest(t, img, path)
+	err := runSandboxInitializerTest(t, img, path)
 	if err != nil {
 		t.Fatalf("sandbox initializer failed: %s\n", err)
 	}

--- a/pkg/image/squashfs_test.go
+++ b/pkg/image/squashfs_test.go
@@ -16,12 +16,6 @@ import (
 // createSquashfs creates a small but valid squashfs file that can be used
 // with an image.
 func createSquashfs(t *testing.T) string {
-	dir, dirErr := ioutil.TempDir("", "squashfsHdrTesting-")
-	if dirErr != nil {
-		t.Fatalf("impossible to create temporary directory: %s\n", dirErr)
-	}
-	defer os.RemoveAll(dir)
-
 	sqshFile, fileErr := ioutil.TempFile("", "")
 	if fileErr != nil {
 		t.Fatalf("impossible to create temporary file: %s\n", fileErr)
@@ -40,7 +34,7 @@ func createSquashfs(t *testing.T) string {
 		t.Skipf("%s is not  available, skipping the test...", cmdBin)
 	}
 
-	cmd := exec.Command(cmdBin, dir, sqshFilePath)
+	cmd := exec.Command(cmdBin, t.TempDir(), sqshFilePath)
 	cmdErr := cmd.Run()
 	if cmdErr != nil {
 		t.Fatalf("cannot create squashfs volume: %s\n", cmdErr)
@@ -109,11 +103,7 @@ func TestSquashfsInitializer(t *testing.T) {
 	img.File.Close()
 
 	// Invalid image
-	invalidPath, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("impossible to create temporary directory: %s\n", err)
-	}
-	defer os.RemoveAll(invalidPath)
+	invalidPath := t.TempDir()
 	img.File, err = os.Open(invalidPath)
 	if err != nil {
 		t.Fatalf("open() failed: %s\n", err)

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -121,11 +121,7 @@ var testNetworks []string
 func TestGetAllNetworkConfigList(t *testing.T) {
 	test.EnsurePrivilege(t)
 
-	emptyDir, err := ioutil.TempDir("", "empty_conf_")
-	if err != nil {
-		t.Errorf("failed to creaty empty configuration directory: %s", err)
-	}
-	defer os.Remove(emptyDir)
+	emptyDir := t.TempDir()
 
 	testCNIPath := []struct {
 		name           string

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -26,10 +26,7 @@ const busyboxSIF = "../../../e2e/testdata/busybox_" + runtime.GOARCH + ".sif"
 func TestFromSif(t *testing.T) {
 	test.EnsurePrivilege(t)
 
-	bundlePath, err := ioutil.TempDir("", "bundle")
-	if err != nil {
-		t.Fatal(err)
-	}
+	bundlePath := t.TempDir()
 	f, err := ioutil.TempFile("", "busybox")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sypgp/sypgp_test.go
+++ b/pkg/sypgp/sypgp_test.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -225,11 +224,7 @@ func TestEnsureDirPrivate(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	tmpdir, err := ioutil.TempDir("", "test-ensure-dir-private")
-	if err != nil {
-		t.Fatalf("Cannot create temporary directory")
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	cases := []struct {
 		name        string
@@ -473,11 +468,7 @@ func TestGenKeyPair(t *testing.T) {
 	}
 
 	// Create a temporary directory to store the keyring
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	keyring := NewHandle(dir)
 
@@ -774,11 +765,7 @@ func TestRemoveKey(t *testing.T) {
 }
 
 func TestGlobalKeyRing(t *testing.T) {
-	dir, err := ioutil.TempDir("", "global-keyring-")
-	if err != nil {
-		t.Fatalf("could not create temporary global keyring: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	keypairOptions := GenKeyPairOptions{
 		Name:      "test",
@@ -788,7 +775,7 @@ func TestGlobalKeyRing(t *testing.T) {
 
 	keyring := NewHandle(dir, GlobalHandleOpt())
 
-	_, err = keyring.GenKeyPair(keypairOptions)
+	_, err := keyring.GenKeyPair(keypairOptions)
 	if err == nil {
 		t.Errorf("unexpected success while generating keypair for global keyring")
 	}

--- a/pkg/util/archive/copy_test.go
+++ b/pkg/util/archive/copy_test.go
@@ -30,11 +30,8 @@ func TestCopyWithTar(t *testing.T) {
 }
 
 func testCopyWithTar(t *testing.T) {
-	srcRoot, err := ioutil.TempDir("", "copywithtar-src-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(srcRoot)
+	srcRoot := t.TempDir()
+	t.Logf("srcRoot location: %s\n", srcRoot)
 
 	// Source Files
 	srcFile := filepath.Join(srcRoot, "srcFile")
@@ -52,16 +49,13 @@ func testCopyWithTar(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dstRoot, err := ioutil.TempDir("", "copywithtar-dst-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dstRoot)
+	dstRoot := t.TempDir()
+	t.Logf("dstRoot location: %s\n", dstRoot)
 
 	// Perform the actual copy to a subdir of our dst tempdir.
 	// This ensures CopyWithTar has to create the dest directory, which is
 	// where the non-wrapped call would fail for unprivileged users.
-	err = CopyWithTar(srcRoot, path.Join(dstRoot, "dst"))
+	err := CopyWithTar(srcRoot, path.Join(dstRoot, "dst"))
 	if err != nil {
 		t.Fatalf("Error during CopyWithTar: %v", err)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

### This fixes or addresses the following GitHub issues:


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
