### PR TITLE
e2e: close pipe to actions.fuseMount sshfs container

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1621,7 +1621,10 @@ func (c actionTests) fuseMount(t *testing.T) {
 	}()
 
 	// terminate ssh server once done
-	defer stdinWriter.Write([]byte("bye"))
+	defer func() {
+		stdinWriter.Write([]byte("bye"))
+		stdinWriter.Close()
+	}()
 
 	// wait until ssh server is up and running
 	retry := 0


### PR DESCRIPTION
## Description of the Pull Request (PR):

In the actions.fuseMount test, don't just write to the STDIN pipe for the sshfs container, close it also. This ensures `cat > /dev/null`  in the container will see EOF and exit.

### This fixes or addresses the following GitHub issues:

 - Fixes #1114 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
