### PR TITLE
e2e: remove pull concurrency 3 check

### DIFF
--- a/e2e/pull/concurrency.go
+++ b/e2e/pull/concurrency.go
@@ -74,14 +74,11 @@ func (c ctx) testConcurrentPulls(t *testing.T) {
 	}{
 		// test traditional sequential download
 		{"Concurrency1Cfg", map[string]string{"download concurrency": "1"}, nil, 0},
-		// test concurrency 3
-		{"Concurrency3Cfg", map[string]string{"download concurrency": "3"}, nil, 0},
 		// test concurrency 10
 		{"Concurrency10Cfg", map[string]string{"download concurrency": "10"}, nil, 0},
 
-		// test 1/3/10 goroutines (set via env vars)
+		// test 1/10 goroutines (set via env vars)
 		{"Concurrency1Env", nil, []string{"SINGULARITY_DOWNLOAD_CONCURRENCY=1"}, 0},
-		{"Concurrency3Env", nil, []string{"SINGULARITY_DOWNLOAD_CONCURRENCY=3"}, 0},
 		{"Concurrency10Env", nil, []string{"SINGULARITY_DOWNLOAD_CONCURRENCY=10"}, 0},
 
 		// test concurrent download with 1 MiB and 8 MiB part size


### PR DESCRIPTION
## Description of the Pull Request (PR):

The default download concurrency is 3, so it is exercised in all other library pull operations. We don't need to explicitly test it.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
