### PR TITLE
fix: permit rpm bootstrap on Fedora 36

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -141,19 +141,28 @@ func (c *YumConveyor) getRPMPath() (err error) {
 
 	if rpmDBPath == "" {
 		return fmt.Errorf("could not find dbpath")
-	} else if rpmDBPath != `%{_var}/lib/rpm` {
-		return fmt.Errorf("RPM database is using a weird path: %s\n"+
-			"You are probably running this bootstrap on Debian or Ubuntu.\n"+
-			"There is a way to work around this problem:\n"+
-			"Create a file at path %s/.rpmmacros.\n"+
-			"Place the following lines into the '.rpmmacros' file:\n"+
-			"%s\n"+
-			"%s\n"+
-			"After creating the file, re-run the bootstrap.\n"+
-			"More info: https://github.com/sylabs/singularity/issues/241\n",
-			rpmDBPath, os.Getenv("HOME"), `%_var /var`, `%_dbpath %{_var}/lib/rpm`)
 	}
 
+	// %{_var}/lib/rpm is the 'traditional' dbpath
+	if rpmDBPath != `%{_var}/lib/rpm` {
+		// Fedora 36 now uses a different rpm dbpath, and may fail to bootstrap older distros
+		if rpmDBPath == `%{_usr}/lib/sysimage/rpm` {
+			sylog.Warningf("Your host system is using a new RPM database path: %v", rpmDBPath)
+			sylog.Warningf("Bootstrapping older distributions may require an ~/.rpmmacros file containing:\n" +
+				"\t\t_dbpath %%{_var}/lib/rpm\n")
+		} else {
+			// If we're on a 'foreign' system, with neither old or new paths, and ~/.rpmmacros will be required.
+			return fmt.Errorf("RPM database is using a non-standard path: %s\n"+
+				"You are probably running this bootstrap on Debian or Ubuntu.\n"+
+				"There is a way to work around this problem:\n"+
+				"Create a file at path %s/.rpmmacros.\n"+
+				"Place the following lines into the '.rpmmacros' file:\n"+
+				"%s\n"+
+				"%s\n"+
+				"After creating the file, re-run the bootstrap.\n"+
+				rpmDBPath, os.Getenv("HOME"), `%_var /var`, `%_dbpath %{_var}/lib/rpm`)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fedora 36 now uses `%{_usr}/lib/sysimage/rpm` as the rpm dbpath. Previously we errored out on anything except `%{_var}/lib/rpm`. We need to accept the new path so that Fedora 36 can bootstrap itself. We need to warn that bootstrapping older distributions may require setting the old path in an `~/.rpmmacros` file.


### This fixes or addresses the following GitHub issues:

 - Fixes #902 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
