### PR TITLE
fix: correct CAPSET_MAX for changes in #1072

### DIFF
--- a/cmd/starter/c/include/capability.h
+++ b/cmd/starter/c/include/capability.h
@@ -16,8 +16,8 @@
 
 /* 2.6.32 kernel is the minimal kernel version supported where latest cap is 33 */
 #define CAPSET_MIN  33
-/* 37 is the latest cap since many kernel versions */
-#define CAPSET_MAX  37
+/* 40 is the latest cap since kernel 5.9 */
+#define CAPSET_MAX  40
 
 /* Support only 64 bits sets, since kernel 2.6.26 */
 #ifdef _LINUX_CAPABILITY_VERSION_3


### PR DESCRIPTION
## Description of the Pull Request (PR):

In #1072, additional capabilities were added in Go code. The C starter code uses a loop up to CAPSET_MAX when reconciling capabilities vs supported on the machine. Because CAPSET_MAX was still 37, not 40, it failed to trim the 3 upper capabilities that are unsupported on older kernels.

Correct CAPSET_MAX to fix the issue on older kernels.


### This fixes or addresses the following GitHub issues:

 - Fixes #1079


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
