### PR TITLE
e2e: gate AllowNet* tests with require.Network (release-3.11)

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -598,9 +598,10 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			exit: 255,
 		},
 		{
-			name:    "AllowNetUsersUserOK",
-			argv:    []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
-			profile: e2e.UserProfile,
+			name:              "AllowNetUsersUserOK",
+			addRequirementsFn: e2e.Privileged(require.Network),
+			argv:              []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
+			profile:           e2e.UserProfile,
 			directives: map[string]string{
 				"allow net users":    u.Name,
 				"allow net networks": "bridge",
@@ -608,9 +609,10 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name:    "AllowNetUsersUIDOK",
-			argv:    []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
-			profile: e2e.UserProfile,
+			name:              "AllowNetUsersUIDOK",
+			addRequirementsFn: e2e.Privileged(require.Network),
+			argv:              []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
+			profile:           e2e.UserProfile,
 			directives: map[string]string{
 				"allow net users":    fmt.Sprintf("%d", u.UID),
 				"allow net networks": "bridge",
@@ -645,9 +647,10 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			exit: 255,
 		},
 		{
-			name:    "AllowNetGroupsGroupOK",
-			argv:    []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
-			profile: e2e.UserProfile,
+			name:              "AllowNetGroupsGroupOK",
+			addRequirementsFn: e2e.Privileged(require.Network),
+			argv:              []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
+			profile:           e2e.UserProfile,
 			directives: map[string]string{
 				"allow net groups":   g.Name,
 				"allow net networks": "bridge",
@@ -655,9 +658,10 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name:    "AllowNetGroupsGIDOK",
-			argv:    []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
-			profile: e2e.UserProfile,
+			name:              "AllowNetGroupsGIDOK",
+			addRequirementsFn: e2e.Privileged(require.Network),
+			argv:              []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
+			profile:           e2e.UserProfile,
 			directives: map[string]string{
 				"allow net groups":   fmt.Sprintf("%d", g.GID),
 				"allow net networks": "bridge",
@@ -665,7 +669,8 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name: "AllowNetNetworksMultiMulti",
+			name:              "AllowNetNetworksMultiMulti",
+			addRequirementsFn: e2e.Privileged(require.Network),
 			// Two networks allowed, asking for both
 			argv:    []string{"--net", "--network", "bridge,ptp", c.env.ImagePath, "true"},
 			profile: e2e.UserProfile,
@@ -677,9 +682,10 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 		},
 		{
 			// Two networks allowed, asking for one
-			name:    "AllowNetNetworksMultiOne",
-			argv:    []string{"--net", "--network", "ptp", c.env.ImagePath, "true"},
-			profile: e2e.UserProfile,
+			name:              "AllowNetNetworksMultiOne",
+			addRequirementsFn: e2e.Privileged(require.Network),
+			argv:              []string{"--net", "--network", "ptp", c.env.ImagePath, "true"},
+			profile:           e2e.UserProfile,
 			directives: map[string]string{
 				"allow net users":    u.Name,
 				"allow net networks": "bridge,ptp",


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1370

Don't attempt to look for CNI bridge network success via the AllowNet* config directives on hosts that don't support setting up the network.

### This fixes or addresses the following GitHub issues:

 - Fixes #1369


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
