### PR TITLE
fix: avoid incorrect error with --fakeroot --net --network=fakeroot (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   error.
 - Ensure consistent binding of libraries under `--nv/--rocm` when duplicate
   `<library>.so[.version]` files are listed by `ldconfig -p`.
+- Avoid incorrect error when requesting fakeroot network.
 
 ## 3.11.0 \[2023-02-10\]
 

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -2290,7 +2290,6 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 		sessionNetNs = "/netns"
 	)
 
-	fakeroot := c.engine.EngineConfig.GetFakeroot()
 	net := c.engine.EngineConfig.GetNetwork()
 
 	// If we haven't requested a network namespace, or we have but with no config, we are done here
@@ -2298,10 +2297,21 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 		return nil, nil
 	}
 
-	// Otherwise start checking what's permitted for the current user
+	// In fakeroot mode only permit the `fakeroot` CNI config, overriding any other request.
 	euid := os.Geteuid()
+	fakeroot := c.engine.EngineConfig.GetFakeroot()
+	forceFakerootNet := false
+	if fakeroot && euid != 0 && net != fakerootNet {
+		sylog.Warningf("Only --network=%s is permitted in --fakeroot mode. You requested '%s'.", fakerootNet, net)
+		sylog.Warningf("Overriding with --network=%s", fakerootNet)
+	}
+	if fakeroot && euid != 0 {
+		forceFakerootNet = true
+		net = fakerootNet
+	}
+
 	allowedNetUnpriv := false
-	if euid != 0 {
+	if euid != 0 && !forceFakerootNet {
 		// Is the user permitted in the list of unpriv users / groups permitted to use CNI?
 		allowedNetUser, err := user.UIDInList(euid, c.engine.EngineConfig.File.AllowNetUsers)
 		if err != nil {
@@ -2314,7 +2324,11 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 		// Is/are the requested network(s) in the list of networks allowed for unpriv CNI?
 		allowedNetNetwork := false
 		for _, n := range strings.Split(net, ",") {
-			allowedNetNetwork = slice.ContainsString(c.engine.EngineConfig.File.AllowNetNetworks, n)
+			// Allowed in singularity.conf
+			adminPermitted := slice.ContainsString(c.engine.EngineConfig.File.AllowNetNetworks, n)
+			// 'fakeroot' network is always allowed in --fakeroot mode
+			fakerootPermitted := fakeroot && net == fakerootNet
+			allowedNetNetwork = adminPermitted || fakerootPermitted
 			// If any one requested network is not allowed, disallow the whole config
 			if !allowedNetNetwork {
 				sylog.Errorf("Network %s is not permitted for unprivileged users.", n)
@@ -2339,14 +2353,7 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 	if err := system.Points.AddBind(mount.SharedTag, procNetNs, nspath, 0); err != nil {
 		return nil, fmt.Errorf("could not hold network namespace reference: %s", err)
 	}
-	networks := strings.Split(c.engine.EngineConfig.GetNetwork(), ",")
-
-	// In fakeroot mode only permit the `fakeroot` CNI config
-	if fakeroot && euid != 0 && net != fakerootNet {
-		// set as debug message to avoid annoying warning
-		sylog.Debugf("only '%s' network is allowed for regular user, you requested '%s'", fakerootNet, net)
-		networks = []string{fakerootNet}
-	}
+	networks := strings.Split(net, ",")
 
 	cniPath := &network.CNIPath{}
 

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -802,8 +802,6 @@ func (l *Launcher) setNamespaces() {
 	// so we fallback to none
 	if l.cfg.Namespaces.Net {
 		if l.cfg.Fakeroot && l.cfg.Network != "none" {
-			l.engineConfig.SetNetwork("fakeroot")
-
 			if buildcfg.SINGULARITY_SUID_INSTALL == 0 || !l.engineConfig.File.AllowSetuid {
 				sylog.Warningf(
 					"fakeroot with unprivileged installation or 'allow setuid = no' " +


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1355

Due to incorrect logic / ordering of checks in prepareNetworkSetup, the combination of `--fakeroot --net --network=fakeroot` generated a false error stating that the fakeroot network was not permitted.

However, execution continued, and the fakeroot network was (correctly) used.

This is a minimal PR to correct the ordering of checks, such that `--fakeroot --net --network=fakeroot` doesn't give a false error.

The code handling checks for permitted networks is messy, and still needs a proper refactor. There is overriding of the `--network` setting for `--fakeroot` in the CLI->launcher layer as well, due to way in which the default network is implemented, via flag default value.

In addition, there doesn't seem to be a good reason as to why `allowed net networks` shouldn't apply when `--fakeroot` is being used. This can be tackled in the deferred refactor.

### This fixes or addresses the following GitHub issues:

 - Fixes #1352


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
