### PR TITLE
deprecate image driver plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Changes Since Last Release
 
+### Changed defaults / behaviours
+
+- Image driver plugins, implementing the RegisterImageDriver callback, are
+  deprecated and will be removed in 4.0. Support for the example plugin,
+  permitting Ubuntu unprivileged overlay functionality, will be replaced with a
+  non-plugin implementation.
+
 ### Development / Testing
 
 - The `e2e-test` makefile target now accepts an argument `E2E_GROUPS` to only

--- a/examples/plugins/ubuntu-userns-overlay-plugin/README.md
+++ b/examples/plugins/ubuntu-userns-overlay-plugin/README.md
@@ -1,0 +1,9 @@
+# Deprecation Warning
+
+This plugin, implementing support for unprivileged overlays on patched Ubuntu
+kernels, will not be supported from SingularityCE 4.0.
+
+Image driver plugins, implementing the RegisterImageDriver callback, are
+deprecated and will be removed in 4.0. Support for this example plugin,
+permitting Ubuntu unprivileged overlay functionality, will be replaced with a
+non-plugin implementation.

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -153,18 +153,18 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 	}
 
 	// load image driver plugins
-	callbackType := (singularitycallback.RegisterImageDriver)(nil)
+	callbackType := (singularitycallback.RegisterImageDriver)(nil) // nolint:staticcheck
 	callbacks, err := plugin.LoadCallbacks(callbackType)
 	if err != nil {
 		return fmt.Errorf("while loading plugins callbacks '%T': %s", callbackType, err)
 	}
 	for _, callback := range callbacks {
-		if err := callback.(singularitycallback.RegisterImageDriver)(c.userNS); err != nil {
+		if err := callback.(singularitycallback.RegisterImageDriver)(c.userNS); err != nil { // nolint:staticcheck
 			return fmt.Errorf("while registering image driver: %s", err)
 		}
 	}
 
-	driverName := c.engine.EngineConfig.File.ImageDriver
+	driverName := c.engine.EngineConfig.File.ImageDriver // nolint:staticcheck
 	imageDriver = image.GetDriver(driverName)
 	if driverName != "" && imageDriver == nil {
 		return fmt.Errorf("%q: no such image driver", driverName)
@@ -497,7 +497,7 @@ func (c *container) setupImageDriver(system *mount.System) error {
 
 			umountPoints = append(umountPoints, sp)
 
-			sylog.Debugf("Starting image driver %s", c.engine.EngineConfig.File.ImageDriver)
+			sylog.Debugf("Starting image driver %s", c.engine.EngineConfig.File.ImageDriver) // nolint:staticcheck
 			if err := imageDriver.Start(params); err != nil {
 				return fmt.Errorf("failed to start driver: %s", err)
 			}
@@ -511,7 +511,7 @@ func (c *container) setupImageDriver(system *mount.System) error {
 		if params.UsernsFd != -1 {
 			defer unix.Close(params.UsernsFd)
 		}
-		sylog.Debugf("Starting image driver %s", c.engine.EngineConfig.File.ImageDriver)
+		sylog.Debugf("Starting image driver %s", c.engine.EngineConfig.File.ImageDriver) // nolint:staticcheck
 		if err := imageDriver.Start(params); err != nil {
 			return fmt.Errorf("failed to start driver: %s", err)
 		}

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -176,7 +176,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		return err
 	}
 
-	if sendFd || e.EngineConfig.File.ImageDriver != "" {
+	if sendFd || e.EngineConfig.File.ImageDriver != "" { // nolint:staticcheck
 		fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 		if err != nil {
 			return fmt.Errorf("failed to create socketpair to pass file descriptor: %s", err)
@@ -1023,7 +1023,7 @@ func (e *EngineOperations) setSessionLayer(img *image.Image) error {
 
 	// overlay is handled by the image driver
 	if overlayDriver {
-		if e.EngineConfig.File.ImageDriver == "" {
+		if e.EngineConfig.File.ImageDriver == "" { // nolint:staticcheck
 			return fmt.Errorf("you need to specify an image driver with 'enable overlay = driver'")
 		}
 		if !writableImage || hasSIFOverlay {

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -903,20 +903,19 @@ func (l *Launcher) prepareImage(c context.Context, image string) error {
 	if (l.cfg.Namespaces.User || insideUserNs) && fs.IsFile(image) {
 		convert := true
 		// load image driver plugins
-		if l.engineConfig.File.ImageDriver != "" {
-
-			callbackType := (singularitycallback.RegisterImageDriver)(nil)
+		if l.engineConfig.File.ImageDriver != "" { // nolint:staticcheck
+			callbackType := (singularitycallback.RegisterImageDriver)(nil) // nolint:staticcheck
 			callbacks, err := plugin.LoadCallbacks(callbackType)
 			if err != nil {
 				sylog.Debugf("Loading plugins callbacks '%T' failed: %s", callbackType, err)
 			} else {
 				for _, callback := range callbacks {
-					if err := callback.(singularitycallback.RegisterImageDriver)(true); err != nil {
+					if err := callback.(singularitycallback.RegisterImageDriver)(true); err != nil { // nolint:staticcheck
 						sylog.Debugf("While registering image driver: %s", err)
 					}
 				}
 			}
-			driver := imgutil.GetDriver(l.engineConfig.File.ImageDriver)
+			driver := imgutil.GetDriver(l.engineConfig.File.ImageDriver) // nolint:staticcheck
 			if driver != nil && driver.Features()&imgutil.ImageFeature != 0 {
 				// the image driver indicates support for image so let's
 				// proceed with the image driver without conversion

--- a/pkg/plugin/callback/runtime/engine/singularity/singularity.go
+++ b/pkg/plugin/callback/runtime/engine/singularity/singularity.go
@@ -27,8 +27,11 @@ type MonitorContainer func(config *config.Common, pid int, signals chan os.Signa
 // - internal/pkg/runtime/engine/singularity/process_linux.go
 type PostStartProcess func(config *config.Common, pid int) error
 
-// RegisterImageDriver callback is called before the container
-// creation setup to register an image driver.
-// This callback is called in:
-// - internal/pkg/runtime/engine/singularity/container_linux.go
+// RegisterImageDriver callback is called before the container creation setup to
+// register an image driver. This callback is called in: -
+// internal/pkg/runtime/engine/singularity/container_linux.go
+//
+// Deprecated: Image driver plugins will not be supported from SingularityCE
+// 4.0. Handling of unprivilged overlays via plugin will be replaced with kernel
+// support.
 type RegisterImageDriver func(unprivileged bool) error

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -69,12 +69,13 @@ type File struct {
 	MksquashfsMem           string   `directive:"mksquashfs mem"`
 	NvidiaContainerCliPath  string   `directive:"nvidia-container-cli path"`
 	UnsquashfsPath          string   `directive:"unsquashfs path"`
-	ImageDriver             string   `directive:"image driver"`
-	DownloadConcurrency     uint     `default:"3" directive:"download concurrency"`
-	DownloadPartSize        uint     `default:"5242880" directive:"download part size"`
-	DownloadBufferSize      uint     `default:"32768" directive:"download buffer size"`
-	SystemdCgroups          bool     `default:"yes" authorized:"yes,no" directive:"systemd cgroups"`
-	SIFFUSE                 bool     `default:"no" authorized:"yes,no" directive:"sif fuse"`
+	// Deprecated: ImageDriver is deprecated and will be removed in 4.0.
+	ImageDriver         string `directive:"image driver"`
+	DownloadConcurrency uint   `default:"3" directive:"download concurrency"`
+	DownloadPartSize    uint   `default:"5242880" directive:"download part size"`
+	DownloadBufferSize  uint   `default:"32768" directive:"download buffer size"`
+	SystemdCgroups      bool   `default:"yes" authorized:"yes,no" directive:"systemd cgroups"`
+	SIFFUSE             bool   `default:"no" authorized:"yes,no" directive:"sif fuse"`
 }
 
 const TemplateAsset = `# SINGULARITY.CONF
@@ -440,6 +441,9 @@ shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }
 
 # IMAGE DRIVER: [STRING]
 # DEFAULT: Undefined
+#
+# DEPRECATED - Will be removed in 4.0.
+#
 # This option specifies the name of an image driver provided by a plugin that
 # will be used to handle image mounts. If the 'enable overlay' option is set
 # to 'driver' the driver name specified here will also be used to handle


### PR DESCRIPTION
## Description of the Pull Request (PR):

Mark the callback and the config entry for image driver plugins deprecated.

### This fixes or addresses the following GitHub issues:

 - Fixes #1051


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
