### PR TITLE
feat: oci: enable --env-file in --oci mode 

### DIFF
--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -645,5 +645,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		"oci environment singularityenv": c.ociSingularityEnv,
 		"oci environment option":         c.ociEnvOption,
+		"oci environment file":           c.ociEnvFile,
 	}
 }

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -829,7 +829,7 @@ func (l *Launcher) setEnv(ctx context.Context, args []string) error {
 
 		content, err := os.ReadFile(l.cfg.EnvFile)
 		if err != nil {
-			return fmt.Errorf("could not read %q environment file: %w", l.cfg.EnvFile, err)
+			return fmt.Errorf("could not read environment file %q: %w", l.cfg.EnvFile, err)
 		}
 
 		env, err := interpreter.EvaluateEnv(ctx, content, args, currentEnv)
@@ -844,12 +844,12 @@ func (l *Launcher) setEnv(ctx context.Context, args []string) error {
 		for _, envar := range env {
 			e := strings.SplitN(envar, "=", 2)
 			if len(e) != 2 {
-				sylog.Warningf("Ignore environment variable %q: '=' is missing", envar)
+				sylog.Warningf("Ignored environment variable %q: '=' is missing", envar)
 				continue
 			}
 			// Ensure we don't overwrite --env variables with environment file
 			if _, ok := l.cfg.Env[e[0]]; ok {
-				sylog.Warningf("Ignore environment variable %s from %s: override from --env", e[0], l.cfg.EnvFile)
+				sylog.Warningf("Ignored environment variable %s from %s: override from --env", e[0], l.cfg.EnvFile)
 			} else {
 				l.cfg.Env[e[0]] = e[1]
 			}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -127,9 +127,6 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "Proot")
 	}
 
-	if lo.EnvFile != "" {
-		badOpt = append(badOpt, "EnvFile")
-	}
 	if lo.CleanEnv {
 		badOpt = append(badOpt, "CleanEnv")
 	}
@@ -319,11 +316,18 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	// Assemble the runtime & user-requested environment, which will be merged
 	// with the image ENV and set in the container at runtime.
 	rtEnv := defaultEnv(image, bundleDir)
-	// SINGULARITYENV_
+	// SINGULARITYENV_ has lowest priority
 	rtEnv = mergeMap(rtEnv, singularityEnvMap())
-	// --env flag
+	// --env-file can override SINGULARITYENV_
+	if l.cfg.EnvFile != "" {
+		e, err := envFileMap(ctx, l.cfg.EnvFile)
+		if err != nil {
+			return err
+		}
+		rtEnv = mergeMap(rtEnv, e)
+	}
+	// --env flag can override --env-file and SINGULARITYENV_
 	rtEnv = mergeMap(rtEnv, l.cfg.Env)
-	// TODO - --env-file
 
 	b, err := native.New(
 		native.OptBundlePath(bundleDir),

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -6,7 +6,9 @@
 package oci
 
 import (
+	"context"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -54,6 +56,82 @@ func TestSingularityEnvMap(t *testing.T) {
 			}
 			if got := singularityEnvMap(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("singularityEnvMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnvFileMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		envFile string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "EmptyFile",
+			envFile: "",
+			want:    map[string]string{},
+			wantErr: false,
+		},
+		{
+			name: "Simple",
+			envFile: `FOO=BAR
+			ABC=123`,
+			want: map[string]string{
+				"FOO": "BAR",
+				"ABC": "123",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "DoubleQuote",
+			envFile: `FOO="FOO BAR"`,
+			want: map[string]string{
+				"FOO": "FOO BAR",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "SingleQuote",
+			envFile: `FOO='FOO BAR'`,
+			want: map[string]string{
+				"FOO": "FOO BAR",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "MultiLine",
+			envFile: "FOO=\"FOO\nBAR\"",
+			want: map[string]string{
+				"FOO": "FOO\nBAR",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid",
+			envFile: "!!!@@NOTAVAR",
+			want:    map[string]string{},
+			wantErr: true,
+		},
+	}
+
+	tmpDir := t.TempDir()
+	envFile := filepath.Join(tmpDir, "env-file")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.WriteFile(envFile, []byte(tt.envFile), 0o755); err != nil {
+				t.Fatalf("Could not write test env-file: %v", err)
+			}
+
+			got, err := envFileMap(context.Background(), envFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("envFileMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("envFileMap() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

** Stacked on 1169 - please review 1169 first **

Allow --env-file to be used to provide environment variables in a file, when running a container in --oci mode.

We use the same approach as the native runtime for compatibility. The env file is evaluated in the embedded shell interpreter, but starting with an empty environment. This handles quoting, comments etc. for us, and keeps maximum compatibility with the existing handling.

### This fixes or addresses the following GitHub issues:

 - Fixes #1030


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
