### PR TITLE
Bump golangci-lint to v1.49 (master)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ executors:
       - image: ubuntu:22.04
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.44
+      - image: golangci/golangci-lint:v1.49
   ubuntu-machine:
     machine:
       image: ubuntu-2004:202111-02

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
   enable:
     - containedctx
     - contextcheck
-    - deadcode
     - decorder
     - dupl
     - gofumpt
@@ -32,6 +31,7 @@ linters:
     - nakedret
     - revive
     - staticcheck
+    - unused
 
 linters-settings:
   misspell:

--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -27,23 +27,6 @@ type instance struct {
 
 type instanceList struct {
 	Instances []instance `json:"instances"`
-}
-
-func (c *ctx) listInstance(t *testing.T, listArgs ...string) (stdout string, stderr string, success bool) {
-	var args []string
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(c.profile),
-		e2e.WithCommand("instance list"),
-		e2e.WithArgs(args...),
-		e2e.PostRun(func(t *testing.T) {
-			success = !t.Failed()
-		}),
-		e2e.ExpectExit(0, e2e.GetStreams(&stdout, &stderr)),
-	)
-
-	return
 }
 
 func (c *ctx) stopInstance(t *testing.T, instance string, stopArgs ...string) (stdout string, stderr string, success bool) {

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -16,7 +16,6 @@ import (
 
 type ctx struct {
 	env             e2e.TestEnv
-	imgCache        string
 	keyringDir      string
 	passphraseInput []e2e.SingularityConsoleOp
 }

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -19,7 +19,6 @@ import (
 // LocalConveyor only needs to hold the conveyor to have the needed data to pack
 type LocalConveyor struct {
 	src string
-	b   *types.Bundle
 }
 
 // LocalPacker ...

--- a/internal/pkg/build/sources/conveyorPacker_shub.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -16,8 +16,7 @@ import (
 
 // ShubConveyorPacker only needs to hold the conveyor to have the needed data to pack.
 type ShubConveyorPacker struct {
-	recipe types.Definition
-	b      *types.Bundle
+	b *types.Bundle
 	LocalPacker
 }
 

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -200,21 +200,6 @@ func (h *Handle) CleanCache(cacheType string, dryRun bool, days int) (err error)
 	return err
 }
 
-// cleanAllCaches is an utility function that wipes all files in the
-// cache directory, will return a error if one occurs
-func (h *Handle) cleanAllCaches() {
-	if h.disabled {
-		return
-	}
-
-	for _, ct := range append(FileCacheTypes, OciCacheTypes...) {
-		dir := h.getCacheTypeDir(ct)
-		if err := os.RemoveAll(dir); err != nil {
-			sylog.Verbosef("unable to clean %s cache, directory %s: %v", ct, dir, err)
-		}
-	}
-}
-
 // IsDisabled returns true if the cache is disabled
 func (h *Handle) IsDisabled() bool {
 	return h.disabled

--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -57,7 +57,7 @@ func ProgressBarCallback(ctx context.Context) ProgressCallback {
 	}
 
 	return func(totalSize int64, r io.Reader, w io.Writer) error {
-		p, bar := initProgressBar(totalSize)
+		p, bar := initProgressBar(totalSize) //nolint:contextcheck
 
 		// create proxy reader
 		bodyProgress := bar.ProxyReader(r)

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -382,32 +382,9 @@ func (c *Config) SetNsPath(nstype specs.LinuxNamespaceType, path string) error {
 func (c *Config) SetNsPathFromSpec(namespaces []specs.LinuxNamespace) error {
 	for _, namespace := range namespaces {
 		if namespace.Path != "" {
-			cpath := unsafe.Pointer(C.CString(namespace.Path))
-			l := len(namespace.Path)
-			size := C.size_t(l)
-
-			if l > C.MAX_PATH_SIZE-1 {
-				return fmt.Errorf("%s namespace path too big", namespace.Type)
+			if err := c.SetNsPath(namespace.Type, namespace.Path); err != nil {
+				return err
 			}
-
-			switch namespace.Type {
-			case specs.UserNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.user[0]), cpath, size)
-			case specs.IPCNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.ipc[0]), cpath, size)
-			case specs.UTSNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.uts[0]), cpath, size)
-			case specs.PIDNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.pid[0]), cpath, size)
-			case specs.NetworkNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.network[0]), cpath, size)
-			case specs.MountNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.mount[0]), cpath, size)
-			case specs.CgroupNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.cgroup[0]), cpath, size)
-			}
-
-			C.free(cpath)
 		}
 	}
 


### PR DESCRIPTION
Bump `golangci-lint` to v1.49. Replace deprecated `deadcode` linter with `unused`. Address various lint.