### PR TITLE
e2e: Move umask manipulating tests to SEQ

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2096,6 +2096,7 @@ func (c actionTests) bindImage(t *testing.T) {
 }
 
 // actionUmask tests that the within-container umask is correct in action flows
+// Must be run in sequential section as it modifies host process umask.
 func (c actionTests) actionUmask(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
@@ -2286,6 +2287,7 @@ func (c actionTests) actionNoMount(t *testing.T) {
 
 // actionCompat checks that the --compat flag sets up the expected environment
 // for improved oci/docker compatibility
+// Must be run in sequential section as it modifies host process umask.
 func (c actionTests) actionCompat(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
@@ -2447,9 +2449,9 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"exit and signals":          c.exitSignals,             // test exit and signals propagation
 		"fuse mount":                c.fuseMount,               // test fusemount option
 		"bind image":                c.bindImage,               // test bind image with --bind and --mount
-		"umask":                     c.actionUmask,             // test umask propagation
 		"no-mount":                  c.actionNoMount,           // test --no-mount
-		"compat":                    c.actionCompat,            // test --compat
+		"compat":                    np(c.actionCompat),        // test --compat
+		"umask":                     np(c.actionUmask),         // test umask propagation
 		"invalidRemote":             np(c.invalidRemote),       // GHSA-5mv9-q7fq-9394
 		"SIFFUSE":                   np(c.actionSIFFUSE),       // test --sif-fuse
 		"NoSIFFUSE":                 np(c.actionNoSIFFUSE),     // test absence of squashfs and CleanupHost()


### PR DESCRIPTION
## Description of the Pull Request (PR):

The actionUmask and actionCompat tests manipulate the process umask. They should be run in the SEQ (non-parallel) section of the end to end tests.

### This fixes or addresses the following GitHub issues:

 - Fixes #1111

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
