### PR TITLE
fix: lack of passwd / group should be warning in --oci mode

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -906,6 +906,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("user", c.testDockerUSER)
 			// Regressions
 			t.Run("issue 4524", c.issue4524)
+			t.Run("issue 1286", c.issue1286)
 		},
 		// Tests that are especially slow, or run against a local docker
 		// registry, can be run in parallel, with `--disable-cache` used within

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -179,3 +179,20 @@ From: continuumio/miniconda3:latest
 		),
 	)
 }
+
+// https://github.com/sylabs/singularity/issues/1286
+// Ensure the bare docker://hello-world image runs in all modes
+func (c ctx) issue1286(t *testing.T) {
+	for _, profile := range e2e.AllProfiles() {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(profile.String()),
+			e2e.WithProfile(profile),
+			e2e.WithCommand("run"),
+			e2e.WithArgs("docker://hello-world"),
+			e2e.ExpectExit(0,
+				e2e.ExpectOutput(e2e.ContainMatch, "Hello from Docker!"),
+			),
+		)
+	}
+}

--- a/e2e/internal/e2e/profile.go
+++ b/e2e/internal/e2e/profile.go
@@ -163,6 +163,18 @@ var OCIProfiles = map[string]Profile{
 	},
 }
 
+// AllProfiles is initialized to the union of NativeProfiles and OCIProfiles
+func AllProfiles() map[string]Profile {
+	ap := map[string]Profile{}
+	for k, p := range NativeProfiles {
+		ap[k] = p
+	}
+	for k, p := range OCIProfiles {
+		ap[k] = p
+	}
+	return ap
+}
+
 // Privileged returns whether the test should be executed with
 // elevated privileges or not.
 func (p Profile) Privileged() bool {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -327,18 +327,16 @@ func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
 	sylog.Debugf("Updating passwd file: %s", containerPasswd)
 	content, err := files.Passwd(containerPasswd, pw.Dir, int(uid))
 	if err != nil {
-		return fmt.Errorf("while creating passwd file: %w", err)
-	}
-	if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {
+		sylog.Warningf("%s", err)
+	} else if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {
 		return fmt.Errorf("while writing passwd file: %w", err)
 	}
 
 	sylog.Debugf("Updating group file: %s", containerGroup)
 	content, err = files.Group(containerGroup, int(uid), []int{int(gid)})
 	if err != nil {
-		return fmt.Errorf("while creating group file: %w", err)
-	}
-	if err := os.WriteFile(containerGroup, content, 0o755); err != nil {
+		sylog.Warningf("%s", err)
+	} else if err := os.WriteFile(containerGroup, content, 0o755); err != nil {
 		return fmt.Errorf("while writing passwd file: %w", err)
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

In the --oci launcher, When a minimal container doesn't have an `/etc/passwd` or `/etc/groups` file then don't fail with a fatal error. Instead warn like the native runtime does.

### This fixes or addresses the following GitHub issues:

 - Fixes #1286 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
