### PR TITLE
e2e: address two missed docker sources from #982

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -890,6 +890,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("issue 4524", c.issue4524)
 			t.Run("issue 4943", c.issue4943)
 			t.Run("issue 5172", c.issue5172)
+			t.Run("issue 274", c.issue274) // https://github.com/sylabs/singularity/issues/274
 		},
 	}
 }

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -126,3 +126,58 @@ func (c ctx) issue5172(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 }
+
+// https://github.com/sylabs/singularity/issues/274
+// The conda profile.d script must be able to be source'd from %environment.
+// This has been broken by changes to mvdan.cc/sh interacting badly with our
+// custom internalExecHandler.
+// The test is quite heavyweight, but is warranted IMHO to ensure that conda
+// environment activation works as expected, as this is a common use-case
+// for SingularityCE.
+func (c ctx) issue274(t *testing.T) {
+	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue274-", "")
+	defer cleanup(t)
+	imagePath := filepath.Join(imageDir, "container")
+
+	// Create a minimal conda environment on the current miniconda3 base.
+	// Source the conda profile.d code and activate the env from `%environment`.
+	def := `Bootstrap: docker
+From: continuumio/miniconda3:latest
+
+%post
+
+	. /opt/conda/etc/profile.d/conda.sh
+	conda create -n env
+
+%environment
+
+	source /opt/conda/etc/profile.d/conda.sh
+	conda activate env
+`
+	defFile, err := e2e.WriteTempFile(imageDir, "deffile", def)
+	if err != nil {
+		t.Fatalf("Unable to create test definition file: %v", err)
+	}
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("build"),
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(imagePath, defFile),
+		e2e.ExpectExit(0),
+	)
+	// An exec of `conda info` in the container should show environment active, no errors.
+	// I.E. the `%environment` section should have worked.
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("exec"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(imagePath, "conda", "info"),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(e2e.ContainMatch, "active environment : env"),
+			e2e.ExpectError(e2e.ExactMatch, ""),
+		),
+	)
+}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -636,6 +636,5 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5057":               c.issue5057, // https://github.com/sylabs/hpcng/issues/5057
 		"issue 5426":               c.issue5426, // https://github.com/sylabs/hpcng/issues/5426
 		"issue 43":                 c.issue43,   // https://github.com/sylabs/singularity/issues/43
-		"issue 274":                c.issue274,  // https://github.com/sylabs/singularity/issues/274
 	}
 }

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -120,61 +119,6 @@ func (c ctx) issue43(t *testing.T) {
 		e2e.ExpectExit(
 			0,
 			e2e.ExpectOutput(e2e.ExactMatch, `/foo/bar/$LIB/baz.so`),
-		),
-	)
-}
-
-// https://github.com/sylabs/singularity/issues/274
-// The conda profile.d script must be able to be source'd from %environment.
-// This has been broken by changes to mvdan.cc/sh interacting badly with our
-// custom internalExecHandler.
-// The test is quite heavyweight, but is warranted IMHO to ensure that conda
-// environment activation works as expected, as this is a common use-case
-// for SingularityCE.
-func (c ctx) issue274(t *testing.T) {
-	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue274-", "")
-	defer cleanup(t)
-	imagePath := filepath.Join(imageDir, "container")
-
-	// Create a minimal conda environment on the current miniconda3 base.
-	// Source the conda profile.d code and activate the env from `%environment`.
-	def := `Bootstrap: docker
-From: continuumio/miniconda3:latest
-
-%post
-
-	. /opt/conda/etc/profile.d/conda.sh
-	conda create -n env
-
-%environment
-
-	source /opt/conda/etc/profile.d/conda.sh
-	conda activate env
-`
-	defFile, err := e2e.WriteTempFile(imageDir, "deffile", def)
-	if err != nil {
-		t.Fatalf("Unable to create test definition file: %v", err)
-	}
-
-	c.env.RunSingularity(
-		t,
-		e2e.AsSubtest("build"),
-		e2e.WithProfile(e2e.RootProfile),
-		e2e.WithCommand("build"),
-		e2e.WithArgs(imagePath, defFile),
-		e2e.ExpectExit(0),
-	)
-	// An exec of `conda info` in the container should show environment active, no errors.
-	// I.E. the `%environment` section should have worked.
-	c.env.RunSingularity(
-		t,
-		e2e.AsSubtest("exec"),
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("exec"),
-		e2e.WithArgs(imagePath, "conda", "info"),
-		e2e.ExpectExit(0,
-			e2e.ExpectOutput(e2e.ContainMatch, "active environment : env"),
-			e2e.ExpectError(e2e.ExactMatch, ""),
 		),
 	)
 }

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -410,8 +410,8 @@ func (c *imgBuildTests) issue3848(t *testing.T) {
 		File: tmpfile,
 	}
 
-	defTmpl := `Bootstrap: docker
-From: alpine:latest
+	defTmpl := `Bootstrap: library
+From: alpine:3.11.5
 
 %files
 	{{ .File }}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Two e2e tests with docker sources were missed in #982 due to a case-sensitive search for bootstrap: docker.

Move one to the docker e2e group. Modify the other to use a library alpine image.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
