### PR TITLE
e2e: fix: use temp HOME for docker (release-3.11)

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -118,17 +118,18 @@ func (c ctx) testDockerPulls(t *testing.T) {
 func (c ctx) testDockerHost(t *testing.T) {
 	require.Command(t, "docker")
 
+	// Temporary homedir for docker commands, so invoking docker doesn't create
+	// a ~/.docker that may interfere elsewhere.
+	tmpHome, cleanupHome := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
+	t.Cleanup(func() { e2e.Privileged(cleanupHome)(t) })
+
 	// Create a Dockerfile for a small image we can build locally
-	tmpPath, err := fs.MakeTmpDir(c.env.TestDir, "docker-", 0o755)
-	err = errors.Wrapf(err, "creating temporary directory in %q for docker host test", c.env.TestDir)
-	if err != nil {
-		t.Fatalf("failed to create temporary directory: %+v", err)
-	}
-	defer os.RemoveAll(tmpPath)
+	tmpPath, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
+	t.Cleanup(func() { cleanup(t) })
 
 	dockerfile := filepath.Join(tmpPath, "Dockerfile")
 	dockerfileContent := []byte("FROM alpine:latest\n")
-	err = os.WriteFile(dockerfile, dockerfileContent, 0o644)
+	err := os.WriteFile(dockerfile, dockerfileContent, 0o644)
 	if err != nil {
 		t.Fatalf("failed to create temporary Dockerfile: %+v", err)
 	}
@@ -141,6 +142,7 @@ func (c ctx) testDockerHost(t *testing.T) {
 	e2e.Privileged(func(t *testing.T) {
 		cmd := exec.Command("docker", "build", "-t", dockerRef, tmpPath)
 		cmd.Dir = tmpPath
+		cmd.Env = append(cmd.Env, "HOME="+tmpHome)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {
@@ -249,6 +251,7 @@ func (c ctx) testDockerHost(t *testing.T) {
 	// Clean up docker image
 	e2e.Privileged(func(t *testing.T) {
 		cmd := exec.Command("docker", "rmi", dockerRef)
+		cmd.Env = append(cmd.Env, "HOME="+tmpHome)
 		_, err = cmd.Output()
 		if err != nil {
 			t.Fatalf("Unexpected error while cleaning up docker image.\n%s", err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1409

When we call out to `docker`, do so with a custom `$HOME`, so that any configuration, cache etc. created there cannot affect other tests that may attempt to read configuration etc. at that location.


### This fixes or addresses the following GitHub issues:

 - Fixes #1396


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
