### PR TITLE
feat: oci: support --env option in --oci mode

### DIFF
--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -640,5 +640,9 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5057":               c.issue5057, // https://github.com/sylabs/hpcng/issues/5057
 		"issue 5426":               c.issue5426, // https://github.com/sylabs/hpcng/issues/5426
 		"issue 43":                 c.issue43,   // https://github.com/sylabs/singularity/issues/43
+		//
+		// --oci mode
+		//
+		"oci environment option": c.ociEnvOption,
 	}
 }

--- a/e2e/env/oci.go
+++ b/e2e/env/oci.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularityenv
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+)
+
+func (c ctx) ociEnvOption(t *testing.T) {
+	e2e.EnsureOCIImage(t, c.env)
+	defaultImage := "oci-archive:" + c.env.OCIImagePath
+
+	tests := []struct {
+		name     string
+		image    string
+		envOpt   []string
+		hostEnv  []string
+		matchEnv string
+		matchVal string
+	}{
+		{
+			name:     "DefaultPath",
+			image:    defaultImage,
+			matchEnv: "PATH",
+			matchVal: defaultPath,
+		},
+		{
+			name:     "DefaultPathOverride",
+			image:    defaultImage,
+			envOpt:   []string{"PATH=/"},
+			matchEnv: "PATH",
+			matchVal: "/",
+		},
+		{
+			name:     "AppendDefaultPath",
+			image:    defaultImage,
+			envOpt:   []string{"APPEND_PATH=/foo"},
+			matchEnv: "PATH",
+			matchVal: defaultPath + ":/foo",
+		},
+		{
+			name:     "PrependDefaultPath",
+			image:    defaultImage,
+			envOpt:   []string{"PREPEND_PATH=/foo"},
+			matchEnv: "PATH",
+			matchVal: "/foo:" + defaultPath,
+		},
+		{
+			name:     "TestMultiLine",
+			image:    defaultImage,
+			envOpt:   []string{"MULTI=Hello\nWorld"},
+			matchEnv: "MULTI",
+			matchVal: "Hello\nWorld",
+		},
+		{
+			name:     "TestEscapedNewline",
+			image:    defaultImage,
+			envOpt:   []string{"ESCAPED=Hello\\nWorld"},
+			matchEnv: "ESCAPED",
+			matchVal: "Hello\\nWorld",
+		},
+		{
+			name:     "TestInvalidKey",
+			image:    defaultImage,
+			envOpt:   []string{"BASH_FUNC_ml%%=TEST"},
+			matchEnv: "BASH_FUNC_ml%%",
+			matchVal: "",
+		},
+		{
+			name:     "TestDefaultLdLibraryPath",
+			image:    defaultImage,
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: singularityLibs,
+		},
+		{
+			name:     "TestCustomTrailingCommaPath",
+			image:    defaultImage,
+			envOpt:   []string{"LD_LIBRARY_PATH=/foo,"},
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo,:" + singularityLibs,
+		},
+		{
+			name:     "TestCustomLdLibraryPath",
+			image:    defaultImage,
+			envOpt:   []string{"LD_LIBRARY_PATH=/foo"},
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo:" + singularityLibs,
+		},
+		{
+			name:     "SINGULARITY_NAME",
+			image:    defaultImage,
+			matchEnv: "SINGULARITY_NAME",
+			matchVal: defaultImage,
+		},
+	}
+
+	for _, tt := range tests {
+		args := make([]string, 0)
+		if tt.envOpt != nil {
+			args = append(args, "--env", strings.Join(tt.envOpt, ","))
+		}
+		args = append(args, tt.image, "/bin/sh", "-c", "echo \"${"+tt.matchEnv+"}\"")
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithEnv(tt.hostEnv),
+			e2e.WithArgs(args...),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
+			),
+		)
+	}
+}

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -137,3 +137,11 @@ func (l *Launcher) getReverseUserMaps() (uidMap, gidMap []specs.LinuxIDMapping, 
 
 	return uidMap, gidMap, nil
 }
+
+// defaultEnv returns default environment variables set in the container.
+func defaultEnv(image, bundle string) map[string]string {
+	return map[string]string{
+		"SINGULARITY_CONTAINER": bundle,
+		"SINGULARITY_NAME":      image,
+	}
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

* Merge image config ENV and env vars requested by user with the --env CLI option.
* Set default SINGULARITY_CONTAINER and SINGULARITY_NAME env variables.
* Set default LD_LIBRARY_PATH to be used later for library injection (this is a singularity default).
* Handle APPEND_PATH / PREPEND PATH like native runtime mode.

### This fixes or addresses the following GitHub issues:

 - Fixes #1029 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
