### PR TITLE
rocm: fixups and --oci support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
     - Additional namespaces requests with `--net`, `--uts`, `--user`.
     - Container environment variables via `--env`, `--env-file`, and
       `SINGULARITYENV_` host env vars.
+    - `--rocm` to bind ROCm GPU libraries and devices into the container.
 - Instance name is available inside an instance via the new
   `SINGULARITY_INSTANCE` environment variable.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,12 @@
 - Instance name is available inside an instance via the new
   `SINGULARITY_INSTANCE` environment variable.
 
+### Bug Fixes
+
+- In `--rocm` mode, the whole of `/dev/dri` is now bound into the container when
+  `--contain` is in use. This makes `/dev/dri/render` devices available,
+  required for later ROCm versions.
+
 ## 3.10.4 \[2022-11-10\]
 
 ### Bug Fixes

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -24,10 +24,11 @@ From: %[1]s
 
 %%setup
 	touch $SINGULARITY_ROOTFS%[2]s
+	touch $SINGULARITY_ROOTFS%[3]s
 %%post
-	%[3]s
+	%[4]s
 %%test
-	%[3]s
+	%[4]s
 `
 
 type ctx struct {
@@ -207,9 +208,17 @@ func (c ctx) testNvCCLI(t *testing.T) {
 
 func (c ctx) testRocm(t *testing.T) {
 	require.Rocm(t)
-	// Use Ubuntu 20.04 as this is the most recent distro officially supported by ROCm.
+	require.Command(t, "lsmod")
+
+	// rocminfo now needs lsmod - do a brittle bind in for simplicity.
+	lsmod, err := exec.LookPath("lsmod")
+	if err != nil {
+		t.Fatalf("while finding lsmod: %v", err)
+	}
+
+	// Use Ubuntu 22.04 as this is the most recent distro officially supported by ROCm.
 	// We can't use our test image as it's alpine based and we need a compatible glibc.
-	imageURL := "docker://ubuntu:20.04"
+	imageURL := "docker://ubuntu:22.04"
 	imageFile, err := fs.MakeTmpFile("", "test-rocm-", 0o755)
 	if err != nil {
 		t.Fatalf("Could not create test file: %v", err)
@@ -235,27 +244,27 @@ func (c ctx) testRocm(t *testing.T) {
 		{
 			name:    "User",
 			profile: e2e.UserProfile,
-			args:    []string{"--rocm", imagePath, "rocminfo"},
+			args:    []string{"-B", lsmod, "--rocm", imagePath, "rocminfo"},
 		},
 		{
 			name:    "UserContain",
 			profile: e2e.UserProfile,
-			args:    []string{"--contain", "--rocm", imagePath, "rocminfo"},
+			args:    []string{"-B", lsmod, "--contain", "--rocm", imagePath, "rocminfo"},
 		},
 		{
 			name:    "UserNamespace",
 			profile: e2e.UserNamespaceProfile,
-			args:    []string{"--rocm", imagePath, "rocminfo"},
+			args:    []string{"-B", lsmod, "--rocm", imagePath, "rocminfo"},
 		},
 		{
 			name:    "Fakeroot",
 			profile: e2e.FakerootProfile,
-			args:    []string{"--rocm", imagePath, "rocminfo"},
+			args:    []string{"-B", lsmod, "--rocm", imagePath, "rocminfo"},
 		},
 		{
 			name:    "Root",
 			profile: e2e.RootProfile,
-			args:    []string{"--rocm", imagePath, "rocminfo"},
+			args:    []string{"-B", lsmod, "--rocm", imagePath, "rocminfo"},
 		},
 	}
 
@@ -273,9 +282,18 @@ func (c ctx) testRocm(t *testing.T) {
 
 func (c ctx) ociTestRocm(t *testing.T) {
 	require.Rocm(t)
-	// Use Ubuntu 20.04 as this is the most recent distro officially supported by ROCm.
+
+	require.Command(t, "lsmod")
+
+	// rocminfo now needs lsmod - do a brittle bind in for simplicity.
+	lsmod, err := exec.LookPath("lsmod")
+	if err != nil {
+		t.Fatalf("while finding lsmod: %v", err)
+	}
+
+	// Use Ubuntu 22.04 as this is the most recent distro officially supported by ROCm.
 	// We can't use our test image as it's alpine based and we need a compatible glibc.
-	imageURL := "docker://ubuntu:20.04"
+	imageURL := "docker://ubuntu:22.04"
 
 	// Basic test that we can run the bound in `rocminfo` which *should* be on the PATH
 	tests := []struct {
@@ -284,15 +302,15 @@ func (c ctx) ociTestRocm(t *testing.T) {
 	}{
 		{
 			profile: e2e.OCIUserProfile,
-			args:    []string{"--rocm", imageURL, "rocminfo"},
+			args:    []string{"-B", lsmod, "--rocm", imageURL, "rocminfo"},
 		},
 		{
 			profile: e2e.OCIFakerootProfile,
-			args:    []string{"--rocm", imageURL, "rocminfo"},
+			args:    []string{"-B", lsmod, "--rocm", imageURL, "rocminfo"},
 		},
 		{
 			profile: e2e.OCIRootProfile,
-			args:    []string{"--rocm", imageURL, "rocminfo"},
+			args:    []string{"-B", lsmod, "--rocm", imageURL, "rocminfo"},
 		},
 	}
 
@@ -365,7 +383,7 @@ func (c ctx) testBuildNvidiaLegacy(t *testing.T) {
 		},
 	}
 
-	rawDef := fmt.Sprintf(buildDefinition, sourceImage, nvsmi, "nvidia-smi")
+	rawDef := fmt.Sprintf(buildDefinition, sourceImage, nvsmi, "", "nvidia-smi")
 
 	for _, tt := range tests {
 		defFile := e2e.RawDefFile(t, tmpdir, strings.NewReader(rawDef))
@@ -439,7 +457,7 @@ func (c ctx) testBuildNvCCLI(t *testing.T) {
 		},
 	}
 
-	rawDef := fmt.Sprintf(buildDefinition, sourceImage, nvsmi, "nvidia-smi")
+	rawDef := fmt.Sprintf(buildDefinition, sourceImage, nvsmi, "", "nvidia-smi")
 
 	for _, tt := range tests {
 		defFile := e2e.RawDefFile(t, tmpdir, strings.NewReader(rawDef))
@@ -471,13 +489,20 @@ func (c ctx) testBuildNvCCLI(t *testing.T) {
 //nolint:dupl
 func (c ctx) testBuildRocm(t *testing.T) {
 	require.Rocm(t)
+	require.Command(t, "lsmod")
+
+	// rocminfo now needs lsmod - do a brittle bind in for simplicity.
+	lsmod, err := exec.LookPath("lsmod")
+	if err != nil {
+		t.Fatalf("while finding lsmod: %v", err)
+	}
 
 	// ignore the error as it's already done in the require call above
 	rocmInfo, _ := exec.LookPath("rocminfo")
 
-	// Use Ubuntu 20.04 as this is the most recent distro officially supported by ROCm.
+	// Use Ubuntu 22.04 as this is the most recent distro officially supported by ROCm.
 	// We can't use our test image as it's alpine based and we need a compatible glibc.
-	imageURL := "docker://ubuntu:20.04"
+	imageURL := "docker://ubuntu:22.04"
 
 	tmpdir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "build-rocm-image", "build with rocm")
 	defer cleanup(t)
@@ -525,7 +550,7 @@ func (c ctx) testBuildRocm(t *testing.T) {
 		},
 	}
 
-	rawDef := fmt.Sprintf(buildDefinition, sourceImage, rocmInfo, "rocminfo")
+	rawDef := fmt.Sprintf(buildDefinition, sourceImage, rocmInfo, lsmod, "rocminfo")
 
 	for _, tt := range tests {
 		defFile := e2e.RawDefFile(t, tmpdir, strings.NewReader(rawDef))
@@ -535,7 +560,7 @@ func (c ctx) testBuildRocm(t *testing.T) {
 		if tt.setRocmFlag {
 			args = append(args, "--rocm")
 		}
-		args = append(args, "--force", "--sandbox", sandboxImage, defFile)
+		args = append(args, "-B", lsmod, "--force", "--sandbox", sandboxImage, defFile)
 
 		c.env.RunSingularity(
 			t,

--- a/etc/rocmliblist.conf
+++ b/etc/rocmliblist.conf
@@ -26,6 +26,8 @@ libmcwamp_cpu.so
 libmcwamp_hsa.so
 libmiopengemm.so
 libMIOpen.so
+libdrm.so
+libdrm_amdgpu.so
 libnuma.so
 libpci.so
 librccl.so

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1449,7 +1449,7 @@ func (c *container) addDevMount(system *mount.System) error {
 		}
 
 		if c.engine.EngineConfig.GetRocm() {
-			devs, err := gpu.RocmDevices(true)
+			devs, err := gpu.RocmDevices()
 			if err != nil {
 				return fmt.Errorf("failed to get rocm devices: %v", err)
 			}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -15,10 +15,14 @@ import (
 	"strings"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/internal/pkg/util/gpu"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/bind"
 )
+
+const containerLibDir = "/.singularity.d/libs"
 
 // getMounts returns a mount list for the container's OCI runtime spec.
 func (l *Launcher) getMounts() ([]specs.Mount, error) {
@@ -35,6 +39,12 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 	if err := l.addBindMounts(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring bind mount(s): %w", err)
 	}
+	if (l.cfg.Rocm || l.singularityConf.AlwaysUseRocm) && !l.cfg.NoRocm {
+		if err := l.addRocmMounts(mounts); err != nil {
+			return nil, fmt.Errorf("while configuring ROCm mount(s): %w", err)
+		}
+	}
+
 	return *mounts, nil
 }
 
@@ -249,5 +259,90 @@ func addBindMount(mounts *[]specs.Mount, b bind.Path) error {
 			Type:        "none",
 			Options:     opts,
 		})
+	return nil
+}
+
+func addDevBindMount(mounts *[]specs.Mount, b bind.Path) error {
+	opts := []string{"bind", "nosuid"}
+	if b.Readonly() {
+		opts = append(opts, "ro")
+	}
+
+	b.Source = filepath.Clean(b.Source)
+	if !strings.HasPrefix(b.Source, "/dev") {
+		return fmt.Errorf("device bind source must be an absolute path under /dev: %s", b.Source)
+	}
+	if b.Source != b.Destination {
+		return fmt.Errorf("device bind source %s must be the same as destination %s", b.Source, b.Destination)
+	}
+	if _, err := os.Stat(b.Source); err != nil {
+		return fmt.Errorf("cannot stat bind source %s: %w", b.Source, err)
+	}
+
+	sylog.Debugf("Adding device bind of %s to %s, with options %v", b.Source, b.Destination, opts)
+
+	*mounts = append(*mounts,
+		specs.Mount{
+			Source:      b.Source,
+			Destination: b.Destination,
+			Type:        "none",
+			Options:     opts,
+		})
+	return nil
+}
+
+func (l *Launcher) addRocmMounts(mounts *[]specs.Mount) error {
+	gpuConfFile := filepath.Join(buildcfg.SINGULARITY_CONFDIR, "rocmliblist.conf")
+
+	libs, bins, err := gpu.RocmPaths(gpuConfFile)
+	if err != nil {
+		sylog.Warningf("While finding ROCm bind points: %v", err)
+	}
+	if len(libs) == 0 {
+		sylog.Warningf("Could not find any ROCm libraries on this host!")
+	}
+
+	devs, err := gpu.RocmDevices()
+	if err != nil {
+		sylog.Warningf("While finding ROCm devices: %v", err)
+	}
+	if len(devs) == 0 {
+		sylog.Warningf("Could not find any ROCm devices on this host!")
+	}
+
+	for _, binary := range bins {
+		containerBinary := filepath.Join("/usr/bin", filepath.Base(binary))
+		bind := bind.Path{
+			Source:      binary,
+			Destination: containerBinary,
+			Options:     map[string]*bind.Option{"ro": {}},
+		}
+		if err := addBindMount(mounts, bind); err != nil {
+			return err
+		}
+	}
+
+	for _, lib := range libs {
+		containerLib := filepath.Join(containerLibDir, filepath.Base(lib))
+		bind := bind.Path{
+			Source:      lib,
+			Destination: containerLib,
+			Options:     map[string]*bind.Option{"ro": {}},
+		}
+		if err := addBindMount(mounts, bind); err != nil {
+			return err
+		}
+	}
+
+	for _, dev := range devs {
+		bind := bind.Path{
+			Source:      dev,
+			Destination: dev,
+		}
+		if err := addDevBindMount(mounts, bind); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/internal/pkg/util/gpu/rocm.go
+++ b/internal/pkg/util/gpu/rocm.go
@@ -7,6 +7,7 @@ package gpu
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 )
 
@@ -21,19 +22,16 @@ func RocmPaths(configFilePath string) ([]string, []string, error) {
 	return paths(rocmFiles)
 }
 
-// RocmDevices return list of all non-GPU rocm devices present on host. If withGPU
-// is true all GPUs are included in the resulting list as well.
-func RocmDevices(withGPU bool) ([]string, error) {
-	// Must bind in all GPU DRI devices
-	rocmGlob := "/dev/dri/card*"
-	if !withGPU {
-		rocmGlob = "/dev/dri/card[^0-9]*"
+// RocmDevices returns a list of /dev entries required for ROCm functionality.
+func RocmDevices() ([]string, error) {
+	// Use same paths as ROCm Docker container documentation.
+	// Must bind in all GPU DRI devices, and /dev/kfd device.
+	devs := []string{}
+	if _, err := os.Stat("/dev/dri"); err == nil {
+		devs = append(devs, "/dev/dri")
 	}
-	devs, err := filepath.Glob(rocmGlob)
-	if err != nil {
-		return nil, fmt.Errorf("could not list rocm devices: %v", err)
+	if _, err := os.Stat("/dev/kfd"); err == nil {
+		devs = append(devs, "/dev/kfd")
 	}
-	// /dev/kfd is also required
-	devs = append(devs, "/dev/kfd")
 	return devs, nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

A selection of ROCm fixes and addition of --oci support. Am including all in a single PR to minimize amount of work needed testing on a ROCm enabled system.

* In `--oci` mode ensure user and group entries written to container passwd / group files. Required to proceed with ROCm stuff.

* When binding ROCm devices with --contain in effect, we were only taking /dev/dri/cardxxx and /dev/kfd. At least some circumstances also require /dev/dri. Bind the whole of /dev/dri, just like the AMD ROCm container documentation for Docker does.

* Under --oci mode, allow --rocm, which will bind ROCm devices, libraries, and binaries into the container.

* e2e: minimal --rocm --oci test

* fix: rocm: update rocmliblist and fix e2e tests -`rocminfo` now needs `lsmod` and libdrm libdrm_amdgpu. Bind the former in tests, the libraries from rocmliblist.conf. We can now use Ubuntu 22.04 for ROCm tests.

You may need to trust me that this works :-) Here's the output on a Fedora 37 machine with a ROCm supported GPU:

```
$ make -C builddir e2e-test E2E_GROUPS=GPU
...
--- PASS: TestE2E (28.26s)
    --- PASS: TestE2E/PAR (0.00s)
        --- PASS: TestE2E/PAR/GPU (0.00s)
            --- SKIP: TestE2E/PAR/GPU/build_nvidia (0.00s)
            --- SKIP: TestE2E/PAR/GPU/build_nvccli (0.00s)
            --- SKIP: TestE2E/PAR/GPU/nvccli (0.00s)
            --- SKIP: TestE2E/PAR/GPU/nvidia (0.00s)
            --- PASS: TestE2E/PAR/GPU/rocm (17.42s)
                --- PASS: TestE2E/PAR/GPU/rocm/User (0.20s)
                --- PASS: TestE2E/PAR/GPU/rocm/UserContain (0.18s)
                --- PASS: TestE2E/PAR/GPU/rocm/UserNamespace (1.56s)
                --- PASS: TestE2E/PAR/GPU/rocm/Fakeroot (0.55s)
                --- PASS: TestE2E/PAR/GPU/rocm/Root (0.18s)
            --- PASS: TestE2E/PAR/GPU/build_rocm (21.48s)
                --- PASS: TestE2E/PAR/GPU/build_rocm/WithRocmRoot (1.31s)
                --- PASS: TestE2E/PAR/GPU/build_rocm/WithRocmFakeroot (1.71s)
                --- PASS: TestE2E/PAR/GPU/build_rocm/WithoutRocmRoot (1.14s)
                --- PASS: TestE2E/PAR/GPU/build_rocm/WithoutRocmFakeroot (2.19s)
            --- PASS: TestE2E/PAR/GPU/oci_rocm (25.08s)
                --- PASS: TestE2E/PAR/GPU/oci_rocm/OCIUser (13.37s)
                --- PASS: TestE2E/PAR/GPU/oci_rocm/OCIFakeroot (3.84s)
                --- PASS: TestE2E/PAR/GPU/oci_rocm/OCIRoot (7.84s)
```


### This fixes or addresses the following GitHub issues:

 - Fixes #1034 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
