### PR TITLE
feat: oci: add SINGULARITYENV_ handling for --oci mode

### DIFF
--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -643,6 +643,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		// --oci mode
 		//
-		"oci environment option": c.ociEnvOption,
+		"oci environment singularityenv": c.ociSingularityEnv,
+		"oci environment option":         c.ociEnvOption,
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -319,9 +319,11 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	// Assemble the runtime & user-requested environment, which will be merged
 	// with the image ENV and set in the container at runtime.
 	rtEnv := defaultEnv(image, bundleDir)
+	// SINGULARITYENV_
+	rtEnv = mergeMap(rtEnv, singularityEnvMap())
 	// --env flag
 	rtEnv = mergeMap(rtEnv, l.cfg.Env)
-	// TODO - --env-file, SINGULARITYENV_
+	// TODO - --env-file
 
 	b, err := native.New(
 		native.OptBundlePath(bundleDir),

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestSingularityEnvMap(t *testing.T) {
+	tests := []struct {
+		name   string
+		setEnv map[string]string
+		want   map[string]string
+	}{
+		{
+			name:   "None",
+			setEnv: map[string]string{},
+			want:   map[string]string{},
+		},
+		{
+			name:   "NonPrefixed",
+			setEnv: map[string]string{"FOO": "bar"},
+			want:   map[string]string{},
+		},
+		{
+			name:   "PrefixedSingle",
+			setEnv: map[string]string{"SINGULARITYENV_FOO": "bar"},
+			want:   map[string]string{"FOO": "bar"},
+		},
+		{
+			name: "PrefixedMultiple",
+			setEnv: map[string]string{
+				"SINGULARITYENV_FOO": "bar",
+				"SINGULARITYENV_ABC": "123",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+				"ABC": "123",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.setEnv {
+				os.Setenv(k, v)
+				t.Cleanup(func() {
+					os.Unsetenv(k)
+				})
+			}
+			if got := singularityEnvMap(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("singularityEnvMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

** Stacked on 1166 - please review 1166 first **

Pass SINGULARITYENV_ prefixed environment variables into container in --oci mode.

### This fixes or addresses the following GitHub issues:

 - Fixes #1031 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
