### PR TITLE
chore(ci): update to Ubuntu 22.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,10 @@ executors:
       - image: golangci/golangci-lint:v1.50
   ubuntu-machine:
     machine:
-      image: ubuntu-2004:202111-02
+      image: ubuntu-2204:2022.10.1
   ubuntu-machine-large:
     machine:
-      image: ubuntu-2004:202111-02
+      image: ubuntu-2204:2022.10.1
     resource_class: large
 
 commands:
@@ -107,7 +107,7 @@ commands:
           command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q update
       - run:
           name: Install dependencies
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin libglib2.0-dev squashfuse
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>DEBIAN_FRONTEND=noninteractive apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin libglib2.0-dev squashfuse dbus-user-session
       - run:
           name: Install proot
           command: |-
@@ -118,6 +118,18 @@ commands:
           command: |-
             <<# parameters.sudo >>sudo <</ parameters.sudo >>curl -L -o /usr/local/bin/crun https://github.com/containers/crun/releases/download/1.6/crun-1.6-linux-amd64
             <<# parameters.sudo >>sudo <</ parameters.sudo >>chmod +x /usr/local/bin/crun
+
+  cgroups-delegation:
+    steps:
+      - run:
+          name: Enable full cgroups v2 delegation
+          command: |-
+            sudo mkdir -p /etc/systemd/system/user@.service.d
+            cat \<<EOF | sudo tee /etc/systemd/system/user@.service.d/delegate.conf
+            [Service]
+            Delegate=cpu cpuset io memory pids
+            EOF
+            sudo systemctl daemon-reload
 
   configure-singularity:
     steps:
@@ -235,16 +247,28 @@ jobs:
           version: << pipeline.parameters.go-version >>
       - stop-background-apt
       - install-deps-apt
+      - cgroups-delegation
       - update-submodules
       - install-singularity
       - run:
           name: Run E2E tests
           no_output_timeout: 35m
           command: |-
-            export E2E_PARALLEL=8 && \
-            export E2E_DOCKER_USERNAME=$CIRCLE_CI_DOCKER_USERNAME && \
-            export E2E_DOCKER_PASSWORD=$CIRCLE_CI_DOCKER_PASSWORD && \
-            make -C ./builddir e2e-test
+            # CircleCI image sets DBUS_SESSION_BUS_ADDRESS to /dev/null to avoid
+            # issues with headless browser testing tools, but we must have a
+            # working dbus for cgroups tests.
+            systemctl --user daemon-reload
+            systemctl --user start dbus
+            export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$UID/bus
+            
+            # CircleCI agent starts our command in a cgroup with resource files
+            # owned by root. For rootless cgroup tests, we must be in a cgroup
+            # owned by ourselves.
+            systemd-run --user --scope sh -c ' \
+              export E2E_PARALLEL=8 && \
+              export E2E_DOCKER_USERNAME=$CIRCLE_CI_DOCKER_USERNAME && \
+              export E2E_DOCKER_PASSWORD=$CIRCLE_CI_DOCKER_PASSWORD && \
+              make -C ./builddir e2e-test'
       - store_artifacts:
           path: builddir/e2e-cmd-report.txt
 

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -532,6 +532,10 @@ func (c *ctx) actionFlagV2(t *testing.T, tt actionFlagTest, profile e2e.Profile)
 	if tt.skipV2 {
 		t.Skip()
 	}
+	// Don't try to test a resource that doesn't exist in our caller cgroup.
+	// E.g. some systems don't have io.bfq.*
+	require.CgroupsResourceExists(t, "", tt.resourceV2)
+
 	// In rootless mode, can only test subsystems that have been delegated
 	if !profile.Privileged() {
 		require.CgroupsV2Delegated(t, tt.delegationV2)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update CI image to Ubuntu 22.04 LTS.

With cgroups v2 this now enables the rootless cgroups tests, which require a dbus user session. The CI image doesn't include the relevant package, so we need to install that too.

The e2e tests job now includes some workaround to make the CI agent spawned job provide an environment that's more typical for a user... undoing some things the CI image does to help out headless browser test tools. We must have a user dbus and a delegated cgroup for all of the rootless cgroups tests to be possible.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
