### PR TITLE
Improved discussion of LICENSE_DEPENDENCIES.md in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,8 @@ all your interactions with the project members and users.
    - New features / functionalities
 1. PRs which introduce a new Go dependency to the project via `go get` and
    additions to `go.mod` should explain why the dependency is required.
-1. Any new or updated dependency should be reflected in `LICENSE_DEPENDENCIES.md`, by
-   running `scripts/update-license-dependencies.sh`
+1. Any new or updated dependency should be reflected in
+   `LICENSE_DEPENDENCIES.md`, by running `scripts/update-license-dependencies.sh`
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,8 @@ all your interactions with the project members and users.
 1. PRs which introduce a new Go dependency to the project via `go get` and
    additions to `go.mod` should explain why the dependency is required.
 1. Any new or updated dependency should be reflected in
-   `LICENSE_DEPENDENCIES.md`, by running `scripts/update-license-dependencies.sh`
+   `LICENSE_DEPENDENCIES.md`, by running
+   `scripts/update-license-dependencies.sh`
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,9 @@ all your interactions with the project members and users.
    - Backwards incompatible changes
    - New features / functionalities
 1. PRs which introduce a new Go dependency to the project via `go get` and
-   additions to `go.mod` should explain why the dependency is required. Any
-   new dependency should be added to the `LICENSE_DEPENDENCIES.md` by
-   running `scripts/update-license-dependencies.md`.
+   additions to `go.mod` should explain why the dependency is required.
+1. Any new or updated dependency should be reflected in `LICENSE_DEPENDENCIES.md`, by
+   running `scripts/update-license-dependencies.sh`
 
 ## Documentation
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Addresses two problems in `CONTRIBUTING.md`, specifically in the discussion of `LICENSE_DEPENDENCIES.md`:

- Replaced use of the phrase "Any new dependency" with the hopefully clearer "Any new or updated dependency". (The former could be misinterpreted to mean "only wholly new dependencies" excluding, e.g., version bumps, and that would be incorrect.)
- Fixed typo in the name of the update script: its extension is `.sh` but was given as `.md`

### This fixes or addresses the following GitHub issues:

 - Addresses #1392 

