### PR TITLE
chore: pick 3.10.4 release prep to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.19.2'
+    default: '1.19.3'
 
 executors:
   node:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
   namespace, on systems with a kernel that supports unprivileged
   overlay mounts in a user namespace.
 
+## 3.10.4 \[2022-11-10\]
+
 ### Bug Fixes
 
 - Ensure `make dist` doesn't include conmon binary or intermediate files.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,7 +56,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.19.2 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.19.3 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz
@@ -114,11 +114,11 @@ cd singularity
 By default your clone will be on the `main` branch which is where development
 of SingularityCE happens. To build a specific version of SingularityCE, check
 out a [release tag](https://github.com/sylabs/singularity/tags) before
-compiling. E.g. to build the 3.10.3 release checkout the
-`v3.10.3` tag:
+compiling. E.g. to build the 3.10.4 release checkout the
+`v3.10.4` tag:
 
 ```sh
-git checkout --recurse-submodules v3.10.3
+git checkout --recurse-submodules v3.10.4
 ```
 
 ## Compiling SingularityCE
@@ -169,7 +169,7 @@ build and install the RPM like this:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-export VERSION=3.10.3  # this is the singularity version, change as you need
+export VERSION=3.10.4  # this is the singularity version, change as you need
 
 # Fetch the source
 wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-ce-${VERSION}.tar.gz


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump go to 1.19.3

Update docs for 3.10.4

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
