### PR TITLE
chore: bump golangci-lint to 1.50 (release-3.10)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ executors:
       - image: ubuntu:22.04
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.49
+      - image: golangci/golangci-lint:v1.50
   ubuntu-machine:
     machine:
       image: ubuntu-2004:202111-02

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -168,6 +168,11 @@ func (m *Manager) UpdateFromFile(path string) error {
 }
 
 // AddProc adds the process with specified pid to the managed cgroup
+//
+// Disable context check as it raises a warning throuch lcmanager.New, which is
+// in a dependency we cannot modify to pass a context.
+//
+// nolint:contextcheck
 func (m *Manager) AddProc(pid int) (err error) {
 	if m.group == "" || m.cgroup == nil {
 		return ErrUnitialized
@@ -253,6 +258,11 @@ func checkRootless(group string, systemd bool) (rootless bool, err error) {
 
 // newManager creates a new Manager, with the associated resources and cgroup.
 // The Manager is ready to manage the cgroup but does not apply limits etc.
+//
+// Disable context check as it raises a warning throuch lcmanager.New, which is
+// in a dependency we cannot modify to pass a context.
+//
+// nolint:contextcheck
 func newManager(resources *specs.LinuxResources, group string, systemd bool) (manager *Manager, err error) {
 	if resources == nil {
 		return nil, fmt.Errorf("non-nil cgroup LinuxResources definition is required")
@@ -381,6 +391,11 @@ func NewManagerWithFile(specPath string, pid int, group string, systemd bool) (m
 // GetManager returns a Manager for the provided cgroup name/path.
 // It can only return a cgroupfs manager, as we aren't wiring back up to systemd
 // through dbus etc.
+//
+// Disable context check as it raises a warning throuch lcmanager.New, which is
+// in a dependency we cannot modify to pass a context.
+//
+// nolint:contextcheck
 func GetManagerForGroup(group string) (manager *Manager, err error) {
 	if group == "" {
 		return nil, fmt.Errorf("cannot load cgroup - no name/path specified")

--- a/pkg/util/archive/copy.go
+++ b/pkg/util/archive/copy.go
@@ -16,6 +16,11 @@ import (
 
 // CopyWithTar is a wrapper around the docker pkg/archive/copy CopyWithTar allowing unprivileged use.
 // It forces ownership to the current uid/gid in unprivileged situations.
+//
+// Disable context check as it raises a warning through the docker dependency we
+// cannot modify to pass a context.
+//
+// nolint:contextcheck
 func CopyWithTar(src, dst string) error {
 	ar := da.NewDefaultArchiver()
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump golangci-lint to 1.50.

Silence contextcheck warnings that are for a path through dependencies we cannot modify.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
