### PR TITLE
oci: Add --fakeroot support to --oci mode 

### DIFF
--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -6,6 +6,10 @@
 package cli
 
 import (
+	"errors"
+	"os"
+	"os/exec"
+
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/app/singularity"
@@ -150,6 +154,10 @@ var OciRunCmd = &cobra.Command{
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciRun(cmd.Context(), args[0], &ociArgs); err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				os.Exit(exitErr.ExitCode())
+			}
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -72,7 +72,7 @@ func (c actionTests) actionOciRun(t *testing.T) {
 		},
 	}
 
-	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIUserProfile} {
+	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tt := range tests {
 				cmdArgs := []string{tt.imageRef}
@@ -144,7 +144,7 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			exit: 0,
 		},
 	}
-	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIUserProfile} {
+	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tt := range tests {
 				c.env.RunSingularity(
@@ -198,7 +198,7 @@ func (c actionTests) actionOciShell(t *testing.T) {
 		},
 	}
 
-	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIUserProfile} {
+	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tt := range tests {
 				c.env.RunSingularity(

--- a/internal/pkg/runtime/engine/fakeroot/config/config.go
+++ b/internal/pkg/runtime/engine/fakeroot/config/config.go
@@ -15,4 +15,5 @@ type EngineConfig struct {
 	Envs     []string `json:"envs"`
 	Home     string   `json:"home"`
 	BuildEnv bool     `json:"buildEnv"`
+	NoPIDNS  bool     `json:"NoPIDNS"`
 }

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -95,7 +95,11 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 
 	g.AddOrReplaceLinuxNamespace(specs.UserNamespace, "")
 	g.AddOrReplaceLinuxNamespace(specs.MountNamespace, "")
-	g.AddOrReplaceLinuxNamespace(specs.PIDNamespace, "")
+
+	// If we enter a PID NS in the --oci action -> oci run flow, then crun / runc will fail.
+	if !e.EngineConfig.NoPIDNS {
+		g.AddOrReplaceLinuxNamespace(specs.PIDNamespace, "")
+	}
 
 	uid := uint32(os.Getuid())
 	gid := uint32(os.Getgid())

--- a/internal/pkg/runtime/launcher/oci/README.md
+++ b/internal/pkg/runtime/launcher/oci/README.md
@@ -1,0 +1,142 @@
+# internal/pkg/runtime/launcher/oci
+
+This package contains routines that configure and launch a container in an OCI
+bundle format, using a low-level OCI runtime, either `crun` or `runc` at this
+time. `crun` is currently preferred. `runc` is used where `crun` is not
+available.
+
+**Note** - at present, all functionality works with either `crun` or `runc`.
+However, in future `crun` may be required for all functionality, as `runc` does
+not support some limited ID mappings etc. that may be beneficial in an HPC
+scenario.
+
+The package contrasts with `internal/pkg/runtime/launcher/native` which executes
+Singularity format containers (SIF/Sandbox/squashfs/ext3), using one of our own
+runtime engines (`internal/pkg/runtime/engine/*`).
+
+There are two flows that are implemented here.
+
+* Basic OCI runtime operations agains an existing bundle, which will be executed
+  via the `singularity oci` command group. These are not widely used by
+  end-users of singularity.
+* A `Launcher`, that implements an `Exec` function that will be called by
+  'actions' (run/shell/exec) in `--oci` mode, and will:
+  * Prepare an OCI bundle according to `launcher.Options` passed through from
+    the CLI layer.
+  * Execute the bundle, interactively, via the OCI Run operation.
+
+**Note** - this area of code is under heavy development for experimental
+introduction in CE 3.11. It is likely that it will be heavily refactored, and
+split, in future.
+
+## Basic OCI Operations
+
+The following files implement basic OCI operations on a runtime bundle:
+
+### `oci_linux.go`
+
+Defines constants, path resolution, and minimal bundle locking functions.
+
+### `oci_runc_linux.go`
+
+Holds implementations of the Run / Start / Exec / Kill / Delete / Pause / Resume
+/ State OCI runtime operations.
+
+See
+<https://github.com/opencontainers/runtime-spec/blob/main/runtime.md#operations>
+
+These functions are thin wrappers around the `runc`/`crun` operations of the
+same name.
+
+### `oci_conmon_linux.go`
+
+Hold an implementation of the Create OCI runtime operation. This calls out to
+`conmon`, which in turn calls `crun` or `runc`.
+
+`conmon` is used to manage logging and console streams for containers that are
+started backgrounded, so we don't have to do that ourselves.
+
+### `oci_attach_linux.go`
+
+Implements an `Attach` function, which can attach the user's console to the
+streams of a container running in the background, which is being monitored by
+conmon.
+
+### Testing
+
+End-to-end flows of basic OCI operations on an existing bundle are tested in the
+OCI group of the e2e suite, `e2e/oci`.
+
+## Launcher Flow
+
+The `Launcher` type connects the standard singularity CLI actions
+(run/shell/exec), to execution of an OCI container in a native bundle. Invoked
+with the `--oci` flag, this is in contrast to running a Singularity format
+container, with Singularity's own runtime engine.
+
+### `spec_linux.go`
+
+Provides a minimal OCI runtime spec, that will form the basis of container
+execution that is roughly comparable to running a native singularity container
+with `--compat` (`--containall`).
+
+### `mounts_linux.go`
+
+Provides code handling the addition of required mounts to the OCI runtime spec.
+
+### `process_linux.go`
+
+Provides code handling configuration of container process execution, including
+user mapping.
+
+### `launcher_linux.go`
+
+Implements `Launcher.Exec`, which is called from the CLI layer. It will:
+
+* Create a temporary bundle directory.
+* Use `pkg/ocibundle/native` to retrieve the specified image, and extract it in
+  the temporary bundle.
+* Configure the container by creating an appropriate runtime spec.
+* Call the interactive OCI Run function to execute the container with `crun` or
+  `runc`.
+
+### Namespace Considerations
+
+An OCI container started via `Launch.Exec` as a non-root user always uses at
+least one user namespace.
+
+The user namespace is created *prior to* calling `runc` or `crun`, so we'll call
+it an *outer* user namespace.
+
+Creation of this outer user namespace is via using the `RunNS` function, instead
+of `Run`. The `RunNS` function executes the Singularity `starter` binary, with a
+minimal configuration of the fakeroot engine (
+`internal/pkg/runtime/engine/fakeroot/config`).
+
+The `starter` will create a user namespace and ID mapping, and will then execute
+`singularity oci run` to perform the basic OCI Run operation against the bundle
+that the `Launcher.Exec` function has prepared.
+
+The outer user namespace from which `runc` or `crun` is called *always* maps the
+host user id to root inside the userns.
+
+When a container is run in `--fakeroot` mode, the outer user namespace is the
+only user namespace. The OCI runtime config does not request any additional
+userns or ID mapping be performed by `crun` / `runc`.
+
+When a container is **not** run in `--fakeroot` mode, the OCI runtime config for
+the bundle requests that `crun` / `runc`:
+
+* Create another, inner, user namespace for the container.
+* Apply an ID mapping which reverses the 'fakeroot' outer ID mapping.
+
+I.E. when a container runs without `--fakeroot`, the ID mapping is:
+
+* User ID on host (1001)
+* Root in outer user namespace (0)
+* User ID in container (1001)
+
+### Testing
+
+End-to-end testing of ßthe launcher flow is via the `e2e/actions` suite. Tests
+prefixed `oci`.

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -203,9 +203,6 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "PwdPath")
 	}
 
-	if lo.Fakeroot {
-		badOpt = append(badOpt, "Fakeroot")
-	}
 	if lo.Boot {
 		badOpt = append(badOpt, "Boot")
 	}
@@ -290,12 +287,18 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	}
 
 	spec.Process.User = l.getProcessUser()
-	uidMap, gidMap, err := l.getIDMaps()
-	if err != nil {
-		return err
+
+	// If we are *not* requesting fakeroot, then we need to map the container
+	// uid back to host uid, through the initial fakeroot userns.
+	if !l.cfg.Fakeroot && os.Getuid() != 0 {
+		uidMap, gidMap, err := l.getReverseUserMaps()
+		if err != nil {
+			return err
+		}
+		spec.Linux.UIDMappings = uidMap
+		spec.Linux.GIDMappings = gidMap
 	}
-	spec.Linux.UIDMappings = uidMap
-	spec.Linux.GIDMappings = gidMap
+
 	cwd, err := l.getProcessCwd()
 	if err != nil {
 		return err
@@ -328,9 +331,16 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		return fmt.Errorf("while generating container id: %w", err)
 	}
 
-	err = Run(ctx, id.String(), b.Path(), "")
-	if exiterr, ok := err.(*exec.ExitError); ok {
-		os.Exit(exiterr.ExitCode())
+	if os.Getuid() == 0 {
+		// Direct execution of runc/crun run.
+		err = Run(ctx, id.String(), b.Path(), "")
+	} else {
+		// Reexec singularity oci run in a userns with mappings.
+		err = RunNS(ctx, id.String(), b.Path(), "")
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		os.Exit(exitErr.ExitCode())
 	}
 	return err
 }

--- a/internal/pkg/runtime/launcher/oci/oci_conmon_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_conmon_linux.go
@@ -87,6 +87,12 @@ func Create(containerID, bundlePath string) error {
 	defer startParent.Close()
 
 	singularityBin := filepath.Join(buildcfg.BINDIR, "singularity")
+
+	rsd, err := runtimeStateDir()
+	if err != nil {
+		return err
+	}
+
 	cmdArgs := []string{
 		"--api-version", "1",
 		"--cid", containerID,
@@ -97,7 +103,7 @@ func Create(containerID, bundlePath string) error {
 		"--container-pidfile", path.Join(sd, containerPidFile),
 		"--log-path", path.Join(sd, containerLogFile),
 		"--runtime-arg", "--root",
-		"--runtime-arg", runtimeStateDir(),
+		"--runtime-arg", rsd,
 		"--runtime-arg", "--log",
 		"--runtime-arg", path.Join(sd, runcLogFile),
 		"--full-attach",

--- a/internal/pkg/runtime/launcher/oci/oci_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_linux.go
@@ -52,12 +52,16 @@ func runtime() (path string, err error) {
 }
 
 // runtimeStateDir returns path to use for crun/runc's state handling.
-func runtimeStateDir() string {
-	uid := os.Getuid()
-	if uid == 0 {
-		return "/run/singularity-oci"
+func runtimeStateDir() (path string, err error) {
+	// Ensure we get correct uid for host if we were re-exec'd in id mapped userns
+	pw, err := user.CurrentOriginal()
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("/run/user/%d/singularity-oci", uid)
+	if pw.UID == 0 {
+		return "/run/singularity-oci", nil
+	}
+	return fmt.Sprintf("/run/user/%d/singularity-oci", pw.UID), nil
 }
 
 // stateDir returns the path to container state handled by conmon/singularity

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -37,25 +37,17 @@ func MinimalSpec() (*specs.Spec, error) {
 	// Singularity's cap-add / cap-drop mechanism.
 	config.Process.Capabilities = &specs.LinuxCapabilities{
 		Bounding: []string{
-			"CAP_NET_BIND_SERVICE",
+			"CAP_CHOWN",
+			"CAP_DAC_OVERRIDE",
+			"CAP_FOWNER",
+			"CAP_FSETID",
 			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Permitted: []string{
 			"CAP_NET_BIND_SERVICE",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Inheritable: []string{},
-		Effective: []string{
-			"CAP_NET_BIND_SERVICE",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Ambient: []string{
-			"CAP_NET_BIND_SERVICE",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
+			"CAP_SETFCAP",
+			"CAP_SETGID",
+			"CAP_SETPCAP",
+			"CAP_SETUID",
+			"CAP_SYS_CHROOT",
 		},
 	}
 
@@ -64,19 +56,16 @@ func MinimalSpec() (*specs.Spec, error) {
 
 	config.Linux = &specs.Linux{
 		// Minimum namespaces matching native runtime with --compat / --containall.
-		// TODO: ßAdditional namespaces can be added by launcher.
+		// TODO: Additional namespaces to be added by launcher.
 		Namespaces: []specs.LinuxNamespace{
 			{
-				Type: "ipc",
+				Type: specs.IPCNamespace,
 			},
 			{
-				Type: "pid",
+				Type: specs.PIDNamespace,
 			},
 			{
-				Type: "mount",
-			},
-			{
-				Type: "user",
+				Type: specs.MountNamespace,
 			},
 		},
 	}

--- a/internal/pkg/util/starter/starter.go
+++ b/internal/pkg/util/starter/starter.go
@@ -126,7 +126,7 @@ func Run(name string, config *config.Common, ops ...CommandOp) error {
 	cmd.Stderr = c.stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("while running %s: %s", c.path, err)
+		return fmt.Errorf("while running %s: %w", c.path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Implements initial --fakeroot support for --oci mode. Mirrors behavior with --compat / --contain.

The process of accomplishing this is fairly complex. In theory, we should be able to call `crun` directly from host namespaces. We can let `crun` create a default userns and user mapping, or be able to request arbitrary explicit uid mappings (permitted by /etc/subuid /etc/subgid) to be applied.

Unfortunately this can hit bugs as this path is not well tested in `crun`. See e.g.

* https://github.com/containers/crun/issues/1077
* https://github.com/containers/crun/issues/1072

To avoid requiring the very latest `crun` with fixes, instead move to creating a userns ourselves, with a 'fakeroot' ID mapping in place, and call `crun` from that. This is the kind of flow implemented in other runtimes that call `crun`, such as `podman`.... so `crun` is well tested with it.

We can use the singularity `starter` with the `fakeroot` engine ,and a minimal config, to create the userns and id mapping. We already use it this way to perform a simple `rm` cleanup in `--fakeroot` execution of a native singularity container. This approach avoids having to implement further C/Go executables, or making large imports, such as the `reexec` + `unshare` packages from `github.com/containers/storage`

We are now, by default, calling `crun` or `runc` with a `fakeroot` setup... with host uid/gid mapped to 0 inside the userns. This is default for most OCI runtimes, however singularity default is to preserve the host id.

We need to have (fake) root inside the userns for `crun` / `runc` to work properly... so to return to the host uid in the container we insert an inner user namespace / ID mapping request into the bundle `config.json`. This reverses the mapping, i.e.

- User ID on host (1001)
- Root in outer user namespace (0)
- User ID in container (1001)

I've added a README.md in this PR, as things are rather complex:

https://github.com/sylabs/singularity/blob/9680663bb1eccbfade2de9f639e1e4be49ffb3bf/internal/pkg/runtime/launcher/oci/README.md

Note that there are likely still some rough edges, and the oci launcher package is getting toward the point where it should be split, but I don't want to add too much more to this single review.

### This fixes or addresses the following GitHub issues:

 - Fixes #1035


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
