### PR TITLE
fix: show applicable mem limit in instance stats (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 
 - Fix implied `--writable-tmpfs` with `--nvccli`, to avoid r/o filesytem
   error.
-- Ensure consistent binding of libraries under `--nv/--rocm` when duplicate
-  `<library>.so[.version]` files are listed by `ldconfig -p`.
 - Avoid incorrect error when requesting fakeroot network.
 - Pass computed `LD_LIBRARY_PATH` to wrapped unsquashfs. Fixes issues where
   `unsquashfs` on host uses libraries in non-default paths.
+- Show correct memory limit in `instance stats` when a limit is set.
+- Ensure consistent binding of libraries under `--nv/--rocm` when duplicate
+  `<library>.so[.version]` files are listed by `ldconfig -p`.
 
 ## 3.11.0 \[2023-02-10\]
 

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -54,7 +54,7 @@ func (c *ctx) instanceStats(t *testing.T, profile e2e.Profile) {
 	}{
 		{
 			name:           "basic stats create",
-			createArgs:     []string{c.env.ImagePath},
+			createArgs:     []string{"--memory", "250M", c.env.ImagePath},
 			statsErrorCode: 0,
 			startErrorCode: 0,
 		},
@@ -85,13 +85,18 @@ func (c *ctx) instanceStats(t *testing.T, profile e2e.Profile) {
 				e2e.WithCommand("instance stats"),
 				e2e.WithArgs("--no-stream", instanceName),
 				e2e.ExpectExit(tt.statsErrorCode,
-					e2e.ExpectOutput(e2e.ContainMatch, instanceName),
+					// Header (column spacing varies by content)
 					e2e.ExpectOutput(e2e.ContainMatch, "INSTANCE NAME"),
 					e2e.ExpectOutput(e2e.ContainMatch, "CPU USAGE"),
 					e2e.ExpectOutput(e2e.ContainMatch, "MEM USAGE / LIMIT"),
 					e2e.ExpectOutput(e2e.ContainMatch, "MEM %"),
 					e2e.ExpectOutput(e2e.ContainMatch, "BLOCK I/O"),
 					e2e.ExpectOutput(e2e.ContainMatch, "PIDS"),
+					e2e.ExpectOutput(e2e.ContainMatch, "PIDS"),
+					// Instance name is visible
+					e2e.ExpectOutput(e2e.ContainMatch, instanceName),
+					// Memory limit is visible
+					e2e.ExpectOutput(e2e.ContainMatch, "/ 250MiB"),
 				),
 			)
 			c.env.RunSingularity(

--- a/internal/app/singularity/instance_linux.go
+++ b/internal/app/singularity/instance_linux.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strings"
 	"syscall"
@@ -161,20 +162,22 @@ func calculateBlockIO(stats *libcgroups.BlkioStats) (float64, float64) {
 // calculateMemoryUsage returns the current usage, limit, and percentage
 func calculateMemoryUsage(stats *libcgroups.MemoryStats) (float64, float64, float64) {
 	// Note that there is also MaxUsage
-	memUsage := float64(stats.Usage.Usage)
-	memLimit := 0.0
+	memUsage := stats.Usage.Usage
+	memLimit := stats.Usage.Limit
 	memPercent := 0.0
 
-	// Calculate total memory of system
-	in := &syscall.Sysinfo_t{}
-	err := syscall.Sysinfo(in)
-	if err == nil {
-		memLimit = float64(in.Totalram) * float64(in.Unit)
+	// If there is no limit, show system RAM instead of max uint64...
+	if memLimit == math.MaxUint64 {
+		in := &syscall.Sysinfo_t{}
+		err := syscall.Sysinfo(in)
+		if err == nil {
+			memLimit = in.Totalram * uint64(in.Unit)
+		}
 	}
 	if memLimit != 0 {
-		memPercent = memUsage / memLimit * 100.0
+		memPercent = float64(memUsage) / float64(memLimit) * 100.0
 	}
-	return memUsage, memLimit, memPercent
+	return float64(memUsage), float64(memLimit), memPercent
 }
 
 func calculateCPUUsage(prevTime, prevCPU uint64, cpuStats *libcgroups.CpuStats) (cpuPercent float64, curTime, curCPU uint64) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1358

When a cgroups memory limit is set, show this in the instance stats output. Show the system total RAM when a limit is not set.

### This fixes or addresses the following GitHub issues:

 - Fixes #1281 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
