### PR TITLE
e2e: improve ImageVerify efficiency and replace defer-based cleanups

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -41,7 +41,11 @@ func (c ctx) testDockerPulls(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %+v", err)
 	}
-	defer os.RemoveAll(tmpPath)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.RemoveAll(tmpPath)
+		}
+	})
 
 	tmpImage := filepath.Join(tmpPath, tmpContainerFile)
 
@@ -124,7 +128,11 @@ func (c ctx) testDockerHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %+v", err)
 	}
-	defer os.RemoveAll(tmpPath)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.RemoveAll(tmpPath)
+		}
+	})
 
 	dockerfile := filepath.Join(tmpPath, "Dockerfile")
 	dockerfileContent := []byte("FROM alpine:latest\n")
@@ -259,7 +267,11 @@ func (c ctx) testDockerHost(t *testing.T) {
 // AUFS sanity tests
 func (c ctx) testDockerAUFS(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "aufs-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	c.env.RunSingularity(
@@ -306,7 +318,11 @@ func (c ctx) testDockerAUFS(t *testing.T) {
 // Check force permissions for user builds #977
 func (c ctx) testDockerPermissions(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "perm-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	c.env.RunSingularity(
@@ -352,7 +368,11 @@ func (c ctx) testDockerPermissions(t *testing.T) {
 // Check whiteout of symbolic links #1592 #1576
 func (c ctx) testDockerWhiteoutSymlink(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "whiteout-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	c.env.RunSingularity(
@@ -372,7 +392,11 @@ func (c ctx) testDockerWhiteoutSymlink(t *testing.T) {
 
 func (c ctx) testDockerDefFile(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "def-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	getKernelMajor := func(t *testing.T) (major int) {
@@ -416,7 +440,7 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		deffile := e2e.PrepareDefFile(e2e.DefFileDetails{
+		defFile := e2e.PrepareDefFile(e2e.DefFileDetails{
 			Bootstrap: "docker",
 			From:      tt.from,
 		})
@@ -426,7 +450,7 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
-			e2e.WithArgs([]string{imagePath, deffile}...),
+			e2e.WithArgs([]string{imagePath, defFile}...),
 			e2e.PreRun(func(t *testing.T) {
 				require.Arch(t, tt.archRequired)
 				if getKernelMajor(t) < tt.kernelMajorRequired {
@@ -434,8 +458,12 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 				}
 			}),
 			e2e.PostRun(func(t *testing.T) {
-				defer os.Remove(imagePath)
-				defer os.Remove(deffile)
+				t.Cleanup(func() {
+					if !t.Failed() {
+						os.Remove(imagePath)
+						os.Remove(defFile)
+					}
+				})
 
 				if t.Failed() {
 					return
@@ -450,7 +478,11 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 
 func (c ctx) testDockerRegistry(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "registry-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	tests := []struct {
@@ -496,8 +528,12 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 			e2e.WithCommand("build"),
 			e2e.WithArgs("--disable-cache", "--no-https", imagePath, defFile),
 			e2e.PostRun(func(t *testing.T) {
-				defer os.Remove(imagePath)
-				defer os.Remove(defFile)
+				t.Cleanup(func() {
+					if !t.Failed() {
+						os.Remove(imagePath)
+						os.Remove(defFile)
+					}
+				})
 
 				if t.Failed() || tt.exit != 0 {
 					return
@@ -512,7 +548,11 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 
 func (c ctx) testDockerLabels(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "labels-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	// Test container & set labels
@@ -552,7 +592,11 @@ func (c ctx) testDockerLabels(t *testing.T) {
 //nolint:dupl
 func (c ctx) testDockerCMD(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	home, err := os.UserHomeDir()
@@ -651,7 +695,11 @@ func (c ctx) testDockerCMD(t *testing.T) {
 //nolint:dupl
 func (c ctx) testDockerENTRYPOINT(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	home, err := os.UserHomeDir()
@@ -737,7 +785,11 @@ func (c ctx) testDockerENTRYPOINT(t *testing.T) {
 //nolint:dupl
 func (c ctx) testDockerCMDENTRYPOINT(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	imagePath := filepath.Join(imageDir, "container")
 
 	home, err := os.UserHomeDir()

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -458,18 +458,16 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 				}
 			}),
 			e2e.PostRun(func(t *testing.T) {
-				t.Cleanup(func() {
-					if !t.Failed() {
-						os.Remove(imagePath)
-						os.Remove(defFile)
-					}
-				})
-
 				if t.Failed() {
 					return
 				}
 
 				c.env.ImageVerify(t, imagePath)
+
+				if !t.Failed() {
+					os.Remove(imagePath)
+					os.Remove(defFile)
+				}
 			}),
 			e2e.ExpectExit(0),
 		)
@@ -528,18 +526,16 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 			e2e.WithCommand("build"),
 			e2e.WithArgs("--disable-cache", "--no-https", imagePath, defFile),
 			e2e.PostRun(func(t *testing.T) {
-				t.Cleanup(func() {
-					if !t.Failed() {
-						os.Remove(imagePath)
-						os.Remove(defFile)
-					}
-				})
-
 				if t.Failed() || tt.exit != 0 {
 					return
 				}
 
 				c.env.ImageVerify(t, imagePath)
+
+				if !t.Failed() {
+					os.Remove(imagePath)
+					os.Remove(defFile)
+				}
 			}),
 			e2e.ExpectExit(tt.exit),
 		)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -130,7 +130,11 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tc := range tt {
 				dn, cleanup := c.tempDir(t, "build-from")
-				defer cleanup()
+				t.Cleanup(func() {
+					if !t.Failed() {
+						cleanup()
+					}
+				})
 
 				imagePath := path.Join(dn, "sandbox")
 
@@ -160,7 +164,11 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 							return
 						}
 
-						defer os.RemoveAll(imagePath)
+						t.Cleanup(func() {
+							if !t.Failed() {
+								os.RemoveAll(imagePath)
+							}
+						})
 						c.env.ImageVerify(t, imagePath)
 					}),
 					e2e.ExpectExit(0),
@@ -205,7 +213,11 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 
 	for _, tc := range tt {
 		dn, cleanup := c.tempDir(t, "non-root-build")
-		defer cleanup()
+		t.Cleanup(func() {
+			if !t.Failed() {
+				cleanup()
+			}
+		})
 
 		imagePath := path.Join(dn, "container")
 
@@ -236,13 +248,21 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 
 	tmpdir, cleanup := c.tempDir(t, "build-local-image")
 
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	liDefFile := e2e.PrepareDefFile(e2e.DefFileDetails{
 		Bootstrap: "localimage",
 		From:      c.env.ImagePath,
 	})
-	defer os.Remove(liDefFile)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(liDefFile)
+		}
+	})
 
 	labels := make(map[string]string)
 	labels["FOO"] = "bar"
@@ -251,7 +271,11 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 		From:      c.env.ImagePath,
 		Labels:    labels,
 	})
-	defer os.Remove(liLabelDefFile)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(liLabelDefFile)
+		}
+	})
 
 	sandboxImage := path.Join(tmpdir, "test-sandbox")
 
@@ -271,7 +295,11 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 		From:      sandboxImage,
 		Labels:    labels,
 	})
-	defer os.Remove(localSandboxDefFile)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(localSandboxDefFile)
+		}
+	})
 
 	tt := []struct {
 		name      string
@@ -301,7 +329,11 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 						if t.Failed() {
 							return
 						}
-						defer os.RemoveAll(imagePath)
+						t.Cleanup(func() {
+							if !t.Failed() {
+								os.RemoveAll(imagePath)
+							}
+						})
 						c.env.ImageVerify(t, imagePath)
 					}),
 					e2e.ExpectExit(0),
@@ -313,7 +345,11 @@ func (c imgBuildTests) buildLocalImage(t *testing.T) {
 
 func (c imgBuildTests) badPath(t *testing.T) {
 	dn, cleanup := c.tempDir(t, "bad-path")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	imagePath := path.Join(dn, "container")
 
@@ -332,7 +368,11 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer os.Remove(tmpfile) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(tmpfile)
+		}
+	})
 
 	tests := []struct {
 		name    string
@@ -511,7 +551,11 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 
 	for _, tt := range tests {
 		dn, cleanup := c.tempDir(t, "multi-stage-definition")
-		defer cleanup()
+		t.Cleanup(func() {
+			if !t.Failed() {
+				cleanup()
+			}
+		})
 
 		imagePath := path.Join(dn, "container")
 
@@ -526,7 +570,11 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 			e2e.WithCommand("build"),
 			e2e.WithArgs(args...),
 			e2e.PostRun(func(t *testing.T) {
-				defer os.Remove(defFile)
+				t.Cleanup(func() {
+					if !t.Failed() {
+						os.Remove(defFile)
+					}
+				})
 
 				e2e.DefinitionImageVerify(t, c.env.CmdPath, imagePath, tt.correct)
 			}),
@@ -542,7 +590,11 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer os.Remove(tmpfile) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(tmpfile)
+		}
+	})
 
 	tt := map[string]e2e.DefFileDetails{
 		"Empty": {
@@ -807,7 +859,11 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 		t.Run(profile.String(), func(t *testing.T) {
 			for name, dfd := range tt {
 				dn, cleanup := c.tempDir(t, "build-definition")
-				defer cleanup()
+				t.Cleanup(func() {
+					if !t.Failed() {
+						cleanup()
+					}
+				})
 
 				imagePath := path.Join(dn, "container")
 
@@ -823,7 +879,11 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 						if t.Failed() {
 							return
 						}
-						defer os.Remove(defFile)
+						t.Cleanup(func() {
+							if !t.Failed() {
+								os.Remove(defFile)
+							}
+						})
 						e2e.DefinitionImageVerify(t, c.env.CmdPath, imagePath, dfd)
 					}),
 					e2e.ExpectExit(0),
@@ -858,7 +918,11 @@ func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 	// We create a temporary directory to store the image, making sure tests
 	// will not pollute each other
 	dn, cleanup := c.tempDir(t, "pem-encryption")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	// Generate the PEM file
 	pemFile, _ := e2e.GeneratePemFiles(t, c.env.TestDir)
@@ -926,7 +990,11 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	// We create a temporary directory to store the image, making sure tests
 	// will not pollute each other
 	dn, cleanup := c.tempDir(t, "passphrase-encryption")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	// If the version of cryptsetup is not compatible with Singularity encryption,
 	// the build commands are expected to fail
@@ -1024,7 +1092,11 @@ func (c imgBuildTests) buildUpdateSandbox(t *testing.T) {
 	const badSandbox = "/bad/sandbox/path"
 
 	testDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "build-sandbox-", "")
-	defer e2e.Privileged(cleanup)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			e2e.Privileged(cleanup)
+		}
+	})
 
 	tests := []struct {
 		name     string
@@ -1073,10 +1145,10 @@ func (c imgBuildTests) buildUpdateSandbox(t *testing.T) {
 // buildWithFingerprint checks that we correctly verify a source image fingerprint when specified
 func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 	tmpDir, remove := e2e.MakeTempDir(t, "", "imgbuild-fingerprint-", "")
-	defer func() {
+	t.Cleanup(func() {
 		c.env.KeyringDir = ""
 		remove(t)
-	}()
+	})
 
 	pgpDir, _ := e2e.MakeSyPGPDir(t, tmpDir)
 	c.env.KeyringDir = pgpDir
@@ -1240,7 +1312,11 @@ func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		defer os.Remove(defFile)
+		t.Cleanup(func() {
+			if !t.Failed() {
+				os.Remove(defFile)
+			}
+		})
 		c.env.RunSingularity(t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(e2e.RootProfile),
@@ -1258,7 +1334,11 @@ func (c imgBuildTests) buildBindMount(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	tmpdir, cleanup := c.tempDir(t, "build-local-image")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	dir, _ := e2e.MakeTempDir(t, tmpdir, "mount", "")
 
@@ -1426,7 +1506,11 @@ func (c imgBuildTests) testWritableTmpfs(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	tmpdir, cleanup := c.tempDir(t, "build-writabletmpfs-test")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	// Definition will attempt to touch a file in /var/test during %test.
 	// This would fail without a writable tmpfs.
@@ -1450,7 +1534,11 @@ func (c imgBuildTests) buildLibraryHost(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	tmpdir, cleanup := c.tempDir(t, "build-libraryhost-test")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	// Library hostname in the From URI
 	// The hostname is invalid, and we should get an error to that effect.
@@ -1503,7 +1591,11 @@ func (c imgBuildTests) buildProot(t *testing.T) {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tc := range tt {
 				dn, cleanup := c.tempDir(t, "build-proot")
-				defer cleanup()
+				t.Cleanup(func() {
+					if !t.Failed() {
+						cleanup()
+					}
+				})
 
 				imagePath := path.Join(dn, "image.sif")
 
@@ -1522,7 +1614,11 @@ func (c imgBuildTests) buildProot(t *testing.T) {
 							return
 						}
 
-						defer os.RemoveAll(imagePath)
+						t.Cleanup(func() {
+							if !t.Failed() {
+								os.RemoveAll(imagePath)
+							}
+						})
 						c.env.ImageVerify(t, imagePath)
 					}),
 					e2e.ExpectExit(0),
@@ -1535,7 +1631,11 @@ func (c imgBuildTests) buildProot(t *testing.T) {
 // Check that test and runscript that specify a custom #! use it as the interpreter.
 func (c imgBuildTests) buildCustomShebang(t *testing.T) {
 	tmpdir, cleanup := c.tempDir(t, "build-shebang-test")
-	defer cleanup()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
 
 	definition := `Bootstrap: localimage
 From: %s

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -36,7 +36,11 @@ func (c imgBuildTests) issue4203(t *testing.T) {
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_4203.def"),
 		e2e.PostRun(func(t *testing.T) {
-			defer os.Remove(image)
+			t.Cleanup(func() {
+				if !t.Failed() {
+					os.Remove(image)
+				}
+			})
 
 			if t.Failed() {
 				return
@@ -99,7 +103,11 @@ func (c *imgBuildTests) issue4407(t *testing.T) {
 					return
 				}
 
-				defer os.RemoveAll(imagePath)
+				t.Cleanup(func() {
+					if !t.Failed() {
+						os.RemoveAll(imagePath)
+					}
+				})
 
 				c.env.ImageVerify(t, imagePath)
 			}),
@@ -117,7 +125,11 @@ func (c *imgBuildTests) issue4583(t *testing.T) {
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_4583.def"),
 		e2e.PostRun(func(t *testing.T) {
-			defer os.Remove(image)
+			t.Cleanup(func() {
+				if !t.Failed() {
+					os.Remove(image)
+				}
+			})
 
 			if t.Failed() {
 				return
@@ -291,11 +303,11 @@ func (c *imgBuildTests) issue5315(t *testing.T) {
 func (c *imgBuildTests) issue5435(t *testing.T) {
 	// create a directory that we don't care about
 	cwd, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "throwaway-dir-", "")
-	defer func(t *testing.T) {
+	t.Cleanup(func() {
 		if !t.Failed() {
 			cleanup(t)
 		}
-	}(t)
+	})
 
 	c.env.RunSingularity(
 		t,
@@ -352,7 +364,11 @@ func (c *imgBuildTests) issue5668(t *testing.T) {
 		t.Fatalf("Could not get home dir: %v", err)
 	}
 	sbDir, sbCleanup := e2e.MakeTempDir(t, home, "issue-5668-", "")
-	defer e2e.Privileged(sbCleanup)(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			e2e.Privileged(sbCleanup)(t)
+		}
+	})
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -368,7 +384,11 @@ func (c *imgBuildTests) issue5690(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	sandbox, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-5690-", "")
-	defer e2e.Privileged(cleanup)(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			e2e.Privileged(cleanup)(t)
+		}
+	})
 
 	c.env.RunSingularity(
 		t,
@@ -389,7 +409,11 @@ func (c *imgBuildTests) issue5690(t *testing.T) {
 
 func (c *imgBuildTests) issue3848(t *testing.T) {
 	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-3848-", "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 
 	f, err := os.CreateTemp(tmpDir, "test-def-")
 	if err != nil {
@@ -401,7 +425,11 @@ func (c *imgBuildTests) issue3848(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpfile) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(tmpfile)
+		}
+	})
 
 	d := struct {
 		From string

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -25,14 +25,14 @@ func (env TestEnv) ImageVerify(t *testing.T, imagePath string) {
 		AsSubtest("BasicIntegrityTests"),
 		WithProfile(UserProfile),
 		WithCommand("exec"),
-		WithArgs(imagePath, "/bin/sh", "-c", "( false ) || "+
-			"( test -f /.singularity.d/runscript -a "+
-			"-f /.singularity.d/env/01-base.sh -a "+
-			"-f /.singularity.d/actions/shell -a "+
-			"-f /.singularity.d/actions/exec -a "+
-			"-f /.singularity.d/actions/run -a "+
-			"-L /environment -a "+
-			"-L /singularity )"),
+		WithArgs(imagePath, "/bin/sh", "-c",
+			"test -f /.singularity.d/runscript -a "+
+				"-f /.singularity.d/env/01-base.sh -a "+
+				"-f /.singularity.d/actions/shell -a "+
+				"-f /.singularity.d/actions/exec -a "+
+				"-f /.singularity.d/actions/run -a "+
+				"-L /environment -a "+
+				"-L /singularity"),
 		ExpectExit(0),
 	)
 

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -37,12 +37,12 @@ func (env TestEnv) ImageVerify(t *testing.T, imagePath string) {
 	)
 
 	tests := []struct {
-		// name      string
+		name      string
 		jsonPath  []string
 		expectOut string
 	}{
 		{
-			// name:      "LabelCheckType",
+			name:      "LabelCheckType",
 			jsonPath:  []string{"type"},
 			expectOut: "container",
 		},
@@ -55,13 +55,15 @@ func (env TestEnv) ImageVerify(t *testing.T, imagePath string) {
 
 	verifyOutput := func(t *testing.T, r *SingularityCmdResult) {
 		for _, tt := range tests {
-			jsonOut, err := jsonparser.GetString(r.Stdout, tt.jsonPath...)
-			if err != nil {
-				t.Fatalf("unable to get expected output from json: %v", err)
-			}
-			if jsonOut != tt.expectOut {
-				t.Fatalf("unexpected failure: got: '%s', expecting: '%s'", jsonOut, tt.expectOut)
-			}
+			t.Run(tt.name, func(t *testing.T) {
+				jsonOut, err := jsonparser.GetString(r.Stdout, tt.jsonPath...)
+				if err != nil {
+					t.Fatalf("unable to get expected output from json: %v", err)
+				}
+				if jsonOut != tt.expectOut {
+					t.Fatalf("unexpected failure: got: '%s', expecting: '%s'", jsonOut, tt.expectOut)
+				}
+			})
 		}
 	}
 

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -20,84 +20,41 @@ import (
 
 // ImageVerify checks for an image integrity.
 func (env TestEnv) ImageVerify(t *testing.T, imagePath string) {
-	tt := []struct {
-		name string
-		argv []string
-		exit int
-	}{
-		{
-			name: "False",
-			argv: []string{imagePath, "false"},
-			exit: 1,
-		},
-		{
-			name: "RunScript",
-			argv: []string{imagePath, "test", "-f", "/.singularity.d/runscript"},
-			exit: 0,
-		},
-		{
-			name: "OneBase",
-			argv: []string{imagePath, "test", "-f", "/.singularity.d/env/01-base.sh"},
-			exit: 0,
-		},
-		{
-			name: "ActionsShell",
-			argv: []string{imagePath, "test", "-f", "/.singularity.d/actions/shell"},
-			exit: 0,
-		},
-		{
-			name: "ActionsExec",
-			argv: []string{imagePath, "test", "-f", "/.singularity.d/actions/exec"},
-			exit: 0,
-		},
-		{
-			name: "ActionsRun",
-			argv: []string{imagePath, "test", "-f", "/.singularity.d/actions/run"},
-			exit: 0,
-		},
-		{
-			name: "Environment",
-			argv: []string{imagePath, "test", "-L", "/environment"},
-			exit: 0,
-		},
-		{
-			name: "Singularity",
-			argv: []string{imagePath, "test", "-L", "/singularity"},
-			exit: 0,
-		},
-	}
-
-	for _, tc := range tt {
-		env.RunSingularity(
-			t,
-			AsSubtest(tc.name),
-			WithProfile(UserProfile),
-			WithCommand("exec"),
-			WithArgs(tc.argv...),
-			ExpectExit(tc.exit),
-		)
-	}
+	env.RunSingularity(
+		t,
+		AsSubtest("BasicIntegrityTests"),
+		WithProfile(UserProfile),
+		WithCommand("exec"),
+		WithArgs(imagePath, "/bin/sh", "-c", "( false ) || "+
+			"( test -f /.singularity.d/runscript -a "+
+			"-f /.singularity.d/env/01-base.sh -a "+
+			"-f /.singularity.d/actions/shell -a "+
+			"-f /.singularity.d/actions/exec -a "+
+			"-f /.singularity.d/actions/run -a "+
+			"-L /environment -a "+
+			"-L /singularity )"),
+		ExpectExit(0),
+	)
 
 	tests := []struct {
-		name      string
+		// name      string
 		jsonPath  []string
 		expectOut string
 	}{
 		{
-			name:      "LabelCheckType",
+			// name:      "LabelCheckType",
 			jsonPath:  []string{"type"},
 			expectOut: "container",
 		},
 		{
-			name:      "LabelCheckSchemaVersion",
+			// name:      "LabelCheckSchemaVersion",
 			jsonPath:  []string{"data", "attributes", "labels", "org.label-schema.schema-version"},
 			expectOut: "1.0",
 		},
 	}
 
-	// Verify the label partition
-	for _, tt := range tests {
-		verifyOutput := func(t *testing.T, r *SingularityCmdResult) {
+	verifyOutput := func(t *testing.T, r *SingularityCmdResult) {
+		for _, tt := range tests {
 			jsonOut, err := jsonparser.GetString(r.Stdout, tt.jsonPath...)
 			if err != nil {
 				t.Fatalf("unable to get expected output from json: %v", err)
@@ -106,16 +63,16 @@ func (env TestEnv) ImageVerify(t *testing.T, imagePath string) {
 				t.Fatalf("unexpected failure: got: '%s', expecting: '%s'", jsonOut, tt.expectOut)
 			}
 		}
-
-		env.RunSingularity(
-			t,
-			AsSubtest(tt.name),
-			WithProfile(UserProfile),
-			WithCommand("inspect"),
-			WithArgs([]string{"--json", "--labels", imagePath}...),
-			ExpectExit(0, verifyOutput),
-		)
 	}
+
+	env.RunSingularity(
+		t,
+		AsSubtest("LabelChecks"),
+		WithProfile(UserProfile),
+		WithCommand("inspect"),
+		WithArgs([]string{"--json", "--labels", imagePath}...),
+		ExpectExit(0, verifyOutput),
+	)
 }
 
 // DefinitionImageVerify checks for image correctness based off off supplied DefFileDetail

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -55,7 +55,11 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 	// Use a one-time cache directory specific to this pull. This ensures we are always
 	// testing an entire pull operation, performing the download into an empty cache.
 	cacheDir, cleanup := e2e.MakeCacheDir(t, "")
-	defer cleanup(t)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
 	c.env.UnprivCacheDir = cacheDir
 
 	// We use a string rather than a slice of strings to avoid having an empty
@@ -346,7 +350,11 @@ func (c ctx) testPullCmd(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create temporary directory for pull test: %+v", err)
 			}
-			defer os.RemoveAll(tmpdir)
+			t.Cleanup(func() {
+				if !t.Failed() {
+					os.RemoveAll(tmpdir)
+				}
+			})
 
 			if tt.setPullDir {
 				tt.pullDir, err = os.MkdirTemp(tmpdir, "pull_dir.")
@@ -476,12 +484,14 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s", err)
 	}
-	defer func() {
-		err := os.RemoveAll(cacheDir)
-		if err != nil {
-			t.Fatalf("failed to delete temporary directory %s: %s", cacheDir, err)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			err := os.RemoveAll(cacheDir)
+			if err != nil {
+				t.Fatalf("failed to delete temporary directory %s: %s", cacheDir, err)
+			}
 		}
-	}()
+	})
 
 	c.env.UnprivCacheDir = cacheDir
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

There are two kinds of changes here. First, the number of times `singularity exec` and `singularity inspect` are invoked from the `ImageVerify()` function has been reduced from 8 and 2, respectively, to 1 and 1, respectively.

Second, and relatedly, code that invokes `ImageVerify()` and used `defer f()` statements for cleanup has been changed to use `t.Cleanup()` statements that, crucially, check for `!t.Failed()` before performing the actual cleanup operations. This is a good idea in general, since suppressing cleanups when a test fails allows for more straightforward manual inspection of the fail state. This is a change we should eventually make throughout our test suites. But in this case it's especially important, because the consolidation of `singularity exec` and `singularity inspect` invocations means that error messages, should they occur, will be less detailed than before, and manual inspection of the fail state will be especially important. (This is a trade-off between test efficiency and the quality of automated error messages, where, in this case, we have decided in favor of the former.)

### This fixes or addresses the following GitHub issues:

 - Fixes #1106 

