### PR TITLE
feat: Allow kernel supported unpriv overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   deprecated and will be removed in 4.0. Support for the example plugin,
   permitting Ubuntu unprivileged overlay functionality, will be replaced with a
   non-plugin implementation.
+- When the kernel supports unprivileged overlay mounts in a user
+  namespace, the container will be constructed using an overlay
+  instead of underlay layout.
 
 ### Development / Testing
 
@@ -49,6 +52,9 @@
   - May fail if the `%post` script requires privileged operations that `proot`
     cannot emulate.
 - Add new Linux capabilities: `CAP_PERFMON`, `CAP_BPF`, `CAP_CHECKPOINT_RESTORE`.
+- `--writable-tmpfs` is now available when running unprivileged, or
+  explicitly requesting a user namespace, on systems with a kernel
+  that supports unprivileged overlay mounts in a user namespace.
 
 ### Bug Fixes
 

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -353,23 +353,6 @@ func (c configTests) configGlobal(t *testing.T) {
 			directiveValue: "no",
 			exit:           1,
 		},
-		// use user namespace profile to force underlay use
-		{
-			name:           "EnableUnderlayNo",
-			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
-			profile:        e2e.UserNamespaceProfile,
-			directive:      "enable underlay",
-			directiveValue: "no",
-			exit:           255,
-		},
-		{
-			name:           "EnableUnderlayYes",
-			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
-			profile:        e2e.UserNamespaceProfile,
-			directive:      "enable underlay",
-			directiveValue: "yes",
-			exit:           0,
-		},
 		// test image is owned by root:root
 		{
 			name:           "LimitContainerOwnersUser",
@@ -723,6 +706,28 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 				"allow net users": u.Name,
 			},
 			exit: 255,
+		},
+		// disable overlay to force underlay
+		{
+			name:    "EnableUnderlayNo",
+			argv:    []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile: e2e.UserProfile,
+			directives: map[string]string{
+				"enable overlay":  "no",
+				"enable underlay": "no",
+			},
+
+			exit: 255,
+		},
+		{
+			name:    "EnableUnderlayYes",
+			argv:    []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile: e2e.UserProfile,
+			directives: map[string]string{
+				"enable overlay":  "no",
+				"enable underlay": "yes",
+			},
+			exit: 0,
 		},
 	}
 

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -6,8 +6,15 @@
 package overlay
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
 
+	"github.com/sylabs/singularity/internal/pkg/util/bin"
+	"github.com/sylabs/singularity/pkg/sylog"
 	"golang.org/x/sys/unix"
 )
 
@@ -120,4 +127,72 @@ func IsIncompatible(err error) bool {
 		return true
 	}
 	return false
+}
+
+var ErrNoRootlessOverlay = errors.New("rootless overlay not supported by kernel")
+
+// CheckRootless checks whether the kernel overlay driver supports unprivileged use in a user namespace.
+func CheckRootless() error {
+	mountBin, err := bin.FindBin("mount")
+	if err != nil {
+		return fmt.Errorf("while looking for mount command: %s", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "check-overlay")
+	if err != nil {
+		return fmt.Errorf("while creating temporary directories: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	lowerDir := filepath.Join(tmpDir, "l")
+	if err := os.Mkdir(lowerDir, 0o777); err != nil {
+		return fmt.Errorf("while creating temporary directories: %w", err)
+	}
+	upperDir := filepath.Join(tmpDir, "u")
+	if err := os.Mkdir(upperDir, 0o777); err != nil {
+		return fmt.Errorf("while creating temporary directories: %w", err)
+	}
+	workDir := filepath.Join(tmpDir, "w")
+	if err := os.Mkdir(workDir, 0o777); err != nil {
+		return fmt.Errorf("while creating temporary directories: %w", err)
+	}
+	mountDir := filepath.Join(tmpDir, "m")
+	if err := os.Mkdir(mountDir, 0o777); err != nil {
+		return fmt.Errorf("while creating temporary directories: %w", err)
+	}
+
+	args := []string{
+		"-t", "overlay",
+		"-o", fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,userxattr", lowerDir, upperDir, workDir),
+		"none",
+		mountDir,
+	}
+
+	cmd := exec.Command(mountBin, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	// Unshare user and mount namespace
+	cmd.SysProcAttr.Unshareflags = syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS
+	// Map to user to root inside the user namespace
+	cmd.SysProcAttr.UidMappings = []syscall.SysProcIDMap{
+		{
+			ContainerID: 0,
+			HostID:      os.Getuid(),
+			Size:        1,
+		},
+	}
+	cmd.SysProcAttr.GidMappings = []syscall.SysProcIDMap{
+		{
+			ContainerID: 0,
+			HostID:      os.Getgid(),
+			Size:        1,
+		},
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		sylog.Debugf("Rootless overlay not supported on this system: %s\n%s", err, out)
+		return ErrNoRootlessOverlay
+	}
+
+	sylog.Debugf("Rootless overlay appears supported on this system.")
+	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

When we are running a container in a user namespace, check whether the kernel supports rootless overlay. If it does, use this instead of underlay.

At present, the visible effects of this are that:

* When running under a user namespace, on a supported system, the overlay session layout is used. The rootfs in the container will appear as an overlay fs mount.

* When running under a user namespace, on a supported system, the `--writable-tmpfs` option can be used, with the same semantics as in set-uid mode.

Note that this changeset does not allow unprivileged persistent overlays (singularity `--overlay` flag). It will be possible to enable
unprivileged overlay directory mounts at a later point, and potentially other overlay mounts via FUSE drivers.

The principle benefit at this stage is to avoid the complex, and numerous, bind mounts used by the underlay layout.

ToDo: Refactor the underlay / overlay handling to a simpler, more linear flow.

**Testing note** - CircleCI is using an Ubuntu 22.04 image that supports unprivileged overlay. The non-unpriv overlay flow can be tested on e.g. CentOS 7.

### This fixes or addresses the following GitHub issues:

 - Fixes #818

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
