### PR TITLE
chore: bump go to 1.19.5 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.19.3'
+    default: '1.19.5'
 
 executors:
   node:


### PR DESCRIPTION
Will move up to 1.20 after the 3.11 release, to avoid change in RC->release period.
