### PR TITLE
updated go-toml dependency to v2 (release-3.11)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -83,6 +83,7 @@ The following have contributed code and/or documentation to this repository.
 - Oliver Breitwieser <obreitwi@kip.uni-heidelberg.de>, <oliver@breitwieser.eu>
 - Oliver Freyermuth <freyermuth@physik.uni-bonn.de>
 - Olivier Sallou <olivier.sallou@irisa.fr>
+- Omer Preminger <omer@sylabs.io>
 - Peter Steinbach <steinbach@scionics.de>
 - Petr Votava <votava.petr@gene.com>
 - Rafal Gumienny <rafal.gumienny@gmail.com>

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -311,12 +311,6 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/opencontainers/umoci/blob/master/third_party/shared/COPYING>
 
-## github.com/pelletier/go-toml
-
-**License:** Apache-2.0
-
-**License URL:** <https://github.com/pelletier/go-toml/blob/master/LICENSE>
-
 ## github.com/prometheus/client_golang/prometheus
 
 **License:** Apache-2.0
@@ -874,6 +868,12 @@ The dependencies and their licenses are as follows:
 **License:** MIT
 
 **License URL:** <https://github.com/morikuni/aec/blob/master/LICENSE>
+
+## github.com/pelletier/go-toml/v2
+
+**License:** MIT
+
+**License URL:** <https://github.com/pelletier/go-toml/blob/master/v2/LICENSE>
 
 ## github.com/rivo/uniseg
 

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -18,7 +18,7 @@ import (
 
 //  NOTE
 //  ----
-//  Tests in this package/topic are run in a a mount namespace only. There is
+//  Tests in this package/topic are run in a mount namespace only. There is
 //  no PID namespace, in order that the systemd cgroups manager functionality
 //  can be exercised.
 //
@@ -143,7 +143,7 @@ func (c *ctx) instanceApply(t *testing.T, profile e2e.Profile) {
 			startErrorCode: 255,
 			// e2e test currently only captures the error from the CLI process, not the error displayed by the
 			// starter process, so we check for the generic CLI error.
-			startErrorOut: "parsing error",
+			startErrorOut: "toml: expected character",
 			rootfull:      true,
 			rootless:      true,
 		},
@@ -276,7 +276,7 @@ func (c *ctx) actionApply(t *testing.T, profile e2e.Profile, imageRef string) {
 			name:            "invalid toml",
 			args:            []string{"--apply-cgroups", "testdata/cgroups/invalid.toml", imageRef, "/bin/sleep", "5"},
 			expectErrorCode: 255,
-			expectErrorOut:  "parsing error",
+			expectErrorOut:  "toml: expected character",
 			rootfull:        true,
 			rootless:        true,
 			skipOCI:         false,

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221014010322-58c91d646d86
 	github.com/opencontainers/selinux v1.11.0
 	github.com/opencontainers/umoci v0.4.7
-	github.com/pelletier/go-toml v1.9.5
+	github.com/pelletier/go-toml/v2 v2.0.6
 	github.com/pkg/errors v0.9.1
 	github.com/seccomp/libseccomp-golang v0.10.0
 	github.com/shopspring/decimal v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -530,8 +530,8 @@ github.com/opencontainers/umoci v0.4.7 h1:mbIbtMpZ3v9oMpKaLopnWoLykgmnixeLzq51Ez
 github.com/opencontainers/umoci v0.4.7/go.mod h1:lgJ4bnwJezsN1o/5d7t/xdRPvmf8TvBko5kKYJsYvgo=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
-github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
-github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
+github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -626,6 +626,7 @@ github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -634,6 +635,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/sylabs/json-resp v0.8.2 h1:k2dgtMXL+nztYtxrI24Zck/sfexyly4D1+X504eZTKQ=
 github.com/sylabs/json-resp v0.8.2/go.mod h1:Q9X4wRlZNPv3x76KaL8vTCBO4aC/DP2gh13xdtEqd1g=

--- a/internal/pkg/cgroups/config_linux.go
+++ b/internal/pkg/cgroups/config_linux.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 )
 
 func Int64ptr(i int) *int64 {

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	toml "github.com/pelletier/go-toml"
+	toml "github.com/pelletier/go-toml/v2"
 	"github.com/sylabs/sif/v2/pkg/integrity"
 	"github.com/sylabs/sif/v2/pkg/sif"
 )
@@ -32,9 +32,9 @@ var (
 
 // EclConfig describes the structure of an execution control list configuration file
 type EclConfig struct {
-	Activated  bool        `toml:"activated"`      // toggle the activation of the ECL rules
-	Legacy     bool        `toml:"legacyinsecure"` // Legacy (insecure) signature mode
-	ExecGroups []Execgroup `toml:"execgroup"`      // Slice of all execution groups
+	Activated  bool        `toml:"activated"`           // toggle the activation of the ECL rules
+	Legacy     bool        `toml:"legacyinsecure"`      // Legacy (insecure) signature mode
+	ExecGroups []Execgroup `toml:"execgroup,omitempty"` // Slice of all execution groups
 }
 
 // Execgroup describes an execution group, the main unit of configuration:

--- a/internal/pkg/syecl/testdata/TestAPutConfig/BlackList.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/BlackList.golden
@@ -2,7 +2,7 @@ activated = true
 legacyinsecure = false
 
 [[execgroup]]
-  dirpath = "/var/data3"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29"]
-  mode = "blacklist"
-  tagname = "name"
+tagname = 'name'
+mode = 'blacklist'
+dirpath = '/var/data3'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29']

--- a/internal/pkg/syecl/testdata/TestAPutConfig/BlackListLegacy.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/BlackListLegacy.golden
@@ -2,7 +2,7 @@ activated = true
 legacyinsecure = true
 
 [[execgroup]]
-  dirpath = "/var/data3"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29"]
-  mode = "blacklist"
-  tagname = "name"
+tagname = 'name'
+mode = 'blacklist'
+dirpath = '/var/data3'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29']

--- a/internal/pkg/syecl/testdata/TestAPutConfig/KitchenSink.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/KitchenSink.golden
@@ -2,19 +2,19 @@ activated = true
 legacyinsecure = false
 
 [[execgroup]]
-  dirpath = "/var/data1"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
-  mode = "whitelist"
-  tagname = "name"
+tagname = 'name'
+mode = 'whitelist'
+dirpath = '/var/data1'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29', '7064B1D6EFF01B1262FED3F03581D99FE87EAFD1']
 
 [[execgroup]]
-  dirpath = "/var/data2"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
-  mode = "whitestrict"
-  tagname = "name"
+tagname = 'name'
+mode = 'whitestrict'
+dirpath = '/var/data2'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29', '7064B1D6EFF01B1262FED3F03581D99FE87EAFD1']
 
 [[execgroup]]
-  dirpath = "/var/data3"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29"]
-  mode = "blacklist"
-  tagname = "name"
+tagname = 'name'
+mode = 'blacklist'
+dirpath = '/var/data3'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29']

--- a/internal/pkg/syecl/testdata/TestAPutConfig/KitchenSinkLegacy.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/KitchenSinkLegacy.golden
@@ -2,19 +2,19 @@ activated = true
 legacyinsecure = true
 
 [[execgroup]]
-  dirpath = "/var/data1"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
-  mode = "whitelist"
-  tagname = "name"
+tagname = 'name'
+mode = 'whitelist'
+dirpath = '/var/data1'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29', '7064B1D6EFF01B1262FED3F03581D99FE87EAFD1']
 
 [[execgroup]]
-  dirpath = "/var/data2"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
-  mode = "whitestrict"
-  tagname = "name"
+tagname = 'name'
+mode = 'whitestrict'
+dirpath = '/var/data2'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29', '7064B1D6EFF01B1262FED3F03581D99FE87EAFD1']
 
 [[execgroup]]
-  dirpath = "/var/data3"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29"]
-  mode = "blacklist"
-  tagname = "name"
+tagname = 'name'
+mode = 'blacklist'
+dirpath = '/var/data3'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29']

--- a/internal/pkg/syecl/testdata/TestAPutConfig/WhiteList.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/WhiteList.golden
@@ -2,7 +2,7 @@ activated = true
 legacyinsecure = false
 
 [[execgroup]]
-  dirpath = "/var/data1"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
-  mode = "whitelist"
-  tagname = "name"
+tagname = 'name'
+mode = 'whitelist'
+dirpath = '/var/data1'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29', '7064B1D6EFF01B1262FED3F03581D99FE87EAFD1']

--- a/internal/pkg/syecl/testdata/TestAPutConfig/WhiteListLegacy.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/WhiteListLegacy.golden
@@ -2,7 +2,7 @@ activated = true
 legacyinsecure = true
 
 [[execgroup]]
-  dirpath = "/var/data1"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
-  mode = "whitelist"
-  tagname = "name"
+tagname = 'name'
+mode = 'whitelist'
+dirpath = '/var/data1'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29', '7064B1D6EFF01B1262FED3F03581D99FE87EAFD1']

--- a/internal/pkg/syecl/testdata/TestAPutConfig/WhiteStrict.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/WhiteStrict.golden
@@ -2,7 +2,7 @@ activated = true
 legacyinsecure = false
 
 [[execgroup]]
-  dirpath = "/var/data2"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
-  mode = "whitestrict"
-  tagname = "name"
+tagname = 'name'
+mode = 'whitestrict'
+dirpath = '/var/data2'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29', '7064B1D6EFF01B1262FED3F03581D99FE87EAFD1']

--- a/internal/pkg/syecl/testdata/TestAPutConfig/WhiteStrictLegacy.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/WhiteStrictLegacy.golden
@@ -2,7 +2,7 @@ activated = true
 legacyinsecure = true
 
 [[execgroup]]
-  dirpath = "/var/data2"
-  keyfp = ["F34371D0ACD5D09EB9BD853A80600A5FA11BBD29", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
-  mode = "whitestrict"
-  tagname = "name"
+tagname = 'name'
+mode = 'whitestrict'
+dirpath = '/var/data2'
+keyfp = ['F34371D0ACD5D09EB9BD853A80600A5FA11BBD29', '7064B1D6EFF01B1262FED3F03581D99FE87EAFD1']


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1383

Updates the Go dependency on [github.com/pelletier/go-toml](https://github.com/pelletier/go-toml) to v2

### This fixes or addresses the following GitHub issues:

 - Fixes #1216


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
