### PR TITLE
Minimize e2e library / docker pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,10 @@ executors:
   ubuntu-machine:
     machine:
       image: ubuntu-2004:202111-02
+  ubuntu-machine-large:
+    machine:
+      image: ubuntu-2004:202111-02
+    resource_class: large
 
 commands:
   update-submodules:
@@ -218,7 +222,7 @@ jobs:
           command: make -C ./builddir integration-test
 
   e2e-tests:
-    executor: ubuntu-machine
+    executor: ubuntu-machine-large
     steps:
       - checkout
       - check-changes

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -53,36 +53,23 @@ func (c ctx) testDockerPulls(t *testing.T) {
 		exit    int
 	}{
 		{
-			name:  "AlpineLatestPull",
+			name:  "BusyboxLatestPull",
 			image: tmpImage,
-			uri:   "docker://alpine:latest",
+			uri:   "docker://busybox:latest",
 			exit:  0,
-		},
-		{
-			name:  "Alpine3.9Pull",
-			image: filepath.Join(tmpPath, "alpine.sif"),
-			uri:   "docker://alpine:3.9",
-			exit:  0,
-		},
-		{
-			name:    "Alpine3.9ForcePull",
-			options: []string{"--force"},
-			image:   tmpImage,
-			uri:     "docker://alpine:3.9",
-			exit:    0,
-		},
-		{
-			name:    "BusyboxLatestPull",
-			options: []string{"--force"},
-			image:   tmpImage,
-			uri:     "docker://busybox:latest",
-			exit:    0,
 		},
 		{
 			name:  "BusyboxLatestPullFail",
 			image: tmpImage,
 			uri:   "docker://busybox:latest",
 			exit:  255,
+		},
+		{
+			name:    "BusyboxLatestPullForce",
+			options: []string{"--force"},
+			image:   tmpImage,
+			uri:     "docker://busybox:latest",
+			exit:    0,
 		},
 		{
 			name:    "Busybox1.28Pull",
@@ -231,7 +218,7 @@ func (c ctx) testDockerHost(t *testing.T) {
 					e2e.AsSubtest(tt.name),
 					e2e.WithProfile(e2e.UserProfile),
 					e2e.WithCommand("pull"),
-					e2e.WithArgs(tmpImage, pullURI),
+					e2e.WithArgs("--disable-cache", tmpImage, pullURI),
 					e2e.ExpectExit(tt.exit),
 				)
 			})
@@ -242,7 +229,7 @@ func (c ctx) testDockerHost(t *testing.T) {
 					e2e.AsSubtest(tt.name),
 					e2e.WithProfile(e2e.UserProfile),
 					e2e.WithCommand("pull"),
-					e2e.WithArgs(tmpImage, pullURI),
+					e2e.WithArgs("--disable-cache", tmpImage, pullURI),
 					e2e.ExpectExit(tt.exit),
 				)
 			})
@@ -401,44 +388,20 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 		archRequired        string
 		from                string
 	}{
-		// This only provides Arch for amd64
 		{
-			name:                "Arch",
+			name:                "Alpine",
+			kernelMajorRequired: 0,
+			from:                "alpine:latest",
+		},
+		{
+			name:                "AlmaLinux_9",
 			kernelMajorRequired: 3,
-			archRequired:        "amd64",
-			from:                "dock0/arch:latest",
+			from:                "almalinux:9",
 		},
 		{
-			name:                "BusyBox",
-			kernelMajorRequired: 0,
-			from:                "busybox:latest",
-		},
-		// CentOS6 is for amd64 (or i386) only
-		{
-			name:                "CentOS_6",
-			kernelMajorRequired: 0,
-			archRequired:        "amd64",
-			from:                "centos:6",
-		},
-		{
-			name:                "CentOS_7",
-			kernelMajorRequired: 0,
-			from:                "centos:7",
-		},
-		{
-			name:                "AlmaLinux_8",
+			name:                "Ubuntu_2204",
 			kernelMajorRequired: 3,
-			from:                "almalinux:8",
-		},
-		{
-			name:                "Ubuntu_1604",
-			kernelMajorRequired: 0,
-			from:                "ubuntu:16.04",
-		},
-		{
-			name:                "Ubuntu_1804",
-			kernelMajorRequired: 3,
-			from:                "ubuntu:18.04",
+			from:                "ubuntu:22.04",
 		},
 	}
 
@@ -523,7 +486,7 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 			t,
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
-			e2e.WithArgs("--no-https", imagePath, defFile),
+			e2e.WithArgs("--disable-cache", "--no-https", imagePath, defFile),
 			e2e.PostRun(func(t *testing.T) {
 				defer os.Remove(imagePath)
 				defer os.Remove(defFile)
@@ -870,16 +833,14 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	}
 
 	return testhelper.Tests{
-		// Run all docker:// source tests sequentially amongst themselves, so we
+		// Run most docker:// source tests sequentially amongst themselves, so we
 		// don't hit DockerHub massively in parallel, and we benefit from
 		// caching as the same images are used frequently.
 		"ordered": func(t *testing.T) {
 			t.Run("AUFS", c.testDockerAUFS)
 			t.Run("def file", c.testDockerDefFile)
-			t.Run("docker host", c.testDockerHost)
 			t.Run("permissions", c.testDockerPermissions)
 			t.Run("pulls", c.testDockerPulls)
-			t.Run("registry", c.testDockerRegistry)
 			t.Run("whiteout symlink", c.testDockerWhiteoutSymlink)
 			t.Run("labels", c.testDockerLabels)
 			t.Run("cmd", c.testDockerCMD)
@@ -888,9 +849,15 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("cmd quotes", c.testDockerCMDQuotes)
 			// Regressions
 			t.Run("issue 4524", c.issue4524)
-			t.Run("issue 4943", c.issue4943)
-			t.Run("issue 5172", c.issue5172)
-			t.Run("issue 274", c.issue274) // https://github.com/sylabs/singularity/issues/274
 		},
+		// Tests that are especially slow, or run against a local docker
+		// registry, can be run in parallel, with `--disable-cache` used within
+		// them to avoid docker caching concurrency issues.
+		"docker host": c.testDockerHost,
+		"registry":    c.testDockerRegistry,
+		// Regressions
+		"issue 4943": c.issue4943,
+		"issue 5172": c.issue5172,
+		"issue 274":  c.issue274, // https://github.com/sylabs/singularity/issues/274
 	}
 }

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -71,7 +71,7 @@ func (c ctx) issue4943(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs("--force", "/dev/null", image),
+		e2e.WithArgs("--disable-cache", "--force", "/dev/null", image),
 		e2e.ExpectExit(0),
 	)
 }
@@ -103,7 +103,7 @@ func (c ctx) issue5172(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs("--sandbox", imagePath, regImage),
+		e2e.WithArgs("--disable-cache", "--sandbox", imagePath, regImage),
 		e2e.PostRun(func(t *testing.T) {
 			if !t.Failed() {
 				os.RemoveAll(imagePath)
@@ -116,7 +116,7 @@ func (c ctx) issue5172(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("pull"),
-		e2e.WithArgs(imagePath, regImage),
+		e2e.WithArgs("--disable-cache", imagePath, regImage),
 		e2e.PostRun(func(t *testing.T) {
 			if !t.Failed() {
 				os.RemoveAll(imagePath)
@@ -158,12 +158,13 @@ From: continuumio/miniconda3:latest
 		t.Fatalf("Unable to create test definition file: %v", err)
 	}
 
+	// Run build with cache disabled, so we can be a parallel test (we are slooow!)
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("build"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs(imagePath, defFile),
+		e2e.WithArgs("--disable-cache", imagePath, defFile),
 		e2e.ExpectExit(0),
 	)
 	// An exec of `conda info` in the container should show environment active, no errors.

--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -8,6 +8,7 @@ package ecl
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -16,11 +17,15 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/syecl"
 )
 
-// KeyMap contains test keys.
-var KeyMap = map[string]string{
-	"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
-	"key2": "78F8AD36B0DCB84B707F23853D608DAE21C8CA10",
-}
+var (
+	// KeyMap contains test keys.
+	KeyMap = map[string]string{
+		"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
+		"key2": "78F8AD36B0DCB84B707F23853D608DAE21C8CA10",
+	}
+
+	busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
+)
 
 type ctx struct {
 	env e2e.TestEnv
@@ -88,7 +93,7 @@ func (c *ctx) eclConfig(t *testing.T) {
 			name:    "build signed image",
 			command: "build",
 			profile: e2e.UserProfile,
-			args:    []string{signed, "library://busybox"},
+			args:    []string{signed, busyboxSIF},
 			exit:    0,
 		},
 		{

--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -8,7 +8,6 @@ package ecl
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -17,15 +16,11 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/syecl"
 )
 
-var (
-	// KeyMap contains test keys.
-	KeyMap = map[string]string{
-		"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
-		"key2": "78F8AD36B0DCB84B707F23853D608DAE21C8CA10",
-	}
-
-	busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
-)
+// KeyMap contains test keys.
+var KeyMap = map[string]string{
+	"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
+	"key2": "78F8AD36B0DCB84B707F23853D608DAE21C8CA10",
+}
 
 type ctx struct {
 	env e2e.TestEnv
@@ -93,7 +88,7 @@ func (c *ctx) eclConfig(t *testing.T) {
 			name:    "build signed image",
 			command: "build",
 			profile: e2e.UserProfile,
-			args:    []string{signed, busyboxSIF},
+			args:    []string{signed, e2e.BusyboxSIF(t)},
 			exit:    0,
 		},
 		{

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -11,6 +11,7 @@ package singularityenv
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -29,12 +30,13 @@ const (
 )
 
 func (c ctx) singularityEnv(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
 	// Singularity defines a path by default. See singularityware/singularity/etc/init.
-	defaultImage := "library://alpine:3.11.5"
-
+	defaultImage := "testdata/busybox_" + runtime.GOARCH + ".sif"
 	// This image sets a custom path.
-	customImage := "library://lolcow"
-	customPath := "/usr/games:" + defaultPath
+	// See e2e/testdata/Singularity
+	customImage := c.env.ImagePath
+	customPath := defaultPath + ":/go/bin:/usr/local/go/bin"
 
 	// Append or prepend this path.
 	partialPath := "/foo"
@@ -124,8 +126,12 @@ func (c ctx) singularityEnv(t *testing.T) {
 
 func (c ctx) singularityEnvOption(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
-
-	imageDefaultPath := defaultPath + ":/go/bin:/usr/local/go/bin"
+	// Singularity defines a path by default. See singularityware/singularity/etc/init.
+	defaultImage := "testdata/busybox_" + runtime.GOARCH + ".sif"
+	// This image sets a custom path.
+	// See e2e/testdata/Singularity
+	customImage := c.env.ImagePath
+	customPath := defaultPath + ":/go/bin:/usr/local/go/bin"
 
 	tests := []struct {
 		name     string
@@ -137,102 +143,102 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 	}{
 		{
 			name:     "DefaultPath",
-			image:    "library://alpine:3.11.5",
+			image:    defaultImage,
 			matchEnv: "PATH",
 			matchVal: defaultPath,
 		},
 		{
 			name:     "DefaultPathOverride",
-			image:    "library://alpine:3.11.5",
+			image:    defaultImage,
 			envOpt:   []string{"PATH=/"},
 			matchEnv: "PATH",
 			matchVal: "/",
 		},
 		{
 			name:     "AppendDefaultPath",
-			image:    "library://alpine:3.11.5",
+			image:    defaultImage,
 			envOpt:   []string{"APPEND_PATH=/foo"},
 			matchEnv: "PATH",
 			matchVal: defaultPath + ":/foo",
 		},
 		{
 			name:     "PrependDefaultPath",
-			image:    "library://alpine:3.11.5",
+			image:    defaultImage,
 			envOpt:   []string{"PREPEND_PATH=/foo"},
 			matchEnv: "PATH",
 			matchVal: "/foo:" + defaultPath,
 		},
 		{
-			name:     "DefaultPathTestImage",
-			image:    c.env.ImagePath,
+			name:     "DefaultPathImage",
+			image:    customImage,
 			matchEnv: "PATH",
-			matchVal: imageDefaultPath,
+			matchVal: customPath,
 		},
 		{
 			name:     "DefaultPathTestImageOverride",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			envOpt:   []string{"PATH=/"},
 			matchEnv: "PATH",
 			matchVal: "/",
 		},
 		{
 			name:     "AppendDefaultPathTestImage",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			envOpt:   []string{"APPEND_PATH=/foo"},
 			matchEnv: "PATH",
-			matchVal: imageDefaultPath + ":/foo",
+			matchVal: customPath + ":/foo",
 		},
 		{
 			name:     "AppendLiteralDefaultPathTestImage",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			envOpt:   []string{"PATH=$PATH:/foo"},
 			matchEnv: "PATH",
-			matchVal: imageDefaultPath + ":/foo",
+			matchVal: customPath + ":/foo",
 		},
 		{
 			name:     "PrependDefaultPathTestImage",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			envOpt:   []string{"PREPEND_PATH=/foo"},
 			matchEnv: "PATH",
-			matchVal: "/foo:" + imageDefaultPath,
+			matchVal: "/foo:" + customPath,
 		},
 		{
 			name:     "PrependLiteralDefaultPathTestImage",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			envOpt:   []string{"PATH=/foo:$PATH"},
 			matchEnv: "PATH",
-			matchVal: "/foo:" + imageDefaultPath,
+			matchVal: "/foo:" + customPath,
 		},
 		{
 			name:     "TestImageCgoEnabledDefault",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			matchEnv: "CGO_ENABLED",
 			matchVal: "0",
 		},
 		{
 			name:     "TestImageCgoEnabledOverride",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			envOpt:   []string{"CGO_ENABLED=1"},
 			matchEnv: "CGO_ENABLED",
 			matchVal: "1",
 		},
 		{
 			name:     "TestImageCgoEnabledOverride_KO",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			hostEnv:  []string{"CGO_ENABLED=1"},
 			matchEnv: "CGO_ENABLED",
 			matchVal: "0",
 		},
 		{
 			name:     "TestImageCgoEnabledOverrideFromEnv",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			hostEnv:  []string{"SINGULARITYENV_CGO_ENABLED=1"},
 			matchEnv: "CGO_ENABLED",
 			matchVal: "1",
 		},
 		{
 			name:     "TestImageCgoEnabledOverrideEnvOptionPrecedence",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			hostEnv:  []string{"SINGULARITYENV_CGO_ENABLED=1"},
 			envOpt:   []string{"CGO_ENABLED=2"},
 			matchEnv: "CGO_ENABLED",
@@ -240,14 +246,14 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 		},
 		{
 			name:     "TestImageCgoEnabledOverrideEmpty",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			envOpt:   []string{"CGO_ENABLED="},
 			matchEnv: "CGO_ENABLED",
 			matchVal: "",
 		},
 		{
 			name:     "TestImageOverrideHost",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			hostEnv:  []string{"FOO=bar"},
 			envOpt:   []string{"FOO=foo"},
 			matchEnv: "FOO",
@@ -255,21 +261,21 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 		},
 		{
 			name:     "TestMultiLine",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			hostEnv:  []string{"MULTI=Hello\nWorld"},
 			matchEnv: "MULTI",
 			matchVal: "Hello\nWorld",
 		},
 		{
 			name:     "TestEscapedNewline",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			hostEnv:  []string{"ESCAPED=Hello\\nWorld"},
 			matchEnv: "ESCAPED",
 			matchVal: "Hello\\nWorld",
 		},
 		{
 			name:  "TestInvalidKey",
-			image: c.env.ImagePath,
+			image: customImage,
 			// We try to set an invalid env var... and make sure
 			// we have no error output from the interpreter as it
 			// should be ignored, not passed into the container.
@@ -279,20 +285,20 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 		},
 		{
 			name:     "TestDefaultLdLibraryPath",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: singularityLibs,
 		},
 		{
 			name:     "TestCustomTrailingCommaPath",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo,"},
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo,:" + singularityLibs,
 		},
 		{
 			name:     "TestCustomLdLibraryPath",
-			image:    c.env.ImagePath,
+			image:    customImage,
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo"},
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo:" + singularityLibs,

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -11,7 +11,6 @@ package singularityenv
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -32,7 +31,7 @@ const (
 func (c ctx) singularityEnv(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 	// Singularity defines a path by default. See singularityware/singularity/etc/init.
-	defaultImage := "testdata/busybox_" + runtime.GOARCH + ".sif"
+	defaultImage := e2e.BusyboxSIF(t)
 	// This image sets a custom path.
 	// See e2e/testdata/Singularity
 	customImage := c.env.ImagePath
@@ -127,7 +126,7 @@ func (c ctx) singularityEnv(t *testing.T) {
 func (c ctx) singularityEnvOption(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 	// Singularity defines a path by default. See singularityware/singularity/etc/init.
-	defaultImage := "testdata/busybox_" + runtime.GOARCH + ".sif"
+	defaultImage := e2e.BusyboxSIF(t)
 	// This image sets a custom path.
 	// See e2e/testdata/Singularity
 	customImage := c.env.ImagePath

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"runtime"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -25,12 +24,11 @@ func (c ctx) issue5426(t *testing.T) {
 	defer cleanup(t)
 
 	// Build a current sandbox
-	busyboxSIF := "testdata/busybox_" + runtime.GOARCH + ".sif"
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs("--force", "--sandbox", sandboxDir, busyboxSIF),
+		e2e.WithArgs("--force", "--sandbox", sandboxDir, e2e.BusyboxSIF(t)),
 		e2e.ExpectExit(0),
 	)
 

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -24,11 +25,12 @@ func (c ctx) issue5426(t *testing.T) {
 	defer cleanup(t)
 
 	// Build a current sandbox
+	busyboxSIF := "testdata/busybox_" + runtime.GOARCH + ".sif"
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs("--force", "--sandbox", sandboxDir, "library://alpine:3.11.5"),
+		e2e.WithArgs("--force", "--sandbox", sandboxDir, busyboxSIF),
 		e2e.ExpectExit(0),
 	)
 

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -23,7 +23,10 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
-var testFileContent = "Test file content\n"
+var (
+	testFileContent = "Test file content\n"
+	busyboxSIF      = "testdata/busybox_" + runtime.GOARCH + ".sif"
+)
 
 type imgBuildTests struct {
 	env e2e.TestEnv
@@ -84,6 +87,10 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 		// 	name:       "ShubDefFile",
 		// 	buildSpec:  "../examples/shub/Singularity",
 		// },
+		{
+			name:      "LibraryURI",
+			buildSpec: "library://alpine:3.11.5",
+		},
 		{
 			name:      "LibraryDefFile",
 			buildSpec: "../examples/library/Singularity",
@@ -174,11 +181,11 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 	}{
 		{
 			name:      "local sif",
-			buildSpec: "testdata/busybox_" + runtime.GOARCH + ".sif",
+			buildSpec: busyboxSIF,
 		},
 		{
 			name:      "local sif to sandbox",
-			buildSpec: "testdata/busybox_" + runtime.GOARCH + ".sif",
+			buildSpec: busyboxSIF,
 			args:      []string{"--sandbox"},
 		},
 		{
@@ -337,8 +344,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 			name: "FileCopySimple",
 			dfd: []e2e.DefFileDetails{
 				{
-					Bootstrap: "library",
-					From:      "alpine:3.11.5",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					Stage:     "one",
 					Files: []e2e.FilePair{
 						{
@@ -352,8 +359,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "library",
-					From:      "alpine:3.11.5",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					FilesFrom: []e2e.FileSection{
 						{
 							Stage: "one",
@@ -389,8 +396,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 			name: "FileCopyComplex",
 			dfd: []e2e.DefFileDetails{
 				{
-					Bootstrap: "library",
-					From:      "alpine:3.11.5",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					Stage:     "one",
 					Files: []e2e.FilePair{
 						{
@@ -404,8 +411,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "library",
-					From:      "alpine:3.11.5",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					Stage:     "two",
 					Files: []e2e.FilePair{
 						{
@@ -419,8 +426,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "library",
-					From:      "alpine:3.11.5",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					Stage:     "three",
 					FilesFrom: []e2e.FileSection{
 						{
@@ -452,8 +459,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "library",
-					From:      "alpine:3.11.5",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					FilesFrom: []e2e.FileSection{
 						{
 							Stage: "three",
@@ -538,12 +545,12 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 
 	tt := map[string]e2e.DefFileDetails{
 		"Empty": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 		},
 		"Help": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Help: []string{
 				"help info line 1",
 				"help info line 2",
@@ -551,8 +558,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Files": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Files: []e2e.FilePair{
 				{
 					Src: tmpfile,
@@ -565,8 +572,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Test": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Test: []string{
 				"echo testscript line 1",
 				"echo testscript line 2",
@@ -574,8 +581,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Startscript": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			StartScript: []string{
 				"echo startscript line 1",
 				"echo startscript line 2",
@@ -583,8 +590,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Runscript": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			RunScript: []string{
 				"echo runscript line 1",
 				"echo runscript line 2",
@@ -592,8 +599,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Env": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Env: []string{
 				"testvar1=one",
 				"testvar2=two",
@@ -601,8 +608,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Labels": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Labels: map[string]string{
 				"customLabel1": "one",
 				"customLabel2": "two",
@@ -610,29 +617,29 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Pre": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Pre: []string{
 				filepath.Join(c.env.TestDir, "PreFile1"),
 			},
 		},
 		"Setup": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Setup: []string{
 				filepath.Join(c.env.TestDir, "SetupFile1"),
 			},
 		},
 		"Post": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Post: []string{
 				"PostFile1",
 			},
 		},
 		"AppHelp": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -653,8 +660,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppEnv": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -675,8 +682,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppLabels": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -697,8 +704,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppFiles": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -729,8 +736,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppInstall": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -747,8 +754,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppRun": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -769,8 +776,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppTest": {
-			Bootstrap: "library",
-			From:      "alpine:3.11.5",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -866,7 +873,7 @@ func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 
 	// First with the command line argument
 	imgPath1 := filepath.Join(dn, "encrypted_cmdline_option.sif")
-	cmdArgs := []string{"--encrypt", "--pem-path", pemFile, imgPath1, "library://alpine:latest"}
+	cmdArgs := []string{"--encrypt", "--pem-path", pemFile, imgPath1, busyboxSIF}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -885,7 +892,7 @@ func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 	// Second with the environment variable
 	pemEnvVar := fmt.Sprintf("%s=%s", "SINGULARITY_ENCRYPTION_PEM_PATH", pemFile)
 	imgPath2 := filepath.Join(dn, "encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", imgPath2, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", imgPath2, busyboxSIF}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -930,7 +937,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	}
 	cmdlineTestImgPath := filepath.Join(dn, "encrypted_cmdline_option.sif")
 	// The image is deleted during cleanup of the temporary directory
-	cmdArgs := []string{"--passphrase", cmdlineTestImgPath, "library://alpine:latest"}
+	cmdArgs := []string{"--passphrase", cmdlineTestImgPath, busyboxSIF}
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("passphrase flag"),
@@ -950,7 +957,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 
 	// With the command line argument, using --encrypt and --passphrase
 	cmdlineTest2ImgPath := filepath.Join(dn, "encrypted_cmdline2_option.sif")
-	cmdArgs = []string{"--encrypt", "--passphrase", cmdlineTest2ImgPath, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", "--passphrase", cmdlineTest2ImgPath, busyboxSIF}
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("encrypt and passphrase flags"),
@@ -971,7 +978,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	// With the environment variable
 	passphraseEnvVar := fmt.Sprintf("%s=%s", "SINGULARITY_ENCRYPTION_PASSPHRASE", e2e.Passphrase)
 	envvarImgPath := filepath.Join(dn, "encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", envvarImgPath, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", envvarImgPath, busyboxSIF}
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("passphrase env var"),
@@ -991,7 +998,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 
 	// Finally a test that must fail: try to specify the passphrase on the command line
 	dummyImgPath := filepath.Join(dn, "dummy_encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", "--passphrase", e2e.Passphrase, dummyImgPath, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", "--passphrase", e2e.Passphrase, dummyImgPath, busyboxSIF}
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("passphrase on cmdline"),
@@ -1100,7 +1107,7 @@ func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 		{
 			name:    "build single signed source image",
 			command: "build",
-			args:    []string{singleSigned, "library://busybox"},
+			args:    []string{singleSigned, busyboxSIF},
 		},
 		{
 			name:    "build double signed source image",

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -23,10 +22,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
-var (
-	testFileContent = "Test file content\n"
-	busyboxSIF      = "testdata/busybox_" + runtime.GOARCH + ".sif"
-)
+var testFileContent = "Test file content\n"
 
 type imgBuildTests struct {
 	env e2e.TestEnv
@@ -173,6 +169,7 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 }
 
 func (c imgBuildTests) nonRootBuild(t *testing.T) {
+	busyboxSIF := e2e.BusyboxSIF(t)
 	tt := []struct {
 		name        string
 		buildSpec   string
@@ -328,6 +325,7 @@ func (c imgBuildTests) badPath(t *testing.T) {
 }
 
 func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
+	busyboxSIF := e2e.BusyboxSIF(t)
 	tmpfile, err := e2e.WriteTempFile(c.env.TestDir, "testFile-", testFileContent)
 	if err != nil {
 		log.Fatal(err)
@@ -537,6 +535,7 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 
 //nolint:maintidx
 func (c imgBuildTests) buildDefinition(t *testing.T) {
+	busyboxSIF := e2e.BusyboxSIF(t)
 	tmpfile, err := e2e.WriteTempFile(c.env.TestDir, "testFile-", testFileContent)
 	if err != nil {
 		log.Fatal(err)
@@ -848,6 +847,8 @@ func (c *imgBuildTests) ensureImageIsEncrypted(t *testing.T, imgPath string) {
 }
 
 func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
+	busyboxSIF := e2e.BusyboxSIF(t)
+
 	// Expected results for a successful command execution
 	expectedExitCode := 0
 	expectedStderr := ""
@@ -914,6 +915,8 @@ func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 // while using a passphrase. Note that it covers both the normal case and when the
 // version of cryptsetup available is not compliant.
 func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
+	busyboxSIF := e2e.BusyboxSIF(t)
+
 	// Expected results for a successful command execution
 	expectedExitCode := 0
 	expectedStderr := ""
@@ -1107,7 +1110,7 @@ func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 		{
 			name:    "build single signed source image",
 			command: "build",
-			args:    []string{singleSigned, busyboxSIF},
+			args:    []string{singleSigned, e2e.BusyboxSIF(t)},
 		},
 		{
 			name:    "build double signed source image",

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -404,13 +404,15 @@ func (c *imgBuildTests) issue3848(t *testing.T) {
 	defer os.Remove(tmpfile) // clean up
 
 	d := struct {
+		From string
 		File string
 	}{
+		From: busyboxSIF,
 		File: tmpfile,
 	}
 
-	defTmpl := `Bootstrap: library
-From: alpine:3.11.5
+	defTmpl := `Bootstrap: localimage
+From: {{ .From }}
 
 %files
 	{{ .File }}

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -407,7 +407,7 @@ func (c *imgBuildTests) issue3848(t *testing.T) {
 		From string
 		File string
 	}{
-		From: busyboxSIF,
+		From: e2e.BusyboxSIF(t),
 		File: tmpfile,
 	}
 

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -76,4 +76,17 @@ func PullImage(t *testing.T, env TestEnv, imageURL string, arch string, path str
 		WithArgs("--force", "--allow-unsigned", "--arch", arch, path, imageURL),
 		ExpectExit(0),
 	)
+}
+
+// BusyboxImage will provide the path to a local busybox SIF image for the current architecture
+func BusyboxSIF(t *testing.T) string {
+	busyboxSIF := "testdata/busybox_" + runtime.GOARCH + ".sif"
+	_, err := os.Stat(busyboxSIF)
+	if os.IsNotExist(err) {
+		t.Fatalf("busybox image not found for %s", runtime.GOARCH)
+	}
+	if err != nil {
+		t.Error(err)
+	}
+	return busyboxSIF
 }

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
@@ -17,12 +16,11 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
-var busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
-
 func (c ctx) testOverlayCreate(t *testing.T) {
 	require.Filesystem(t, "overlay")
 	require.MkfsExt3(t)
 	e2e.EnsureImage(t, c.env)
+	busyboxSIF := e2e.BusyboxSIF(t)
 
 	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "overlay", "")
 	defer cleanup(t)

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
@@ -15,6 +16,8 @@ import (
 type ctx struct {
 	env e2e.TestEnv
 }
+
+var busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
 
 func (c ctx) testOverlayCreate(t *testing.T) {
 	require.Filesystem(t, "overlay")
@@ -38,7 +41,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs(sifSignedImage, "library://busybox:1.31.1"),
+		e2e.WithArgs(sifSignedImage, busyboxSIF),
 		e2e.ExpectExit(0),
 	)
 
@@ -65,7 +68,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs(sifImage, "library://busybox:1.31.1"),
+		e2e.WithArgs(sifImage, busyboxSIF),
 		e2e.ExpectExit(0),
 	)
 
@@ -161,7 +164,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 			t,
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
-			e2e.WithArgs("--encrypt", sifEncryptedImage, "library://busybox:1.31.1"),
+			e2e.WithArgs("--encrypt", sifEncryptedImage, busyboxSIF),
 			e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
 			e2e.ExpectExit(0),
 		)

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -19,6 +20,8 @@ import (
 type ctx struct {
 	env e2e.TestEnv
 }
+
+var busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
 
 // testRun555Cache tests the specific case where the cache directory is
 // 0555 for access rights, and we try to run a singularity run command
@@ -34,7 +37,7 @@ func (c ctx) testRun555Cache(t *testing.T) {
 	}
 	// Directory is deleted when tempDir is deleted
 
-	cmdArgs := []string{"library://lolcow"}
+	cmdArgs := []string{"library://alpine:3.11.5", "true"}
 	// We explicitly pass the environment to the command, not through c.env.ImgCacheDir
 	// because c.env is shared between all the tests, something we do not want here.
 	cacheDirEnv := fmt.Sprintf("%s=%s", cache.DirEnv, cacheDir)
@@ -66,7 +69,7 @@ func (c ctx) testRunPEMEncrypted(t *testing.T) {
 	defer cleanup(t)
 
 	imgPath := filepath.Join(tempDir, "encrypted_cmdline_pem-path.sif")
-	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, "library://alpine:3.11.5"}
+	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, busyboxSIF}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -116,7 +119,7 @@ func (c ctx) testRunPassphraseEncrypted(t *testing.T) {
 	defer cleanup(t)
 
 	imgPath := filepath.Join(tempDir, "encrypted_cmdline_passphrase.sif")
-	cmdArgs := []string{"--encrypt", imgPath, "library://alpine:3.11.5"}
+	cmdArgs := []string{"--encrypt", imgPath, busyboxSIF}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.RootProfile),

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -20,8 +19,6 @@ import (
 type ctx struct {
 	env e2e.TestEnv
 }
-
-var busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
 
 // testRun555Cache tests the specific case where the cache directory is
 // 0555 for access rights, and we try to run a singularity run command
@@ -69,7 +66,7 @@ func (c ctx) testRunPEMEncrypted(t *testing.T) {
 	defer cleanup(t)
 
 	imgPath := filepath.Join(tempDir, "encrypted_cmdline_pem-path.sif")
-	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, busyboxSIF}
+	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, e2e.BusyboxSIF(t)}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -119,7 +116,7 @@ func (c ctx) testRunPassphraseEncrypted(t *testing.T) {
 	defer cleanup(t)
 
 	imgPath := filepath.Join(tempDir, "encrypted_cmdline_passphrase.sif")
-	cmdArgs := []string{"--encrypt", imgPath, busyboxSIF}
+	cmdArgs := []string{"--encrypt", imgPath, e2e.BusyboxSIF(t)}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.RootProfile),

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -8,7 +8,6 @@ package sign
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -23,8 +22,6 @@ type ctx struct {
 }
 
 const imgName = "testImage.sif"
-
-var busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
 
 func (c ctx) singularitySignHelpOption(t *testing.T) {
 	c.env.KeyringDir = c.keyringDir
@@ -48,7 +45,7 @@ func (c *ctx) prepareImage(t *testing.T) (string, func(*testing.T)) {
 	}
 	imgPath := filepath.Join(tempDir, imgName)
 
-	err = fs.CopyFile(busyboxSIF, imgPath, 0o755)
+	err = fs.CopyFile(e2e.BusyboxSIF(t), imgPath, 0o755)
 	if err != nil {
 		t.Fatalf("failed to copy temporary image: %s", err)
 	}

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -77,7 +77,7 @@ func (c ctx) singularitySignIDOption(t *testing.T) {
 		},
 		{
 			name:       "sign non-exsistent ID",
-			args:       []string{"--sif-id", "5", imgPath},
+			args:       []string{"--sif-id", "9", imgPath},
 			expectOp:   e2e.ExpectError(e2e.ContainMatch, "integrity: object not found"),
 			expectExit: 255,
 		},


### PR DESCRIPTION
## Description of the Pull Request (PR):

As much as easily possible, replace use of a library pull with a local busybox or built alpine test image.

Remove redundant docker pulls, that aren't really testing anything additional.
    
Move docker tests that are very slow, or pulling from local registries, to be parallel again. Modify these tests so that they use `--disable-cache` to avoid docker cache concurrency issues. The other ordered tests are checking the path pulling through the cache.

With these changes, e2e parallelism is better, so it is sensible to use a `resource_class: large` VM for e2e only.

### This fixes or addresses the following GitHub issues:

 - Fixes #913 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
