### PR TITLE
actions: Add --oci flag to call OCI launcher

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -84,6 +84,8 @@ var (
 	memorySwap        string // bytes
 	oomKillDisable    bool
 	pidsLimit         int
+
+	ociRuntime bool
 )
 
 // --app
@@ -800,6 +802,16 @@ var actionProotFlag = cmdline.Flag{
 	Hidden:       true,
 }
 
+// --oci
+var actionOCIFlag = cmdline.Flag{
+	ID:           "actionOCI",
+	Value:        &ociRuntime,
+	DefaultValue: false,
+	Name:         "oci",
+	Usage:        "Launch container with OCI runtime (experimental)",
+	EnvKeys:      []string{"OCI"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -893,5 +905,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionPidsLimitFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionSIFFUSEFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionProotFlag, actionsCmd...)
+		cmdManager.RegisterFlagForCmd(&actionOCIFlag, actionsCmd...)
 	})
 }

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/client/shub"
 	"github.com/sylabs/singularity/internal/pkg/runtime/launcher"
 	"github.com/sylabs/singularity/internal/pkg/runtime/launcher/native"
+	ocilauncher "github.com/sylabs/singularity/internal/pkg/runtime/launcher/oci"
 	"github.com/sylabs/singularity/internal/pkg/util/uri"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
@@ -335,9 +336,18 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 	// Explicitly use the interface type here, as we will add alternative launchers later...
 	var l launcher.Launcher
 
-	l, err = native.NewLauncher(opts...)
-	if err != nil {
-		return fmt.Errorf("while configuring container: %s", err)
+	if ociRuntime {
+		sylog.Debugf("Using OCI runtime launcher.")
+		l, err = ocilauncher.NewLauncher(opts...)
+		if err != nil {
+			return fmt.Errorf("while configuring container: %s", err)
+		}
+	} else {
+		sylog.Debugf("Using native runtime launcher.")
+		l, err = native.NewLauncher(opts...)
+		if err != nil {
+			return fmt.Errorf("while configuring container: %s", err)
+		}
 	}
 
 	return l.Exec(cmd.Context(), image, args, instanceName)

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -903,7 +903,7 @@ func (c actionTests) actionBasicProfiles(t *testing.T) {
 		},
 	}
 
-	for _, profile := range e2e.Profiles {
+	for _, profile := range e2e.NativeProfiles {
 		profile := profile
 
 		t.Run(profile.String(), func(t *testing.T) {
@@ -1426,7 +1426,7 @@ func (c actionTests) actionBinds(t *testing.T) {
 		},
 	}
 
-	for _, profile := range e2e.Profiles {
+	for _, profile := range e2e.NativeProfiles {
 		profile := profile
 		createWorkspaceDirs(t)
 
@@ -2338,6 +2338,24 @@ func countSquashfuseMounts(t *testing.T) int {
 	return count
 }
 
+func (c actionTests) ociRuntime(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	for _, p := range []e2e.Profile{e2e.OCIUserProfile, e2e.OCIRootProfile} {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(p.String()),
+			e2e.WithProfile(p),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(c.env.ImagePath, "/bin/true"),
+			e2e.ExpectExit(
+				255,
+				e2e.ExpectError(e2e.ContainMatch, "not implemented"),
+			),
+		)
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := actionTests{
@@ -2379,6 +2397,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"umask":                 c.actionUmask,         // test umask propagation
 		"no-mount":              c.actionNoMount,       // test --no-mount
 		"compat":                c.actionCompat,        // test --compat
+		"ociRuntime":            c.ociRuntime,          // test --oci (unimplemented)
 		"invalidRemote":         np(c.invalidRemote),   // GHSA-5mv9-q7fq-9394
 		"SIFFUSE":               np(c.actionSIFFUSE),   // test --sif-fuse
 		"NoSIFFUSE":             np(c.actionNoSIFFUSE), // test absence of squashfs and CleanupHost()

--- a/e2e/internal/e2e/profile.go
+++ b/e2e/internal/e2e/profile.go
@@ -20,19 +20,29 @@ const (
 	fakerootProfile          = "FakerootProfile"
 	userNamespaceProfile     = "UserNamespaceProfile"
 	rootUserNamespaceProfile = "RootUserNamespaceProfile"
+	ociUserProfile           = "OCIUserProfile"
+	ociRootProfile           = "OCIRootProfile"
+	ociFakerootProfile       = "OCIFakerootProfile"
 )
 
 var (
-	// UserProfile is the execution profile for a regular user.
-	UserProfile = Profiles[userProfile]
-	// RootProfile is the execution profile for root.
-	RootProfile = Profiles[rootProfile]
-	// FakerootProfile is the execution profile for fakeroot.
-	FakerootProfile = Profiles[fakerootProfile]
-	// UserNamespaceProfile is the execution profile for a regular user and a user namespace.
-	UserNamespaceProfile = Profiles[userNamespaceProfile]
-	// RootUserNamespaceProfile is the execution profile for root and a user namespace.
-	RootUserNamespaceProfile = Profiles[rootUserNamespaceProfile]
+	// UserProfile is the execution profile for a regular user, using the Singularity native runtime.
+	UserProfile = NativeProfiles[userProfile]
+	// RootProfile is the execution profile for root, using the Singularity native runtime.
+	RootProfile = NativeProfiles[rootProfile]
+	// FakerootProfile is the execution profile for fakeroot, using the Singularity native runtime.
+	FakerootProfile = NativeProfiles[fakerootProfile]
+	// UserNamespaceProfile is the execution profile for a regular user and a user namespace, using the Singularity native runtime.
+	UserNamespaceProfile = NativeProfiles[userNamespaceProfile]
+	// RootUserNamespaceProfile is the execution profile for root and a user namespace, using the Singularity native runtime.
+	RootUserNamespaceProfile = NativeProfiles[rootUserNamespaceProfile]
+	// OCIUserProfile is the execution profile for a regular user, using the Singularity native runtime.
+	OCIUserProfile = OCIProfiles[ociUserProfile]
+	// RootProfile is the execution profile for root, using the Singularity native runtime.
+	OCIRootProfile = OCIProfiles[ociRootProfile]
+	// FakerootProfile is the execution profile for fakeroot, using the Singularity native runtime.
+	OCIFakerootProfile = OCIProfiles[ociFakerootProfile]
+	// UserNamespaceProfile is the execution profile for a regular user and a user namespace, using the Singularity native runtime.
 )
 
 // Profile represents various properties required to run an E2E test
@@ -56,8 +66,8 @@ type Profile struct {
 	optionForCommands []string         // singularity commands concerned by the option to be added
 }
 
-// Profiles defines all available profiles.
-var Profiles = map[string]Profile{
+// NativeProfiles defines all available profiles for the native singularity runtime
+var NativeProfiles = map[string]Profile{
 	userProfile: {
 		name:              "User",
 		privileged:        false,
@@ -106,6 +116,40 @@ var Profiles = map[string]Profile{
 		defaultCwd:        "/root", // need to run in a directory owned by root
 		requirementsFn:    require.UserNamespace,
 		singularityOption: "--userns",
+		optionForCommands: []string{"shell", "exec", "run", "test", "instance start"},
+	},
+}
+
+// OCIProfiles defines all available profiles for the OCI runtime
+var OCIProfiles = map[string]Profile{
+	ociUserProfile: {
+		name:              "OCIUser",
+		privileged:        false,
+		hostUID:           origUID,
+		containerUID:      origUID,
+		defaultCwd:        "",
+		requirementsFn:    ociRequirements,
+		singularityOption: "--oci",
+		optionForCommands: []string{"shell", "exec", "run", "test", "instance start"},
+	},
+	ociRootProfile: {
+		name:              "OCIRoot",
+		privileged:        true,
+		hostUID:           0,
+		containerUID:      0,
+		defaultCwd:        "",
+		requirementsFn:    ociRequirements,
+		singularityOption: "--oci",
+		optionForCommands: []string{"shell", "exec", "run", "test", "instance start"},
+	},
+	ociFakerootProfile: {
+		name:              "OCIFakeroot",
+		privileged:        false,
+		hostUID:           origUID,
+		containerUID:      0,
+		defaultCwd:        "",
+		requirementsFn:    ociRequirements,
+		singularityOption: "--oci --fakeroot",
 		optionForCommands: []string{"shell", "exec", "run", "test", "instance start"},
 	},
 }
@@ -184,6 +228,29 @@ func (p Profile) String() string {
 // correctly execute commands with the fakeroot profile.
 func fakerootRequirements(t *testing.T) {
 	require.UserNamespace(t)
+
+	uid := uint32(origUID)
+
+	// check that current user has valid mappings in /etc/subuid
+	if _, err := fakeroot.GetIDRange(fakeroot.SubUIDFile, uid); err != nil {
+		t.Fatalf("fakeroot configuration error: %s", err)
+	}
+
+	// check that current user has valid mappings in /etc/subgid;
+	// since that file contains the group mappings for a given user
+	// *name*, it is keyed by user name, not by group name. This
+	// means that even if we are requesting the *group* mappings, we
+	// need to pass the *user* ID.
+	if _, err := fakeroot.GetIDRange(fakeroot.SubGIDFile, uid); err != nil {
+		t.Fatalf("fakeroot configuration error: %s", err)
+	}
+}
+
+// ociRequirements ensures requirements are satisfied to correctly execute
+// commands with the OCI runtime / profile.
+func ociRequirements(t *testing.T) {
+	require.UserNamespace(t)
+	require.Command(t, "runc")
 
 	uid := uint32(origUID)
 

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -492,8 +492,8 @@ func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 	// a profile is required
 	if s.profile.name == "" {
 		i := 0
-		availableProfiles := make([]string, len(Profiles))
-		for profile := range Profiles {
+		availableProfiles := make([]string, len(NativeProfiles))
+		for profile := range NativeProfiles {
 			availableProfiles[i] = profile
 			i++
 		}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -13,12 +13,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/runtime/launcher"
 )
 
 var (
 	ErrUnsupportedOption = errors.New("not supported by OCI launcher")
-	ErrNotImplemented    = errors.New("not implemented")
+	ErrNotImplemented    = errors.New("not implemented by OCI launcher")
 )
 
 // Launcher will holds configuration for, and will launch a container using an
@@ -54,10 +55,10 @@ func checkOpts(lo launcher.Options) error {
 	if lo.WritableTmpfs {
 		badOpt = append(badOpt, "WritableTmpfs")
 	}
-	if lo.OverlayPaths != nil {
+	if len(lo.OverlayPaths) > 0 {
 		badOpt = append(badOpt, "OverlayPaths")
 	}
-	if lo.ScratchDirs != nil {
+	if len(lo.ScratchDirs) > 0 {
 		badOpt = append(badOpt, "ScratchDirs")
 	}
 	if lo.WorkDir != "" {
@@ -74,16 +75,16 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "NoHome")
 	}
 
-	if lo.BindPaths != nil {
+	if len(lo.BindPaths) > 0 {
 		badOpt = append(badOpt, "BindPaths")
 	}
-	if lo.FuseMount != nil {
+	if len(lo.FuseMount) > 0 {
 		badOpt = append(badOpt, "FuseMount")
 	}
-	if lo.Mounts != nil {
+	if len(lo.Mounts) > 0 {
 		badOpt = append(badOpt, "Mounts")
 	}
-	if lo.NoMount != nil {
+	if len(lo.NoMount) > 0 {
 		badOpt = append(badOpt, "NoMount")
 	}
 
@@ -103,14 +104,14 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "NoRocm")
 	}
 
-	if lo.ContainLibs != nil {
+	if len(lo.ContainLibs) > 0 {
 		badOpt = append(badOpt, "ContainLibs")
 	}
 	if lo.Proot != "" {
 		badOpt = append(badOpt, "Proot")
 	}
 
-	if lo.Env != nil {
+	if len(lo.Env) > 0 {
 		badOpt = append(badOpt, "Env")
 	}
 	if lo.EnvFile != "" {
@@ -139,10 +140,12 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "Namespaces.User")
 	}
 
-	if lo.Network != "" {
+	// Network always set in CLI layer even if network namespace not requested.
+	if lo.Namespaces.Net && lo.Network != "" {
 		badOpt = append(badOpt, "Network")
 	}
-	if lo.NetworkArgs != nil {
+
+	if len(lo.NetworkArgs) > 0 {
 		badOpt = append(badOpt, "NetworkArgs")
 	}
 	if lo.Hostname != "" {
@@ -167,7 +170,7 @@ func checkOpts(lo launcher.Options) error {
 	if lo.NoPrivs {
 		badOpt = append(badOpt, "NoPrivs")
 	}
-	if lo.SecurityOpts != nil {
+	if len(lo.SecurityOpts) > 0 {
 		badOpt = append(badOpt, "SecurityOpts")
 	}
 	if lo.NoUmask {
@@ -178,7 +181,8 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "CGroupsJSON")
 	}
 
-	if lo.ConfigFile != "" {
+	// ConfigFile always set by CLI. We should support only the default from build time.
+	if lo.ConfigFile != "" && lo.ConfigFile != buildcfg.SINGULARITY_CONF_FILE {
 		badOpt = append(badOpt, "ConfigFile")
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Depends on #1021

Add an `--oci` flag to actions (run/shell/exec) that calls the (no-op) OCI launcher instead of the singularity native runtime launcher.

Fix OCI launcher supported option checks for empty structs (not just nils), and always set options.

Add E2E profiles and a test for unimplemented error on the --oci option.

### This fixes or addresses the following GitHub issues:

 - Fixes #1022 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
