### PR TITLE
Environment Variables for Verification

### DIFF
--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -167,5 +167,5 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 	if err := singularity.Sign(cpath, opts...); err != nil {
 		sylog.Fatalf("Failed to sign container: %v", err)
 	}
-	sylog.Infof("Signature created and applied to %v\n", cpath)
+	sylog.Infof("Signature created and applied to image '%v'", cpath)
 }

--- a/cmd/internal/cli/verify.go
+++ b/cmd/internal/cli/verify.go
@@ -88,6 +88,7 @@ var verifyPublicKeyFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "key",
 	Usage:        "path to the public key file",
+	EnvKeys:      []string{"VERIFY_KEY"},
 }
 
 // -l|--local

--- a/cmd/internal/cli/verify.go
+++ b/cmd/internal/cli/verify.go
@@ -8,7 +8,6 @@ package cli
 
 import (
 	"crypto"
-	"fmt"
 	"os"
 
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -169,6 +168,8 @@ func doVerifyCmd(cmd *cobra.Command, cpath string) {
 
 	switch {
 	case cmd.Flag(verifyPublicKeyFlag.Name).Changed:
+		sylog.Infof("Verifying image with key material from '%v'", pubKeyPath)
+
 		v, err := signature.LoadVerifierFromPEMFile(pubKeyPath, crypto.SHA256)
 		if err != nil {
 			sylog.Fatalf("Failed to load key material: %v", err)
@@ -176,6 +177,8 @@ func doVerifyCmd(cmd *cobra.Command, cpath string) {
 		opts = append(opts, singularity.OptVerifyWithVerifier(v))
 
 	default:
+		sylog.Infof("Verifying image with PGP key material")
+
 		// Set keyserver option, if applicable.
 		if localVerify {
 			opts = append(opts, singularity.OptVerifyWithPGP())
@@ -222,17 +225,15 @@ func doVerifyCmd(cmd *cobra.Command, cpath string) {
 		}
 
 		if verifyErr != nil {
-			sylog.Fatalf("Failed to verify container: %s", verifyErr)
+			sylog.Fatalf("Failed to verify container: %v", verifyErr)
 		}
 	} else {
 		opts = append(opts, singularity.OptVerifyCallback(outputVerify))
 
-		fmt.Printf("Verifying image: %s\n", cpath)
-
 		if err := singularity.Verify(cmd.Context(), cpath, opts...); err != nil {
-			sylog.Fatalf("Failed to verify container: %s", err)
+			sylog.Fatalf("Failed to verify container: %v", err)
 		}
 
-		fmt.Printf("Container verified: %s\n", cpath)
+		sylog.Infof("Verified signature(s) from image '%v'", cpath)
 	}
 }

--- a/docs/content.go
+++ b/docs/content.go
@@ -755,15 +755,18 @@ Enterprise Performance Computing (EPC)`
 	// verify
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	VerifyUse   string = `verify [verify options...] <image path>`
-	VerifyShort string = `Verify cryptographic signatures attached to an image`
+	VerifyShort string = `Verify digital signature(s) within an image`
 	VerifyLong  string = `
-  The verify command allows a user to verify cryptographic signatures on SIF 
-  container files. There may be multiple signatures for data objects and 
-  multiple data objects signed. By default the command searches for the primary 
-  partition signature. If found, a list of all verification blocks applied on 
-  the primary partition is gathered so that data integrity (hashing) and 
-  signature verification is done for all those blocks.`
+  The verify command allows a user to verify one or more digital signatures
+  within a SIF image.
+
+  Key material can be provided via PEM-encoded file, or via the PGP keyring. To
+  manage the PGP keyring, see 'singularity help key'.`
 	VerifyExample string = `
+  Verify with a public key:
+  $ singularity verify --key public.pem container.sif
+
+  Verify with PGP:
   $ singularity verify container.sif`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -6,363 +6,175 @@
 package verify
 
 import (
-	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/buger/jsonparser"
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
-	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
 type ctx struct {
-	env            e2e.TestEnv
-	corruptedImage string
-	successImage   string
+	e2e.TestEnv
 }
 
-type verifyOutput struct {
-	name        string
-	fingerprint string
-	local       bool
-	keyCheck    bool
-	dataCheck   bool
-}
-
-const (
-	successURL   = "library://sylabs/tests/verify_success:1.0.2"
-	corruptedURL = "library://sylabs/tests/verify_corrupted:1.0.1"
-)
-
-func getNameJSON(keyNum int) []string {
-	return []string{"SignerKeys", fmt.Sprintf("[%d]", keyNum), "Signer", "Name"}
-}
-
-func getFingerprintJSON(keyNum int) []string {
-	return []string{"SignerKeys", fmt.Sprintf("[%d]", keyNum), "Signer", "Fingerprint"}
-}
-
-func getLocalJSON(keyNum int) []string {
-	return []string{"SignerKeys", fmt.Sprintf("[%d]", keyNum), "Signer", "KeyLocal"}
-}
-
-func getKeyCheckJSON(keyNum int) []string {
-	return []string{"SignerKeys", fmt.Sprintf("[%d]", keyNum), "Signer", "KeyCheck"}
-}
-
-func getDataCheckJSON(keyNum int) []string {
-	return []string{"SignerKeys", fmt.Sprintf("[%d]", keyNum), "Signer", "DataCheck"}
-}
-
-func (c ctx) singularityVerifyAllKeyNum(t *testing.T) {
-	keyNumPath := []string{"Signatures"}
+func (c *ctx) verify(t *testing.T) {
+	keyPath := filepath.Join("..", "test", "keys", "public.pem")
 
 	tests := []struct {
-		name         string
-		expectNumOut int64  // Is the expected number of Signatures
-		imageURL     string // Is the URL to the container
-		imagePath    string // Is the path to the container
-		expectExit   int
+		name       string
+		envs       []string
+		flags      []string
+		imagePath  string
+		expectCode int
+		expectOps  []e2e.SingularityCmdResultOp
 	}{
 		{
-			name:         "verify number signers fail",
-			expectNumOut: 0,
-			imageURL:     corruptedURL,
-			imagePath:    c.corruptedImage,
-			expectExit:   255,
-		},
-		{
-			name:         "verify number signers success",
-			expectNumOut: 2,
-			imageURL:     successURL,
-			imagePath:    c.successImage,
-			expectExit:   0,
-		},
-	}
-
-	for _, tt := range tests {
-		if !fs.IsFile(tt.imagePath) {
-			t.Fatalf("image file (%s) does not exist", tt.imagePath)
-		}
-
-		verifyOutput := func(t *testing.T, r *e2e.SingularityCmdResult) {
-			// Get the Signatures and compare it
-			eNum, err := jsonparser.GetInt(r.Stdout, keyNumPath...)
-			if err != nil {
-				err = errors.Wrap(err, "getting key number from JSON")
-				t.Fatalf("unable to get expected output from json: %+v", err)
-			}
-			if eNum != tt.expectNumOut {
-				t.Fatalf("unexpected failure: got: '%d', expecting: '%d'", eNum, tt.expectNumOut)
-			}
-		}
-
-		// Inspect the container, and get the output
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
-			e2e.WithCommand("verify"),
-			e2e.WithArgs("--legacy-insecure", "--all", "--json", tt.imagePath),
-			e2e.ExpectExit(tt.expectExit, verifyOutput),
-		)
-	}
-}
-
-func (c ctx) singularityVerifySigner(t *testing.T) {
-	tests := []struct {
-		expectOutput []verifyOutput
-		name         string
-		imagePath    string
-		imageURL     string
-		expectExit   int
-		verifyLocal  bool
-	}{
-		// corrupted verify
-		{
-			name:         "corrupted signatures",
-			verifyLocal:  false,
-			imageURL:     corruptedURL,
-			imagePath:    c.corruptedImage,
-			expectExit:   255,
-			expectOutput: []verifyOutput{},
-		},
-
-		// corrupted verify with --local
-		{
-			name:         "corrupted signatures local",
-			imageURL:     corruptedURL,
-			imagePath:    c.corruptedImage,
-			verifyLocal:  true,
-			expectExit:   255,
-			expectOutput: []verifyOutput{},
-		},
-
-		// Verify 'verify_container_success.sif'
-		{
-			name:        "verify success",
-			verifyLocal: false,
-			imageURL:    successURL,
-			imagePath:   c.successImage,
-			expectExit:  0,
-			expectOutput: []verifyOutput{
-				{
-					name:        "WestleyK (Testing key; used for signing test containers) \u003cwestley@sylabs.io\u003e",
-					fingerprint: "7605bc2716168df057d6c600aceec62c8bd91bee",
-					local:       false,
-					keyCheck:    true,
-					dataCheck:   true,
-				},
+			name:  "Help",
+			flags: []string{"--help"},
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "Verify digital signature(s) within an image"),
 			},
 		},
-
-		// Verify 'verify_container_success.sif' with --local
 		{
-			name:         "verify non local fail",
-			imageURL:     successURL,
-			imagePath:    c.successImage,
-			verifyLocal:  true,
-			expectExit:   255,
-			expectOutput: []verifyOutput{},
+			name:      "OK",
+			imagePath: filepath.Join("..", "test", "images", "one-group-signed-pgp.sif"),
+			flags:     []string{"--local"},
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectError(e2e.ContainMatch, "Verifying image with PGP key material"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing entity: SingularityCE Tests <singularityce@example.com>"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Fingerprint: F34371D0ACD5D09EB9BD853A80600A5FA11BBD29"),
+				e2e.ExpectError(e2e.ContainMatch, "Verified signature(s) from image"),
+			},
+		},
+		{
+			name:      "LegacyObjectIDFlag",
+			flags:     []string{"--local", "--legacy-insecure", "--sif-id", "2"},
+			imagePath: filepath.Join("..", "test", "images", "one-group-signed-legacy.sif"),
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectError(e2e.ContainMatch, "Verifying image with PGP key material"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing entity: SingularityCE Tests <singularityce@example.com>"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Fingerprint: F34371D0ACD5D09EB9BD853A80600A5FA11BBD29"),
+				e2e.ExpectError(e2e.ContainMatch, "Verified signature(s) from image"),
+			},
+		},
+		{
+			name:       "LegacyObjectIDFlagNotFound",
+			flags:      []string{"--local", "--legacy-insecure", "--sif-id", "9"},
+			imagePath:  filepath.Join("..", "test", "images", "one-group-signed-legacy.sif"),
+			expectCode: 255,
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectError(e2e.ContainMatch, "Verifying image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "integrity: object not found"),
+			},
+		},
+		{
+			name:      "LegacyGroupIDFlag",
+			flags:     []string{"--local", "--legacy-insecure", "--group-id", "1"},
+			imagePath: filepath.Join("..", "test", "images", "one-group-signed-legacy-group.sif"),
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectError(e2e.ContainMatch, "Verifying image with PGP key material"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing entity: SingularityCE Tests <singularityce@example.com>"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Fingerprint: F34371D0ACD5D09EB9BD853A80600A5FA11BBD29"),
+				e2e.ExpectError(e2e.ContainMatch, "Verified signature(s) from image"),
+			},
+		},
+		{
+			name:       "LegacyGroupIDFlagNotFound",
+			flags:      []string{"--local", "--legacy-insecure", "--group-id", "5"},
+			imagePath:  filepath.Join("..", "test", "images", "one-group-signed-legacy-group.sif"),
+			expectCode: 255,
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectError(e2e.ContainMatch, "Verifying image with PGP key material"),
+				e2e.ExpectError(e2e.ContainMatch, "integrity: group not found"),
+			},
+		},
+		{
+			name:      "LegacyAllFlag",
+			flags:     []string{"--local", "--legacy-insecure", "--all"},
+			imagePath: filepath.Join("..", "test", "images", "one-group-signed-legacy-all.sif"),
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectError(e2e.ContainMatch, "Verifying image with PGP key material"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Signing entity: SingularityCE Tests <singularityce@example.com>"),
+				e2e.ExpectOutput(e2e.ContainMatch, "Fingerprint: F34371D0ACD5D09EB9BD853A80600A5FA11BBD29"),
+				e2e.ExpectError(e2e.ContainMatch, "Verified signature(s) from image"),
+			},
+		},
+		{
+			name:      "JSONFlag",
+			imagePath: filepath.Join("..", "test", "images", "one-group-signed-pgp.sif"),
+			flags:     []string{"--local", "--json"},
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectError(e2e.ContainMatch, "Verifying image with PGP key material"),
+			},
+		},
+		{
+			name:      "KeyFlag",
+			flags:     []string{"--key", keyPath},
+			imagePath: filepath.Join("..", "test", "images", "one-group-signed-dsse.sif"),
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectError(e2e.ContainMatch, "Verifying image with key material from '"+keyPath+"'"),
+				e2e.ExpectError(e2e.ContainMatch, "Verified signature(s) from image"),
+			},
+		},
+		{
+			name:      "KeyEnvVar",
+			envs:      []string{"SINGULARITY_VERIFY_KEY=" + keyPath},
+			imagePath: filepath.Join("..", "test", "images", "one-group-signed-dsse.sif"),
+			expectOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectError(e2e.ContainMatch, "Verifying image with key material from '"+keyPath+"'"),
+				e2e.ExpectError(e2e.ContainMatch, "Verified signature(s) from image"),
+			},
 		},
 	}
 
 	for _, tt := range tests {
-		verifyOutput := func(t *testing.T, r *e2e.SingularityCmdResult) {
-			for keyNum, vo := range tt.expectOutput {
-				eName, err := jsonparser.GetString(r.Stdout, getNameJSON(keyNum)...)
-				if err != nil {
-					err = errors.Wrap(err, "getting string from JSON")
-					t.Fatalf("unable to get expected output from json: %+v", err)
-				}
-				if eName != vo.name {
-					t.Fatalf("unexpected failure: got: '%s', expecting: '%s'", eName, vo.name)
-				}
-
-				// Get the Fingerprint and compare it
-				eFingerprint, err := jsonparser.GetString(r.Stdout, getFingerprintJSON(keyNum)...)
-				if err != nil {
-					err = errors.Wrap(err, "getting string from JSON")
-					t.Fatalf("unable to get expected output from json: %+v", err)
-				}
-				if eFingerprint != vo.fingerprint {
-					t.Fatalf("unexpected failure: got: '%s', expecting: '%s'", eFingerprint, vo.fingerprint)
-				}
-
-				// Get the Local and compare it
-				eLocal, err := jsonparser.GetBoolean(r.Stdout, getLocalJSON(keyNum)...)
-				if err != nil {
-					err = errors.Wrap(err, "getting boolean from JSON")
-					t.Fatalf("unable to get expected output from json: %+v", err)
-				}
-				if eLocal != vo.local {
-					t.Fatalf("unexpected failure: got: '%v', expecting: '%v'", eLocal, vo.local)
-				}
-
-				// Get the KeyCheck and compare it
-				eKeyCheck, err := jsonparser.GetBoolean(r.Stdout, getKeyCheckJSON(keyNum)...)
-				if err != nil {
-					err = errors.Wrap(err, "getting boolean from JSON")
-					t.Fatalf("unable to get expected output from json: %+v", err)
-				}
-				if eKeyCheck != vo.keyCheck {
-					t.Fatalf("unexpected failure: got: '%v', expecting: '%v'", eKeyCheck, vo.keyCheck)
-				}
-
-				// Get the DataCheck and compare it
-				eDataCheck, err := jsonparser.GetBoolean(r.Stdout, getDataCheckJSON(keyNum)...)
-				if err != nil {
-					err = errors.Wrap(err, "getting boolean from JSON")
-					t.Fatalf("unable to get expected output from json: %+v", err)
-				}
-				if eDataCheck != vo.dataCheck {
-					t.Fatalf("unexpected failure: got: '%v', expecting: '%v'", eDataCheck, vo.dataCheck)
-				}
-			}
-		}
-
-		if !fs.IsFile(tt.imagePath) {
-			t.Fatalf("image file (%s) does not exist", tt.imagePath)
-		}
-
-		args := []string{"--legacy-insecure", "--json"}
-		if tt.verifyLocal {
-			args = append(args, "--local")
-		}
-		args = append(args, tt.imagePath)
-
-		// Inspect the container, and get the output
-		c.env.RunSingularity(
-			t,
+		c.RunSingularity(t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithEnv(tt.envs),
 			e2e.WithCommand("verify"),
-			e2e.WithArgs(args...),
-			e2e.ExpectExit(tt.expectExit, verifyOutput),
+			e2e.WithArgs(append(tt.flags, tt.imagePath)...),
+			e2e.ExpectExit(tt.expectCode, tt.expectOps...),
 		)
 	}
 }
 
-func (c ctx) checkGroupidOption(t *testing.T) {
-	cmdArgs := []string{"--legacy-insecure", "--group-id", "1", c.successImage}
-	c.env.RunSingularity(
+func (c *ctx) importPGPKeypairs(t *testing.T) {
+	c.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("verify"),
-		e2e.WithArgs(cmdArgs...),
-		e2e.ExpectExit(
-			0,
-			e2e.ExpectOutput(e2e.RegexMatch, "Container verified: .*/verify_success.sif"),
-		),
-	)
-}
-
-func (c ctx) checkIDOption(t *testing.T) {
-	cmdArgs := []string{"--legacy-insecure", "--sif-id", "1", c.successImage}
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("verify"),
-		e2e.WithArgs(cmdArgs...),
-		e2e.ExpectExit(
-			0,
-			e2e.ExpectOutput(e2e.RegexMatch, "Container verified: .*/verify_success.sif"),
-		),
-	)
-}
-
-func (c ctx) checkAllOption(t *testing.T) {
-	cmdArgs := []string{"--legacy-insecure", "--all", c.successImage}
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("verify"),
-		e2e.WithArgs(cmdArgs...),
-		e2e.ExpectExit(
-			0,
-			e2e.ExpectOutput(e2e.RegexMatch, "Container verified: .*/verify_success.sif"),
-		),
-	)
-}
-
-func (c ctx) checkURLOption(t *testing.T) {
-	if !fs.IsFile(c.successImage) {
-		t.Fatalf("image file (%s) does not exist", c.successImage)
-	}
-
-	cmdArgs := []string{"--legacy-insecure", "--url", "https://keys.sylabs.io", c.successImage}
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("verify"),
-		e2e.WithArgs(cmdArgs...),
-		e2e.ExpectExit(
-			0,
-			e2e.ExpectOutput(e2e.RegexMatch, "Container verified: .*/verify_success.sif"),
-		),
-	)
-}
-
-func (c ctx) singularityVerifyKeyOption(t *testing.T) {
-	imagePath := filepath.Join("..", "test", "images", "one-group-signed-dsse.sif")
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("verify"),
-		e2e.WithArgs(
-			"--key",
-			filepath.Join("..", "test", "keys", "public.pem"),
-			imagePath,
-		),
-		e2e.ExpectExit(
-			0,
-			e2e.ExpectOutput(e2e.ContainMatch, "Container verified: "+imagePath),
-		),
-	)
-}
-
-func (c ctx) singularityVerifyKeyEnv(t *testing.T) {
-	imagePath := filepath.Join("..", "test", "images", "one-group-signed-dsse.sif")
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithEnv([]string{"SINGULARITY_VERIFY_KEY=" + filepath.Join("..", "test", "keys", "public.pem")}),
-		e2e.WithCommand("verify"),
-		e2e.WithArgs(imagePath),
-		e2e.ExpectExit(
-			0,
-			e2e.ExpectOutput(e2e.ContainMatch, "Container verified: "+imagePath),
-		),
+		e2e.WithCommand("key import"),
+		e2e.WithArgs(filepath.Join("..", "test", "keys", "private.asc")),
+		e2e.ExpectExit(0),
 	)
 }
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
-		env:            env,
-		corruptedImage: filepath.Join(env.TestDir, "verify_corrupted.sif"),
-		successImage:   filepath.Join(env.TestDir, "verify_success.sif"),
+		TestEnv: env,
 	}
 
 	return testhelper.Tests{
 		"ordered": func(t *testing.T) {
-			// We pull the two images required for the tests once
-			// We should be able to sign amd64 on other archs too!
-			e2e.PullImage(t, c.env, successURL, "amd64", c.successImage)
-			e2e.PullImage(t, c.env, corruptedURL, "amd64", c.corruptedImage)
+			var err error
 
-			t.Run("checkAllOption", c.checkAllOption)
-			t.Run("singularityVerifyAllKeyNum", c.singularityVerifyAllKeyNum)
-			t.Run("singularityVerifySigner", c.singularityVerifySigner)
-			t.Run("singularityVerifyGroupIdOption", c.checkGroupidOption)
-			t.Run("singularityVerifyIDOption", c.checkIDOption)
-			t.Run("singularityVerifyURLOption", c.checkURLOption)
-			t.Run("singularityVerifyKeyOption", c.singularityVerifyKeyOption)
-			t.Run("singularityVerifyKeyEnv", c.singularityVerifyKeyEnv)
+			// Create a temporary PGP keyring.
+			c.KeyringDir, err = os.MkdirTemp("", "e2e-sign-keyring-")
+			if err != nil {
+				t.Fatalf("failed to create temporary directory: %s", err)
+			}
+			defer func() {
+				err := os.RemoveAll(c.KeyringDir)
+				if err != nil {
+					t.Fatalf("failed to delete temporary directory: %s", err)
+				}
+			}()
+
+			c.importPGPKeypairs(t)
+
+			t.Run("Verify", c.verify)
 		},
 	}
 }

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -324,6 +324,22 @@ func (c ctx) singularityVerifyKeyOption(t *testing.T) {
 	)
 }
 
+func (c ctx) singularityVerifyKeyEnv(t *testing.T) {
+	imagePath := filepath.Join("..", "test", "images", "one-group-signed-dsse.sif")
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithEnv([]string{"SINGULARITY_VERIFY_KEY=" + filepath.Join("..", "test", "keys", "public.pem")}),
+		e2e.WithCommand("verify"),
+		e2e.WithArgs(imagePath),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ContainMatch, "Container verified: "+imagePath),
+		),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
@@ -346,6 +362,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("singularityVerifyIDOption", c.checkIDOption)
 			t.Run("singularityVerifyURLOption", c.checkURLOption)
 			t.Run("singularityVerifyKeyOption", c.singularityVerifyKeyOption)
+			t.Run("singularityVerifyKeyEnv", c.singularityVerifyKeyEnv)
 		},
 	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add visual indication of key material being used by `singularity verify`. Improve `singularity verify` documentation. Define `SINGULARITY_VERIFY_KEY ` environment variable for '--key' flag of `singularity verify`. Simplify `singularity verify` end-to-end tests, and add coverage for `SINGULARITY_VERIFY_KEY ` environment variable.

### This fixes or addresses the following GitHub issues:


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
