### PR TITLE
Point at sycloud.io SCS endpoints (release-3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Ensure `make dist` doesn't include conmon binary or intermediate files.
+- Point at sycloud.io for SCS endpoints to work around sylabs.io domain issue.
 
 ## 3.10.3 \[2022-10-06\]
 
@@ -1215,7 +1216,7 @@ This point release addresses the following issues:
   the existing container ecosystem
 - Added support for new URIs (`build` & `run/exec/shell/start`):
   - `library://` - Supports the
-    [Sylabs.io Cloud Library](https://cloud.sylabs.io/library)
+    [Sylabs Cloud Library](https://cloud.sylabs.io/library)
   - `docker-daemon:` - Supports images managed by the locally running docker
     daemon
   - `docker-archive:` - Supports archived docker images
@@ -1250,7 +1251,7 @@ This point release addresses the following issues:
 - Added `singularity capability` command to allow fine grained control over the
   capabilities of running containers
 - Added `singularity push` command to push images to the
-  [Sylabs.io Cloud Library](https://cloud.sylabs.io/library)
+  [Sylabs Cloud Library](https://cloud.sylabs.io/library)
 
 ### Changed Commands
 
@@ -1309,14 +1310,14 @@ This point release addresses the following issues:
   supports `sandbox` image types\]
 - The `singularity build` command now supports the following flags for
   integration with the
-  [Sylabs.io Cloud Library](https://cloud.sylabs.io/library):
+  [Sylabs Cloud Library](https://cloud.sylabs.io/library):
   - `-r|--remote`: Build the image remotely on the Sylabs Remote Builder
     (currently unavailable)
   - `-d|--detached`: Detach from the `stdout` of the remote build \[requires
     `--remote`\]
   - `--builder <string>`: Specifies the URL of the remote builder to access
   - `--library <string>`: Specifies the URL of the
-    [Sylabs.io Cloud Library](https://cloud.sylabs.io/library) to push the built
+    [Sylabs Cloud Library](https://cloud.sylabs.io/library) to push the built
     image to when the build command destination is in the form
     `library://<reference>`
 - The `bootstrap` keyword in the definition file now supports the following

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// LibraryProtocol holds the sylabs cloud library base URI,
-	// for more info refer to https://cloud.sylabs.io/library.
+	// for more info refer to https://cloud.sycloud.io/library.
 	LibraryProtocol = "library"
 	// ShubProtocol holds singularity hub base URI,
 	// for more info refer to https://singularity-hub.org/

--- a/docs/content.go
+++ b/docs/content.go
@@ -58,7 +58,7 @@ Enterprise Performance Computing (EPC)`
 
   Targets can also be remote and defined by a URI of the following formats:
 
-      library://  an image library (default https://cloud.sylabs.io/library)
+      library://  an image library (default https://cloud.sycloud.io/library)
       docker://   a Docker/OCI registry (default Docker Hub)
       shub://     a Singularity registry (default Singularity Hub)
       oras://     an OCI registry that holds SIF files using ORAS`
@@ -465,7 +465,7 @@ Enterprise Performance Computing (EPC)`
                       command group.)
 
   library://*         A SIF container hosted on a Library
-                      (default https://cloud.sylabs.io/library)
+                      (default https://cloud.sycloud.io/library)
 
   docker://*          A Docker/OCI container hosted on Docker Hub or another
                       OCI registry.
@@ -615,7 +615,7 @@ Enterprise Performance Computing (EPC)`
       oras://registry/namespace/image:tag
 
   http, https: Pull an image using the http(s?) protocol
-      https://library.sylabs.io/v1/imagefile/library/default/alpine:latest`
+      https://library.production.sycloud.io/v1/imagefile/library/default/alpine:latest`
 	PullExample string = `
   From Sylabs cloud library
   $ singularity pull alpine.sif library://alpine:latest
@@ -662,7 +662,7 @@ Enterprise Performance Computing (EPC)`
 	SearchShort string = `Search a Container Library for images`
 	SearchLong  string = `
   Search a Container Library for container images matching the search query.
-  (default cloud.sylabs.io). You can specify an alternate architecture, and/or limit
+  (default cloud.sycloud.io). You can specify an alternate architecture, and/or limit
   the results to only signed images.`
 	SearchExample string = `
   $ singularity search lolcow

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -20,7 +20,7 @@ const (
 
   A 'remote endpoint' is the Sylabs Cloud, a Singularity Enterprise installation,
   or a compatible group of services. The remote endpoint is a single address,
-  e.g. 'cloud.sylabs.io' through which linked library, builder and keystore
+  e.g. 'cloud.sycloud.io' through which linked library, builder and keystore
   sevices will be automatically discovered.
 
   To configure a remote endpoint you must 'remote add' it. You can 'remote login' if
@@ -52,7 +52,7 @@ const (
   be used for singularity remote services. Authentication with a newly created
   endpoint will occur automatically.`
 	RemoteAddExample string = `
-  $ singularity remote add SylabsCloud cloud.sylabs.io`
+  $ singularity remote add SylabsCloud cloud.sycloud.io`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote remove command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -96,7 +96,7 @@ const (
   an OCI/Docker registry or a keyserver.
 
   If no endpoint or registry is specified, the command will login to the currently
-  active remote endpoint. This is cloud.sylabs.io by default.`
+  active remote endpoint. This is cloud.sycloud.io by default.`
 	RemoteLoginExample string = `
   To log in to an endpoint:
   $ singularity remote login SylabsCloud

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -179,13 +179,13 @@ var tests = []testStruct{
 	{
 		desc:             "bad library URI",
 		srcURI:           "library://busybox:1.31.1",
-		library:          "https://bad-library.sylabs.io",
+		library:          "https://bad-library.production.sycloud.io",
 		expectedExitCode: 255,
 	},
 	{
 		desc:             "default library URI",
 		srcURI:           "library://busybox:1.31.1",
-		library:          "https://library.sylabs.io",
+		library:          "https://library.production.sycloud.io",
 		force:            true,
 		expectedExitCode: 0,
 	},
@@ -193,20 +193,20 @@ var tests = []testStruct{
 	// pulling with library URI containing host name and library argument
 	{
 		desc:             "library URI containing host name and library argument",
-		srcURI:           "library://notlibrary.sylabs.io/library/default/busybox:1.31.1",
-		library:          "https://notlibrary.sylabs.io",
+		srcURI:           "library://notlibrary.production.sycloud.io/library/default/busybox:1.31.1",
+		library:          "https://notlibrary.production.sycloud.io",
 		expectedExitCode: 255,
 	},
 
 	// pulling with library URI containing host name
 	{
 		desc:             "library URI containing bad host name",
-		srcURI:           "library://notlibrary.sylabs.io/library/default/busybox:1.31.1",
+		srcURI:           "library://notlibrary.production.sycloud.io/library/default/busybox:1.31.1",
 		expectedExitCode: 255,
 	},
 	{
 		desc:             "library URI containing host name",
-		srcURI:           "library://library.sylabs.io/library/default/busybox:1.31.1",
+		srcURI:           "library://library.production.sycloud.io/library/default/busybox:1.31.1",
 		force:            true,
 		expectedExitCode: 0,
 	},

--- a/e2e/pull/regressions.go
+++ b/e2e/pull/regressions.go
@@ -16,8 +16,8 @@ import (
 // with `--library https://library.sylabs.io` from the default Sylabs cloud library.
 func (c ctx) issue5808(t *testing.T) {
 	testEndpoint := "issue5808"
-	testEndpointURI := "https://cloud.staging.sylabs.io"
-	defaultLibraryURI := "https://library.sylabs.io"
+	testEndpointURI := "https://cloud.staging.sycloud.io"
+	defaultLibraryURI := "https://library.production.sycloud.io"
 	testImage := "library://sylabs/tests/signed:1.0.0"
 
 	pullDir, cleanup := e2e.MakeTempDir(t, "", "issue5808", "")

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -37,8 +37,8 @@ func (c ctx) remoteAdd(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"AddCloud", "cloud", "cloud.sylabs.io"},
-		{"AddOtherCloud", "other", "cloud.sylabs.io"},
+		{"AddCloud", "cloud", "cloud.sycloud.io"},
+		{"AddOtherCloud", "other", "cloud.sycloud.io"},
 	}
 
 	for _, tt := range testPass {
@@ -58,7 +58,7 @@ func (c ctx) remoteAdd(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"AddExistingRemote", "cloud", "cloud.sylabs.io"},
+		{"AddExistingRemote", "cloud", "cloud.sycloud.io"},
 		{"AddExistingRemoteInvalidURI", "other", "anythingcangohere"},
 	}
 
@@ -93,8 +93,8 @@ func (c ctx) remoteRemove(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"addCloud", "cloud", "cloud.sylabs.io"},
-		{"addOther", "other", "cloud.sylabs.io"},
+		{"addCloud", "cloud", "cloud.sycloud.io"},
+		{"addOther", "other", "cloud.sycloud.io"},
 	}
 
 	for _, tt := range add {
@@ -185,8 +185,8 @@ func (c ctx) remoteUse(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"addCloud", "cloud", "cloud.sylabs.io"},
-		{"addOther", "other", "cloud.sylabs.io"},
+		{"addCloud", "cloud", "cloud.sycloud.io"},
+		{"addOther", "other", "cloud.sycloud.io"},
 	}
 
 	for _, tt := range add {
@@ -240,7 +240,7 @@ func (c ctx) remoteStatus(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"addCloud", "cloud", "cloud.sylabs.io"},
+		{"addCloud", "cloud", "cloud.sycloud.io"},
 		{"addInvalidRemote", "invalid", "notarealendpoint"},
 	}
 
@@ -329,8 +329,8 @@ func (c ctx) remoteList(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"addCloud", "cloud", "cloud.sylabs.io"},
-		{"addRemote", "remote", "cloud.sylabs.io"},
+		{"addCloud", "cloud", "cloud.sycloud.io"},
+		{"addRemote", "remote", "cloud.sycloud.io"},
 	}
 
 	for _, tt := range add {
@@ -655,7 +655,7 @@ func (c ctx) remoteLoginRepeated(t *testing.T) {
 
 func (c ctx) remoteKeyserver(t *testing.T) {
 	var (
-		sylabsKeyserver = "https://keys.sylabs.io"
+		sylabsKeyserver = "https://keys.production.sycloud.io"
 		testKeyserver   = "http://localhost:11371"
 		addKeyserver    = "remote add-keyserver"
 		removeKeyserver = "remote remove-keyserver"
@@ -681,9 +681,9 @@ func (c ctx) remoteKeyserver(t *testing.T) {
 			command: addKeyserver,
 			args:    []string{"--insecure", testKeyserver},
 			listLines: []string{
-				"URI                     GLOBAL  INSECURE  ORDER",
+				"URI                                 GLOBAL  INSECURE  ORDER",
 				sylabsKeyserver + "  YES     NO        1*",
-				testKeyserver + "  YES     YES       2",
+				testKeyserver + "              YES     YES       2",
 			},
 			expectExit: 0,
 			profile:    e2e.RootProfile,
@@ -714,8 +714,8 @@ func (c ctx) remoteKeyserver(t *testing.T) {
 			command: addKeyserver,
 			args:    []string{"--order", "1", testKeyserver},
 			listLines: []string{
-				"URI                     GLOBAL  INSECURE  ORDER",
-				testKeyserver + "  YES     NO        1",
+				"URI                                 GLOBAL  INSECURE  ORDER",
+				testKeyserver + "              YES     NO        1",
 				sylabsKeyserver + "  YES     NO        2*",
 			},
 			expectExit: 0,
@@ -751,8 +751,8 @@ func (c ctx) remoteKeyserver(t *testing.T) {
 			command: addKeyserver,
 			args:    []string{sylabsKeyserver},
 			listLines: []string{
-				"URI                     GLOBAL  INSECURE  ORDER",
-				testKeyserver + "  YES     NO        1",
+				"URI                                 GLOBAL  INSECURE  ORDER",
+				testKeyserver + "              YES     NO        1",
 				sylabsKeyserver + "  YES     NO        2*",
 			},
 			expectExit: 0,
@@ -763,7 +763,7 @@ func (c ctx) remoteKeyserver(t *testing.T) {
 			command: removeKeyserver,
 			args:    []string{testKeyserver},
 			listLines: []string{
-				"URI                     GLOBAL  INSECURE  ORDER",
+				"URI                                 GLOBAL  INSECURE  ORDER",
 				sylabsKeyserver + "  YES     NO        1*",
 			},
 			expectExit: 0,

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -292,7 +292,7 @@ func (c ctx) checkURLOption(t *testing.T) {
 		t.Fatalf("image file (%s) does not exist", c.successImage)
 	}
 
-	cmdArgs := []string{"--legacy-insecure", "--url", "https://keys.sylabs.io", c.successImage}
+	cmdArgs := []string{"--legacy-insecure", "--url", "https://keys.production.sycloud.io", c.successImage}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),

--- a/etc/remote.yaml
+++ b/etc/remote.yaml
@@ -1,6 +1,6 @@
 Active: SylabsCloud
 Remotes:
   SylabsCloud:
-    URI: cloud.sylabs.io
+    URI: cloud.sycloud.io
     System: true
     Exclusive: false

--- a/internal/app/singularity/push.go
+++ b/internal/app/singularity/push.go
@@ -39,7 +39,7 @@ type LibraryPushSpec struct {
 	Description string
 	// AllowUnsigned must be set to true to allow push of an unsigned container image to succeed
 	AllowUnsigned bool
-	// FrontendURI is the URI for the frontend (ie. https://cloud.sylabs.io)
+	// FrontendURI is the URI for the frontend (ie. https://cloud.sycloud.io)
 	FrontendURI string
 }
 

--- a/internal/pkg/build/remotebuilder/remotebuilder_test.go
+++ b/internal/pkg/build/remotebuilder/remotebuilder_test.go
@@ -31,9 +31,9 @@ func TestBuild(t *testing.T) {
 		builderAddr   string
 	}{
 		{"BadBuilderURI", false, "ftp:?abc//foo.bar:abc"},
-		{"BadBuilderScheme", false, "ftp://build.sylabs.io"},
-		{"SuccessBuilderAddr", true, "http://build.sylabs.io"},
-		{"SuccessBuilderAddrSecure", true, "https://build.sylabs.io"},
+		{"BadBuilderScheme", false, "ftp://build.production.sycloud.io"},
+		{"SuccessBuilderAddr", true, "http://build.production.sycloud.io"},
+		{"SuccessBuilderAddrSecure", true, "https://build.production.sycloud.io"},
 	}
 
 	// Loop over test cases

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryURL = "https://library.sylabs.io/"
+	libraryURL = "https://library.production.sycloud.io/"
 	libraryURI = "library://alpine:latest"
 )
 

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -24,10 +24,10 @@ const defaultTimeout = 10 * time.Second
 
 // Default Sylabs cloud service endpoints.
 const (
-	SCSDefaultCloudURI     = "cloud.sylabs.io"
-	SCSDefaultLibraryURI   = "https://library.sylabs.io"
-	SCSDefaultKeyserverURI = "https://keys.sylabs.io"
-	SCSDefaultBuilderURI   = "https://build.sylabs.io"
+	SCSDefaultCloudURI     = "cloud.sycloud.io"
+	SCSDefaultLibraryURI   = "https://library.production.sycloud.io"
+	SCSDefaultKeyserverURI = "https://keys.production.sycloud.io"
+	SCSDefaultBuilderURI   = "https://build.production.sycloud.io"
 )
 
 // SCS cloud services

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -64,7 +64,7 @@ func TestWriteToReadFrom(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -144,7 +144,7 @@ func TestSyncFrom(t *testing.T) {
 			usr: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -152,7 +152,7 @@ func TestSyncFrom(t *testing.T) {
 			res: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -162,7 +162,7 @@ func TestSyncFrom(t *testing.T) {
 			sys: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token", // should be ignored by SyncFrom
 					},
 				},
@@ -170,7 +170,7 @@ func TestSyncFrom(t *testing.T) {
 			usr: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -178,11 +178,11 @@ func TestSyncFrom(t *testing.T) {
 			res: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -192,7 +192,7 @@ func TestSyncFrom(t *testing.T) {
 			sys: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token", // should be ignored by SyncFrom
 					},
 				},
@@ -200,11 +200,11 @@ func TestSyncFrom(t *testing.T) {
 			usr: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -212,11 +212,11 @@ func TestSyncFrom(t *testing.T) {
 			res: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -226,7 +226,7 @@ func TestSyncFrom(t *testing.T) {
 			sys: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token", // should be ignored by SyncFrom
 					},
 				},
@@ -238,7 +238,7 @@ func TestSyncFrom(t *testing.T) {
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -246,11 +246,11 @@ func TestSyncFrom(t *testing.T) {
 			res: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -261,7 +261,7 @@ func TestSyncFrom(t *testing.T) {
 				DefaultRemote: "sylabs-global",
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token", // should be ignored by SyncFrom
 					},
 				},
@@ -273,7 +273,7 @@ func TestSyncFrom(t *testing.T) {
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -282,11 +282,11 @@ func TestSyncFrom(t *testing.T) {
 				DefaultRemote: "sylabs-global",
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -297,7 +297,7 @@ func TestSyncFrom(t *testing.T) {
 				DefaultRemote: "sylabs-global",
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token", // should be ignored by SyncFrom
 					},
 				},
@@ -310,7 +310,7 @@ func TestSyncFrom(t *testing.T) {
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -319,11 +319,11 @@ func TestSyncFrom(t *testing.T) {
 				DefaultRemote: "sylabs",
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -349,7 +349,7 @@ func TestSyncFrom(t *testing.T) {
 			sys: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -357,11 +357,11 @@ func TestSyncFrom(t *testing.T) {
 			usr: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 					"sylabs-global": {
-						URI: "cloud.sylabs.io",
+						URI: "cloud.sycloud.io",
 					},
 				},
 			},
@@ -397,14 +397,14 @@ func TestAddRemote(t *testing.T) {
 				DefaultRemote: "",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
 			},
 			id: "cloud",
 			ep: &endpoint.Config{
-				URI:   "cloud.sylabs.io",
+				URI:   "cloud.sycloud.io",
 				Token: testToken,
 			},
 		},
@@ -427,14 +427,14 @@ func TestAddRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
 			},
 			id: "cloud",
 			ep: &endpoint.Config{
-				URI:   "cloud.sylabs.io",
+				URI:   "cloud.sycloud.io",
 				Token: testToken,
 			},
 		},
@@ -458,14 +458,14 @@ func TestAddRemote(t *testing.T) {
 			DefaultRemote: "",
 			Remotes: map[string]*endpoint.Config{
 				"cloud": {
-					URI:   "cloud.sylabs.io",
+					URI:   "cloud.sycloud.io",
 					Token: testToken,
 				},
 			},
 		},
 		id: "cloud",
 		ep: &endpoint.Config{
-			URI:   "cloud.sylabs.io",
+			URI:   "cloud.sycloud.io",
 			Token: testToken,
 		},
 	}
@@ -485,7 +485,7 @@ func TestRemoveRemote(t *testing.T) {
 				DefaultRemote: "",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -505,7 +505,7 @@ func TestRemoveRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -531,7 +531,7 @@ func TestRemoveRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -585,7 +585,7 @@ func TestRenameRemote(t *testing.T) {
 				DefaultRemote: "",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -594,7 +594,7 @@ func TestRenameRemote(t *testing.T) {
 				DefaultRemote: "",
 				Remotes: map[string]*endpoint.Config{
 					"newCloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -612,7 +612,7 @@ func TestRenameRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -625,7 +625,7 @@ func TestRenameRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"newCloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -678,7 +678,7 @@ func TestRenameRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -708,14 +708,14 @@ func TestGetRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
 			},
 			id: "cloud",
 			ep: &endpoint.Config{
-				URI:   "cloud.sylabs.io",
+				URI:   "cloud.sycloud.io",
 				Token: testToken,
 			},
 		},
@@ -742,7 +742,7 @@ func TestGetRemote(t *testing.T) {
 				DefaultRemote: "cloud",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -771,13 +771,13 @@ func TestGetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
 			},
 			ep: &endpoint.Config{
-				URI:   "cloud.sylabs.io",
+				URI:   "cloud.sycloud.io",
 				Token: testToken,
 			},
 		},
@@ -808,7 +808,7 @@ func TestGetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -820,7 +820,7 @@ func TestGetDefaultRemote(t *testing.T) {
 				DefaultRemote: "notaremote",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -848,7 +848,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -861,7 +861,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -889,7 +889,7 @@ func TestSetDefaultRemote(t *testing.T) {
 				DefaultRemote: "cloud",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -917,7 +917,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -932,7 +932,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token:     testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -963,7 +963,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -990,7 +990,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:       "cloud.sylabs.io",
+						URI:       "cloud.sycloud.io",
 						Exclusive: true,
 						Token:     testToken,
 					},
@@ -1073,7 +1073,7 @@ func TestGetServiceURI(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -1107,7 +1107,7 @@ func TestGetServiceURI(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},


### PR DESCRIPTION
## Description of the Pull Request (PR):

Due to issues with the sylabs.io domain, SCS endpoints are currently hosted at sycloud.io.

Adjust references in the code to unblock CI and development work at this point. The URIs are expected to remain valid on restoration of the sylabs.io domain, but this PR is likely to be rolled back.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
