### PR TITLE
makefile: make clean on conmon sources in make dist (release-3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Ensure `make dist` doesn't include conmon binary or intermediate files.
+
 ## 3.10.3 \[2022-10-06\]
 
 ### Security Related Fixes

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -24,7 +24,7 @@ check: codegen
 	@echo "       PASS"
 
 .PHONY: dist
-dist:
+dist: conmon_CLEAN
 	$(V) if test -e '$(SOURCEDIR)/vendor' ; then \
 		echo 'E: There is a vendor directory in $(SOURCEDIR).' ; \
 		echo 'E: This is unexpected. Abort.' ; \


### PR DESCRIPTION
## Description of the Pull Request (PR):

Avoids including conmon binary or intermediate build files in the dist tar.gz.


### This fixes or addresses the following GitHub issues:

 - Fixes #941


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
