### PR TITLE
e2e: always use UserProfile for ImageVerify

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -106,7 +106,7 @@ func (c ctx) testDockerPulls(t *testing.T) {
 					if path == tmpContainerFile {
 						path = filepath.Join(tmpPath, tmpContainerFile)
 					}
-					c.env.ImageVerify(t, path, e2e.UserProfile)
+					c.env.ImageVerify(t, path)
 				}
 			}),
 			e2e.ExpectExit(tt.exit),
@@ -354,7 +354,7 @@ func (c ctx) testDockerWhiteoutSymlink(t *testing.T) {
 			if t.Failed() {
 				return
 			}
-			c.env.ImageVerify(t, imagePath, e2e.UserProfile)
+			c.env.ImageVerify(t, imagePath)
 		}),
 		e2e.ExpectExit(0),
 	)
@@ -431,7 +431,7 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 					return
 				}
 
-				c.env.ImageVerify(t, imagePath, e2e.RootProfile)
+				c.env.ImageVerify(t, imagePath)
 			}),
 			e2e.ExpectExit(0),
 		)
@@ -495,7 +495,7 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 					return
 				}
 
-				c.env.ImageVerify(t, imagePath, e2e.RootProfile)
+				c.env.ImageVerify(t, imagePath)
 			}),
 			e2e.ExpectExit(tt.exit),
 		)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -159,7 +159,7 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 						}
 
 						defer os.RemoveAll(imagePath)
-						c.env.ImageVerify(t, imagePath, profile)
+						c.env.ImageVerify(t, imagePath)
 					}),
 					e2e.ExpectExit(0),
 				)
@@ -222,7 +222,7 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 			}),
 
 			e2e.PostRun(func(t *testing.T) {
-				c.env.ImageVerify(t, imagePath, e2e.UserProfile)
+				c.env.ImageVerify(t, imagePath)
 			}),
 			e2e.ExpectExit(0),
 		)
@@ -259,7 +259,7 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--sandbox", sandboxImage, c.env.ImagePath),
 		e2e.PostRun(func(t *testing.T) {
-			c.env.ImageVerify(t, sandboxImage, e2e.UserProfile)
+			c.env.ImageVerify(t, sandboxImage)
 		}),
 		e2e.ExpectExit(0),
 	)
@@ -300,7 +300,7 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 							return
 						}
 						defer os.RemoveAll(imagePath)
-						c.env.ImageVerify(t, imagePath, profile)
+						c.env.ImageVerify(t, imagePath)
 					}),
 					e2e.ExpectExit(0),
 				)
@@ -1522,7 +1522,7 @@ func (c imgBuildTests) buildProot(t *testing.T) {
 						}
 
 						defer os.RemoveAll(imagePath)
-						c.env.ImageVerify(t, imagePath, profile)
+						c.env.ImageVerify(t, imagePath)
 					}),
 					e2e.ExpectExit(0),
 				)

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -101,7 +101,7 @@ func (c *imgBuildTests) issue4407(t *testing.T) {
 
 				defer os.RemoveAll(imagePath)
 
-				c.env.ImageVerify(t, imagePath, e2e.RootProfile)
+				c.env.ImageVerify(t, imagePath)
 			}),
 			e2e.ExpectExit(0),
 		)

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -19,7 +19,7 @@ import (
 )
 
 // ImageVerify checks for an image integrity.
-func (env TestEnv) ImageVerify(t *testing.T, imagePath string, profile Profile) {
+func (env TestEnv) ImageVerify(t *testing.T, imagePath string) {
 	tt := []struct {
 		name string
 		argv []string
@@ -71,7 +71,7 @@ func (env TestEnv) ImageVerify(t *testing.T, imagePath string, profile Profile) 
 		env.RunSingularity(
 			t,
 			AsSubtest(tc.name),
-			WithProfile(profile),
+			WithProfile(UserProfile),
 			WithCommand("exec"),
 			WithArgs(tc.argv...),
 			ExpectExit(tc.exit),


### PR DESCRIPTION
## Description of the Pull Request (PR):

The e2e ImageVerify function is currently running under a passed-in profile. When the profile is userns, or fakeroot, this will require extraction of a SIF image to sandbox before inspection.

Builds should always create an image that is executable by a normal user, so we can always use the UserProfile and avoid the extractions.

### This fixes or addresses the following GitHub issues:

 - Fixes #1103

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
