### PR TITLE
fix: Pass LD_LIBRARY_PATH to wrapped unsquashfs correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fix implied `--writable-tmpfs` with `--nvccli`, to avoid r/o filesytem
   error.
 - Avoid incorrect error when reqesting fakeroot network.
+- Pass computed `LD_LIBRARY_PATH` to wrapped unsquashfs. Fixes issues where
+  `unsquashfs` on host uses libraries in non-default paths.
 
 ## 3.11.0 \[2023-02-10\]
 

--- a/internal/pkg/image/unpacker/squashfs_singularity.go
+++ b/internal/pkg/image/unpacker/squashfs_singularity.go
@@ -279,7 +279,7 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 	cmd := exec.Command(filepath.Join(buildcfg.BINDIR, "singularity"), args...)
 	cmd.Dir = "/"
 	cmd.Env = []string{
-		fmt.Sprintf("LD_LIBRARY_PATH=%s", strings.Join(libraryPath, string(os.PathListSeparator))),
+		fmt.Sprintf("SINGULARITYENV_LD_LIBRARY_PATH=%s", strings.Join(libraryPath, string(os.PathListSeparator))),
 		fmt.Sprintf("SINGULARITY_DEBUG=%s", os.Getenv("SINGULARITY_DEBUG")),
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

In our handling of unsquashfs extraction, wrapped in a minimal container invocation, we are computing an LD_LIBRARY_PATH that holds the paths to all libraries needed by unsquashfs.

Unfortunately, we were setting `LD_LIBRARY_PATH` in the outer environment, and it does not pass into the container by default. We need to set `SINGULARITYENV_LD_LIBRARY_PATH` to pass it in.

This is very challenging to write a test for, as it requires modifying host binaries or ld.so.conf etc. Verified fix using the reproducer detailed in #1335.

### This fixes or addresses the following GitHub issues:

 - Fixes #1335 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
