### PR TITLE
Environment Variables for Signing Key Material

### DIFF
--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -7,7 +7,6 @@ package cli
 
 import (
 	"crypto"
-	"fmt"
 
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -132,7 +131,7 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 	// Set key material.
 	switch {
 	case cmd.Flag(signPrivateKeyFlag.Name).Changed:
-		fmt.Printf("Signing image with key material from '%s'\n", priKeyPath)
+		sylog.Infof("Signing image with key material from '%v'", priKeyPath)
 
 		s, err := signature.LoadSignerFromPEMFile(priKeyPath, crypto.SHA256, cryptoutils.GetPasswordFromStdIn)
 		if err != nil {
@@ -141,7 +140,7 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 		opts = append(opts, singularity.OptSignWithSigner(s))
 
 	default:
-		fmt.Println("Signing image with PGP key material")
+		sylog.Infof("Signing image with PGP key material")
 
 		// Set entity selector option, and ensure the entity is decrypted.
 		var f sypgp.EntitySelector
@@ -166,7 +165,7 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 
 	// Sign the image.
 	if err := singularity.Sign(cpath, opts...); err != nil {
-		sylog.Fatalf("Failed to sign container: %s", err)
+		sylog.Fatalf("Failed to sign container: %v", err)
 	}
-	fmt.Printf("Signature created and applied to %s\n", cpath)
+	sylog.Infof("Signature created and applied to %v\n", cpath)
 }

--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -72,6 +72,7 @@ var signPrivateKeyFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "key",
 	Usage:        "path to the private key file",
+	EnvKeys:      []string{"SIGN_KEY"},
 }
 
 // -k|--keyidx
@@ -131,6 +132,8 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 	// Set key material.
 	switch {
 	case cmd.Flag(signPrivateKeyFlag.Name).Changed:
+		fmt.Printf("Signing image with key material from '%s'\n", priKeyPath)
+
 		s, err := signature.LoadSignerFromPEMFile(priKeyPath, crypto.SHA256, cryptoutils.GetPasswordFromStdIn)
 		if err != nil {
 			sylog.Fatalf("Failed to load key material: %v", err)
@@ -138,6 +141,8 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 		opts = append(opts, singularity.OptSignWithSigner(s))
 
 	default:
+		fmt.Println("Signing image with PGP key material")
+
 		// Set entity selector option, and ensure the entity is decrypted.
 		var f sypgp.EntitySelector
 		if cmd.Flag(signKeyIdxFlag.Name).Changed {
@@ -160,7 +165,6 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 	}
 
 	// Sign the image.
-	fmt.Printf("Signing image: %s\n", cpath)
 	if err := singularity.Sign(cpath, opts...); err != nil {
 		sylog.Fatalf("Failed to sign container: %s", err)
 	}

--- a/docs/content.go
+++ b/docs/content.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2017-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -736,14 +736,19 @@ Enterprise Performance Computing (EPC)`
 	// sign
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	SignUse   string = `sign [sign options...] <image path>`
-	SignShort string = `Attach digital signature(s) to an image`
+	SignShort string = `Add digital signature(s) to an image`
 	SignLong  string = `
   The sign command allows a user to add one or more digital signatures to a SIF
   image. By default, one digital signature is added for each object group in
   the file.
-  
-  To generate a key pair, see 'singularity help key newpair'`
+
+  Key material can be provided via PEM-encoded file, or an entity in the PGP
+  keyring. To manage the PGP keyring, see 'singularity help key'.`
 	SignExample string = `
+  Sign with a private key:
+  $ singularity sign --key private.pem container.sif
+
+  Sign with PGP:
   $ singularity sign container.sif`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -216,6 +216,23 @@ func (c ctx) singularitySignKeyOption(t *testing.T) {
 	)
 }
 
+func (c ctx) singularitySignKeyEnv(t *testing.T) {
+	imgPath, cleanup := c.prepareImage(t)
+	defer cleanup(t)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithEnv([]string{"SINGULARITY_SIGN_KEY=" + filepath.Join("..", "test", "keys", "private.pem")}),
+		e2e.WithCommand("sign"),
+		e2e.WithArgs(imgPath),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
+		),
+	)
+}
+
 func (c *ctx) generateKeypair(t *testing.T) {
 	keyGenInput := []e2e.SingularityConsoleOp{
 		e2e.ConsoleSendLine("e2e sign test key"),
@@ -268,6 +285,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("singularitySignGroupIDOption", c.singularitySignGroupIDOption)
 			t.Run("singularitySignKeyidxOption", c.singularitySignKeyidxOption)
 			t.Run("singularitySignKeyOption", c.singularitySignKeyOption)
+			t.Run("singularitySignKeyEnv", c.singularitySignKeyEnv)
 		},
 	}
 }

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -6,250 +6,161 @@
 package sign
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
-	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
 type ctx struct {
-	env             e2e.TestEnv
-	keyringDir      string
-	passphraseInput []e2e.SingularityConsoleOp
+	e2e.TestEnv
 }
 
-const imgName = "testImage.sif"
-
-func (c ctx) singularitySignHelpOption(t *testing.T) {
-	c.env.KeyringDir = c.keyringDir
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("sign"),
-		e2e.WithArgs("--help"),
-		e2e.ExpectExit(
-			0,
-			e2e.ExpectOutput(e2e.ContainMatch, "Add digital signature(s) to an image"),
-		),
-	)
-}
-
-func (c *ctx) prepareImage(t *testing.T) (string, func(*testing.T)) {
-	// Get a refresh unsigned image
-	tempDir, err := os.MkdirTemp("", "")
+func getImage(t *testing.T) string {
+	dst, err := os.CreateTemp("", "e2e-sign-keyring-*")
 	if err != nil {
-		t.Fatalf("failed to create temporary directory: %s", err)
+		t.Fatal(err)
 	}
-	imgPath := filepath.Join(tempDir, imgName)
+	defer dst.Close()
 
-	err = fs.CopyFile(e2e.BusyboxSIF(t), imgPath, 0o755)
+	src, err := os.Open(filepath.Join("..", "test", "images", "one-group.sif"))
 	if err != nil {
-		t.Fatalf("failed to copy temporary image: %s", err)
+		t.Fatal(err)
+	}
+	defer src.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		t.Fatal(err)
 	}
 
-	return filepath.Join(tempDir, "testImage.sif"), func(t *testing.T) {
-		err := os.RemoveAll(tempDir)
-		if err != nil {
-			t.Fatalf("failed to delete temporary directory: %s", err)
-		}
-	}
+	return dst.Name()
 }
 
-//nolint:dupl
-func (c ctx) singularitySignIDOption(t *testing.T) {
-	imgPath, cleanup := c.prepareImage(t)
-	defer cleanup(t)
+func (c *ctx) sign(t *testing.T) {
+	keyPath := filepath.Join("..", "test", "keys", "private.pem")
 
 	tests := []struct {
 		name       string
-		args       []string
-		expectOp   e2e.SingularityCmdResultOp
-		expectExit int
+		envs       []string
+		flags      []string
+		expectCode int
+		expectOps  []e2e.SingularityCmdResultOp
 	}{
 		{
-			name:       "sign deffile",
-			args:       []string{"--sif-id", "1", imgPath},
-			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
-			expectExit: 0,
+			name:  "Help",
+			flags: []string{"--help"},
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Add digital signature(s) to an image"),
+			},
 		},
 		{
-			name:       "sign non-exsistent ID",
-			args:       []string{"--sif-id", "9", imgPath},
-			expectOp:   e2e.ExpectError(e2e.ContainMatch, "integrity: object not found"),
-			expectExit: 255,
+			name: "OK",
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+			},
+		},
+		{
+			name:  "ObjectIDFlag",
+			flags: []string{"--sif-id", "1"},
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+			},
+		},
+		{
+			name:       "ObjectIDFlagNotFound",
+			flags:      []string{"--sif-id", "9"},
+			expectCode: 255,
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "integrity: object not found"),
+			},
+		},
+		{
+			name:  "GroupIDFlag",
+			flags: []string{"--group-id", "1"},
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+			},
+		},
+		{
+			name:       "GroupIDFlagNotFound",
+			flags:      []string{"--group-id", "5"},
+			expectCode: 255,
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "integrity: group not found"),
+			},
+		},
+		{
+			name:  "AllFlag",
+			flags: []string{"--all"},
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+			},
+		},
+		{
+			name:  "KeyIndexFlag",
+			flags: []string{"--keyidx", "0"},
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+			},
+		},
+		{
+			name:       "KeyIndexFlagOutOfRange",
+			flags:      []string{"--keyidx", "1"},
+			expectCode: 255,
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Failed to sign container: index out of range"),
+			},
+		},
+		{
+			name:  "KeyFlag",
+			flags: []string{"--key", keyPath},
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with key material from '"+keyPath+"'"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+			},
+		},
+		{
+			name: "KeyEnvVar",
+			envs: []string{"SINGULARITY_SIGN_KEY=" + keyPath},
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with key material from '"+keyPath+"'"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+			},
 		},
 	}
 
-	c.env.KeyringDir = c.keyringDir
-
 	for _, tt := range tests {
-		c.env.RunSingularity(
-			t,
+		imgPath := getImage(t)
+		defer os.Remove(imgPath)
+
+		c.RunSingularity(t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithEnv(tt.envs),
 			e2e.WithCommand("sign"),
-			e2e.WithArgs(tt.args...),
-			e2e.ConsoleRun(c.passphraseInput...),
-			e2e.ExpectExit(tt.expectExit, tt.expectOp),
+			e2e.WithArgs(append(tt.flags, imgPath)...),
+			e2e.ExpectExit(tt.expectCode, tt.expectOps...),
 		)
 	}
 }
 
-func (c ctx) singularitySignAllOption(t *testing.T) {
-	imgPath, cleanup := c.prepareImage(t)
-	defer cleanup(t)
-
-	tests := []struct {
-		name       string
-		args       []string
-		expectOp   e2e.SingularityCmdResultOp
-		expectExit int
-	}{
-		{
-			name:       "sign default",
-			args:       []string{imgPath},
-			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
-			expectExit: 0,
-		},
-		{
-			name:       "sign all",
-			args:       []string{"--all", imgPath},
-			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
-			expectExit: 0,
-		},
-	}
-
-	c.env.KeyringDir = c.keyringDir
-
-	for _, tt := range tests {
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
-			e2e.WithCommand("sign"),
-			e2e.WithArgs(tt.args...),
-			e2e.ConsoleRun(c.passphraseInput...),
-			e2e.ExpectExit(tt.expectExit, tt.expectOp),
-		)
-	}
-}
-
-//nolint:dupl
-func (c ctx) singularitySignGroupIDOption(t *testing.T) {
-	imgPath, cleanup := c.prepareImage(t)
-	defer cleanup(t)
-
-	tests := []struct {
-		name       string
-		args       []string
-		expectOp   e2e.SingularityCmdResultOp
-		expectExit int
-	}{
-		{
-			name:       "groupID 0",
-			args:       []string{"--group-id", "1", imgPath},
-			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
-			expectExit: 0,
-		},
-		{
-			name:       "groupID 5",
-			args:       []string{"--group-id", "5", imgPath},
-			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "integrity: group not found"),
-			expectExit: 255,
-		},
-	}
-
-	c.env.KeyringDir = c.keyringDir
-
-	for _, tt := range tests {
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
-			e2e.WithCommand("sign"),
-			e2e.WithArgs(tt.args...),
-			e2e.ConsoleRun(c.passphraseInput...),
-			e2e.ExpectExit(tt.expectExit, tt.expectOp),
-		)
-	}
-}
-
-func (c ctx) singularitySignKeyidxOption(t *testing.T) {
-	imgPath, cleanup := c.prepareImage(t)
-	defer cleanup(t)
-
-	cmdArgs := []string{"--keyidx", "0", imgPath}
-	c.env.KeyringDir = c.keyringDir
-	c.env.RunSingularity(
+func (c *ctx) importPGPKeypairs(t *testing.T) {
+	c.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("sign"),
-		e2e.WithArgs(cmdArgs...),
-		e2e.ConsoleRun(c.passphraseInput...),
-		e2e.ExpectExit(
-			0,
-			e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
-		),
-	)
-}
-
-func (c ctx) singularitySignKeyOption(t *testing.T) {
-	imgPath, cleanup := c.prepareImage(t)
-	defer cleanup(t)
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("sign"),
-		e2e.WithArgs(
-			"--key",
-			filepath.Join("..", "test", "keys", "private.pem"),
-			imgPath,
-		),
-		e2e.ExpectExit(
-			0,
-			e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
-		),
-	)
-}
-
-func (c ctx) singularitySignKeyEnv(t *testing.T) {
-	imgPath, cleanup := c.prepareImage(t)
-	defer cleanup(t)
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithEnv([]string{"SINGULARITY_SIGN_KEY=" + filepath.Join("..", "test", "keys", "private.pem")}),
-		e2e.WithCommand("sign"),
-		e2e.WithArgs(imgPath),
-		e2e.ExpectExit(
-			0,
-			e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
-		),
-	)
-}
-
-func (c *ctx) generateKeypair(t *testing.T) {
-	keyGenInput := []e2e.SingularityConsoleOp{
-		e2e.ConsoleSendLine("e2e sign test key"),
-		e2e.ConsoleSendLine("jdoe@sylabs.io"),
-		e2e.ConsoleSendLine("sign e2e test"),
-		e2e.ConsoleSendLine("passphrase"),
-		e2e.ConsoleSendLine("passphrase"),
-		e2e.ConsoleSendLine("n"),
-	}
-
-	c.env.KeyringDir = c.keyringDir
-	c.env.RunSingularity(
-		t,
-		e2e.ConsoleRun(keyGenInput...),
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("key"),
-		e2e.WithArgs("newpair"),
+		e2e.WithCommand("key import"),
+		e2e.WithArgs(filepath.Join("..", "test", "keys", "private.asc")),
 		e2e.ExpectExit(0),
 	)
 }
@@ -257,35 +168,28 @@ func (c *ctx) generateKeypair(t *testing.T) {
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
-		env: env,
+		TestEnv: env,
 	}
 
 	return testhelper.Tests{
 		"ordered": func(t *testing.T) {
 			var err error
-			// We need one single key pair in a single keyring for all the tests
-			c.keyringDir, err = os.MkdirTemp("", "e2e-sign-keyring-")
+
+			// Create a temporary PGP keyring.
+			c.KeyringDir, err = os.MkdirTemp("", "e2e-sign-keyring-")
 			if err != nil {
 				t.Fatalf("failed to create temporary directory: %s", err)
 			}
 			defer func() {
-				err := os.RemoveAll(c.keyringDir)
+				err := os.RemoveAll(c.KeyringDir)
 				if err != nil {
 					t.Fatalf("failed to delete temporary directory: %s", err)
 				}
 			}()
-			c.generateKeypair(t)
 
-			c.passphraseInput = []e2e.SingularityConsoleOp{
-				e2e.ConsoleSendLine("passphrase"),
-			}
-			t.Run("singularitySignAllOption", c.singularitySignAllOption)
-			t.Run("singularitySignHelpOption", c.singularitySignHelpOption)
-			t.Run("singularitySignIDOption", c.singularitySignIDOption)
-			t.Run("singularitySignGroupIDOption", c.singularitySignGroupIDOption)
-			t.Run("singularitySignKeyidxOption", c.singularitySignKeyidxOption)
-			t.Run("singularitySignKeyOption", c.singularitySignKeyOption)
-			t.Run("singularitySignKeyEnv", c.singularitySignKeyEnv)
+			c.importPGPKeypairs(t)
+
+			t.Run("Sign", c.sign)
 		},
 	}
 }

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -32,7 +32,7 @@ func (c ctx) singularitySignHelpOption(t *testing.T) {
 		e2e.WithArgs("--help"),
 		e2e.ExpectExit(
 			0,
-			e2e.ExpectOutput(e2e.ContainMatch, "Attach digital signature(s) to an image"),
+			e2e.ExpectOutput(e2e.ContainMatch, "Add digital signature(s) to an image"),
 		),
 	)
 }

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -59,16 +59,16 @@ func (c *ctx) sign(t *testing.T) {
 		{
 			name: "OK",
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
 			name:  "ObjectIDFlag",
 			flags: []string{"--sif-id", "1"},
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func (c *ctx) sign(t *testing.T) {
 			flags:      []string{"--sif-id", "9"},
 			expectCode: 255,
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
 				e2e.ExpectError(e2e.ContainMatch, "integrity: object not found"),
 			},
 		},
@@ -84,8 +84,8 @@ func (c *ctx) sign(t *testing.T) {
 			name:  "GroupIDFlag",
 			flags: []string{"--group-id", "1"},
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
@@ -93,7 +93,7 @@ func (c *ctx) sign(t *testing.T) {
 			flags:      []string{"--group-id", "5"},
 			expectCode: 255,
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
 				e2e.ExpectError(e2e.ContainMatch, "integrity: group not found"),
 			},
 		},
@@ -101,16 +101,16 @@ func (c *ctx) sign(t *testing.T) {
 			name:  "AllFlag",
 			flags: []string{"--all"},
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
 			name:  "KeyIndexFlag",
 			flags: []string{"--keyidx", "0"},
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func (c *ctx) sign(t *testing.T) {
 			flags:      []string{"--keyidx", "1"},
 			expectCode: 255,
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
 				e2e.ExpectError(e2e.ContainMatch, "Failed to sign container: index out of range"),
 			},
 		},
@@ -126,16 +126,16 @@ func (c *ctx) sign(t *testing.T) {
 			name:  "KeyFlag",
 			flags: []string{"--key", keyPath},
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with key material from '"+keyPath+"'"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with key material from '"+keyPath+"'"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 		{
 			name: "KeyEnvVar",
 			envs: []string{"SINGULARITY_SIGN_KEY=" + keyPath},
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.ContainMatch, "Signing image with key material from '"+keyPath+"'"),
-				e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied"),
+				e2e.ExpectError(e2e.ContainMatch, "Signing image with key material from '"+keyPath+"'"),
+				e2e.ExpectError(e2e.ContainMatch, "Signature created and applied"),
 			},
 		},
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add visual indication of key material being used by `singularity sign`. Improve `singularity sign` documentation. Define `SINGULARITY_SIGN_KEY` environment variable for '--key' flag of `singularity sign`. Simplify `singularity sign` end-to-end tests, and add coverage for `SINGULARITY_SIGN_KEY` environment variable.


### This fixes or addresses the following GitHub issues:

 - Fixes #1148 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
