### PR TITLE
fix: block overlay for panfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@
 - In `--rocm` mode, the whole of `/dev/dri` is now bound into the container when
   `--contain` is in use. This makes `/dev/dri/render` devices available,
   required for later ROCm versions.
+- Overlay is blocked on the `panfs` filesystem, allowing sandbox directories to be
+  run from `panfs` without error.
 
 ## 3.10.4 \[2022-11-10\]
 

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -41,6 +41,7 @@ const (
 	ecrypt int64 = 0xF15F
 	lustre int64 = 0x0BD00BD0 //nolint:misspell
 	gpfs   int64 = 0x47504653
+	panfs  int64 = 0xAAD7AAEA
 )
 
 var incompatibleFs = map[int64]fs{
@@ -68,6 +69,11 @@ var incompatibleFs = map[int64]fs{
 	// GPFS filesystem
 	gpfs: {
 		name:       "GPFS",
+		overlayDir: lowerDir | upperDir,
+	},
+	// panfs filesystem
+	panfs: {
+		name:       "PANFS",
 		overlayDir: lowerDir | upperDir,
 	},
 }

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -145,6 +145,24 @@ func TestCheckLowerUpper(t *testing.T) {
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
+		{
+			name:                  "PANFS mock lower",
+			path:                  "/",
+			fsName:                "PANFS",
+			dir:                   lowerDir,
+			fsType:                panfs,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
+		{
+			name:                  "PANFS mock upper",
+			path:                  "/",
+			fsName:                "PANFS",
+			dir:                   upperDir,
+			fsType:                panfs,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
 	}
 
 	if IsIncompatible(nil) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

A sandbox container on a panfs (Panasas) filesystem causes an overlay error at runtime. Add panfs to to the list of incompatible filesystems.

Block panfs as both lower and upper overlay dirs, until support is confirmed with Panasas (same situation as GPFS).


### This fixes or addresses the following GitHub issues:

 - Fixes #1215


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
