### PR TITLE
Replace Deprecated Title Function (release-3.10)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/vbauerster/mpb/v7 v7.5.2
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.3.0
 	mvdan.cc/sh/v3 v3.5.1
@@ -148,7 +149,6 @@ require (
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
-	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220624142145-8cd45d7dbd1f // indirect
 	google.golang.org/grpc v1.47.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,12 +10,13 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/pkg/sylog"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const statusLine = "%s\t%s\t%s\t%s\n"
@@ -107,7 +108,7 @@ func RemoteStatus(usrConfigFile, name string) (err error) {
 	fmt.Fprintf(tw, statusLine, "SERVICE", "STATUS", "VERSION", "URI")
 	for _, n := range names {
 		s := smap[n]
-		fmt.Fprintf(tw, statusLine, strings.Title(s.name), s.status, s.version, s.uri)
+		fmt.Fprintf(tw, statusLine, cases.Title(language.English).String(s.name), s.status, s.version, s.uri)
 	}
 	tw.Flush()
 

--- a/pkg/util/user-agent/agent.go
+++ b/pkg/util/user-agent/agent.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,6 +9,9 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var value string
@@ -29,13 +32,13 @@ func Value() string {
 func InitValue(name, version string) {
 	value = fmt.Sprintf("%v (%v %v) %v",
 		singularityVersion(name, version),
-		strings.Title(runtime.GOOS),
+		cases.Title(language.English).String(runtime.GOOS),
 		runtime.GOARCH,
 		goVersion())
 }
 
 func singularityVersion(name, version string) string {
-	product := strings.Title(name)
+	product := cases.Title(language.English).String(name)
 	ver := strings.Split(version, "-")[0]
 	return fmt.Sprintf("%v/%v", product, ver)
 }


### PR DESCRIPTION
Replace use of [func strings.Title](https://pkg.go.dev/strings#Title), which was deprecated in Go 1.18 ([ref](https://go.dev/doc/go1.18#strings)).