### PR TITLE
feat: Set SINGULARITY_INSTANCE equal to instance name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@
     - Additional namespaces requests with `--net`, `--uts`, `--user`.
     - Container environment variables via `--env`, `--env-file`, and
       `SINGULARITYENV_` host env vars.
+- Instance name is available inside an instance via the new
+  `SINGULARITY_INSTANCE` environment variable.
 
 ## 3.10.4 \[2022-11-10\]
 

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -144,6 +144,12 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 				t.Errorf("Hostname is %s, but expected %s", stdout, testHostname)
 			}
 
+			// Verify that the SINGULARITY_INSTANCE has been set correctly.
+			stdout, _, success = c.execInstance(t, instanceName, "sh", "-c", "echo $SINGULARITY_INSTANCE")
+			if success && !bytes.Equal([]byte(instanceName+"\n"), []byte(stdout)) {
+				t.Errorf("SINGULARITY_INSTANCE is %s, but expected %s", stdout, instanceName)
+			}
+
 			// Stop the instance.
 			c.stopInstance(t, instanceName)
 		}),

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -283,6 +283,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 
 	// Setup instance specific configuration if required.
 	if instanceName != "" {
+		l.generator.AddProcessEnv("SINGULARITY_INSTANCE", instanceName)
 		l.cfg.Namespaces.PID = true
 		l.engineConfig.SetInstance(true)
 		l.engineConfig.SetBootInstance(l.cfg.Boot)
@@ -420,6 +421,7 @@ func (l *Launcher) setImageOrInstance(image string, name string) error {
 		l.cfg.Namespaces.User = file.UserNs
 		l.generator.AddProcessEnv("SINGULARITY_CONTAINER", file.Image)
 		l.generator.AddProcessEnv("SINGULARITY_NAME", filepath.Base(file.Image))
+		l.generator.AddProcessEnv("SINGULARITY_INSTANCE", instanceName)
 		l.engineConfig.SetImage(image)
 		l.engineConfig.SetInstanceJoin(true)
 

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -42,7 +42,7 @@ clear_env() {
         case "${key}" in
         PWD|HOME|OPTIND|UID|SINGULARITY_APPNAME|SINGULARITY_SHELL)
             ;;
-        SINGULARITY_NAME|SINGULARITY_CONTAINER)
+        SINGULARITY_NAME|SINGULARITY_CONTAINER|SINGULARITY_INSTANCE)
             readonly "${key}"
             ;;
         *)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Inside an instance, expose the instance name as the environment variable `SINGULARITY_INSTANCE`.

### This fixes or addresses the following GitHub issues:

 - Fixes #1132 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
