### PR TITLE
e2e: correct docker --no-eval no args test cases (release-3.10)

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -493,7 +493,7 @@ func (c ctx) testDockerCMD(t *testing.T) {
 		{
 			name:         "no-eval/default",
 			args:         []string{},
-			noeval:       false,
+			noeval:       true,
 			expectOutput: `CMD 'quotes' "quotes" $DOLLAR s p a c e s`,
 		},
 		{
@@ -585,7 +585,7 @@ func (c ctx) testDockerENTRYPOINT(t *testing.T) {
 		{
 			name:         "no-eval/default",
 			args:         []string{},
-			noeval:       false,
+			noeval:       true,
 			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s`,
 		},
 		{
@@ -671,7 +671,7 @@ func (c ctx) testDockerCMDENTRYPOINT(t *testing.T) {
 		{
 			name:         "no-eval/default",
 			args:         []string{},
-			noeval:       false,
+			noeval:       true,
 			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s CMD 'quotes' "quotes" $DOLLAR s p a c e s`,
 		},
 		{


### PR DESCRIPTION
## Description of the Pull Request (PR):

e2e: correct docker --no-eval no args test cases


### This fixes or addresses the following GitHub issues:

 - Fixes #922 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
