### PR TITLE
Fix empty if branch in OCI container shell runscript generation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 - Fix compilation on `mipsel`.
 - Fix test code that implied `%test -c <shell>` was supported - it is not.
+- Ensure no empty `if` branch is present in generated OCI image runscripts. Would
+  prevent execution of container by other tools that are not using mvdan.cc/sh.
 
 ## 3.10.0 \[2022-05-17\]
 

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -50,29 +52,37 @@ const ociRunscript = `
 # not evaluate resolved CMD / ENTRYPOINT / ARGS through the shell, and
 # does not modify expected quoting behavior of args.
 if [ -n "$SINGULARITY_NO_EVAL" ]; then
-	# ENTRYPOINT only - run entrypoint plus args
-	if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
-		{{.PrependEntrypoint}}
-		exec "$@"
-	fi
+    # ENTRYPOINT only - run entrypoint plus args
+    if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
+        {{ .PrependEntrypoint }}
+        exec "$@"
+    fi
 
-	# CMD only - run CMD or override with args
-	if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
-		if [ $# -eq 0 ]; then
-			{{.PrependCmd}}
-		fi
-		exec "$@"
-	fi
+    # CMD only - run CMD or override with args
+    if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
+        {{- if .PrependCmd }}
+        if [ $# -eq 0 ]; then
+            {{ .PrependCmd }}
+        fi
+        {{- end }}
+        exec "$@"
+    fi
 
-	# ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
-	# override with user provided args
-	if [ $# -gt 0 ]; then
-		{{.PrependEntrypoint}}
+    # ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
+    # override with user provided args
+    {{- if .PrependEntrypoint }}
+    if [ $# -gt 0 ]; then
+        {{ .PrependEntrypoint }}
 	else
-		{{.PrependCmd}}
-		{{.PrependEntrypoint}}
-	fi
-	exec "$@"
+        {{ .PrependCmd }}
+        {{ .PrependEntrypoint }}
+    fi
+	{{- else if .PrependCmd }}
+    if [ $# -eq 0 ]; then
+        {{ .PrependCmd }}
+    fi
+    {{- end }}
+    exec "$@"
 fi
 
 # Standard Singularity behavior evaluates CMD / ENTRYPOINT / ARGS
@@ -81,33 +91,33 @@ fi
 CMDLINE_ARGS=""
 # prepare command line arguments for evaluation
 for arg in "$@"; do
-		CMDLINE_ARGS="${CMDLINE_ARGS} \"$arg\""
+        CMDLINE_ARGS="${CMDLINE_ARGS} \"$arg\""
 done
 
 # ENTRYPOINT only - run entrypoint plus args
 if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
-	if [ $# -gt 0 ]; then
-		SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${CMDLINE_ARGS}"
-	else
-		SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT}"
-	fi
+    if [ $# -gt 0 ]; then
+        SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${CMDLINE_ARGS}"
+    else
+        SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT}"
+    fi
 fi
 
 # CMD only - run CMD or override with args
 if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
-	if [ $# -gt 0 ]; then
-		SINGULARITY_OCI_RUN="${CMDLINE_ARGS}"
-	else
-		SINGULARITY_OCI_RUN="${OCI_CMD}"
-	fi
+    if [ $# -gt 0 ]; then
+        SINGULARITY_OCI_RUN="${CMDLINE_ARGS}"
+    else
+        SINGULARITY_OCI_RUN="${OCI_CMD}"
+    fi
 fi
 
 # ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
 # override with user provided args
 if [ $# -gt 0 ]; then
-	SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${CMDLINE_ARGS}"
+    SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${CMDLINE_ARGS}"
 else
-	SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
+    SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
 fi
 
 # Evaluate shell expressions first and set arguments accordingly,


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick from: https://github.com/apptainer/apptainer/pull/561

When SingularityCE creates an OCI runscript, it may create an empty shell if branch. This doesn't affect execution of singularity images using the embedded shell interpreter. However, it's not supported by standalone shells. We need to fix this so that:

* If the embedded shell interpreter changes behavior we are covered
* Other tools, that may take SIF as input and run the runscript through a shell, operate as expected.

### This fixes or addresses the following GitHub issues:

 - Fixes #914 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
