### PR TITLE
fix: use conf file value for oci tmpfs size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `crun` will be used as the low-level OCI runtime, when available, rather than
   `runc`. `runc` will not support all rootless OCI runtime functionality used by
   Singularity.
+- `sessiondir maxsize` in `singularity.conf` now defaults to 64 MiB for new
+  installations. This is an increase from 16 MiB in prior versions.
 
 ### Development / Testing
 

--- a/etc/conf/testdata/test_1.out.correct
+++ b/etc/conf/testdata/test_1.out.correct
@@ -145,11 +145,12 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain, ephemeral changes when running with --writable-tmpfs.
+# In --oci mode, each tmpfs mount in the container can be up to this size.
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/etc/conf/testdata/test_2.in
+++ b/etc/conf/testdata/test_2.in
@@ -145,11 +145,12 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain, ephemeral changes when running with --writable-tmpfs,
+# and the equivalent data in --oci mode.
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/etc/conf/testdata/test_2.out.correct
+++ b/etc/conf/testdata/test_2.out.correct
@@ -145,11 +145,12 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain, ephemeral changes when running with --writable-tmpfs.
+# In --oci mode, each tmpfs mount in the container can be up to this size.
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/etc/conf/testdata/test_3.in
+++ b/etc/conf/testdata/test_3.in
@@ -136,11 +136,12 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain, ephemeral changes when running with --writable-tmpfs,
+# and the equivalent data in --oci mode.
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/etc/conf/testdata/test_3.out.correct
+++ b/etc/conf/testdata/test_3.out.correct
@@ -145,11 +145,12 @@ mount slave = yes
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
-sessiondir max size = 16
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain, ephemeral changes when running with --writable-tmpfs.
+# In --oci mode, each tmpfs mount in the container can be up to this size.
+sessiondir max size = 64
 
 
 # LIMIT CONTAINER OWNERS: [STRING]

--- a/etc/conf/testdata/test_default.tmpl
+++ b/etc/conf/testdata/test_default.tmpl
@@ -147,10 +147,11 @@ mount slave = {{ if eq .MountSlave true }}yes{{ else }}no{{ end }}
 
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain, ephemeral changes when running with --writable-tmpfs.
+# In --oci mode, each tmpfs mount in the container can be up to this size.
 sessiondir max size = {{ .SessiondirMaxSize }}
 
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sylabs/singularity/pkg/ocibundle/native"
 	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/util/singularityconf"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
@@ -35,7 +36,8 @@ var (
 // Launcher will holds configuration for, and will launch a container using an
 // OCI runtime.
 type Launcher struct {
-	cfg launcher.Options
+	cfg             launcher.Options
+	singularityConf *singularityconf.File
 }
 
 // NewLauncher returns a oci.Launcher with an initial configuration set by opts.
@@ -50,7 +52,13 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 	if err := checkOpts(lo); err != nil {
 		return nil, err
 	}
-	return &Launcher{lo}, nil
+
+	c := singularityconf.GetCurrentConfig()
+	if c == nil {
+		return nil, fmt.Errorf("singularity configuration is not initialized")
+	}
+
+	return &Launcher{cfg: lo, singularityConf: c}, nil
 }
 
 // checkOpts ensures that options set are supported by the oci.Launcher.

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -10,9 +10,16 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/runtime/launcher"
+	"github.com/sylabs/singularity/pkg/util/singularityconf"
 )
 
 func TestNewLauncher(t *testing.T) {
+	sc, err := singularityconf.GetConfig(nil)
+	if err != nil {
+		t.Fatalf("while initializing singularityconf: %s", err)
+	}
+	singularityconf.SetCurrentConfig(sc)
+
 	tests := []struct {
 		name    string
 		opts    []launcher.Option
@@ -21,7 +28,7 @@ func TestNewLauncher(t *testing.T) {
 	}{
 		{
 			name:    "default",
-			want:    &Launcher{},
+			want:    &Launcher{singularityConf: sc},
 			wantErr: false,
 		},
 		{
@@ -29,7 +36,7 @@ func TestNewLauncher(t *testing.T) {
 			opts: []launcher.Option{
 				launcher.OptHome("/home/test", false, false),
 			},
-			want: &Launcher{cfg: launcher.Options{HomeDir: "/home/test"}},
+			want: &Launcher{cfg: launcher.Options{HomeDir: "/home/test"}, singularityConf: sc},
 		},
 		{
 			name: "unsupportedOption",

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -11,7 +11,6 @@ package oci
 import (
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
@@ -22,7 +21,7 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 	mounts := &[]specs.Mount{}
 	l.addProcMount(mounts)
 	l.addSysMount(mounts)
-	err := addDevMounts(mounts)
+	err := l.addDevMounts(mounts)
 	if err != nil {
 		return nil, fmt.Errorf("while configuring devpts mount: %w", err)
 	}
@@ -37,22 +36,33 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 // addTmpMounts adds tmpfs mounts for /tmp and /var/tmp in the container.
 func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) {
 	*mounts = append(*mounts,
+
 		specs.Mount{
 			Destination: "/tmp",
 			Type:        "tmpfs",
 			Source:      "tmpfs",
-			Options:     []string{"nosuid", "relatime", "mode=777", "size=65536k"},
+			Options: []string{
+				"nosuid",
+				"relatime",
+				"mode=777",
+				fmt.Sprintf("size=%dm", l.singularityConf.SessiondirMaxSize),
+			},
 		},
 		specs.Mount{
-			Destination: "/tmp",
+			Destination: "/var/tmp",
 			Type:        "tmpfs",
 			Source:      "tmpfs",
-			Options:     []string{"nosuid", "relatime", "mode=777", "size=65536k"},
+			Options: []string{
+				"nosuid",
+				"relatime",
+				"mode=777",
+				fmt.Sprintf("size=%dm", l.singularityConf.SessiondirMaxSize),
+			},
 		})
 }
 
 // addDevMounts adds mounts to assemble a minimal /dev in the container.
-func addDevMounts(mounts *[]specs.Mount) error {
+func (l *Launcher) addDevMounts(mounts *[]specs.Mount) error {
 	ptsMount := specs.Mount{
 		Destination: "/dev/pts",
 		Type:        "devpts",
@@ -73,14 +83,25 @@ func addDevMounts(mounts *[]specs.Mount) error {
 			Destination: "/dev",
 			Type:        "tmpfs",
 			Source:      "tmpfs",
-			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			Options: []string{
+				"nosuid",
+				"strictatime",
+				"mode=755",
+				fmt.Sprintf("size=%dm", l.singularityConf.SessiondirMaxSize),
+			},
 		},
 		ptsMount,
 		specs.Mount{
 			Destination: "/dev/shm",
 			Type:        "tmpfs",
 			Source:      "shm",
-			Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+			Options: []string{
+				"nosuid",
+				"noexec",
+				"nodev",
+				"mode=1777",
+				fmt.Sprintf("size=%dm", l.singularityConf.SessiondirMaxSize),
+			},
 		},
 		specs.Mount{
 			Destination: "/dev/mqueue",
@@ -134,7 +155,12 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 				Destination: "/root",
 				Type:        "tmpfs",
 				Source:      "tmpfs",
-				Options:     []string{"nosuid", "relatime", "mode=755", "size=65536k"},
+				Options: []string{
+					"nosuid",
+					"relatime",
+					"mode=755",
+					fmt.Sprintf("size=%dm", l.singularityConf.SessiondirMaxSize),
+				},
 			})
 		return nil
 	}
@@ -148,7 +174,14 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 			Destination: pw.Dir,
 			Type:        "tmpfs",
 			Source:      "tmpfs",
-			Options:     []string{"nosuid", "relatime", "mode=755", "size=65536k", "uid=" + strconv.Itoa(int(pw.UID)), "gid=" + strconv.Itoa(int(pw.GID))},
+			Options: []string{
+				"nosuid",
+				"relatime",
+				"mode=755",
+				fmt.Sprintf("size=%dm", l.singularityConf.SessiondirMaxSize),
+				fmt.Sprintf("uid=%d", pw.UID),
+				fmt.Sprintf("gid=%d", pw.GID),
+			},
 		})
 	return nil
 }

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -47,7 +47,7 @@ type File struct {
 	AlwaysUseRocm           bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
 	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
 	MaxLoopDevices          uint     `default:"256" directive:"max loop devices"`
-	SessiondirMaxSize       uint     `default:"16" directive:"sessiondir max size"`
+	SessiondirMaxSize       uint     `default:"64" directive:"sessiondir max size"`
 	MountDev                string   `default:"yes" authorized:"yes,no,minimal" directive:"mount dev"`
 	EnableOverlay           string   `default:"try" authorized:"yes,no,try,driver" directive:"enable overlay"`
 	BindPath                []string `default:"/etc/localtime,/etc/hosts" directive:"bind path"`
@@ -228,10 +228,11 @@ enable underlay = {{ if eq .EnableUnderlay true }}yes{{ else }}no{{ end }}
 mount slave = {{ if eq .MountSlave true }}yes{{ else }}no{{ end }}
 
 # SESSIONDIR MAXSIZE: [STRING]
-# DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
+# DEFAULT: 64
+# This specifies how large the default tmpfs sessiondir should be (in MB).
+# The sessiondir is used to hold data written to isolated directories when
+# running with --contain, ephemeral changes when running with --writable-tmpfs.
+# In --oci mode, each tmpfs mount in the container can be up to this size.
 sessiondir max size = {{ .SessiondirMaxSize }}
 
 # LIMIT CONTAINER OWNERS: [STRING]


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use the configuration file sessiondir max size value for --oci mode tmpfs mounts.

Increase the default from 16M -> 64M. The 16M default is very low, and has periodically caused issues running programs that create even small amounts of temporary data on --contained filesystems.

### This fixes or addresses the following GitHub issues:

 - Fixes #1140


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
