### PR TITLE
e2e: Use local http source for cache tests

### DIFF
--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -6,11 +6,15 @@
 package cache
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"path"
 	"path/filepath"
 	"testing"
 
-	"github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
 	"github.com/sylabs/singularity/internal/pkg/cache"
@@ -21,17 +25,20 @@ type cacheTests struct {
 	env e2e.TestEnv
 }
 
-const (
-	imgName = "alpine_latest.sif"
-	imgURL  = "library://alpine:latest"
-)
+const imgName = "alpine_latest.sif"
 
-func prepTest(t *testing.T, testEnv e2e.TestEnv, testName string, cacheParentDir string, imagePath string) {
+func prepTest(t *testing.T, testEnv e2e.TestEnv, testName string, cacheParentDir string, imagePath string) (imageURL string, cleanup func()) {
+	// We will pull images from a temporary http server
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, testEnv.ImagePath)
+	}))
+	cleanup = srv.Close
+
 	// If the test imageFile is already present check it's not also in the cache
 	// at the start of our test - we expect to pull it again and then see it
 	// appear in the cache.
 	if fs.IsFile(imagePath) {
-		ensureNotCached(t, testName, imagePath, cacheParentDir)
+		ensureNotCached(t, testName, srv.URL, cacheParentDir)
 	}
 
 	testEnv.UnprivCacheDir = cacheParentDir
@@ -39,11 +46,12 @@ func prepTest(t *testing.T, testEnv e2e.TestEnv, testName string, cacheParentDir
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("pull"),
-		e2e.WithArgs([]string{"--force", imagePath, imgURL}...),
+		e2e.WithArgs([]string{"--force", imagePath, srv.URL}...),
 		e2e.ExpectExit(0),
 	)
 
-	ensureCached(t, testName, imagePath, cacheParentDir)
+	ensureCached(t, testName, srv.URL, cacheParentDir)
+	return srv.URL, cleanup
 }
 
 func (c cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
@@ -95,7 +103,7 @@ func (c cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
 		},
 		{
 			name:               "list type",
-			options:            []string{"list", "--type", "library"},
+			options:            []string{"list", "--type", "net"},
 			needImage:          true,
 			expectedOutput:     "There are 1 container file",
 			expectedEmptyCache: false,
@@ -124,8 +132,11 @@ func (c cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
 			t.Fatalf("Could not create image cache handle: %v", err)
 		}
 
+		imageURL := ""
 		if tt.needImage {
-			prepTest(t, c.env, tt.name, cacheDir, imagePath)
+			var srvCleanup func()
+			imageURL, srvCleanup = prepTest(t, c.env, tt.name, cacheDir, imagePath)
+			defer srvCleanup()
 		}
 
 		c.env.UnprivCacheDir = cacheDir
@@ -139,7 +150,7 @@ func (c cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
 		)
 
 		if tt.needImage && tt.expectedEmptyCache {
-			ensureNotCached(t, tt.name, imagePath, cacheDir)
+			ensureNotCached(t, tt.name, imageURL, cacheDir)
 		}
 	}
 }
@@ -183,7 +194,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		},
 		{
 			name:               "clean type confirmed",
-			options:            []string{"clean", "--type", "library"},
+			options:            []string{"clean", "--type", "net"},
 			expect:             "Do you want to continue? [N/y]",
 			send:               "y",
 			expectedEmptyCache: true,
@@ -191,7 +202,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		},
 		{
 			name:               "clean type not confirmed",
-			options:            []string{"clean", "--type", "library"},
+			options:            []string{"clean", "--type", "net"},
 			expect:             "Do you want to continue? [N/y]",
 			send:               "n",
 			expectedEmptyCache: false,
@@ -230,7 +241,8 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		}
 
 		c.env.UnprivCacheDir = cacheDir
-		prepTest(t, c.env, tc.name, cacheDir, imagePath)
+		imageURL, srvCleanup := prepTest(t, c.env, tc.name, cacheDir, imagePath)
+		defer srvCleanup()
 
 		c.env.RunSingularity(
 			t,
@@ -247,22 +259,22 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 
 		// Check the content of the cache
 		if tc.expectedEmptyCache {
-			ensureNotCached(t, tc.name, imagePath, cacheDir)
+			ensureNotCached(t, tc.name, imageURL, cacheDir)
 		} else {
-			ensureCached(t, tc.name, imagePath, cacheDir)
+			ensureCached(t, tc.name, imageURL, cacheDir)
 		}
 	}
 }
 
 // ensureNotCached checks the entry related to an image is not in the cache
-func ensureNotCached(t *testing.T, testName string, imagePath string, cacheParentDir string) {
-	shasum, err := client.ImageHash(imagePath)
+func ensureNotCached(t *testing.T, testName string, imageURL string, cacheParentDir string) {
+	shasum, err := netHash(imageURL)
 	if err != nil {
-		t.Fatalf("couldn't compute hash of image %s: %v", imagePath, err)
+		t.Fatalf("couldn't compute hash of image %s: %v", imageURL, err)
 	}
 
 	// Where the cached image should be
-	cacheImagePath := path.Join(cacheParentDir, "cache", "library", shasum)
+	cacheImagePath := path.Join(cacheParentDir, "cache", "net", shasum)
 
 	// The image file shouldn't be present
 	if e2e.PathExists(t, cacheImagePath) {
@@ -271,19 +283,36 @@ func ensureNotCached(t *testing.T, testName string, imagePath string, cacheParen
 }
 
 // ensureCached checks the entry related to an image is really in the cache
-func ensureCached(t *testing.T, testName string, imagePath string, cacheParentDir string) {
-	shasum, err := client.ImageHash(imagePath)
+func ensureCached(t *testing.T, testName string, imageURL string, cacheParentDir string) {
+	shasum, err := netHash(imageURL)
 	if err != nil {
-		t.Fatalf("couldn't compute hash of image %s: %v", imagePath, err)
+		t.Fatalf("couldn't compute hash of image %s: %v", imageURL, err)
 	}
 
 	// Where the cached image should be
-	cacheImagePath := path.Join(cacheParentDir, "cache", "library", shasum)
+	cacheImagePath := path.Join(cacheParentDir, "cache", "net", shasum)
 
 	// The image file shouldn't be present
 	if !e2e.PathExists(t, cacheImagePath) {
 		t.Fatalf("%s failed: %s is not in the cache (%s)", testName, imgName, cacheImagePath)
 	}
+}
+
+// netHash computes the expected cache hash for the image at url
+func netHash(url string) (hash string, err error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("error constructing http request: %w", err)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error making http request: %w", err)
+	}
+
+	headerDate := res.Header.Get("Last-Modified")
+	h := sha256.New()
+	h.Write([]byte(url + headerDate))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // E2ETests is the main func to trigger the test suite


### PR DESCRIPTION
## Description of the Pull Request (PR):

When testing the cache commands in the e2e tests, pull from a local http server, rather than the library. This dramatically speeds up the time taken to run these tests, which are necessarily sequential.

```
Before

--- PASS: TestE2E/SEQ/CACHE (121.30s)

After

--- PASS: TestE2E/SEQ/CACHE (4.94s)
```

### This fixes or addresses the following GitHub issues:

 - Fixes #1089

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
