### PR TITLE
instance: CPU usage as percentage

### DIFF
--- a/internal/app/singularity/instance_linux.go
+++ b/internal/app/singularity/instance_linux.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"strings"
 	"syscall"
 	"text/tabwriter"
@@ -178,6 +177,16 @@ func calculateMemoryUsage(stats *libcgroups.MemoryStats) (float64, float64, floa
 	return memUsage, memLimit, memPercent
 }
 
+func calculateCPUUsage(prevTime, prevCPU uint64, cpuStats *libcgroups.CpuStats) (cpuPercent float64, curTime, curCPU uint64) {
+	// Update 1s interval CPU ns usage
+	curTime = uint64(time.Now().UnixNano())
+	curCPU = cpuStats.CpuUsage.TotalUsage
+	deltaCPU := float64(curCPU - prevCPU)
+	deltaTime := float64(curTime - prevTime)
+	cpuPercent = (deltaCPU / deltaTime) * 100
+	return cpuPercent, curTime, curCPU
+}
+
 // InstanceStats uses underlying cgroups to get statistics for a named instance
 func InstanceStats(ctx context.Context, name, instanceUser string, formatJSON bool, noStream bool) error {
 	ii, err := instanceListOrError(instanceUser, name)
@@ -217,6 +226,15 @@ func InstanceStats(ctx context.Context, name, instanceUser string, formatJSON bo
 	tabWriter := tabwriter.NewWriter(os.Stdout, 0, 8, 4, ' ', 0)
 	defer tabWriter.Flush()
 
+	// Retrieve initial state, for first CPU measurement
+	stats, err := manager.GetStats()
+	if err != nil {
+		return fmt.Errorf("while getting stats for pid: %v", err)
+	}
+	prevCPU := stats.CpuStats.CpuUsage.TotalUsage
+	prevTime := uint64(time.Now().UnixNano())
+	cpuPercent := 0.0
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -252,15 +270,13 @@ func InstanceStats(ctx context.Context, name, instanceUser string, formatJSON bo
 				return fmt.Errorf("could not write stats header: %v", err)
 			}
 
-			// CpuUsage denotes the usage of a CPU, aggregate since container inception.
-			// TODO CPU time needs to be a percentage
-			totalCPUTime := strconv.FormatUint(stats.CpuStats.CpuUsage.TotalUsage, 10) + " ns"
+			cpuPercent, prevTime, prevCPU = calculateCPUUsage(prevTime, prevCPU, &stats.CpuStats)
 			memUsage, memLimit, memPercent := calculateMemoryUsage(&stats.MemoryStats)
 			blockRead, blockWrite := calculateBlockIO(&stats.BlkioStats)
 
 			// Generate a shortened stats list
-			_, err = fmt.Fprintf(tabWriter, "%s\t%s\t%s / %s\t%.2f%s\t%s / %s\t%d\n", i.Name,
-				totalCPUTime, units.BytesSize(memUsage), units.BytesSize(memLimit),
+			_, err = fmt.Fprintf(tabWriter, "%s\t%.2f%%\t%s / %s\t%.2f%s\t%s / %s\t%d\n", i.Name,
+				cpuPercent, units.BytesSize(memUsage), units.BytesSize(memLimit),
 				memPercent, "%", units.BytesSize(blockRead), units.BytesSize(blockWrite),
 				stats.PidsStats.Current)
 			tabWriter.Flush()


### PR DESCRIPTION
## Description of the Pull Request (PR):

Show CPU usage as an updating percentages in `instance stats`.

<img width="855" alt="Screenshot 2022-12-09 at 13 07 39" src="https://user-images.githubusercontent.com/4522799/206709756-0e7b8bc1-f863-4bc7-978d-03bf3c65f6c5.png">


### This fixes or addresses the following GitHub issues:

 - Fixes #893


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
