### PR TITLE
feat: reproducible build (SOURCEDIR / BUILDDIR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@
   certificates that are not trust anchors, but can be used to form a
   certificate chain can also be specified via the `--certificate-intermediates`
   flag.
+- A new `--reproducible` flag for `./mconfig` will configure Singularity so that
+  its binaries do not contain non-reproducible paths. This disables plugin
+  functionality.
 
 ### Bug Fixes
 

--- a/internal/app/singularity/plugin_compile_linux.go
+++ b/internal/app/singularity/plugin_compile_linux.go
@@ -41,6 +41,10 @@ type buildToolchain struct {
 
 // getSingularitySrcDir returns the source directory for singularity.
 func getSingularitySrcDir() (string, error) {
+	if buildcfg.IsReproducibleBuild() {
+		return "", fmt.Errorf("plugin functionality is not available in --reproducible builds of singularity")
+	}
+
 	dir := buildcfg.SOURCEDIR
 	canary := filepath.Join(dir, canaryFile)
 	sylog.Debugf("Searching source file %s", canary)

--- a/internal/pkg/buildcfg/confgen/gen.go
+++ b/internal/pkg/buildcfg/confgen/gen.go
@@ -113,6 +113,10 @@ func RelocatePath(original string) (string) {
 {{ range $i, $d := .Defines }}
 {{$d.WriteLine $.IsSuidInstall -}}
 {{end}}
+
+func IsReproducibleBuild() bool {
+	return SOURCEDIR == "REPRODUCIBLE_BUILD"
+}
 `))
 
 func main() {

--- a/internal/pkg/plugin/create.go
+++ b/internal/pkg/plugin/create.go
@@ -53,6 +53,10 @@ const gitIgnore = `singularity_source
 // Create creates a skeleton plugin directory structure
 // to start development of a new plugin.
 func Create(path, name string) error {
+	if buildcfg.IsReproducibleBuild() {
+		return fmt.Errorf("plugin functionality is not available in --reproducible builds of singularity")
+	}
+
 	dir, err := filepath.Abs(path)
 	if err != nil {
 		return fmt.Errorf("could not determine absolute path for %s: %s", path, err)

--- a/internal/pkg/plugin/module.go
+++ b/internal/pkg/plugin/module.go
@@ -149,6 +149,10 @@ func GetModules(dir string) (*GoMod, error) {
 func PrepareGoModules(pluginDir string, disableMinorCheck bool) ([]byte, error) {
 	var goMod bytes.Buffer
 
+	if buildcfg.IsReproducibleBuild() {
+		return nil, fmt.Errorf("plugin functionality is not available in --reproducible builds of singularity")
+	}
+
 	singModules, err := GetModules(buildcfg.SOURCEDIR)
 	if err != nil {
 		return nil, fmt.Errorf("while getting Singularity Go modules: %s", err)

--- a/mconfig
+++ b/mconfig
@@ -83,6 +83,7 @@ libdir=
 localedir=
 mandir=
 
+reproducible=0
 
 usage () {
 	echo "${0##*/}: could not complete configuration"
@@ -141,6 +142,11 @@ usage_args () {
 	echo "     --libdir         install libraries in \`libdir'"
 	echo "     --localedir      install locale dependent data in \`localedir'"
 	echo "     --mandir         install man documentation in \`mandir'"
+  echo
+  echo "  Reproducible builds:"
+  echo "     --reproducible   set reproducible SOURCEDIR & BUILDDIR values in binaries."
+  echo "                      This will disable plugin build functionality."
+
 	echo
 }
 
@@ -371,6 +377,8 @@ while [ $# -ne 0 ]; do
    with_seccomp_check=0; shift;;
   --without-conmon)
    with_conmon=0; shift;;
+  --reproducible)
+   reproducible=1; shift;;
   -V)
    if ! echo "$2" | awk '/^-.*/ || /^$/ { exit 2 }'; then
      echo "error: option requires an argument: $1"

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -13,8 +13,14 @@ config_add_def PACKAGE_STRING \"singularity-ce $package_version\"
 config_add_def PACKAGE_BUGREPORT \"support@sylabs.io\"
 config_add_def PACKAGE_URL \"\"
 
-config_add_def BUILDDIR \"$builddir\"
-config_add_def SOURCEDIR \"$sourcedir\"
+if [ "$reproducible" == "1" ]; then
+   config_add_def BUILDDIR \"REPRODUCIBLE_BUILD\"
+   config_add_def SOURCEDIR \"REPRODUCIBLE_BUILD\"
+else
+   config_add_def SOURCEDIR \"$sourcedir\"
+   config_add_def BUILDDIR \"$builddir\"
+fi
+
 config_add_def PREFIX \"$prefix\"
 config_add_def EXECPREFIX \"$exec_prefix\"
 config_add_def BINDIR \"$bindir\"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add a `--reproducible` flag for mconfig. This will set BUILDDIR and SOURCEDIR in the buildcfg package to a literal `REPRODUCIBLE_BUILD`, so that binaries do not contain the paths to the source.

Disables pluign functionality, which needs the source path for in-tree plugin builds.


### This fixes or addresses the following GitHub issues:

 - Fixes #1173 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
