### PR TITLE
feat: oci: support namespace flags

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2461,8 +2461,9 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		// OCI Runtime Mode
 		//
-		"ociRun":   c.actionOciRun,   // singularity run --oci
-		"ociExec":  c.actionOciExec,  // singularity exec --oci
-		"ociShell": c.actionOciShell, // singularity shell --oci
+		"ociRun":     c.actionOciRun,     // singularity run --oci
+		"ociExec":    c.actionOciExec,    // singularity exec --oci
+		"ociShell":   c.actionOciShell,   // singularity shell --oci
+		"ociNetwork": c.actionOciNetwork, // singularity exec --oci --net
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/containers/image/v5/types"
 	"github.com/google/uuid"
@@ -27,6 +28,7 @@ import (
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/singularityconf"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+	"golang.org/x/term"
 )
 
 var (
@@ -237,6 +239,11 @@ func checkOpts(lo launcher.Options) error {
 // the image config is available, to account for the image's CMD / ENTRYPOINT.
 func (l *Launcher) createSpec() (*specs.Spec, error) {
 	spec := minimalSpec()
+
+	// Override the default Process.Terminal to false if our stdin is not a terminal.
+	if !term.IsTerminal(syscall.Stdin) {
+		spec.Process.Terminal = false
+	}
 
 	spec.Process.User = l.getProcessUser()
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -10,10 +10,14 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/runtime/launcher"
+	"github.com/sylabs/singularity/internal/pkg/test"
 	"github.com/sylabs/singularity/pkg/util/singularityconf"
 )
 
 func TestNewLauncher(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
 	sc, err := singularityconf.GetConfig(nil)
 	if err != nil {
 		t.Fatalf("while initializing singularityconf: %s", err)

--- a/internal/pkg/runtime/launcher/oci/spec_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sylabs/singularity/internal/pkg/runtime/launcher"
+	"github.com/sylabs/singularity/internal/pkg/test"
+)
+
+func Test_addNamespaces(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	tests := []struct {
+		name   string
+		ns     launcher.Namespaces
+		wantNS []specs.LinuxNamespace
+	}{
+		{
+			name:   "none",
+			ns:     launcher.Namespaces{},
+			wantNS: defaultNamespaces,
+		},
+		{
+			name:   "pid",
+			ns:     launcher.Namespaces{PID: true},
+			wantNS: defaultNamespaces,
+		},
+		{
+			name:   "ipc",
+			ns:     launcher.Namespaces{IPC: true},
+			wantNS: defaultNamespaces,
+		},
+		{
+			name:   "user",
+			ns:     launcher.Namespaces{User: true},
+			wantNS: defaultNamespaces,
+		},
+		{
+			name:   "net",
+			ns:     launcher.Namespaces{Net: true},
+			wantNS: append(defaultNamespaces, specs.LinuxNamespace{Type: specs.NetworkNamespace}),
+		},
+		{
+			name:   "uts",
+			ns:     launcher.Namespaces{UTS: true},
+			wantNS: append(defaultNamespaces, specs.LinuxNamespace{Type: specs.UTSNamespace}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := minimalSpec()
+			newSpec := addNamespaces(spec, tt.ns)
+			newNS := newSpec.Linux.Namespaces
+			if !reflect.DeepEqual(newNS, tt.wantNS) {
+				t.Errorf("addNamespaces() got %v, want %v", newNS, tt.wantNS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Support namespace request CLI options.

* --ipc - no effect, always used in --oci mode.
* --net - only supported with --network none.
* --pid - no effect, always used in --oci mode.
* -u / --userns - only effective for root, non-root always uses user ns.
* --uts

Add info logging where the option is redundant.

### This fixes or addresses the following GitHub issues:

 - Fixes #1026


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
