### PR TITLE
e2e: refactor test image handling 

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -15,25 +15,14 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
-const (
-	dockerArchiveURI = "https://s3.amazonaws.com/singularity-ci-public/alpine-docker-save.tar"
-)
-
 func (c actionTests) actionOciRun(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
+	e2e.EnsureDockerArchive(t, c.env)
 
-	// Prepare docker-archive source
-	tmpDir := t.TempDir()
-	dockerArchive := filepath.Join(tmpDir, "docker-archive.tar")
-	err := e2e.DownloadFile(dockerArchiveURI, dockerArchive)
-	if err != nil {
-		t.Fatalf("Could not download docker archive test file: %v", err)
-	}
-	defer os.Remove(dockerArchive)
 	// Prepare oci source (oci directory layout)
 	ociLayout := t.TempDir()
-	cmd := exec.Command("tar", "-C", ociLayout, "-xf", c.env.OCIImagePath)
-	err = cmd.Run()
+	cmd := exec.Command("tar", "-C", ociLayout, "-xf", c.env.OCIArchivePath)
+	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("Error extracting oci archive to layout: %v", err)
 	}
@@ -46,12 +35,12 @@ func (c actionTests) actionOciRun(t *testing.T) {
 	}{
 		{
 			name:     "docker-archive",
-			imageRef: "docker-archive:" + dockerArchive,
+			imageRef: "docker-archive:" + c.env.DockerArchivePath,
 			exit:     0,
 		},
 		{
 			name:     "oci-archive",
-			imageRef: "oci-archive:" + c.env.OCIImagePath,
+			imageRef: "oci-archive:" + c.env.OCIArchivePath,
 			exit:     0,
 		},
 		{
@@ -95,9 +84,9 @@ func (c actionTests) actionOciRun(t *testing.T) {
 
 // exec tests min fuctionality for singularity exec
 func (c actionTests) actionOciExec(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 
-	imageRef := "oci-archive:" + c.env.OCIImagePath
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
 	tests := []struct {
 		name string
@@ -169,7 +158,7 @@ func (c actionTests) actionOciExec(t *testing.T) {
 
 // Shell interaction tests
 func (c actionTests) actionOciShell(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 
 	tests := []struct {
 		name       string
@@ -179,7 +168,7 @@ func (c actionTests) actionOciShell(t *testing.T) {
 	}{
 		{
 			name: "ShellExit",
-			argv: []string{"oci-archive:" + c.env.OCIImagePath},
+			argv: []string{"oci-archive:" + c.env.OCIArchivePath},
 			consoleOps: []e2e.SingularityConsoleOp{
 				// "cd /" to work around issue where a long
 				// working directory name causes the test
@@ -195,7 +184,7 @@ func (c actionTests) actionOciShell(t *testing.T) {
 		},
 		{
 			name: "ShellBadCommand",
-			argv: []string{"oci-archive:" + c.env.OCIImagePath},
+			argv: []string{"oci-archive:" + c.env.OCIArchivePath},
 			consoleOps: []e2e.SingularityConsoleOp{
 				e2e.ConsoleSendLine("_a_fake_command"),
 				e2e.ConsoleSendLine("exit"),
@@ -222,8 +211,8 @@ func (c actionTests) actionOciShell(t *testing.T) {
 }
 
 func (c actionTests) actionOciNetwork(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
-	imageRef := "oci-archive:" + c.env.OCIImagePath
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
 	tests := []struct {
 		name       string
@@ -283,8 +272,8 @@ func (c actionTests) actionOciNetwork(t *testing.T) {
 
 //nolint:maintidx
 func (c actionTests) actionOciBinds(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
-	imageRef := "oci-archive:" + c.env.OCIImagePath
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
 	workspace, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "bind-workspace-", "")
 	defer e2e.Privileged(cleanup)

--- a/e2e/cache/regressions.go
+++ b/e2e/cache/regressions.go
@@ -80,6 +80,7 @@ func (c cacheTests) issue5097(t *testing.T) {
 // issue5350 - need to handle the cache being inside a non-accessible directory
 // e.g. home directory without perms to access
 func (c cacheTests) issue5350(t *testing.T) {
+	e2e.EnsureORASImage(t, c.env)
 	outerDir, cleanupOuter := e2e.MakeTempDir(t, c.env.TestDir, "issue5350-cache-", "")
 	defer e2e.Privileged(cleanupOuter)(t)
 
@@ -98,7 +99,7 @@ func (c cacheTests) issue5350(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs([]string{"--force", "-s", sandboxDir, "library://alpine:3.11.5"}...),
+		e2e.WithArgs([]string{"--force", "-s", sandboxDir, c.env.OrasTestImage}...),
 		e2e.ExpectExit(0),
 	)
 

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -380,18 +380,18 @@ func (c *ctx) actionApply(t *testing.T, profile e2e.Profile, imageRef string) {
 
 func (c *ctx) actionApplyRoot(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 	t.Run(e2e.RootProfile.String(), func(t *testing.T) {
 		c.actionApply(t, e2e.RootProfile, c.env.ImagePath)
 	})
 	t.Run(e2e.OCIRootProfile.String(), func(t *testing.T) {
-		c.actionApply(t, e2e.OCIRootProfile, "oci-archive:"+c.env.OCIImagePath)
+		c.actionApply(t, e2e.OCIRootProfile, "oci-archive:"+c.env.OCIArchivePath)
 	})
 }
 
 func (c *ctx) actionApplyRootless(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 	for _, profile := range []e2e.Profile{e2e.UserProfile, e2e.UserNamespaceProfile, e2e.FakerootProfile} {
 		t.Run(profile.String(), func(t *testing.T) {
 			c.actionApply(t, profile, c.env.ImagePath)
@@ -399,7 +399,7 @@ func (c *ctx) actionApplyRootless(t *testing.T) {
 	}
 	for _, profile := range []e2e.Profile{e2e.OCIUserProfile, e2e.OCIFakerootProfile} {
 		t.Run(profile.String(), func(t *testing.T) {
-			c.actionApply(t, profile, "oci-archive:"+c.env.OCIImagePath)
+			c.actionApply(t, profile, "oci-archive:"+c.env.OCIArchivePath)
 		})
 	}
 }
@@ -619,18 +619,18 @@ func (c *ctx) actionFlagV2(t *testing.T, tt resourceFlagTest, profile e2e.Profil
 
 func (c *ctx) actionFlagsRoot(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 	t.Run(e2e.RootProfile.String(), func(t *testing.T) {
 		c.actionFlags(t, e2e.RootProfile, c.env.ImagePath)
 	})
 	t.Run(e2e.OCIRootProfile.String(), func(t *testing.T) {
-		c.actionFlags(t, e2e.OCIRootProfile, "oci-archive:"+c.env.OCIImagePath)
+		c.actionFlags(t, e2e.OCIRootProfile, "oci-archive:"+c.env.OCIArchivePath)
 	})
 }
 
 func (c *ctx) actionFlagsRootless(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
-	e2e.EnsureOCIImage(t, c.env)
+	e2e.EnsureOCIArchive(t, c.env)
 	for _, profile := range []e2e.Profile{e2e.UserProfile, e2e.UserNamespaceProfile, e2e.FakerootProfile} {
 		t.Run(profile.String(), func(t *testing.T) {
 			c.actionFlags(t, profile, c.env.ImagePath)
@@ -638,7 +638,7 @@ func (c *ctx) actionFlagsRootless(t *testing.T) {
 	}
 	for _, profile := range []e2e.Profile{e2e.OCIUserProfile, e2e.OCIFakerootProfile} {
 		t.Run(profile.String(), func(t *testing.T) {
-			c.actionFlags(t, profile, "oci-archive:"+c.env.OCIImagePath)
+			c.actionFlags(t, profile, "oci-archive:"+c.env.OCIArchivePath)
 		})
 	}
 }

--- a/e2e/env/oci.go
+++ b/e2e/env/oci.go
@@ -15,8 +15,8 @@ import (
 )
 
 func (c ctx) ociSingularityEnv(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
-	defaultImage := "oci-archive:" + c.env.OCIImagePath
+	e2e.EnsureOCIArchive(t, c.env)
+	defaultImage := "oci-archive:" + c.env.OCIArchivePath
 
 	// Append or prepend this path.
 	partialPath := "/foo"
@@ -83,8 +83,8 @@ func (c ctx) ociSingularityEnv(t *testing.T) {
 }
 
 func (c ctx) ociEnvOption(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
-	defaultImage := "oci-archive:" + c.env.OCIImagePath
+	e2e.EnsureOCIArchive(t, c.env)
+	defaultImage := "oci-archive:" + c.env.OCIArchivePath
 
 	tests := []struct {
 		name     string
@@ -193,8 +193,8 @@ func (c ctx) ociEnvOption(t *testing.T) {
 }
 
 func (c ctx) ociEnvFile(t *testing.T) {
-	e2e.EnsureOCIImage(t, c.env)
-	defaultImage := "oci-archive:" + c.env.OCIImagePath
+	e2e.EnsureOCIArchive(t, c.env)
+	defaultImage := "oci-archive:" + c.env.OCIArchivePath
 
 	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "envfile-", "")
 	defer cleanup(t)

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -204,8 +204,9 @@ func (c *ctx) testContain(t *testing.T) {
 
 // Test by running directly from URI
 func (c *ctx) testInstanceFromURI(t *testing.T) {
-	name := "test_from_library"
-	args := []string{"library://busybox:1.31.1", name}
+	e2e.EnsureORASImage(t, c.env)
+	name := "test_from_uri"
+	args := []string{c.env.OrasTestImage, name}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(c.profile),

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -9,15 +9,17 @@ package e2e
 // from specifying which Singularity binary to use to controlling how Singularity
 // environment variables will be set.
 type TestEnv struct {
-	CmdPath        string // Path to the Singularity binary to use for the execution of a Singularity command
-	ImagePath      string // Path to the image that has to be used for the execution of a Singularity command
-	OrasTestImage  string
-	OCIImagePath   string
-	TestDir        string // Path to the directory from which a Singularity command needs to be executed
-	TestRegistry   string
-	KeyringDir     string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using SINGULARITY_SYPGPDIR which should be avoided when running e2e tests)
-	PrivCacheDir   string // PrivCacheDir sets the location of the image cache to be used by the Singularity command to be executed as root (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
-	UnprivCacheDir string // UnprivCacheDir sets the location of the image cache to be used by the Singularity command to be executed as the unpriv user (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
-	RunDisabled    bool
-	DisableCache   bool // DisableCache can be set to disable the cache during the execution of a e2e command
+	CmdPath           string // Path to the Singularity binary to use for the execution of a Singularity command
+	ImagePath         string // Path to the image that has to be used for the execution of a Singularity command
+	OrasTestImage     string // URI to SIF image pushed into local registry with ORAS
+	OCIArchivePath    string // Path to test OCI archive tar file
+	DockerArchivePath string // Path to test Docker archive tar file
+	TestDir           string // Path to the directory from which a Singularity command needs to be executed
+	TestRegistry      string // Host:Port of local registry
+	TestRegistryImage string // URI to OCI image pushed into local registry
+	KeyringDir        string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using SINGULARITY_SYPGPDIR which should be avoided when running e2e tests)
+	PrivCacheDir      string // PrivCacheDir sets the location of the image cache to be used by the Singularity command to be executed as root (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
+	UnprivCacheDir    string // UnprivCacheDir sets the location of the image cache to be used by the Singularity command to be executed as the unpriv user (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
+	RunDisabled       bool
+	DisableCache      bool // DisableCache can be set to disable the cache during the execution of a e2e command
 }

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -25,6 +25,7 @@ type ctx struct {
 // using that directory as cache. This reflects a problem that is important
 // for the grid use case.
 func (c ctx) testRun555Cache(t *testing.T) {
+	e2e.EnsureORASImage(t, c.env)
 	tempDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
 	defer cleanup(t)
 	cacheDir := filepath.Join(tempDir, "image-cache")
@@ -34,7 +35,7 @@ func (c ctx) testRun555Cache(t *testing.T) {
 	}
 	// Directory is deleted when tempDir is deleted
 
-	cmdArgs := []string{"library://alpine:3.11.5", "true"}
+	cmdArgs := []string{c.env.OrasTestImage, "true"}
 	// We explicitly pass the environment to the command, not through c.env.ImgCacheDir
 	// because c.env is shared between all the tests, something we do not want here.
 	cacheDirEnv := fmt.Sprintf("%s=%s", cache.DirEnv, cacheDir)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fetch the OCI archive image used in tests from Docker Hub, so that it will match the host architecture.

### This fixes or addresses the following GitHub issues:

 - Fixes #1364


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
