### PR TITLE
fix: don't freeze for http(s) pull without content-length (release-3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Ensure `make dist` doesn't include conmon binary or intermediate files.
+- Do not hang on pull from http(s) source that doesn't provide a content-length.
 
 ## 3.10.3 \[2022-10-06\]
 

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -647,6 +647,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("concurrencyConfig", c.testConcurrencyConfig)
 			t.Run("concurrentPulls", c.testConcurrentPulls)
 		},
+		"issue1087": c.issue1087,
 		// Manipulates umask for the process, so must be run alone to avoid
 		// causing permission issues for other tests.
 		"pullUmaskCheck": np(c.testPullUmask),

--- a/e2e/pull/regressions.go
+++ b/e2e/pull/regressions.go
@@ -6,7 +6,12 @@
 package pull
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -68,4 +73,36 @@ func (c ctx) issue5808(t *testing.T) {
 		e2e.WithArgs(argv...),
 		e2e.ExpectExit(0),
 	)
+}
+
+// Must be able to pull from an http(s) source that doesn't set content-length correctly
+func (c ctx) issue1087(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-1087-", "")
+	defer cleanup(t)
+	pullPath := filepath.Join(tmpDir, "test.sif")
+
+	// Start an http server that serves some output without a content-length
+	data := "DATADATADATADATA"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, data)
+	}))
+	defer srv.Close()
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull"),
+		e2e.WithArgs(pullPath, srv.URL),
+		e2e.ExpectExit(0),
+	)
+
+	content, err := os.ReadFile(pullPath)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(content) != data {
+		t.Errorf("Content of file not correct. Expected %s, got %s", data, content)
+	}
 }

--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -52,7 +52,8 @@ func ProgressBarCallback(ctx context.Context) ProgressCallback {
 	if sylog.GetLevel() <= -1 {
 		// If we don't need a bar visible, we just copy data through the callback func
 		return func(totalSize int64, r io.Reader, w io.Writer) error {
-			return CopyWithContext(ctx, w, r)
+			_, err := CopyWithContext(ctx, w, r)
+			return err
 		}
 	}
 
@@ -63,10 +64,15 @@ func ProgressBarCallback(ctx context.Context) ProgressCallback {
 		bodyProgress := bar.ProxyReader(r)
 		defer bodyProgress.Close()
 
-		err := CopyWithContext(ctx, w, bodyProgress)
+		written, err := CopyWithContext(ctx, w, bodyProgress)
 		if err != nil {
 			bar.Abort(true)
 			return err
+		}
+
+		// Must ensure bar is complete for a download with unknown size, or it will hang.
+		if totalSize <= 0 {
+			bar.SetTotal(written, true)
 		}
 		p.Wait()
 
@@ -74,12 +80,12 @@ func ProgressBarCallback(ctx context.Context) ProgressCallback {
 	}
 }
 
-func CopyWithContext(ctx context.Context, dst io.Writer, src io.Reader) error {
+func CopyWithContext(ctx context.Context, dst io.Writer, src io.Reader) (written int64, err error) {
 	// Copy will call the Reader and Writer interface multiple time, in order
 	// to copy by chunk (avoiding loading the whole file in memory).
 	// I insert the ability to cancel before read time as it is the earliest
 	// possible in the call process.
-	_, err := io.Copy(dst, readerFunc(func(p []byte) (int, error) {
+	written, err = io.Copy(dst, readerFunc(func(p []byte) (int, error) {
 		// golang non-blocking channel: https://gobyexample.com/non-blocking-channel-operations
 		select {
 		// if context has been canceled
@@ -91,7 +97,7 @@ func CopyWithContext(ctx context.Context, dst io.Writer, src io.Reader) error {
 			return src.Read(p)
 		}
 	}))
-	return err
+	return written, err
 }
 
 // DownloadProgressBar is used for chunked scs-library-client downloads.


### PR DESCRIPTION
## Description of the Pull Request (PR):

When an http(s) pull doesn't provide a content-length header, we need to ensure the progress bar completes. If we don't do this, the CLI hangs indefinitely.


### This fixes or addresses the following GitHub issues:

 - Fixes #1087


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
