### PR TITLE
fix: fall back to cgroupfs for OCI non-root, non cgroups v2 (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Show correct memory limit in `instance stats` when a limit is set.
 - Ensure consistent binding of libraries under `--nv/--rocm` when duplicate
   `<library>.so[.version]` files are listed by `ldconfig -p`.
+- Fix systemd cgroup manager error when running a container as a non-root
+  user with `--oci`, on systems with cgroups v1 and `runc`.
 
 ## 3.11.0 \[2023-02-10\]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1410

For the `OCI` command group, we need cgroups v2 unified mode in order to call `runc` with `--systemd-cgroup` as a non-root user.

Fall back to cgroupfs operation if this constraint is not satisified.

This fixes a failure when running a container using `runc`. `crun` was falling back to cgroupfs itself, even when `--systemd-cgroup` was specified.


### This fixes or addresses the following GitHub issues:

 - Fixes #1408 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
