### PR TITLE
feat: enable shell for --oci mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ commands:
             <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q update
       - run:
           name: Install dependencies
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>DEBIAN_FRONTEND=noninteractive apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin libglib2.0-dev squashfuse dbus-user-session
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>DEBIAN_FRONTEND=noninteractive apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin libglib2.0-dev squashfuse dbus-user-session uidmap
       - run:
           name: Install proot
           command: |-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,8 @@ sudo apt-get install -y \
     pkg-config \
     squashfs-tools \
     cryptsetup \
-    runc
+    crun \
+    uidmap
 ```
 
 On CentOS/RHEL:
@@ -37,11 +38,11 @@ sudo yum install -y \
     glib2-devel \
     squashfs-tools \
     cryptsetup \
-    runc
+    crun
 ```
 
-_Note - `runc` can be ommitted if you will not use the `singularity oci`
-commands._
+_Note - `crun` can be ommitted if you will not use the `singularity oci`
+commands, or the `--oci` execution mode._
 
 ## Install Go
 

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Vcs-Browser: https://github.com/sylabs/singularity
 
 Package: singularity-ce
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, cryptsetup-bin, libseccomp2, libglib2.0-0, squashfs-tools, runc
+Depends: ${misc:Depends}, ${shlibs:Depends}, crun, cryptsetup-bin, libseccomp2, libglib2.0-0, squashfs-tools, uidmap
 Conflicts:
  singularity-container,
  apptainer,

--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -45,13 +45,14 @@ BuildRequires: libseccomp-devel
 BuildRequires: glib2-devel
 BuildRequires: cryptsetup
 
+Requires: crun
 Requires: cryptsetup
 Requires: glib2
-Requires: runc
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
 Requires: libseccomp2
 %else
+Requires: shadow-utils
 Requires: squashfs-tools
 Requires: libseccomp
 %endif

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2461,7 +2461,8 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		// OCI Runtime Mode
 		//
-		"ociRun":  c.actionOciRun,  // singularity run --oci
-		"ociExec": c.actionOciExec, // singularity exec --oci
+		"ociRun":   c.actionOciRun,   // singularity run --oci
+		"ociExec":  c.actionOciExec,  // singularity exec --oci
+		"ociShell": c.actionOciShell, // singularity shell --oci
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -80,7 +80,7 @@ func (c actionTests) actionOciRun(t *testing.T) {
 				c.env.RunSingularity(
 					t,
 					e2e.AsSubtest(tt.name),
-					e2e.WithProfile(e2e.OCIRootProfile),
+					e2e.WithProfile(e2e.OCIUserProfile),
 					e2e.WithCommand("run"),
 					// While we don't support args we are entering a /bin/sh interactively.
 					e2e.ConsoleRun(e2e.ConsoleSendLine("exit")),

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -80,7 +80,7 @@ func (c actionTests) actionOciRun(t *testing.T) {
 				c.env.RunSingularity(
 					t,
 					e2e.AsSubtest(tt.name),
-					e2e.WithProfile(e2e.OCIUserProfile),
+					e2e.WithProfile(profile),
 					e2e.WithCommand("run"),
 					// While we don't support args we are entering a /bin/sh interactively.
 					e2e.ConsoleRun(e2e.ConsoleSendLine("exit")),
@@ -180,15 +180,19 @@ func (c actionTests) actionOciShell(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.OCIUserProfile),
-			e2e.WithCommand("shell"),
-			e2e.WithArgs(tt.argv...),
-			e2e.ConsoleRun(tt.consoleOps...),
-			e2e.ExpectExit(tt.exit),
-		)
+	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIUserProfile} {
+		t.Run(profile.String(), func(t *testing.T) {
+			for _, tt := range tests {
+				c.env.RunSingularity(
+					t,
+					e2e.AsSubtest(tt.name),
+					e2e.WithProfile(profile),
+					e2e.WithCommand("shell"),
+					e2e.WithArgs(tt.argv...),
+					e2e.ConsoleRun(tt.consoleOps...),
+					e2e.ExpectExit(tt.exit),
+				)
+			}
+		})
 	}
 }

--- a/internal/pkg/runtime/launcher/launcher.go
+++ b/internal/pkg/runtime/launcher/launcher.go
@@ -23,7 +23,7 @@ import "context"
 type Launcher interface {
 	// Exec will execute the container image 'image', starting 'process', and
 	// passing arguments 'args'. If instanceName is specified, the container
-	// must be launched as a background instance, otherwist it must run
+	// must be launched as a background instance, otherwise it must run
 	// interactively, attached to the console.
 	Exec(ctx context.Context, image string, process string, args []string, instanceName string) error
 }

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opencontainers/umoci/pkg/idtools"
 	"github.com/sylabs/singularity/internal/pkg/build/oci"
 	"github.com/sylabs/singularity/internal/pkg/cache"
+	"github.com/sylabs/singularity/internal/pkg/fakeroot"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/sylabs/singularity/pkg/ocibundle"
 	"github.com/sylabs/singularity/pkg/ocibundle/tools"
@@ -156,7 +157,9 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	b.setProcessArgs(g)
 	// TODO - Handle custom env and user
 	b.setProcessEnv(g)
-	b.setProcessUser(g)
+	if err := b.setProcessUser(g); err != nil {
+		return err
+	}
 
 	return b.writeConfig(g)
 }
@@ -166,14 +169,100 @@ func (b *Bundle) Path() string {
 	return b.bundlePath
 }
 
-func (b *Bundle) setProcessUser(g *generate.Generator) {
+func (b *Bundle) setProcessUser(g *generate.Generator) error {
 	// Set non-root uid/gid per Singularity defaults
 	uid := uint32(os.Getuid())
 	if uid != 0 {
 		gid := uint32(os.Getgid())
 		g.Config.Process.User.UID = uid
 		g.Config.Process.User.GID = gid
+		// Get user's configured subuid & subgid ranges
+		subuidRange, err := fakeroot.GetIDRange(fakeroot.SubUIDFile, uid)
+		if err != nil {
+			return err
+		}
+		// We must be able to map at least 0->65535 inside the container
+		if subuidRange.Size < 65536 {
+			return fmt.Errorf("subuid range size (%d) must be at least 65536", subuidRange.Size)
+		}
+		subgidRange, err := fakeroot.GetIDRange(fakeroot.SubGIDFile, uid)
+		if err != nil {
+			return err
+		}
+		if subgidRange.Size <= gid {
+			return fmt.Errorf("subuid range size (%d) must be at least 65536", subgidRange.Size)
+		}
+
+		// Preserve own uid container->host, map everything else to subuid range.
+		if uid < 65536 {
+			g.Config.Linux.UIDMappings = []specs.LinuxIDMapping{
+				{
+					ContainerID: 0,
+					HostID:      subuidRange.HostID,
+					Size:        uid,
+				},
+				{
+					ContainerID: uid,
+					HostID:      uid,
+					Size:        1,
+				},
+				{
+					ContainerID: uid + 1,
+					HostID:      subuidRange.HostID + uid,
+					Size:        subuidRange.Size - uid,
+				},
+			}
+		} else {
+			g.Config.Linux.UIDMappings = []specs.LinuxIDMapping{
+				{
+					ContainerID: 0,
+					HostID:      subuidRange.HostID,
+					Size:        65536,
+				},
+				{
+					ContainerID: uid,
+					HostID:      uid,
+					Size:        1,
+				},
+			}
+		}
+
+		// Preserve own gid container->host, map everything else to subgid range.
+		if gid < 65536 {
+			g.Config.Linux.GIDMappings = []specs.LinuxIDMapping{
+				{
+					ContainerID: 0,
+					HostID:      subgidRange.HostID,
+					Size:        gid,
+				},
+				{
+					ContainerID: gid,
+					HostID:      gid,
+					Size:        1,
+				},
+				{
+					ContainerID: gid + 1,
+					HostID:      subgidRange.HostID + gid,
+					Size:        subgidRange.Size - gid,
+				},
+			}
+		} else {
+			g.Config.Linux.GIDMappings = []specs.LinuxIDMapping{
+				{
+					ContainerID: 0,
+					HostID:      subgidRange.HostID,
+					Size:        65536,
+				},
+				{
+					ContainerID: gid,
+					HostID:      gid,
+					Size:        1,
+				},
+			}
+		}
+		g.Config.Linux.Namespaces = append(g.Config.Linux.Namespaces, specs.LinuxNamespace{Type: "user"})
 	}
+	return nil
 }
 
 func (b *Bundle) setProcessEnv(g *generate.Generator) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Enable `singularity shell --oci ...` with behavior matching native runtime, i.e.

* Run shell set with SINGULARITY_SHELL or --shell
* If not set, try /bin/bash --norc
* If not available, use /bin/sh

### This fixes or addresses the following GitHub issues:

 - Fixes #1025


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
