### PR TITLE
deb: ensure rc packages precede release

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,12 @@
 #!/usr/bin/make -f
 
-srcver = $(shell scripts/get-version)
+# Transform version numbers so that the match debian precedence / rules.
+# https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+#
+# 3.4.2-rc.1            ->  3.4.2~rc.1
+# 3.4.2                 ->  3.4.2
+# 3.4.2+522-gee98ef356  ->  3.4.2+522.gee98ef356
+srcver = $(shell scripts/get-version | sed -e 's,\(^[^+]\+\)-,\1~,; s,-,.,g')
 dist   = $(shell lsb_release -s -c)
 
 DH_VERBOSE=1


### PR DESCRIPTION
## Description of the Pull Request (PR):

Transform version numbers so that the match debian precedence / rules.

https://www.debian.org/doc/debian-policy/ch-controlfields.html#version

```
3.4.2-rc.1            ->  3.4.2~rc.1
3.4.2                 ->  3.4.2
3.4.2+522-gee98ef356  ->  3.4.2+522.gee98ef356
```

### This fixes or addresses the following GitHub issues:

 - Fixes #862


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
