### PR TITLE
e2e: pick fixes #984 and #986 (3.10)

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -755,6 +755,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("issue 4524", c.issue4524)
 			t.Run("issue 4943", c.issue4943)
 			t.Run("issue 5172", c.issue5172)
+			t.Run("issue 274", c.issue274) // https://github.com/sylabs/singularity/issues/274
 		},
 	}
 }

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -126,3 +126,58 @@ func (c ctx) issue5172(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 }
+
+// https://github.com/sylabs/singularity/issues/274
+// The conda profile.d script must be able to be source'd from %environment.
+// This has been broken by changes to mvdan.cc/sh interacting badly with our
+// custom internalExecHandler.
+// The test is quite heavyweight, but is warranted IMHO to ensure that conda
+// environment activation works as expected, as this is a common use-case
+// for SingularityCE.
+func (c ctx) issue274(t *testing.T) {
+	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue274-", "")
+	defer cleanup(t)
+	imagePath := filepath.Join(imageDir, "container")
+
+	// Create a minimal conda environment on the current miniconda3 base.
+	// Source the conda profile.d code and activate the env from `%environment`.
+	def := `Bootstrap: docker
+From: continuumio/miniconda3:latest
+
+%post
+
+	. /opt/conda/etc/profile.d/conda.sh
+	conda create -n env
+
+%environment
+
+	source /opt/conda/etc/profile.d/conda.sh
+	conda activate env
+`
+	defFile, err := e2e.WriteTempFile(imageDir, "deffile", def)
+	if err != nil {
+		t.Fatalf("Unable to create test definition file: %v", err)
+	}
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("build"),
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(imagePath, defFile),
+		e2e.ExpectExit(0),
+	)
+	// An exec of `conda info` in the container should show environment active, no errors.
+	// I.E. the `%environment` section should have worked.
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("exec"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(imagePath, "conda", "info"),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(e2e.ContainMatch, "active environment : env"),
+			e2e.ExpectError(e2e.ExactMatch, ""),
+		),
+	)
+}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -636,6 +636,5 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5057":               c.issue5057, // https://github.com/sylabs/hpcng/issues/5057
 		"issue 5426":               c.issue5426, // https://github.com/sylabs/hpcng/issues/5426
 		"issue 43":                 c.issue43,   // https://github.com/sylabs/singularity/issues/43
-		"issue 274":                c.issue274,  // https://github.com/sylabs/singularity/issues/274
 	}
 }

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -120,61 +119,6 @@ func (c ctx) issue43(t *testing.T) {
 		e2e.ExpectExit(
 			0,
 			e2e.ExpectOutput(e2e.ExactMatch, `/foo/bar/$LIB/baz.so`),
-		),
-	)
-}
-
-// https://github.com/sylabs/singularity/issues/274
-// The conda profile.d script must be able to be source'd from %environment.
-// This has been broken by changes to mvdan.cc/sh interacting badly with our
-// custom internalExecHandler.
-// The test is quite heavyweight, but is warranted IMHO to ensure that conda
-// environment activation works as expected, as this is a common use-case
-// for SingularityCE.
-func (c ctx) issue274(t *testing.T) {
-	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue274-", "")
-	defer cleanup(t)
-	imagePath := filepath.Join(imageDir, "container")
-
-	// Create a minimal conda environment on the current miniconda3 base.
-	// Source the conda profile.d code and activate the env from `%environment`.
-	def := `Bootstrap: docker
-From: continuumio/miniconda3:latest
-
-%post
-
-	. /opt/conda/etc/profile.d/conda.sh
-	conda create -n env
-
-%environment
-
-	source /opt/conda/etc/profile.d/conda.sh
-	conda activate env
-`
-	defFile, err := e2e.WriteTempFile(imageDir, "deffile", def)
-	if err != nil {
-		t.Fatalf("Unable to create test definition file: %v", err)
-	}
-
-	c.env.RunSingularity(
-		t,
-		e2e.AsSubtest("build"),
-		e2e.WithProfile(e2e.RootProfile),
-		e2e.WithCommand("build"),
-		e2e.WithArgs(imagePath, defFile),
-		e2e.ExpectExit(0),
-	)
-	// An exec of `conda info` in the container should show environment active, no errors.
-	// I.E. the `%environment` section should have worked.
-	c.env.RunSingularity(
-		t,
-		e2e.AsSubtest("exec"),
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("exec"),
-		e2e.WithArgs(imagePath, "conda", "info"),
-		e2e.ExpectExit(0,
-			e2e.ExpectOutput(e2e.ContainMatch, "active environment : env"),
-			e2e.ExpectError(e2e.ExactMatch, ""),
 		),
 	)
 }

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -337,8 +337,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 			name: "FileCopySimple",
 			dfd: []e2e.DefFileDetails{
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "library",
+					From:      "alpine:3.11.5",
 					Stage:     "one",
 					Files: []e2e.FilePair{
 						{
@@ -352,8 +352,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "library",
+					From:      "alpine:3.11.5",
 					FilesFrom: []e2e.FileSection{
 						{
 							Stage: "one",
@@ -389,8 +389,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 			name: "FileCopyComplex",
 			dfd: []e2e.DefFileDetails{
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "library",
+					From:      "alpine:3.11.5",
 					Stage:     "one",
 					Files: []e2e.FilePair{
 						{
@@ -404,8 +404,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "library",
+					From:      "alpine:3.11.5",
 					Stage:     "two",
 					Files: []e2e.FilePair{
 						{
@@ -419,8 +419,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "library",
+					From:      "alpine:3.11.5",
 					Stage:     "three",
 					FilesFrom: []e2e.FileSection{
 						{
@@ -452,8 +452,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "library",
+					From:      "alpine:3.11.5",
 					FilesFrom: []e2e.FileSection{
 						{
 							Stage: "three",
@@ -538,12 +538,12 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 
 	tt := map[string]e2e.DefFileDetails{
 		"Empty": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 		},
 		"Help": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Help: []string{
 				"help info line 1",
 				"help info line 2",
@@ -551,8 +551,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Files": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Files: []e2e.FilePair{
 				{
 					Src: tmpfile,
@@ -565,8 +565,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Test": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Test: []string{
 				"echo testscript line 1",
 				"echo testscript line 2",
@@ -574,8 +574,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Startscript": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			StartScript: []string{
 				"echo startscript line 1",
 				"echo startscript line 2",
@@ -583,8 +583,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Runscript": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			RunScript: []string{
 				"echo runscript line 1",
 				"echo runscript line 2",
@@ -592,8 +592,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Env": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Env: []string{
 				"testvar1=one",
 				"testvar2=two",
@@ -601,8 +601,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Labels": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Labels: map[string]string{
 				"customLabel1": "one",
 				"customLabel2": "two",
@@ -610,29 +610,29 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Pre": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Pre: []string{
 				filepath.Join(c.env.TestDir, "PreFile1"),
 			},
 		},
 		"Setup": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Setup: []string{
 				filepath.Join(c.env.TestDir, "SetupFile1"),
 			},
 		},
 		"Post": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Post: []string{
 				"PostFile1",
 			},
 		},
 		"AppHelp": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -653,8 +653,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppEnv": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -675,8 +675,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppLabels": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -697,8 +697,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppFiles": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -729,8 +729,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppInstall": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -747,8 +747,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppRun": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -769,8 +769,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppTest": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "library",
+			From:      "alpine:3.11.5",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -410,8 +410,8 @@ func (c *imgBuildTests) issue3848(t *testing.T) {
 		File: tmpfile,
 	}
 
-	defTmpl := `Bootstrap: docker
-From: alpine:latest
+	defTmpl := `Bootstrap: library
+From: alpine:3.11.5
 
 %files
 	{{ .File }}

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -635,23 +635,23 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		env: env,
 	}
 
-	// Run these pull tests sequentially among themselves, as they perform a lot
-	// of un-cached pulls which could otherwise lead to hitting rate limits.
-	return testhelper.Tests{
-		"ordered": func(t *testing.T) {
-			// Run the tests the do not require setup.
-			t.Run("pullUmaskCheck", c.testPullUmask)
+	np := testhelper.NoParallel
 
+	return testhelper.Tests{
+		// Run pull tests sequentially among themselves, as they perform a lot
+		// of un-cached pulls which could otherwise lead to hitting rate limits.
+		"ordered": func(t *testing.T) {
 			// Setup a test registry to pull from (for oras).
 			c.setup(t)
-
 			t.Run("pull", c.testPullCmd)
 			t.Run("pullDisableCache", c.testPullDisableCacheCmd)
 			t.Run("concurrencyConfig", c.testConcurrencyConfig)
 			t.Run("concurrentPulls", c.testConcurrentPulls)
-
 			// Regressions
 			t.Run("issue5808", c.issue5808)
 		},
+		// Manipulates umask for the process, so must be run alone to avoid
+		// causing permission issues for other tests.
+		"pullUmaskCheck": np(c.testPullUmask),
 	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Cherry pick #984 and #986 to release-3.10

**e2e: address two missed docker sources from #982**
Two e2e tests with docker sources were missed in #982 due to a case-sensitive search for bootstrap: docker. Move one to the docker e2e group. Modify the other to use a library alpine image.

**e2e: fix umask manipulation concurrency issue**
One E2E PULL test manipulates the process umask. To avoid causing permissions issues in other tests it must be run alone, in the SEQ section of the E2E suit, via testhelper.NoParallel.

**e2e: Convert IMGBUILD def file tests docker -> library**

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
