### PR TITLE
fix: gpu: always bind first variant of lib in ldconfig -p output (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix implied `--writable-tmpfs` with `--nvccli`, to avoid r/o filesytem
   error.
+- Ensure consistent binding of libraries under `--nv/--rocm` when duplicate
+  `<library>.so[.version]` files are listed by `ldconfig -p`.
 
 ## 3.11.0 \[2023-02-10\]
 

--- a/internal/pkg/util/gpu/paths.go
+++ b/internal/pkg/util/gpu/paths.go
@@ -117,7 +117,7 @@ func paths(gpuFileList []string) ([]string, []string, error) {
 					sylog.Warningf("Could not close ELIB: %v", err)
 				}
 			} else {
-				for libPath, libName := range ldCache {
+				for libName, libPath := range ldCache {
 					if !strings.HasPrefix(libName, file) {
 						continue
 					}
@@ -154,7 +154,11 @@ func paths(gpuFileList []string) ([]string, []string, error) {
 	return libraries, binaries, nil
 }
 
-// ldcache retrieves a map of absolute path of a library to it's bare name using the system ld cache via `ldconfig -p`
+// ldcache retrieves a map of <library>.so[.version] to its absolute path using
+// the system ld cache via `ldconfig -p`. We only take the first instance of
+// each <library>.so[.version] from `ldconfig -p` output. I.E. if `ldconfig -p`
+// lists three variants of libEGL.so.1 that are in different locations, we only
+// report the first, highest priority, variant.
 func ldCache() (map[string]string, error) {
 	// walk through the ldconfig output and add entries which contain the filenames
 	// returned by nvidia-container-cli OR the nvliblist.conf file contents
@@ -182,7 +186,12 @@ func ldCache() (map[string]string, error) {
 			// libPath is the "/usr/lib64/nvidia/libnvidia-ml.so.1" (from the above example)
 			libName := strings.TrimSpace(string(match[1]))
 			libPath := strings.TrimSpace(string(match[2]))
-			ldCache[libPath] = libName
+
+			// Only take the first entry for a given <library>.so[.version] in the ldconfig output
+			if _, ok := ldCache[libName]; !ok {
+				ldCache[libName] = libPath
+			}
+
 		}
 	}
 	return ldCache, nil

--- a/internal/pkg/util/gpu/paths_test.go
+++ b/internal/pkg/util/gpu/paths_test.go
@@ -39,7 +39,7 @@ func TestLdCache(t *testing.T) {
 	if len(gotCache) == 0 {
 		t.Error("ldCache() gave no results")
 	}
-	for path, name := range gotCache {
+	for name, path := range gotCache {
 		if strings.HasPrefix(name, "ld-linux") {
 			if strings.Contains(path, "ld-linux") {
 				return


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1390

We use the output of `ldconfig -p` to construct a list of libraries to consider for binding into the container with `--nv` / `--rocm` enabled.

Previously, the entire `ldconfig -p` output was parsed into a map of path->library. This map was then iterated over when computing the binds to perform.

It's possible for a given `<library>.so[.version]` to be present at multiple paths, e.g. when a vendor and system `libEGL.so.0` are both present on the system. Because the map is keyed by path, multiple entries would be created in it. Range over map has a random order in Go, and we can only bind a single `<library>.so[.version]` under `.singularity.d/libs` - so the library bound would vary between runs.

This PR modifies the mapping to be library->path and ensures there is only a single `<library>.so[.version]` in the map, making behavior consistent between runs. Only the first occurence of a specific `<library>.so[.version]` in the `ldconfig -p` output will be bound into the container.

There is no impact on systems where `ldconfig -p` does not list multiple locations for the same `<library>.so[.version]`.

### This fixes or addresses the following GitHub issues:

 - Fixes #1345 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
