### PR TITLE
fix: avoid readonly warnings with --env-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Avoid UID / GID readonly var warnings with `--env-file`.
+
 ## 3.11.0 Release Candidate 1 \[2023-01-11\]
 
 *This is the first release candidate for the upcoming Singularity 3.11.0

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -640,6 +640,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5057":               c.issue5057, // https://github.com/sylabs/hpcng/issues/5057
 		"issue 5426":               c.issue5426, // https://github.com/sylabs/hpcng/issues/5426
 		"issue 43":                 c.issue43,   // https://github.com/sylabs/singularity/issues/43
+		"issue 1263":               c.issue1263, // https://github.com/sylabs/singularity/issues/1263
 		//
 		// --oci mode
 		//

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -119,6 +119,32 @@ func (c ctx) issue43(t *testing.T) {
 		e2e.ExpectExit(
 			0,
 			e2e.ExpectOutput(e2e.ExactMatch, `/foo/bar/$LIB/baz.so`),
+		),
+	)
+}
+
+// https://github.com/sylabs/singularity/issues/1263
+// With --env-file we should avoid any override of UID / GID that are set readonly by bash.
+func (c ctx) issue1263(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	// An empty env file is sufficient, as UID/GID come from the mvdan.cc/sh evaluation of it.
+	envFile, err := e2e.WriteTempFile(c.env.TestDir, "env-file", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Remove(envFile)
+	})
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--env-file", envFile, c.env.ImagePath, "/bin/true"),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectError(e2e.UnwantedContainMatch, "readonly variable"),
 		),
 	)
 }

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -857,6 +857,11 @@ func (l *Launcher) setEnv(ctx context.Context, args []string) error {
 			e := strings.SplitN(envar, "=", 2)
 			if len(e) != 2 {
 				sylog.Warningf("Ignored environment variable %q: '=' is missing", envar)
+				continue
+			}
+			// Don't attempt to overwrite bash builtin readonly vars
+			// https://github.com/sylabs/singularity/issues/1263
+			if e[0] == "UID" || e[0] == "GID" {
 				continue
 			}
 			// Ensure we don't overwrite --env variables with environment file


### PR DESCRIPTION
## Description of the Pull Request (PR):

Ensure UID and GID values returned by running shell interpreter on the env-file are not used for container. They are read-only built-ins, and attempting to set them displays a confusing warning.


### This fixes or addresses the following GitHub issues:

 - Fixes #1263 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
