### PR TITLE
feat: oci: support cgroups requests in --oci mode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
     - `--rocm` to bind ROCm GPU libraries and devices into the container.
     - `--nv` to bind Nvidia driver / basic CUDA libraries and devices into
       the container.
+    - `--apply-cgroups`, and the `--cpu*`, `--blkio*`, `--memory*`,
+      `--pids-limit` flags to apply resource limits.
 - Instance name is available inside an instance via the new
   `SINGULARITY_INSTANCE` environment variable.
 - The `sign` command now supports signing with non-PGP key material by

--- a/e2e/env/oci.go
+++ b/e2e/env/oci.go
@@ -72,6 +72,7 @@ func (c ctx) ociSingularityEnv(t *testing.T) {
 			e2e.WithProfile(e2e.OCIUserProfile),
 			e2e.WithCommand("exec"),
 			e2e.WithEnv(tt.env),
+			e2e.WithRootlessEnv(),
 			e2e.WithArgs(tt.image, "/bin/sh", "-c", "echo $PATH"),
 			e2e.ExpectExit(
 				0,
@@ -181,6 +182,7 @@ func (c ctx) ociEnvOption(t *testing.T) {
 			e2e.WithProfile(e2e.OCIUserProfile),
 			e2e.WithCommand("exec"),
 			e2e.WithEnv(tt.hostEnv),
+			e2e.WithRootlessEnv(),
 			e2e.WithArgs(args...),
 			e2e.ExpectExit(
 				0,
@@ -283,6 +285,7 @@ func (c ctx) ociEnvFile(t *testing.T) {
 			e2e.WithProfile(e2e.OCIUserProfile),
 			e2e.WithCommand("exec"),
 			e2e.WithEnv(tt.hostEnv),
+			e2e.WithRootlessEnv(),
 			e2e.WithArgs(args...),
 			e2e.ExpectExit(
 				0,

--- a/e2e/internal/e2e/profile.go
+++ b/e2e/internal/e2e/profile.go
@@ -64,6 +64,7 @@ type Profile struct {
 	requirementsFn    func(*testing.T) // function checking requirements for the profile
 	singularityOption string           // option added to singularity command for the profile
 	optionForCommands []string         // singularity commands concerned by the option to be added
+	oci               bool             // whether the profile uses the OCI low-level runtime
 }
 
 // NativeProfiles defines all available profiles for the native singularity runtime
@@ -77,6 +78,7 @@ var NativeProfiles = map[string]Profile{
 		requirementsFn:    nil,
 		singularityOption: "",
 		optionForCommands: []string{},
+		oci:               false,
 	},
 	rootProfile: {
 		name:              "Root",
@@ -87,6 +89,7 @@ var NativeProfiles = map[string]Profile{
 		requirementsFn:    nil,
 		singularityOption: "",
 		optionForCommands: []string{},
+		oci:               false,
 	},
 	fakerootProfile: {
 		name:              "Fakeroot",
@@ -97,6 +100,7 @@ var NativeProfiles = map[string]Profile{
 		requirementsFn:    fakerootRequirements,
 		singularityOption: "--fakeroot",
 		optionForCommands: []string{"shell", "exec", "run", "test", "instance start", "build"},
+		oci:               false,
 	},
 	userNamespaceProfile: {
 		name:              "UserNamespace",
@@ -107,6 +111,7 @@ var NativeProfiles = map[string]Profile{
 		requirementsFn:    require.UserNamespace,
 		singularityOption: "--userns",
 		optionForCommands: []string{"shell", "exec", "run", "test", "instance start"},
+		oci:               false,
 	},
 	rootUserNamespaceProfile: {
 		name:              "RootUserNamespace",
@@ -117,6 +122,7 @@ var NativeProfiles = map[string]Profile{
 		requirementsFn:    require.UserNamespace,
 		singularityOption: "--userns",
 		optionForCommands: []string{"shell", "exec", "run", "test", "instance start"},
+		oci:               false,
 	},
 }
 
@@ -131,6 +137,7 @@ var OCIProfiles = map[string]Profile{
 		requirementsFn:    ociRequirements,
 		singularityOption: "--oci",
 		optionForCommands: []string{"shell", "exec", "run", "test", "instance start"},
+		oci:               true,
 	},
 	ociRootProfile: {
 		name:              "OCIRoot",
@@ -141,6 +148,7 @@ var OCIProfiles = map[string]Profile{
 		requirementsFn:    ociRequirements,
 		singularityOption: "--oci",
 		optionForCommands: []string{"shell", "exec", "run", "test", "instance start"},
+		oci:               true,
 	},
 	ociFakerootProfile: {
 		name:              "OCIFakeroot",
@@ -151,6 +159,7 @@ var OCIProfiles = map[string]Profile{
 		requirementsFn:    ociRequirements,
 		singularityOption: "--oci --fakeroot",
 		optionForCommands: []string{"shell", "exec", "run", "test", "instance start"},
+		oci:               true,
 	},
 }
 
@@ -158,6 +167,11 @@ var OCIProfiles = map[string]Profile{
 // elevated privileges or not.
 func (p Profile) Privileged() bool {
 	return p.privileged
+}
+
+// OCI returns whether the profile is using an OCI runtime, rather than the singularity native runtime.
+func (p Profile) OCI() bool {
+	return p.oci
 }
 
 // Requirements calls the different require.* functions

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -531,6 +531,20 @@ func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 			cmd.Env = os.Environ()
 		}
 
+		// Clear user-specific DBUS / XDG vars when we are using a priv profile,
+		// as they don't make sense for the root user... and wouldn't be set in a
+		// real root user session.
+		if privileged {
+			i := 0
+			for _, e := range cmd.Env {
+				if !(strings.HasPrefix(e, "DBUS_SESSION_BUS_ADDRESS=") || strings.HasPrefix(e, "XDG_RUNTIME_DIR=")) {
+					cmd.Env[i] = e
+					i++
+				}
+			}
+			cmd.Env = cmd.Env[:i]
+		}
+
 		// By default, each E2E command shares a temporary image cache
 		// directory. If a test is directly testing the cache, or depends on
 		// specific ordered cache behavior then

--- a/internal/app/singularity/oci_linux.go
+++ b/internal/app/singularity/oci_linux.go
@@ -10,9 +10,12 @@ package singularity
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/runtime/launcher/oci"
 	ocibundle "github.com/sylabs/singularity/pkg/ocibundle/sif"
+	"github.com/sylabs/singularity/pkg/util/singularityconf"
 )
 
 // OciArgs contains CLI arguments
@@ -30,52 +33,92 @@ type OciArgs struct {
 
 // OciRun runs a container (equivalent to create/start/delete)
 func OciRun(ctx context.Context, containerID string, args *OciArgs) error {
-	return oci.Run(ctx, containerID, args.BundlePath, args.PidFile)
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.Run(ctx, containerID, args.BundlePath, args.PidFile, systemdCgroups)
 }
 
 // OciCreate creates a container from an OCI bundle
 func OciCreate(containerID string, args *OciArgs) error {
-	return oci.Create(containerID, args.BundlePath)
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.Create(containerID, args.BundlePath, systemdCgroups)
 }
 
 // OciStart starts a previously create container
 func OciStart(containerID string) error {
-	return oci.Start(containerID)
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.Start(containerID, systemdCgroups)
 }
 
 // OciDelete deletes container resources
 func OciDelete(ctx context.Context, containerID string) error {
-	return oci.Delete(ctx, containerID)
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.Delete(ctx, containerID, systemdCgroups)
 }
 
 // OciExec executes a command in a container
 func OciExec(containerID string, cmdArgs []string) error {
-	return oci.Exec(containerID, cmdArgs)
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.Exec(containerID, cmdArgs, systemdCgroups)
 }
 
 // OciKill kills container process
 func OciKill(containerID string, killSignal string) error {
-	return oci.Kill(containerID, killSignal)
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.Kill(containerID, killSignal, systemdCgroups)
 }
 
 // OciPause pauses processes in a container
 func OciPause(containerID string) error {
-	return oci.Pause(containerID)
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.Pause(containerID, systemdCgroups)
 }
 
 // OciResume pauses processes in a container
 func OciResume(containerID string) error {
-	return oci.Resume(containerID)
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.Resume(containerID, systemdCgroups)
 }
 
 // OciState queries container state
 func OciState(containerID string, args *OciArgs) error {
-	return oci.State(containerID)
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.State(containerID, systemdCgroups)
 }
 
 // OciUpdate updates container cgroups resources
 func OciUpdate(containerID string, args *OciArgs) error {
-	return oci.Update(containerID, args.FromFile)
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.Update(containerID, args.FromFile, systemdCgroups)
 }
 
 // OciMount mount a SIF image to create an OCI bundle
@@ -94,4 +137,15 @@ func OciUmount(bundle string) error {
 		return err
 	}
 	return d.Delete()
+}
+
+func systemdCgroups() (use bool, err error) {
+	cfg := singularityconf.GetCurrentConfig()
+	if cfg == nil {
+		cfg, err = singularityconf.Parse(buildcfg.SINGULARITY_CONF_FILE)
+		if err != nil {
+			return false, fmt.Errorf("unable to parse singularity configuration file: %w", err)
+		}
+	}
+	return cfg.SystemdCgroups, nil
 }

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -337,15 +336,8 @@ func NewManagerWithSpec(spec *specs.LinuxResources, pid int, group string, syste
 	if pid == 0 {
 		return nil, fmt.Errorf("a pid is required to create a new cgroup")
 	}
-	if group == "" && !systemd {
-		group = filepath.Join("/singularity", strconv.Itoa(pid))
-	}
-	if group == "" && systemd {
-		if os.Getuid() == 0 {
-			group = "system.slice:singularity:" + strconv.Itoa(pid)
-		} else {
-			group = "user.slice:singularity:" + strconv.Itoa(pid)
-		}
+	if group == "" {
+		group = DefaultPathForPid(systemd, pid)
 	}
 
 	sylog.Debugf("Creating cgroups manager for %s", group)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Honor the --apply-cgroups and individual cgroups resources flags when running in OCI mode.

The launcher instructs runc/crun to create a named cgroup with specified LinuxResources in the config.json. runc/crun must be called with the `--systemd-cgroup` flag when using systemd as cgroup manager.

E2E tests are adapted - they test identical cases for `--oci` mode as the native runtime mode.

### This fixes or addresses the following GitHub issues:

 - Fixes #1032 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
