### PR TITLE
feat: exec / run args support for --oci mode

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2461,6 +2461,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		// OCI Runtime Mode
 		//
-		"ociRun": c.actionOciRun, // singularity run --oci
+		"ociRun":  c.actionOciRun,  // singularity run --oci
+		"ociExec": c.actionOciExec, // singularity exec --oci
 	}
 }

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -12,6 +12,7 @@ type TestEnv struct {
 	CmdPath        string // Path to the Singularity binary to use for the execution of a Singularity command
 	ImagePath      string // Path to the image that has to be used for the execution of a Singularity command
 	OrasTestImage  string
+	OCIImagePath   string
 	TestDir        string // Path to the directory from which a Singularity command needs to be executed
 	TestRegistry   string
 	KeyringDir     string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using SINGULARITY_SYPGPDIR which should be avoided when running e2e tests)

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -202,6 +202,12 @@ func Run(t *testing.T) {
 	testenv.ImagePath = imagePath
 	defer os.Remove(imagePath)
 
+	// OCI Test image
+	ociImagePath := path.Join(name, "oci.tar")
+	t.Log("Path to test OCI image:", ociImagePath)
+	testenv.OCIImagePath = ociImagePath
+	defer os.Remove(ociImagePath)
+
 	// WARNING(Sylabs-team): Please DO NOT add a call to e2e.EnsureImage here.
 	// If you need the test image, add the call at the top of your
 	// own test.

--- a/internal/pkg/runtime/launcher/launcher.go
+++ b/internal/pkg/runtime/launcher/launcher.go
@@ -21,9 +21,9 @@ import "context"
 // It will execute a runtime, such as Singularity's native runtime (via the starter
 // binary), or an external OCI runtime (e.g. runc).
 type Launcher interface {
-	// Exec will execute the container image 'image', passing arguments 'args'
-	// the container#s initial process. If instanceName is specified, the
-	// container must be launched as a background instance, otherwist it must
-	// run interactively, attached to the console.
-	Exec(ctx context.Context, image string, cmd string, args []string, instanceName string) error
+	// Exec will execute the container image 'image', starting 'process', and
+	// passing arguments 'args'. If instanceName is specified, the container
+	// must be launched as a background instance, otherwist it must run
+	// interactively, attached to the console.
+	Exec(ctx context.Context, image string, process string, args []string, instanceName string) error
 }

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -93,11 +93,11 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 // This includes interactive containers, instances, and joining an existing instance.
 //
 //nolint:maintidx
-func (l *Launcher) Exec(ctx context.Context, image string, cmd string, args []string, instanceName string) error {
+func (l *Launcher) Exec(ctx context.Context, image string, process string, args []string, instanceName string) error {
 	var err error
 
 	// Native runtime expects command to execute as arg[0]
-	args = append([]string{cmd}, args...)
+	args = append([]string{process}, args...)
 
 	// Set arguments to pass to contained process.
 	l.generator.SetProcessArgs(args)

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -291,7 +291,12 @@ func (l *Launcher) Exec(ctx context.Context, image string, cmd string, args []st
 		}
 	}
 
-	b, err := native.FromImageRef(image, bundleDir, sysCtx, imgCache)
+	b, err := native.New(
+		native.OptBundlePath(bundleDir),
+		native.OptImageRef(image),
+		native.OptSysCtx(sysCtx),
+		native.OptImgCache(imgCache),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -242,17 +242,9 @@ func checkOpts(lo launcher.Options) error {
 
 // Exec will interactively execute a container via the runc low-level runtime.
 // image is a reference to an OCI image, e.g. docker://ubuntu or oci:/tmp/mycontainer
-func (l *Launcher) Exec(ctx context.Context, image string, cmd string, args []string, instanceName string) error {
+func (l *Launcher) Exec(ctx context.Context, image string, process string, args []string, instanceName string) error {
 	if instanceName != "" {
 		return fmt.Errorf("%w: instanceName", ErrNotImplemented)
-	}
-
-	if cmd != "" {
-		return fmt.Errorf("%w: cmd %v", ErrNotImplemented, cmd)
-	}
-
-	if len(args) > 0 {
-		return fmt.Errorf("%w: args %v", ErrNotImplemented, args)
 	}
 
 	bundleDir, err := os.MkdirTemp("", "oci-bundle")
@@ -296,6 +288,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, cmd string, args []st
 		native.OptImageRef(image),
 		native.OptSysCtx(sysCtx),
 		native.OptImgCache(imgCache),
+		native.OptProcessArgs(process, args),
 	)
 	if err != nil {
 		return err

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/containers/image/v5/types"
@@ -302,5 +303,10 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	if err != nil {
 		return fmt.Errorf("while generating container id: %w", err)
 	}
-	return Run(ctx, id.String(), b.Path(), "")
+
+	err = Run(ctx, id.String(), b.Path(), "")
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		os.Exit(exiterr.ExitCode())
+	}
+	return err
 }

--- a/pkg/ocibundle/native/bundle_linux_test.go
+++ b/pkg/ocibundle/native/bundle_linux_test.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/runtime-tools/validate"
 	"github.com/sylabs/singularity/internal/pkg/cache"
 )
@@ -121,7 +120,11 @@ func TestFromImageRef(t *testing.T) {
 				t.Skipf("docker not available")
 			}
 			bundleDir := t.TempDir()
-			b, err := FromImageRef(tt.imageRef, bundleDir, &types.SystemContext{}, setupCache(t))
+			b, err := New(
+				OptBundlePath(bundleDir),
+				OptImageRef(tt.imageRef),
+				OptImgCache(setupCache(t)),
+			)
 			if err != nil {
 				t.Fatalf("While initializing bundle: %s", err)
 			}


### PR DESCRIPTION
## Description of the Pull Request (PR):

**Stacked on top of #1025 - please review that first**

When using `run` or `exec` with the `--oci` runtime mode, accept arguments on the command line.

For `run`, the arguments override any CMD specified by the image.

For `exec`, the arguments replace ENTRYPOINT/CMD entirely, bypassing the process configuration in the image config.

This mirrors the behavior of Singularity images today, via the exec and run runscripts - but is implemented in the OCI bundle config, rather than a script in the container.

_Also_

* refactor native bundle to functional options
* modify e2e tests to test with args

### This fixes or addresses the following GitHub issues:

 - Closes #1024 
 - Closes #1092 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
