### PR TITLE
feat: run action for OCI bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
           command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q update
       - run:
           name: Install dependencies
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin runc libglib2.0-dev squashfuse
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin crun libglib2.0-dev squashfuse
       - run:
           name: Install proot
           command: |-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,12 +107,17 @@ commands:
           command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q update
       - run:
           name: Install dependencies
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin crun libglib2.0-dev squashfuse
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin libglib2.0-dev squashfuse
       - run:
           name: Install proot
           command: |-
             <<# parameters.sudo >>sudo <</ parameters.sudo >>curl -L -o /usr/local/bin/proot https://proot.gitlab.io/proot/bin/proot
             <<# parameters.sudo >>sudo <</ parameters.sudo >>chmod +x /usr/local/bin/proot
+      - run:
+          name: Install crun
+          command: |-
+            <<# parameters.sudo >>sudo <</ parameters.sudo >>curl -L -o /usr/local/bin/crun https://github.com/containers/crun/releases/download/1.6/crun-1.6-linux-amd64
+            <<# parameters.sudo >>sudo <</ parameters.sudo >>chmod +x /usr/local/bin/crun
 
   configure-singularity:
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - When the kernel supports unprivileged overlay mounts in a user
   namespace, the container will be constructed using an overlay
   instead of underlay layout.
+- `crun` will be used as the low-level OCI runtime, when available, rather than
+  `runc`. `runc` will not support all rootless OCI runtime functionality used by
+  Singularity.
 
 ### Development / Testing
 

--- a/cmd/internal/cli/instance_start_linux.go
+++ b/cmd/internal/cli/instance_start_linux.go
@@ -39,14 +39,14 @@ var instanceStartCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		image := args[0]
 		name := args[1]
-
-		a := append([]string{"/.singularity.d/actions/start"}, args[2:]...)
+		containerCmd := "/.singularity.d/actions/start"
+		containerArgs := args[2:]
 		setVM(cmd)
 		if vm {
-			execVM(cmd, image, a)
+			execVM(cmd, image, containerCmd, containerArgs)
 			return
 		}
-		if err := launchContainer(cmd, image, a, name); err != nil {
+		if err := launchContainer(cmd, image, containerCmd, containerArgs, name); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 

--- a/cmd/internal/cli/startvm.go
+++ b/cmd/internal/cli/startvm.go
@@ -28,7 +28,7 @@ func getHypervisorArgs(sifImage, bzImage, initramfs, singAction, cliExtra string
 	return args
 }
 
-func execVM(cmd *cobra.Command, image string, args []string) {
+func execVM(cmd *cobra.Command, image string, containerCmd string, containerArgs []string) {
 	// SIF image we are running
 	sifImage := image
 
@@ -42,8 +42,8 @@ func execVM(cmd *cobra.Command, image string, args []string) {
 		isInternal = true
 	} else {
 		// Get our "action" (run, exec, shell) based on the action script being called
-		singAction = filepath.Base(args[0])
-		cliExtra = strings.Join(args[1:], " ")
+		singAction = filepath.Base(containerCmd)
+		cliExtra = strings.Join(containerArgs, " ")
 	}
 
 	if err := startVM(sifImage, singAction, cliExtra, isInternal); err != nil {

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2406,24 +2406,6 @@ func countSquashfuseMounts(t *testing.T) int {
 	return count
 }
 
-func (c actionTests) ociRuntime(t *testing.T) {
-	e2e.EnsureImage(t, c.env)
-
-	for _, p := range []e2e.Profile{e2e.OCIUserProfile, e2e.OCIRootProfile} {
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(p.String()),
-			e2e.WithProfile(p),
-			e2e.WithCommand("exec"),
-			e2e.WithArgs(c.env.ImagePath, "/bin/true"),
-			e2e.ExpectExit(
-				255,
-				e2e.ExpectError(e2e.ContainMatch, "not implemented"),
-			),
-		)
-	}
-}
-
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := actionTests{
@@ -2466,9 +2448,12 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"umask":                     c.actionUmask,             // test umask propagation
 		"no-mount":                  c.actionNoMount,           // test --no-mount
 		"compat":                    c.actionCompat,            // test --compat
-		"ociRuntime":                c.ociRuntime,              // test --oci (unimplemented)
 		"invalidRemote":             np(c.invalidRemote),       // GHSA-5mv9-q7fq-9394
 		"SIFFUSE":                   np(c.actionSIFFUSE),       // test --sif-fuse
 		"NoSIFFUSE":                 np(c.actionNoSIFFUSE),     // test absence of squashfs and CleanupHost()
+		//
+		// OCI Runtime Mode
+		//
+		"ociRun": c.actionOciRun, // singularity run --oci
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package actions
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
+)
+
+func (c actionTests) ociBundle(t *testing.T) (string, func()) {
+	require.Seccomp(t)
+	require.Filesystem(t, "overlay")
+
+	bundleDir, err := os.MkdirTemp(c.env.TestDir, "bundle-")
+	if err != nil {
+		err = errors.Wrapf(err, "creating temporary bundle directory at %q", c.env.TestDir)
+		t.Fatalf("failed to create bundle directory: %+v", err)
+	}
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("oci mount"),
+		e2e.WithArgs(c.env.ImagePath, bundleDir),
+		e2e.ExpectExit(0),
+	)
+
+	cleanup := func() {
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.RootProfile),
+			e2e.WithCommand("oci umount"),
+			e2e.WithArgs(bundleDir),
+			e2e.ExpectExit(0),
+		)
+		os.RemoveAll(bundleDir)
+	}
+
+	return bundleDir, cleanup
+}
+
+func (c actionTests) actionOciRun(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	bundle, cleanup := c.ociBundle(t)
+	defer cleanup()
+
+	tests := []struct {
+		name string
+		argv []string
+		exit int
+	}{
+		{
+			name: "NoCommand",
+			argv: []string{bundle},
+			exit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIRootProfile),
+			e2e.WithCommand("run"),
+			// While we don't support args we are entering a /bin/sh interactively, so we need to exit.
+			e2e.ConsoleRun(e2e.ConsoleSendLine("exit")),
+			e2e.WithArgs(tt.argv...),
+			e2e.ExpectExit(tt.exit),
+		)
+	}
+}

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -76,6 +76,7 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 	}
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("mount"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci mount"),
 		e2e.WithArgs(c.env.ImagePath, bundleDir),
@@ -85,6 +86,7 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 	cleanup := func() {
 		c.env.RunSingularity(
 			t,
+			e2e.AsSubtest("umount"),
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("oci umount"),
 			e2e.WithArgs(bundleDir),
@@ -141,6 +143,7 @@ func (c ctx) testOciAttach(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("create"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci create"),
 		e2e.WithArgs("-b", bundleDir, containerID),
@@ -159,6 +162,7 @@ func (c ctx) testOciAttach(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("start"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci start"),
 		e2e.WithArgs(containerID),
@@ -172,6 +176,7 @@ func (c ctx) testOciAttach(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("attach"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci attach"),
 		e2e.WithArgs(containerID),
@@ -190,6 +195,7 @@ func (c ctx) testOciAttach(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("delete"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci delete"),
 		e2e.WithArgs(containerID),
@@ -208,6 +214,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("create"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci create"),
 		e2e.WithArgs("-b", bundleDir, containerID),
@@ -226,6 +233,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("start"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci start"),
 		e2e.WithArgs(containerID),
@@ -239,6 +247,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("pause"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci pause"),
 		e2e.WithArgs(containerID),
@@ -256,6 +265,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("resume"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci resume"),
 		e2e.WithArgs(containerID),
@@ -273,6 +283,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("start again"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci start"),
 		e2e.WithArgs(containerID),
@@ -281,6 +292,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("exec"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci exec"),
 		e2e.WithArgs(containerID, "hostname"),
@@ -290,6 +302,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("kill"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci kill"),
 		e2e.WithArgs(containerID, "KILL"),
@@ -303,6 +316,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("delete"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci delete"),
 		e2e.WithArgs(containerID),
@@ -311,6 +325,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("state fail"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci state"),
 		e2e.WithArgs(containerID),
@@ -318,6 +333,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 	)
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("kill fail"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci kill"),
 		e2e.WithArgs(containerID),
@@ -325,6 +341,7 @@ func (c ctx) testOciBasic(t *testing.T) {
 	)
 	c.env.RunSingularity(
 		t,
+		e2e.AsSubtest("start fail"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci start"),
 		e2e.WithArgs(containerID),
@@ -416,7 +433,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 				t.Run("basic", c.testOciBasic)
 				t.Run("attach", c.testOciAttach)
 				t.Run("run", c.testOciRun)
-				t.Run("help", c.testOciHelp)
 			})),
+		"help": c.testOciHelp,
 	}
 }

--- a/internal/pkg/runtime/launcher/launcher.go
+++ b/internal/pkg/runtime/launcher/launcher.go
@@ -25,5 +25,5 @@ type Launcher interface {
 	// the container#s initial process. If instanceName is specified, the
 	// container must be launched as a background instance, otherwist it must
 	// run interactively, attached to the console.
-	Exec(ctx context.Context, image string, args []string, instanceName string) error
+	Exec(ctx context.Context, image string, cmd string, args []string, instanceName string) error
 }

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -93,8 +93,11 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 // This includes interactive containers, instances, and joining an existing instance.
 //
 //nolint:maintidx
-func (l *Launcher) Exec(ctx context.Context, image string, args []string, instanceName string) error {
+func (l *Launcher) Exec(ctx context.Context, image string, cmd string, args []string, instanceName string) error {
 	var err error
+
+	// Native runtime expects command to execute as arg[0]
+	args = append([]string{cmd}, args...)
 
 	// Set arguments to pass to contained process.
 	l.generator.SetProcessArgs(args)

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/runtime/launcher"
 )
@@ -232,7 +233,23 @@ func checkOpts(lo launcher.Options) error {
 	return nil
 }
 
-// Exec is not yet implemented.
-func (l *Launcher) Exec(ctx context.Context, image string, args []string, instanceName string) error {
-	return ErrNotImplemented
+// Exec will interactively execute a container via the runc low-level runtime.
+func (l *Launcher) Exec(ctx context.Context, image string, cmd string, args []string, instanceName string) error {
+	if instanceName != "" {
+		return fmt.Errorf("%w: instanceName", ErrNotImplemented)
+	}
+
+	if cmd != "" {
+		return fmt.Errorf("%w: cmd %v", ErrNotImplemented, cmd)
+	}
+
+	if len(args) > 0 {
+		return fmt.Errorf("%w: args %v", ErrNotImplemented, args)
+	}
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return fmt.Errorf("while generating container id: %w", err)
+	}
+	return Run(ctx, id.String(), image, "")
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -6,7 +6,6 @@
 package oci
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -52,16 +51,5 @@ func TestNewLauncher(t *testing.T) {
 				t.Errorf("NewLauncher() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestExec(t *testing.T) {
-	l, err := NewLauncher([]launcher.Option{}...)
-	if err != nil {
-		t.Errorf("Couldn't initialize launcher: %s", err)
-	}
-
-	if err := l.Exec(context.Background(), "", []string{}, ""); err != ErrNotImplemented {
-		t.Errorf("Expected %v, got %v", ErrNotImplemented, err)
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/oci_conmon_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_conmon_linux.go
@@ -39,7 +39,7 @@ func Create(containerID, bundlePath string) error {
 	if err != nil {
 		return err
 	}
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
@@ -92,12 +92,12 @@ func Create(containerID, bundlePath string) error {
 		"--cid", containerID,
 		"--name", containerID,
 		"--cuuid", containerUUID.String(),
-		"--runtime", runc,
+		"--runtime", runtimeBin,
 		"--conmon-pidfile", path.Join(sd, conmonPidFile),
 		"--container-pidfile", path.Join(sd, containerPidFile),
 		"--log-path", path.Join(sd, containerLogFile),
 		"--runtime-arg", "--root",
-		"--runtime-arg", runcStateDir,
+		"--runtime-arg", runtimeStateDir(),
 		"--runtime-arg", "--log",
 		"--runtime-arg", path.Join(sd, runcLogFile),
 		"--full-attach",

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -21,21 +21,21 @@ import (
 
 // Delete deletes container resources
 func Delete(ctx context.Context, containerID string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"delete",
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	err = cmd.Run()
 	if err != nil {
 		return fmt.Errorf("while calling runc delete: %w", err)
@@ -63,88 +63,88 @@ func Delete(ctx context.Context, containerID string) error {
 
 // Exec executes a command in a container
 func Exec(containerID string, cmdArgs []string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"exec",
 		containerID,
 	}
-	runcArgs = append(runcArgs, cmdArgs...)
-	cmd := exec.Command(runc, runcArgs...)
+	runtimeArgs = append(runtimeArgs, cmdArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Kill kills container process
 func Kill(containerID string, killSignal string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"kill",
 		containerID,
 		killSignal,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Pause pauses processes in a container
 func Pause(containerID string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"pause",
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Resume pauses processes in a container
 func Resume(containerID string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"resume",
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Run runs a container (equivalent to create/start/delete)
 func Run(ctx context.Context, containerID, bundlePath, pidFile string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
@@ -157,80 +157,80 @@ func Run(ctx context.Context, containerID, bundlePath, pidFile string) error {
 		return fmt.Errorf("failed to change directory to %s: %s", absBundle, err)
 	}
 
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"run",
 		"-b", absBundle,
 	}
 	if pidFile != "" {
-		runcArgs = append(runcArgs, "--pid-file="+pidFile)
+		runtimeArgs = append(runtimeArgs, "--pid-file="+pidFile)
 	}
-	runcArgs = append(runcArgs, containerID)
-	cmd := exec.Command(runc, runcArgs...)
+	runtimeArgs = append(runtimeArgs, containerID)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Start starts a previously created container
 func Start(containerID string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := bin.FindBin("crun")
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"start",
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // State queries container state
 func State(containerID string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"state",
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
 // Update updates container cgroups resources
 func Update(containerID, cgFile string) error {
-	runc, err := bin.FindBin("runc")
+	runtimeBin, err := runtime()
 	if err != nil {
 		return err
 	}
-	runcArgs := []string{
-		"--root", runcStateDir,
+	runtimeArgs := []string{
+		"--root", runtimeStateDir(),
 		"update",
 		"-r", cgFile,
 		containerID,
 	}
 
-	cmd := exec.Command(runc, runcArgs...)
+	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
-	sylog.Debugf("Calling runc with args %v", runcArgs)
+	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -36,7 +36,7 @@ func FindBin(name string) (path string, err error) {
 	case "newuidmap", "newgidmap":
 		return findOnPath(name)
 	// distro provided OCI runtime
-	case "runc":
+	case "crun", "runc":
 		return findOnPath(name)
 	// our, or distro provided conmon
 	case "conmon":


### PR DESCRIPTION
## Description of the Pull Request (PR):

As a first step toward run/shell/exec actions on native OCI images, implement a minimal `singularity run --oci mybundle` which:

* Requires an on-disk bundle with appropriate `config.json`.
* Runs this bundle using `crun` or `runc`.
* Makes no attempt to handle any arguments or options.
* Does not modify the `config.json` - i.e. it must match namespace / mapping requirements for rootless execution etc.

At this stage, the functionality is essentially equivalent to `singularity oci run` and is not yet useful.

The primary purpose of the PR is to refactor some of the code that passes args for launching a container.

In addition, we now use `crun` in preference to `runc` if available. `crun` supports e.g. single uid->uid mapping in a usernamespace (without root mapping).

### This fixes or addresses the following GitHub issues:

 - Fixes #598

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
