### PR TITLE
fix: Ensure bootstrap_history directory populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@
   - May fail if the `%post` script requires privileged operations that `proot`
     cannot emulate.
 
+### Bug Fixes
+
+- Ensure bootstrap_history directory is populated with previous definition files,
+  present in source containers used in a build
+
 ## 3.10.2 \[2022-07-25\]
 
 ### New features / functionalities

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -171,31 +171,29 @@ func insertHelpScript(b *types.Bundle) error {
 }
 
 func insertDefinition(b *types.Bundle) error {
-	// if update, check for existing definition and move it to bootstrap history
-	if b.Opts.Update {
-		if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity")); err == nil {
-			// make bootstrap_history directory if it doesn't exist
-			if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history")); err != nil {
-				err = os.Mkdir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"), 0o755)
-				if err != nil {
-					return err
-				}
-			}
-
-			// look at number of files in bootstrap_history to give correct file name
-			files, err := ioutil.ReadDir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"))
+	// Check for existing definition and move it to bootstrap history
+	if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity")); err == nil {
+		// make bootstrap_history directory if it doesn't exist
+		if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history")); err != nil {
+			err = os.Mkdir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"), 0o755)
 			if err != nil {
 				return err
 			}
+		}
 
-			// name is "Singularity" concatenated with an index based on number of other files in bootstrap_history
-			len := strconv.Itoa(len(files))
-			histName := "Singularity" + len
-			// move old definition into bootstrap_history
-			err = os.Rename(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history", histName))
-			if err != nil {
-				return err
-			}
+		// look at number of files in bootstrap_history to give correct file name
+		files, err := ioutil.ReadDir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"))
+		if err != nil {
+			return err
+		}
+
+		// name is "Singularity" concatenated with an index based on number of other files in bootstrap_history
+		len := strconv.Itoa(len(files))
+		histName := "Singularity" + len
+		// move old definition into bootstrap_history
+		err = os.Rename(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history", histName))
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

In Singularity 2.x the bootstrap_history directory was always
populated with any existing definition file, when an existing image
was used as the source for a build.

It appears that in 3.x this was gated behind a conditional, limiting
it to builds that are explicitly `--update` only. This does not
reflect the documentation or 2.x, so remove this conditional.

### This fixes or addresses the following GitHub issues:

 - Fixes #935 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
