### PR TITLE
fix: handle --nvccli implied --writable-tmpfs correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Fix implied `--writable-tmpfs` with `--nvccli`, to avoid r/o filesytem
+  error.
+
 ## 3.11.0 \[2023-02-10\]
 
 ### Changed defaults / behaviours

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -130,13 +130,6 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	// Overlay or writable image requested?
 	l.engineConfig.SetOverlayImage(l.cfg.OverlayPaths)
 	l.engineConfig.SetWritableImage(l.cfg.Writable)
-	// --writable-tmpfs is for an ephemeral overlay, doesn't make sense if also asking to write to image itself.
-	if l.cfg.Writable && l.cfg.WritableTmpfs {
-		sylog.Warningf("Disabling --writable-tmpfs flag, mutually exclusive with --writable")
-		l.engineConfig.SetWritableTmpfs(false)
-	} else {
-		l.engineConfig.SetWritableTmpfs(l.cfg.WritableTmpfs)
-	}
 
 	// Check key is available for encrypted image, if applicable.
 	// If we are joining an instance, then any encrypted image is already mounted.
@@ -181,10 +174,19 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	l.setNoMountFlags()
 
 	// GPU configuration may add library bind to /.singularity.d/libs.
+	// Note: --nvccli may implicitly add --writable-tmpfs, so handle that *after* GPUs.
 	if err := l.SetGPUConfig(); err != nil {
 		// We must fatal on error, as we are checking for correct ownership of nvidia-container-cli,
 		// which is important to maintain security.
 		sylog.Fatalf("While setting GPU configuration: %s", err)
+	}
+
+	// --writable-tmpfs is for an ephemeral overlay, doesn't make sense if also asking to write to image itself.
+	if l.cfg.Writable && l.cfg.WritableTmpfs {
+		sylog.Warningf("Disabling --writable-tmpfs flag, mutually exclusive with --writable")
+		l.engineConfig.SetWritableTmpfs(false)
+	} else {
+		l.engineConfig.SetWritableTmpfs(l.cfg.WritableTmpfs)
 	}
 
 	// If proot is requested (we are running an unprivileged build, without userns) we must bind it


### PR DESCRIPTION
## Description of the Pull Request (PR):

Setup for `--nvccli` in the native runtime launcher can imply `--writable-tmpfs`. However, in the refactored launcher, the ultimate engineconfig value for `--writable-tmpfs` was set prior to considering GPU options.

Move `--writable-tmpfs` handling after GPU configuration.

This issue *is* correctly detected by the existing e2e tests when running on a machine with an nvidia GPU and functional nvidia-container-cli install. It slipped through testing of 3.11.0 due to a configuration issue on a test machine. That needs to be tackled elsewhere... we can't currently run GPU tests in our SingularityCE CI, unfortunately.

I have manually confirmed this fix on an AWS T4 instance.

### This fixes or addresses the following GitHub issues:

 - Fixes #1351

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
