### PR TITLE
e2e: switch to shared cache by default

### DIFF
--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -303,7 +303,7 @@ func (c actionTests) issue4823(t *testing.T) {
 			expected = e2e.ExpectError(e2e.ContainMatch, "Using image from cache")
 		}
 
-		c.env.ImgCacheDir = cacheDir
+		c.env.UnprivCacheDir = cacheDir
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -34,7 +34,7 @@ func prepTest(t *testing.T, testEnv e2e.TestEnv, testName string, cacheParentDir
 		ensureNotCached(t, testName, imagePath, cacheParentDir)
 	}
 
-	testEnv.ImgCacheDir = cacheParentDir
+	testEnv.UnprivCacheDir = cacheParentDir
 	testEnv.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -128,7 +128,7 @@ func (c cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
 			prepTest(t, c.env, tt.name, cacheDir, imagePath)
 		}
 
-		c.env.ImgCacheDir = cacheDir
+		c.env.UnprivCacheDir = cacheDir
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
@@ -229,7 +229,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 			t.Fatalf("Could not create image cache handle: %v", err)
 		}
 
-		c.env.ImgCacheDir = cacheDir
+		c.env.UnprivCacheDir = cacheDir
 		prepTest(t, c.env, tc.name, cacheDir, imagePath)
 
 		c.env.RunSingularity(

--- a/e2e/cache/regressions.go
+++ b/e2e/cache/regressions.go
@@ -21,7 +21,7 @@ import (
 func (c cacheTests) issue5097(t *testing.T) {
 	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
 	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
+	c.env.UnprivCacheDir = imgCacheDir
 
 	tempDir, imgStoreCleanup := e2e.MakeTempDir(t, "", "", "image store")
 	defer imgStoreCleanup(t)
@@ -82,7 +82,7 @@ func (c cacheTests) issue5350(t *testing.T) {
 
 	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, outerDir)
 	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
+	c.env.UnprivCacheDir = imgCacheDir
 
 	if err := os.Chmod(outerDir, 0o000); err != nil {
 		t.Fatalf("Could not chmod 000 cache outer dir: %v", err)

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -37,14 +37,14 @@ func setupTemporaryDir(t *testing.T, testdir, label string) (string, func(*testi
 	}
 }
 
-// setupTemporaryCache creates a temporary cache directory and modifies
+// setupTemporaryCache creates temporary cache directories and modifies
 // the test environment to use it. The code calling this function is
 // responsible for calling the returned function when its done using the
 // temporary directory.
 func (c *ctx) setupTemporaryCache(t *testing.T) func(*testing.T) {
 	cacheDir, cleanup := setupTemporaryDir(t, c.env.TestDir, "cache-dir")
 
-	c.env.ImgCacheDir = cacheDir
+	c.env.UnprivCacheDir = cacheDir
 
 	return cleanup
 }
@@ -93,10 +93,10 @@ func (c ctx) assertLibraryCacheEntryExists(t *testing.T, imgPath, imgName string
 		t.Fatalf("Cannot get the shasum for image %s: %s", imgPath, err)
 	}
 
-	cacheEntryPath := filepath.Join(c.env.ImgCacheDir, "cache", "library", shasum, imgName)
+	cacheEntryPath := filepath.Join(c.env.UnprivCacheDir, "cache", "library", shasum, imgName)
 	if _, err := os.Stat(cacheEntryPath); os.IsNotExist(err) {
 		ls(t, c.env.TestDir)
-		ls(t, c.env.ImgCacheDir)
+		ls(t, c.env.UnprivCacheDir)
 		t.Fatalf("Cache entry %s for image %s with name %s does not exists: %s",
 			cacheEntryPath, imgPath, imgName, err)
 	}
@@ -105,7 +105,7 @@ func (c ctx) assertLibraryCacheEntryExists(t *testing.T, imgPath, imgName string
 // assertCacheDoesNotExist checks that the image cache that is associated to the
 // test DOES NOT exists.
 func (c ctx) assertCacheDoesNotExist(t *testing.T) {
-	cacheRoot := filepath.Join(c.env.ImgCacheDir, "cache")
+	cacheRoot := filepath.Join(c.env.UnprivCacheDir, "cache")
 	if _, err := os.Stat(cacheRoot); !os.IsNotExist(err) {
 		// The root of the cache does exists
 		t.Fatalf("cache has been incorrectly created (cache root: %s)", cacheRoot)
@@ -204,7 +204,7 @@ func (c ctx) testSingularityReadOnlyCacheDir(t *testing.T) {
 	defer cleanup(t)
 
 	// Change the mode of the image cache to read-only
-	err := os.Chmod(c.env.ImgCacheDir, 0o555)
+	err := os.Chmod(c.env.UnprivCacheDir, 0o555)
 	if err != nil {
 		t.Fatalf("failed to change the access mode to read-only: %s", err)
 	}
@@ -215,7 +215,7 @@ func (c ctx) testSingularityReadOnlyCacheDir(t *testing.T) {
 	// can delete the cache if it was created. Do this _before_
 	// calling c.assertCacheDoesNotExist because that function will
 	// fail if it find a cache.
-	err = os.Chmod(c.env.ImgCacheDir, 0o755)
+	err = os.Chmod(c.env.UnprivCacheDir, 0o755)
 	if err != nil {
 		t.Fatalf("failed to change the access mode to read-only: %s", err)
 	}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -30,11 +30,6 @@ const (
 )
 
 func (c ctx) singularityEnv(t *testing.T) {
-	// use a cache to not download images over and over
-	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
-	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
-
 	// Singularity defines a path by default. See singularityware/singularity/etc/init.
 	defaultImage := "docker://alpine:3.8"
 
@@ -132,11 +127,6 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	imageDefaultPath := defaultPath + ":/go/bin:/usr/local/go/bin"
-
-	// use a cache to not download images over and over
-	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
-	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
 
 	tests := []struct {
 		name     string
@@ -352,11 +342,6 @@ func (c ctx) singularityEnvFile(t *testing.T) {
 	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "envfile-", "")
 	defer cleanup(t)
 	p := filepath.Join(dir, "env.file")
-
-	// use a cache to not download images over and over
-	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
-	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
 
 	tests := []struct {
 		name     string

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -9,13 +9,14 @@ package e2e
 // from specifying which Singularity binary to use to controlling how Singularity
 // environment variables will be set.
 type TestEnv struct {
-	CmdPath       string // Path to the Singularity binary to use for the execution of a Singularity command
-	ImagePath     string // Path to the image that has to be used for the execution of a Singularity command
-	OrasTestImage string
-	TestDir       string // Path to the directory from which a Singularity command needs to be executed
-	TestRegistry  string
-	KeyringDir    string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using SINGULARITY_SYPGPDIR which should be avoided when running e2e tests)
-	ImgCacheDir   string // ImgCacheDir sets the location of the image cache to be used by the Singularity command to be executed (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
-	RunDisabled   bool
-	DisableCache  bool // DisableCache can be set to disable the cache during the execution of a e2e command
+	CmdPath        string // Path to the Singularity binary to use for the execution of a Singularity command
+	ImagePath      string // Path to the image that has to be used for the execution of a Singularity command
+	OrasTestImage  string
+	TestDir        string // Path to the directory from which a Singularity command needs to be executed
+	TestRegistry   string
+	KeyringDir     string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using SINGULARITY_SYPGPDIR which should be avoided when running e2e tests)
+	PrivCacheDir   string // PrivCacheDir sets the location of the image cache to be used by the Singularity command to be executed as root (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
+	UnprivCacheDir string // UnprivCacheDir sets the location of the image cache to be used by the Singularity command to be executed as the unpriv user (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
+	RunDisabled    bool
+	DisableCache   bool // DisableCache can be set to disable the cache during the execution of a e2e command
 }

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -531,21 +531,15 @@ func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 			cmd.Env = os.Environ()
 		}
 
-		// Each command gets by default a clean temporary image cache.
-		// If it is needed to share an image cache between tests, or to manually
-		// set the directory to be used, one shall set the ImgCacheDir of the test
-		// environment. Doing so will overwrite the default creation of an image cache
-		// for the command to be executed. In that context, it is the developer's
-		// responsibility to ensure that the directory is correctly deleted upon successful
-		// or unsuccessful completion of the test.
-		cacheDir := env.ImgCacheDir
-
-		if cacheDir == "" {
-			// cleanCache is a function that will delete the image cache
-			// and fail the test if it cannot be deleted.
-			imgCacheDir, cleanCache := MakeCacheDir(t, env.TestDir)
-			cacheDir = imgCacheDir
-			defer cleanCache(t)
+		// By default, each E2E command shares a temporary image cache
+		// directory. If a test is directly testing the cache, or depends on
+		// specific ordered cache behavior then
+		// TestEnv.PrivCacheDir/UnPrivCacheDir should be overridden to a
+		// separate path in the test. The caller is then responsible for
+		// creating and cleaning up the cache directory.
+		cacheDir := env.UnprivCacheDir
+		if privileged {
+			cacheDir = env.PrivCacheDir
 		}
 		cacheDirEnv := fmt.Sprintf("%s=%s", cache.DirEnv, cacheDir)
 		cmd.Env = append(cmd.Env, cacheDirEnv)

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -220,6 +220,12 @@ var tests = []testStruct{
 }
 
 func (c *ctx) imagePull(t *testing.T, tt testStruct) {
+	// Use a one-time cache directory specific to this pull. This ensures we are always
+	// testing an entire pull operation, performing the download into an empty cache.
+	cacheDir, cleanup := e2e.MakeCacheDir(t, "")
+	defer cleanup(t)
+	c.env.UnprivCacheDir = cacheDir
+
 	// We use a string rather than a slice of strings to avoid having an empty
 	// element in the slice, which would cause the command to fail, without
 	// over-complicating the code.
@@ -478,7 +484,7 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 		}
 	}()
 
-	c.env.ImgCacheDir = cacheDir
+	c.env.UnprivCacheDir = cacheDir
 
 	disableCacheTests := []struct {
 		name      string

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -85,7 +85,6 @@ func (c ctx) singularitySignIDOption(t *testing.T) {
 	}
 
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 
 	for _, tt := range tests {
 		c.env.RunSingularity(
@@ -125,7 +124,6 @@ func (c ctx) singularitySignAllOption(t *testing.T) {
 	}
 
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 
 	for _, tt := range tests {
 		c.env.RunSingularity(
@@ -166,7 +164,6 @@ func (c ctx) singularitySignGroupIDOption(t *testing.T) {
 	}
 
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 
 	for _, tt := range tests {
 		c.env.RunSingularity(
@@ -187,7 +184,6 @@ func (c ctx) singularitySignKeyidxOption(t *testing.T) {
 
 	cmdArgs := []string{"--keyidx", "0", imgPath}
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -231,18 +227,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	return testhelper.Tests{
 		"ordered": func(t *testing.T) {
 			var err error
-			// To speed up the tests, we use a common image cache (we pull the same image several times)
-			c.imgCache, err = ioutil.TempDir("", "e2e-sign-imgcache-")
-			if err != nil {
-				t.Fatalf("failed to create temporary directory: %s", err)
-			}
-			defer func() {
-				err := os.RemoveAll(c.imgCache)
-				if err != nil {
-					t.Fatalf("failed to delete temporary cache: %s", err)
-				}
-			}()
-
 			// We need one single key pair in a single keyring for all the tests
 			c.keyringDir, err = ioutil.TempDir("", "e2e-sign-keyring-")
 			if err != nil {

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -142,6 +142,20 @@ func Run(t *testing.T) {
 	}
 	testenv.TestDir = name
 
+	// Make shared cache dirs for privileged and unpriviliged E2E tests.
+	// Individual tests that depend on specific ordered cache behavior, or
+	// directly test the cache, should override the TestEnv values within the
+	// specific test.
+	privCacheDir, cleanPrivCache := e2e.MakeCacheDir(t, testenv.TestDir)
+	testenv.PrivCacheDir = privCacheDir
+	defer e2e.Privileged(func(t *testing.T) {
+		cleanPrivCache(t)
+	})
+
+	unprivCacheDir, cleanUnprivCache := e2e.MakeCacheDir(t, testenv.TestDir)
+	testenv.UnprivCacheDir = unprivCacheDir
+	defer cleanUnprivCache(t)
+
 	// e2e tests need to run in a somehow agnostic environment, so we
 	// don't use environment of user executing tests in order to not
 	// wrongly interfering with cache stuff, sylabs library tokens,


### PR DESCRIPTION
## Description of the Pull Request (PR):

The SingularityCmd construct used to execute singularity in the e2e tests has defaulted to a fresh, empty cache directory for each execution.

This means that we are downloading full container images on every e2e execution of singularity against docker or library, which slows things down and creates uneccesary request load on the Sylabs Library, Docker Hub, etc.

Switch to using a shared cache by default. Our cache structure has been concurrency safe (given atomic operations on local filesystems) for some time now :crossed_fingers: ... this will also now test that.

Pull tests are modified so that they explicitly use an empty cache, to test the entire pull flow, including container image download.

Any future tests that depend on exercising downloads, the cache specifically, or depend on a specific state / order of cached operations will need to also specify their own cache directory.

### This fixes or addresses the following GitHub issues:

 - Fixes #

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
