### PR TITLE
fix: ensure proot flow doesn't override --remote build

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -148,7 +148,10 @@ func runBuild(cmd *cobra.Command, args []string) {
 	dest := args[0]
 	spec := args[1]
 
-	if syscall.Getuid() != 0 && !buildArgs.fakeroot && fs.IsFile(spec) && !isImage(spec) {
+	// Non-remote build with def file as source
+	rootNeeded := !buildArgs.remote && fs.IsFile(spec) && !isImage(spec)
+
+	if rootNeeded && syscall.Getuid() != 0 && !buildArgs.fakeroot {
 		prootPath, err := bin.FindBin("proot")
 		if err != nil {
 			sylog.Fatalf("--remote, --fakeroot, or the proot command are required to build this source as a non-root user")

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1624,5 +1624,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5435":                      c.issue5435,                 // https://github.com/hpcng/singularity/issues/5435
 		"issue 5668":                      c.issue5668,                 // https://github.com/hpcng/singularity/issues/5435
 		"issue 5690":                      c.issue5690,                 // https://github.com/hpcng/singularity/issues/5690
+		"issue 1273":                      c.issue1273,                 // https://github.com/sylabs/singularity/issues/1273
 	}
 }

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -445,3 +445,22 @@ From: {{ .From }}
 		e2e.ExpectExit(0),
 	)
 }
+
+// Ensure a `--remote` build request fails (not-authorized) and proot flow is not invoked.
+func (c *imgBuildTests) issue1273(t *testing.T) {
+	image := filepath.Join(c.env.TestDir, "issue_1273.sif")
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--remote", image, "testdata/proot_alpine.def"),
+		e2e.PostRun(func(t *testing.T) {
+			os.Remove(image)
+		}),
+		e2e.ExpectExit(
+			255,
+			e2e.ExpectError(e2e.UnwantedContainMatch, "proot"),
+		),
+	)
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Ensure that the proot rootless build doesn't override a --remote build request.


### This fixes or addresses the following GitHub issues:

 - Fixes #1273


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
