### PR TITLE
e2e: Re-work docker / pull related e2e tests (3.10)

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -372,20 +372,6 @@ func (c actionTests) STDPipe(t *testing.T) {
 			input:   "false",
 			exit:    1,
 		},
-		{
-			name:    "TrueDocker",
-			command: "shell",
-			argv:    []string{"docker://busybox"},
-			input:   "true",
-			exit:    0,
-		},
-		{
-			name:    "FalseDocker",
-			command: "shell",
-			argv:    []string{"docker://busybox"},
-			input:   "false",
-			exit:    1,
-		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
 		// 	name:    "TrueShub",
@@ -496,20 +482,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 	}{
 		// Run from supported URI's and check the runscript call works
 		{
-			name:    "RunFromDockerOK",
-			command: "run",
-			argv:    []string{"--bind", bind, "docker://busybox:latest", size},
-			exit:    0,
-			profile: e2e.UserProfile,
-		},
-		{
-			name:    "RunFromDockerWithoutShellOK",
-			command: "run",
-			argv:    []string{"docker://hello-world"},
-			exit:    0,
-			profile: e2e.UserProfile,
-		},
-		{
 			name:    "RunFromLibraryOK",
 			command: "run",
 			argv:    []string{"--bind", bind, "library://busybox:1.31.1", size},
@@ -529,13 +501,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			command: "run",
 			argv:    []string{"--bind", bind, c.env.OrasTestImage, size},
 			exit:    0,
-			profile: e2e.UserProfile,
-		},
-		{
-			name:    "RunFromDockerKO",
-			command: "run",
-			argv:    []string{"--bind", bind, "docker://busybox:latest", "0"},
-			exit:    1,
 			profile: e2e.UserProfile,
 		},
 		{
@@ -560,22 +525,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			exit:    1,
 			profile: e2e.UserProfile,
 		},
-
-		// exec from a supported URI's and check the exit code
-		{
-			name:    "ExecTrueDocker",
-			command: "exec",
-			argv:    []string{"docker://busybox:latest", "true"},
-			exit:    0,
-			profile: e2e.UserProfile,
-		},
-		{
-			name:    "ExecTrueLibrary",
-			command: "exec",
-			argv:    []string{"library://busybox:1.31.1", "true"},
-			exit:    0,
-			profile: e2e.UserProfile,
-		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
 		// 	name:    "ExecTrueShub",
@@ -589,13 +538,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			command: "exec",
 			argv:    []string{c.env.OrasTestImage, "true"},
 			exit:    0,
-			profile: e2e.UserProfile,
-		},
-		{
-			name:    "ExecFalseDocker",
-			command: "exec",
-			argv:    []string{"docker://busybox:latest", "false"},
-			exit:    1,
 			profile: e2e.UserProfile,
 		},
 		{
@@ -623,13 +565,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 
 		// exec from URI with user namespace enabled
 		{
-			name:    "ExecTrueDockerUserns",
-			command: "exec",
-			argv:    []string{"docker://busybox:latest", "true"},
-			exit:    0,
-			profile: e2e.UserNamespaceProfile,
-		},
-		{
 			name:    "ExecTrueLibraryUserns",
 			command: "exec",
 			argv:    []string{"library://busybox:1.31.1", "true"},
@@ -649,13 +584,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			command: "exec",
 			argv:    []string{c.env.OrasTestImage, "true"},
 			exit:    0,
-			profile: e2e.UserNamespaceProfile,
-		},
-		{
-			name:    "ExecFalseDockerUserns",
-			command: "exec",
-			argv:    []string{"docker://busybox:latest", "false"},
-			exit:    1,
 			profile: e2e.UserNamespaceProfile,
 		},
 		{

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -1,7 +1,14 @@
-// Copyright (c) 2019-2021 Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
+
+// The DOCKER E2E group tests functionality of actions, pulls / builds of
+// Docker/OCI source images. These tests are separated from direct SIF build /
+// pull / actions because they examine OCI specific image behavior. They are run
+// ordered, rather than in parallel to avoid any concurrency issues with
+// containers/image. Also, we can then maximally benefit from caching to avoid
+// Docker Hub rate limiting.
 
 package docker
 
@@ -729,16 +736,25 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	}
 
 	return testhelper.Tests{
-		"AUFS":             c.testDockerAUFS,
-		"def file":         c.testDockerDefFile,
-		"permissions":      c.testDockerPermissions,
-		"pulls":            c.testDockerPulls,
-		"registry":         c.testDockerRegistry,
-		"whiteout symlink": c.testDockerWhiteoutSymlink,
-		"labels":           c.testDockerLabels,
-		"cmd":              c.testDockerCMD,
-		"entrypoint":       c.testDockerENTRYPOINT,
-		"cmdentrypoint":    c.testDockerCMDENTRYPOINT,
-		"cmd quotes":       c.testDockerCMDQuotes,
+		// Run all docker:// source tests sequentially amongst themselves, so we
+		// don't hit DockerHub massively in parallel, and we benefit from
+		// caching as the same images are used frequently.
+		"ordered": func(t *testing.T) {
+			t.Run("AUFS", c.testDockerAUFS)
+			t.Run("def file", c.testDockerDefFile)
+			t.Run("permissions", c.testDockerPermissions)
+			t.Run("pulls", c.testDockerPulls)
+			t.Run("registry", c.testDockerRegistry)
+			t.Run("whiteout symlink", c.testDockerWhiteoutSymlink)
+			t.Run("labels", c.testDockerLabels)
+			t.Run("cmd", c.testDockerCMD)
+			t.Run("entrypoint", c.testDockerENTRYPOINT)
+			t.Run("cmdentrypoint", c.testDockerCMDENTRYPOINT)
+			t.Run("cmd quotes", c.testDockerCMDQuotes)
+			// Regressions
+			t.Run("issue 4524", c.issue4524)
+			t.Run("issue 4943", c.issue4943)
+			t.Run("issue 5172", c.issue5172)
+		},
 	}
 }

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package docker
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
+)
+
+// This test will build a sandbox, as a non-root user from a dockerhub image
+// that contains a single folder and file with `000` permission.
+// It will verify that with `--fix-perms` we force files to be accessible,
+// moveable, removable by the user. We check for `700` and `400` permissions on
+// the folder and file respectively.
+func (c ctx) issue4524(t *testing.T) {
+	sandbox := filepath.Join(c.env.TestDir, "issue_4524")
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--fix-perms", "--sandbox", sandbox, "docker://sylabsio/issue4524"),
+		e2e.PostRun(func(t *testing.T) {
+			// If we failed to build the sandbox completely, leave what we have for
+			// investigation.
+			if t.Failed() {
+				t.Logf("Test %s failed, not removing directory %s", t.Name(), sandbox)
+				return
+			}
+
+			if !e2e.PathPerms(t, path.Join(sandbox, "directory"), 0o700) {
+				t.Error("Expected 0700 permissions on 000 test directory in rootless sandbox")
+			}
+			if !e2e.PathPerms(t, path.Join(sandbox, "file"), 0o600) {
+				t.Error("Expected 0600 permissions on 000 test file in rootless sandbox")
+			}
+
+			// If the permissions aren't as we expect them to be, leave what we have for
+			// investigation.
+			if t.Failed() {
+				t.Logf("Test %s failed, not removing directory %s", t.Name(), sandbox)
+				return
+			}
+
+			err := os.RemoveAll(sandbox)
+			if err != nil {
+				t.Logf("Cannot remove sandbox directory: %#v", err)
+			}
+		}),
+		e2e.ExpectExit(0),
+	)
+}
+
+func (c ctx) issue4943(t *testing.T) {
+	require.Arch(t, "amd64")
+
+	const (
+		image = "docker://gitlab-registry.cern.ch/linuxsupport/cc7-base:20191107"
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--force", "/dev/null", image),
+		e2e.ExpectExit(0),
+	)
+}
+
+func (c ctx) issue5172(t *testing.T) {
+	e2e.EnsureRegistry(t)
+
+	u := e2e.UserProfile.HostUser(t)
+
+	// create $HOME/.config/containers/registries.conf
+	regImage := "docker://localhost:5000/my-busybox"
+	regDir := filepath.Join(u.Dir, ".config", "containers")
+	regFile := filepath.Join(regDir, "registries.conf")
+	imagePath := filepath.Join(c.env.TestDir, "issue-5172")
+
+	if err := os.MkdirAll(regDir, 0o755); err != nil {
+		t.Fatalf("can't create directory %s: %s", regDir, err)
+	}
+
+	// add our test registry as insecure and test build/pull
+	b := new(bytes.Buffer)
+	b.WriteString("[registries.insecure]\nregistries = ['localhost']")
+	if err := ioutil.WriteFile(regFile, b.Bytes(), 0o644); err != nil {
+		t.Fatalf("can't create %s: %s", regFile, err)
+	}
+	defer os.RemoveAll(regDir)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--sandbox", imagePath, regImage),
+		e2e.PostRun(func(t *testing.T) {
+			if !t.Failed() {
+				os.RemoveAll(imagePath)
+			}
+		}),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull"),
+		e2e.WithArgs(imagePath, regImage),
+		e2e.PostRun(func(t *testing.T) {
+			if !t.Failed() {
+				os.RemoveAll(imagePath)
+			}
+		}),
+		e2e.ExpectExit(0),
+	)
+}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -31,10 +31,10 @@ const (
 
 func (c ctx) singularityEnv(t *testing.T) {
 	// Singularity defines a path by default. See singularityware/singularity/etc/init.
-	defaultImage := "docker://alpine:3.8"
+	defaultImage := "library://alpine:3.11.5"
 
 	// This image sets a custom path.
-	customImage := "docker://sylabsio/lolcow"
+	customImage := "library://lolcow"
 	customPath := "/usr/games:" + defaultPath
 
 	// Append or prepend this path.
@@ -138,43 +138,30 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 	}{
 		{
 			name:     "DefaultPath",
-			image:    "docker://alpine:3.8",
+			image:    "library://alpine:3.11.5",
 			matchEnv: "PATH",
 			matchVal: defaultPath,
 		},
 		{
 			name:     "DefaultPathOverride",
-			image:    "docker://alpine:3.8",
+			image:    "library://alpine:3.11.5",
 			envOpt:   []string{"PATH=/"},
 			matchEnv: "PATH",
 			matchVal: "/",
 		},
 		{
 			name:     "AppendDefaultPath",
-			image:    "docker://alpine:3.8",
+			image:    "library://alpine:3.11.5",
 			envOpt:   []string{"APPEND_PATH=/foo"},
 			matchEnv: "PATH",
 			matchVal: defaultPath + ":/foo",
 		},
 		{
 			name:     "PrependDefaultPath",
-			image:    "docker://alpine:3.8",
+			image:    "library://alpine:3.11.5",
 			envOpt:   []string{"PREPEND_PATH=/foo"},
 			matchEnv: "PATH",
 			matchVal: "/foo:" + defaultPath,
-		},
-		{
-			name:     "DockerImage",
-			image:    "docker://sylabsio/lolcow",
-			matchEnv: "LC_ALL",
-			matchVal: "C",
-		},
-		{
-			name:     "DockerImageOverride",
-			image:    "docker://sylabsio/lolcow",
-			envOpt:   []string{"LC_ALL=foo"},
-			matchEnv: "LC_ALL",
-			matchVal: "foo",
 		},
 		{
 			name:     "DefaultPathTestImage",

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -54,7 +54,7 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 	e2e.EnsureRegistry(t)
 
 	// use a trailing slash in tests for sandbox intentionally to make sure
-	// `singularity build -s /tmp/sand/ docker://alpine` works,
+	// `singularity build -s /tmp/sand/ <URI>` works,
 	// see https://github.com/sylabs/singularity/issues/4407
 	tt := []struct {
 		name        string
@@ -73,14 +73,6 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 			name:       "Debootstrap",
 			dependency: "debootstrap",
 			buildSpec:  "../examples/debian/Singularity",
-		},
-		{
-			name:      "DockerURI",
-			buildSpec: "docker://busybox",
-		},
-		{
-			name:      "DockerDefFile",
-			buildSpec: "../examples/docker/Singularity",
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
@@ -203,10 +195,6 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 		//		name:      "shub busybox",
 		//		buildSpec: "shub://GodloveD/busybox",
 		//},
-		{
-			name:      "docker busybox",
-			buildSpec: "docker://busybox:latest",
-		},
 	}
 
 	for _, tc := range tt {
@@ -1495,15 +1483,12 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 3848":                      c.issue3848,                 // https://github.com/hpcng/singularity/issues/3848
 		"issue 4203":                      c.issue4203,                 // https://github.com/sylabs/singularity/issues/4203
 		"issue 4407":                      c.issue4407,                 // https://github.com/sylabs/singularity/issues/4407
-		"issue 4524":                      c.issue4524,                 // https://github.com/sylabs/singularity/issues/4524
 		"issue 4583":                      c.issue4583,                 // https://github.com/sylabs/singularity/issues/4583
 		"issue 4820":                      c.issue4820,                 // https://github.com/sylabs/singularity/issues/4820
 		"issue 4837":                      c.issue4837,                 // https://github.com/sylabs/singularity/issues/4837
-		"issue 4943":                      c.issue4943,                 // https://github.com/sylabs/singularity/issues/4943
 		"issue 4967":                      c.issue4967,                 // https://github.com/sylabs/singularity/issues/4967
 		"issue 4969":                      c.issue4969,                 // https://github.com/sylabs/singularity/issues/4969
 		"issue 5166":                      c.issue5166,                 // https://github.com/sylabs/singularity/issues/5166
-		"issue 5172":                      c.issue5172,                 // https://github.com/sylabs/singularity/issues/5172
 		"issue 5250":                      c.issue5250,                 // https://github.com/sylabs/singularity/issues/5250
 		"issue 5315":                      c.issue5315,                 // https://github.com/sylabs/singularity/issues/5315
 		"issue 5435":                      c.issue5435,                 // https://github.com/hpcng/singularity/issues/5435

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -6,7 +6,6 @@
 package imgbuild
 
 import (
-	"bytes"
 	"io/ioutil"
 	"log"
 	"os"
@@ -17,7 +16,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
-	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
@@ -111,50 +109,6 @@ func (c *imgBuildTests) issue4407(t *testing.T) {
 	}
 }
 
-// This test will build a sandbox, as a non-root user from a dockerhub image
-// that contains a single folder and file with `000` permission.
-// It will verify that with `--fix-perms` we force files to be accessible,
-// moveable, removable by the user. We check for `700` and `400` permissions on
-// the folder and file respectively.
-func (c *imgBuildTests) issue4524(t *testing.T) {
-	sandbox := filepath.Join(c.env.TestDir, "issue_4524")
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("build"),
-		e2e.WithArgs("--fix-perms", "--sandbox", sandbox, "docker://sylabsio/issue4524"),
-		e2e.PostRun(func(t *testing.T) {
-			// If we failed to build the sandbox completely, leave what we have for
-			// investigation.
-			if t.Failed() {
-				t.Logf("Test %s failed, not removing directory %s", t.Name(), sandbox)
-				return
-			}
-
-			if !e2e.PathPerms(t, path.Join(sandbox, "directory"), 0o700) {
-				t.Error("Expected 0700 permissions on 000 test directory in rootless sandbox")
-			}
-			if !e2e.PathPerms(t, path.Join(sandbox, "file"), 0o600) {
-				t.Error("Expected 0600 permissions on 000 test file in rootless sandbox")
-			}
-
-			// If the permissions aren't as we expect them to be, leave what we have for
-			// investigation.
-			if t.Failed() {
-				t.Logf("Test %s failed, not removing directory %s", t.Name(), sandbox)
-				return
-			}
-
-			err := os.RemoveAll(sandbox)
-			if err != nil {
-				t.Logf("Cannot remove sandbox directory: %#v", err)
-			}
-		}),
-		e2e.ExpectExit(0),
-	)
-}
-
 func (c *imgBuildTests) issue4583(t *testing.T) {
 	image := filepath.Join(c.env.TestDir, "issue_4583.sif")
 
@@ -199,22 +153,6 @@ func (c imgBuildTests) issue4837(t *testing.T) {
 				os.RemoveAll(filepath.Join(u.Dir, sandboxName))
 			}
 		}),
-		e2e.ExpectExit(0),
-	)
-}
-
-func (c *imgBuildTests) issue4943(t *testing.T) {
-	require.Arch(t, "amd64")
-
-	const (
-		image = "docker://gitlab-registry.cern.ch/linuxsupport/cc7-base:20191107"
-	)
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("build"),
-		e2e.WithArgs("--force", "/dev/null", image),
 		e2e.ExpectExit(0),
 	)
 }
@@ -304,56 +242,6 @@ func (c *imgBuildTests) issue5166(t *testing.T) {
 		e2e.PostRun(func(t *testing.T) {
 			if !t.Failed() {
 				cleanup(t)
-			}
-		}),
-		e2e.ExpectExit(0),
-	)
-}
-
-func (c *imgBuildTests) issue5172(t *testing.T) {
-	e2e.EnsureRegistry(t)
-
-	u := e2e.UserProfile.HostUser(t)
-
-	// create $HOME/.config/containers/registries.conf
-	regImage := "docker://localhost:5000/my-busybox"
-	regDir := filepath.Join(u.Dir, ".config", "containers")
-	regFile := filepath.Join(regDir, "registries.conf")
-	imagePath := filepath.Join(c.env.TestDir, "issue-5172")
-
-	if err := os.MkdirAll(regDir, 0o755); err != nil {
-		t.Fatalf("can't create directory %s: %s", regDir, err)
-	}
-
-	// add our test registry as insecure and test build/pull
-	b := new(bytes.Buffer)
-	b.WriteString("[registries.insecure]\nregistries = ['localhost']")
-	if err := ioutil.WriteFile(regFile, b.Bytes(), 0o644); err != nil {
-		t.Fatalf("can't create %s: %s", regFile, err)
-	}
-	defer os.RemoveAll(regDir)
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("build"),
-		e2e.WithArgs("--sandbox", imagePath, regImage),
-		e2e.PostRun(func(t *testing.T) {
-			if !t.Failed() {
-				os.RemoveAll(imagePath)
-			}
-		}),
-		e2e.ExpectExit(0),
-	)
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("pull"),
-		e2e.WithArgs(imagePath, regImage),
-		e2e.PostRun(func(t *testing.T) {
-			if !t.Failed() {
-				os.RemoveAll(imagePath)
 			}
 		}),
 		e2e.ExpectExit(0),

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -199,42 +199,22 @@ func (c *ctx) testContain(t *testing.T) {
 
 // Test by running directly from URI
 func (c *ctx) testInstanceFromURI(t *testing.T) {
-	instances := []struct {
-		name string
-		uri  string
-	}{
-		{
-			name: "test_from_docker",
-			uri:  "docker://busybox",
-		},
-		{
-			name: "test_from_library",
-			uri:  "library://busybox:1.31.1",
-		},
-		// TODO(mem): reenable this; disabled while shub is down
-		// {
-		// 	name: "test_from_shub",
-		// 	uri:  "shub://singularityhub/busybox",
-		// },
-	}
-
-	for _, i := range instances {
-		args := []string{i.uri, i.name}
-		c.env.RunSingularity(
-			t,
-			e2e.WithProfile(c.profile),
-			e2e.WithCommand("instance start"),
-			e2e.WithArgs(args...),
-			e2e.PostRun(func(t *testing.T) {
-				if t.Failed() {
-					return
-				}
-				c.execInstance(t, i.name, "id")
-				c.stopInstance(t, i.name)
-			}),
-			e2e.ExpectExit(0),
-		)
-	}
+	name := "test_from_library"
+	args := []string{"library://busybox:1.31.1", name}
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(c.profile),
+		e2e.WithCommand("instance start"),
+		e2e.WithArgs(args...),
+		e2e.PostRun(func(t *testing.T) {
+			if t.Failed() {
+				return
+			}
+			c.execInstance(t, name, "id")
+			c.stopInstance(t, name)
+		}),
+		e2e.ExpectExit(0),
+	)
 }
 
 // Execute an instance process, kill master process

--- a/e2e/pull/concurrency.go
+++ b/e2e/pull/concurrency.go
@@ -8,6 +8,7 @@ package pull
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -135,26 +136,16 @@ func (c ctx) testConcurrentPulls(t *testing.T) {
 				envVars:          tt.envVars,
 			}
 
-			// Since we are not passing an image name, change the current
-			// working directory to the temporary directory we just created so
-			// that we know it's clean. We don't do this for the other case in
-			// order to catch spurious files showing up. Maybe later we can
-			// examine the directory and assert that it only contains what we
-			// expect.
-			oldwd, err := os.Getwd()
-			if err != nil {
-				t.Fatalf("Failed to get working directory for pull test: %+v", err)
-			}
-			defer os.Chdir(oldwd)
-
-			os.Chdir(tmpdir)
+			// No explicit image path specified. Will use temp dir as working directory,
+			// so we pull into a clean location.
+			ts.workDir = tmpdir
+			imageName := getImageNameFromURI(ts.srcURI)
+			ts.expectedImage = filepath.Join(tmpdir, imageName)
 
 			// if there's a pullDir, that's where we expect to find the image
 			if ts.pullDir != "" {
-				os.Chdir(ts.pullDir)
+				ts.expectedImage = filepath.Join(ts.pullDir, imageName)
 			}
-
-			ts.expectedImage = getImageNameFromURI(srcURI)
 
 			// pull image
 			c.imagePull(t, ts)

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -1,9 +1,10 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-// This file has been migrated from cmd/singularity/pull_test.go
+// The E2E PULL group tests image pulls of SIF format images (library, oras
+// sources). Docker / OCI image pull is tested as part of the DOCKER E2E group.
 
 package pull
 
@@ -41,6 +42,7 @@ type testStruct struct {
 	setImagePath     bool   // pass destination path
 	setPullDir       bool   // pass --dir
 	expectedExitCode int
+	workDir          string
 	pullDir          string
 	imagePath        string
 	expectedImage    string
@@ -133,14 +135,6 @@ var tests = []testStruct{
 		srcURI:           "alpine:3.11.5",
 		force:            true,
 		unauthenticated:  true,
-		expectedExitCode: 0,
-	},
-
-	{
-		desc:             "image from docker",
-		srcURI:           "docker://alpine:3.8",
-		force:            true,
-		unauthenticated:  false,
 		expectedExitCode: 0,
 	},
 	// TODO(mem): reenable this; disabled while shub is down
@@ -251,6 +245,14 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 		argv += tt.imagePath + " "
 	}
 
+	if tt.workDir == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("unable to get working directory: %s", err)
+		}
+		tt.workDir = wd
+	}
+
 	argv += tt.srcURI
 
 	c.env.RunSingularity(
@@ -258,6 +260,7 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 		e2e.AsSubtest(tt.desc),
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithEnv(tt.envVars),
+		e2e.WithDir(tt.workDir),
 		e2e.WithCommand("pull"),
 		e2e.WithArgs(strings.Split(argv, " ")...),
 		e2e.ExpectExit(tt.expectedExitCode))
@@ -351,26 +354,17 @@ func (c ctx) testPullCmd(t *testing.T) {
 				tt.imagePath = filepath.Join(tmpdir, "image.sif")
 				tt.expectedImage = tt.imagePath
 			} else {
-				// Since we are not passing an image name, change the current
-				// working directory to the temporary directory we just created so
-				// that we know it's clean. We don't do this for the other case in
-				// order to catch spurious files showing up. Maybe later we can
-				// examine the directory and assert that it only contains what we
-				// expect.
-				oldwd, err := os.Getwd()
-				if err != nil {
-					t.Fatalf("Failed to get working directory for pull test: %+v", err)
-				}
-				defer os.Chdir(oldwd)
-
-				os.Chdir(tmpdir)
+				// No explicit image path specified. Will use temp dir as working directory,
+				// so we pull into a clean location.
+				tt.workDir = tmpdir
+				imageName := getImageNameFromURI(tt.srcURI)
+				tt.expectedImage = filepath.Join(tmpdir, imageName)
 
 				// if there's a pullDir, that's where we expect to find the image
 				if tt.pullDir != "" {
-					os.Chdir(tt.pullDir)
+					tt.expectedImage = filepath.Join(tt.pullDir, imageName)
 				}
 
-				tt.expectedImage = getImageNameFromURI(tt.srcURI)
 			}
 
 			// In order to actually test force, there must already be a file present in
@@ -497,11 +491,6 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 			imageSrc:  "library://alpine:latest",
 		},
 		{
-			name:      "docker",
-			imagePath: filepath.Join(c.env.TestDir, "docker.sif"),
-			imageSrc:  "docker://alpine:latest",
-		},
-		{
 			name:      "oras",
 			imagePath: filepath.Join(c.env.TestDir, "oras.sif"),
 			imageSrc:  "oras://localhost:5000/pull_test_sif:latest",
@@ -535,7 +524,7 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 }
 
 // testPullUmask will run some pull tests with different umasks, and
-// ensure the output file hase the correct permissions.
+// ensure the output file has the correct permissions.
 func (c ctx) testPullUmask(t *testing.T) {
 	umask22Image := "0022-umask-pull"
 	umask77Image := "0077-umask-pull"
@@ -646,10 +635,10 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		env: env,
 	}
 
-	// FIX: should run in parallel but the use of Chdir conflicts
-	// with other tests and can lead to test failures
+	// Run these pull tests sequentially among themselves, as they perform a lot
+	// of un-cached pulls which could otherwise lead to hitting rate limits.
 	return testhelper.Tests{
-		"ordered": testhelper.NoParallel(func(t *testing.T) {
+		"ordered": func(t *testing.T) {
 			// Run the tests the do not require setup.
 			t.Run("pullUmaskCheck", c.testPullUmask)
 
@@ -663,6 +652,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 
 			// Regressions
 			t.Run("issue5808", c.issue5808)
-		}),
+		},
 	}
 }

--- a/e2e/testdata/regressions/issue_4203.def
+++ b/e2e/testdata/regressions/issue_4203.def
@@ -1,5 +1,5 @@
-bootstrap: docker
-from: ubuntu:16.04
+bootstrap: library
+from: ubuntu:18.04
 stage: build
 
 %post
@@ -35,8 +35,8 @@ rpc:            bad
 netgroup:       bad
 EOF
 
-bootstrap: docker
-from: ubuntu:16.04
+bootstrap: library
+from: ubuntu:18.04
 stage: final
 
 %files from build

--- a/e2e/testdata/regressions/issue_4820.def
+++ b/e2e/testdata/regressions/issue_4820.def
@@ -1,5 +1,5 @@
-Bootstrap: docker
-From: busybox:latest
+Bootstrap: library
+From: alpine:3.11.5
 
 %appinstall hdf5
 echo "installing hdf5..."

--- a/e2e/testdata/regressions/issue_4969.def
+++ b/e2e/testdata/regressions/issue_4969.def
@@ -1,5 +1,5 @@
-bootstrap: docker
-from: busybox
+bootstrap: library
+from: alpine:3.11.5
 
 %setup
     root=$SINGULARITY_ROOTFS

--- a/e2e/testdata/regressions/issue_5250.def
+++ b/e2e/testdata/regressions/issue_5250.def
@@ -1,5 +1,5 @@
-BootStrap: docker
-From: centos:centos7
+BootStrap: library
+From: centos:7
 
 %post
     yum -y reinstall setup

--- a/e2e/testdata/sshfs.def
+++ b/e2e/testdata/sshfs.def
@@ -1,5 +1,5 @@
-bootstrap: docker
-from: alpine:3.16
+bootstrap: library
+from: alpine:3.15
 
 %post
     apk update


### PR DESCRIPTION
## Description of the Pull Request (PR):

E2E tests using docker:// sources cannot run in parallel with caching, due to issues with concurrency and the containers/image oci/layout. We want to use caching as many tests rely on the same image, and Docker Hub rate limiting is still an issue where it is not trivial to provide credentials.

This changeset:

* Replaces some docker:// sources with equivalent library:// sources, in tests that are not explicitly for verifying docker specific behavior. library:// caching is concurrency safe on local fs with atomic operations (such as CI), allowing a speed-up.

* Removes some redundant docker:// source tests from env/imgbuild etc. which are already covered by the docker group.

* Moves all remaining docker:// source tests into the e2e.docker group, so that all tests using Docker Hub are isolated there. This could be used in future to disable them for e2e runs without Docker Hub credentials etc.

* Runs the e2e.docker tests ordered sequentially, but parallel with respect to other non-docker tests.

* Replaces a problematic Chdir operation in the non-docker pull tests with specifying the working directory on the exec.Command, so that these pull tests can also be run ordered sequentially, but parallel with respect to other non-pull tests.

Speed-up reported on CircleCI from these changes is ~20%

### This fixes or addresses the following GitHub issues:

 - Fixes #977

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
