### PR TITLE
Migrate to gopkg.in/yaml.v3

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -74,6 +74,7 @@ The following have contributed code and/or documentation to this repository.
 - Michael Herzberg <michael@mherzberg.de>
 - Michael Milton <ttmigueltt@gmail.com>
 - Michael Moore <michael.moore@nuance.com>
+- Michael Richards <m.richards@utexas.edu>
 - Mike Frisch <michael.frisch@sylabs.io>
 - Mike Gray <mike@sylabs.io>
 - Nathan Chou <nathan.chou@sylabs.io>, <choun@berkeley.edu>
@@ -104,6 +105,7 @@ The following have contributed code and/or documentation to this repository.
 - Westley Kurtzer <westley@sylabs.io>, <westleyk@nym.hush.com>
 - Yannick Cote <y@sylabs.io>, <yhcote@gmail.com>
 - Yaroslav Halchenko <debian@onerussian.com>
+- Yinuo Chen <ynchen2829@utexas.edu>
 - Onur Yılmaz <csonuryilmaz@gmail.com>
 - Pranathi Locula <locula@deshaw.com>
 ```

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -437,11 +437,11 @@ The dependencies and their licenses are as follows:
 
 **Project URL:** <https://gopkg.in/square/go-jose.v2>
 
-## gopkg.in/yaml.v3
+## gopkg.in/yaml.v2
 
 **License:** Apache-2.0
 
-**Project URL:** <https://gopkg.in/yaml.v3>
+**Project URL:** <https://gopkg.in/yaml.v2>
 
 ## gotest.tools/v3
 

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -437,11 +437,11 @@ The dependencies and their licenses are as follows:
 
 **Project URL:** <https://gopkg.in/square/go-jose.v2>
 
-## gopkg.in/yaml.v2
+## gopkg.in/yaml.v3
 
 **License:** Apache-2.0
 
-**Project URL:** <https://gopkg.in/yaml.v2>
+**Project URL:** <https://gopkg.in/yaml.v3>
 
 ## gotest.tools/v3
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/sys v0.5.0
 	golang.org/x/term v0.5.0
 	golang.org/x/text v0.7.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.4.0
 	mvdan.cc/sh/v3 v3.6.0
 	oras.land/oras-go v1.2.3-0.20230221065300-6cd929aff421
@@ -177,6 +177,6 @@ require (
 	google.golang.org/grpc v1.53.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/internal/app/singularity/remote_add_test.go
+++ b/internal/app/singularity/remote_add_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/internal/pkg/test"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -7,6 +7,7 @@
 package remote
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -19,7 +20,7 @@ import (
 	remoteutil "github.com/sylabs/singularity/internal/pkg/remote/util"
 	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // ErrNoDefault indicates no default remote being set
@@ -75,7 +76,9 @@ func ReadFrom(r io.Reader) (*Config, error) {
 		// If we had data to read in io.Reader, attempt to unmarshal as YAML.
 		// Also, it will fail if the YAML file does not have the expected
 		// structure.
-		if err := yaml.UnmarshalStrict(b, c); err != nil {
+		dec := yaml.NewDecoder(bytes.NewReader(b))
+		dec.KnownFields(true)
+		if err := dec.Decode(c); err != nil {
 			return nil, fmt.Errorf("failed to decode YAML data from io.Reader: %s", err)
 		}
 	}

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 const testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Updates the Go dependency to [yaml v3](https://gopkg.in/yaml.v3).


### This fixes or addresses the following GitHub issues:

 - Fixes #1217


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
