### PR TITLE
e2e: force arch for pull by hash (release-3.11)

### DIFF
--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -37,6 +37,7 @@ type testStruct struct {
 	desc             string // case description
 	srcURI           string // source URI for image
 	library          string // use specific library, XXX(mem): not tested yet
+	arch             string // architecture to force, if any
 	force            bool   // pass --force
 	createDst        bool   // create destination file before pull
 	unauthenticated  bool   // pass --allow-unauthenticated
@@ -61,6 +62,10 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 	// element in the slice, which would cause the command to fail, without
 	// over-complicating the code.
 	argv := ""
+
+	if tt.arch != "" {
+		argv += "--arch " + tt.arch + " "
+	}
 
 	if tt.force {
 		argv += "--force "
@@ -216,6 +221,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 		{
 			desc:             "image with specific hash",
 			srcURI:           "library://alpine:sha256.03883ca565b32e58fa0a496316d69de35741f2ef34b5b4658a6fec04ed8149a8",
+			arch:             "amd64",
 			unauthenticated:  true,
 			expectedExitCode: 0,
 		},


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1371

The v2 library won't serve up an image by hash unless is matches the requestors architecture, or the `--arch` flag is used to specify a different architecture.

Image we pull by hash is always amd64, so set the `--arch` flag appropriately in the test.

Fixes test on non amd64 systems.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
