### PR TITLE
928 delete private key using cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Changes Since Last Release
 
+### New Features & Functionality
+
+- Added `--secret` flag (shorthand: `-s`) to `key remove` subcommand, to allow
+  removal of a private key by fingerprint.
+- Added `--private` as a synonym for `--secret` in `key list`, `key export`, and
+  `key remove` subcommands.
+
 ### Bug Fixes
 
 - Fix implied `--writable-tmpfs` with `--nvccli`, to avoid r/o filesytem

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -29,7 +29,17 @@ var keyExportSecretFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "secret",
 	ShortHand:    "s",
-	Usage:        "export a secret key",
+	Usage:        "export a secret key (synonym for --private)",
+}
+
+// -p|--private
+var keyExportPrivateFlag = cmdline.Flag{
+	ID:           "keyExportPrivateFlag",
+	Value:        &secretExport,
+	DefaultValue: false,
+	Name:         "private",
+	ShortHand:    "p",
+	Usage:        "export a private key (synonym for --secret)",
 }
 
 // -a|--armor
@@ -45,6 +55,7 @@ var keyExportArmorFlag = cmdline.Flag{
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterFlagForCmd(&keyExportSecretFlag, KeyExportCmd)
+		cmdManager.RegisterFlagForCmd(&keyExportPrivateFlag, KeyExportCmd)
 		cmdManager.RegisterFlagForCmd(&keyExportArmorFlag, KeyExportCmd)
 	})
 }

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -32,13 +32,12 @@ var keyExportSecretFlag = cmdline.Flag{
 	Usage:        "export a secret key (synonym for --private)",
 }
 
-// -p|--private
+// --private
 var keyExportPrivateFlag = cmdline.Flag{
 	ID:           "keyExportPrivateFlag",
 	Value:        &secretExport,
 	DefaultValue: false,
 	Name:         "private",
-	ShortHand:    "p",
 	Usage:        "export a private key (synonym for --secret)",
 }
 

--- a/cmd/internal/cli/key_list.go
+++ b/cmd/internal/cli/key_list.go
@@ -30,13 +30,12 @@ var keyListSecretFlag = cmdline.Flag{
 	EnvKeys:      []string{"SECRET"},
 }
 
-// -p|--private
+// --private
 var keyListPrivateFlag = cmdline.Flag{
 	ID:           "keyListPrivateFlag",
 	Value:        &secret,
 	DefaultValue: false,
 	Name:         "private",
-	ShortHand:    "p",
 	Usage:        "list private keys instead of the default which displays public ones (synonym for --secret)",
 	EnvKeys:      []string{"SECRET"},
 }

--- a/cmd/internal/cli/key_list.go
+++ b/cmd/internal/cli/key_list.go
@@ -26,13 +26,25 @@ var keyListSecretFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "secret",
 	ShortHand:    "s",
-	Usage:        "list private keys instead of the default which displays public ones",
+	Usage:        "list secret keys instead of the default which displays public ones (synonym for --private)",
+	EnvKeys:      []string{"SECRET"},
+}
+
+// -p|--private
+var keyListPrivateFlag = cmdline.Flag{
+	ID:           "keyListPrivateFlag",
+	Value:        &secret,
+	DefaultValue: false,
+	Name:         "private",
+	ShortHand:    "p",
+	Usage:        "list private keys instead of the default which displays public ones (synonym for --secret)",
 	EnvKeys:      []string{"SECRET"},
 }
 
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterFlagForCmd(&keyListSecretFlag, KeyListCmd)
+		cmdManager.RegisterFlagForCmd(&keyListPrivateFlag, KeyListCmd)
 	})
 }
 

--- a/cmd/internal/cli/key_remove.go
+++ b/cmd/internal/cli/key_remove.go
@@ -27,13 +27,12 @@ var keyRemoveSecretFlag = cmdline.Flag{
 	Usage:        "remove a secret key (synonym for --private)",
 }
 
-// -p|--private
+// --private
 var keyRemovePrivateFlag = cmdline.Flag{
 	ID:           "keyRemovePrivateFlag",
 	Value:        &secretRemove,
 	DefaultValue: false,
 	Name:         "private",
-	ShortHand:    "p",
 	Usage:        "remove a private key (synonym for --secret)",
 }
 

--- a/cmd/internal/cli/key_remove.go
+++ b/cmd/internal/cli/key_remove.go
@@ -24,12 +24,23 @@ var keyRemoveSecretFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "secret",
 	ShortHand:    "s",
-	Usage:        "remove a secret key",
+	Usage:        "remove a secret key (synonym for --private)",
+}
+
+// -p|--private
+var keyRemovePrivateFlag = cmdline.Flag{
+	ID:           "keyRemovePrivateFlag",
+	Value:        &secretRemove,
+	DefaultValue: false,
+	Name:         "private",
+	ShortHand:    "p",
+	Usage:        "remove a private key (synonym for --secret)",
 }
 
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterFlagForCmd(&keyRemoveSecretFlag, KeyRemoveCmd)
+		cmdManager.RegisterFlagForCmd(&keyRemovePrivateFlag, KeyRemoveCmd)
 	})
 }
 

--- a/cmd/internal/cli/key_remove.go
+++ b/cmd/internal/cli/key_remove.go
@@ -10,9 +10,28 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/sypgp"
 )
+
+var secretRemove bool
+
+// -s|--secret
+var keyRemoveSecretFlag = cmdline.Flag{
+	ID:           "keyRemoveSecretFlag",
+	Value:        &secretRemove,
+	DefaultValue: false,
+	Name:         "secret",
+	ShortHand:    "s",
+	Usage:        "remove a secret key",
+}
+
+func init() {
+	addCmdInit(func(cmdManager *cmdline.CommandManager) {
+		cmdManager.RegisterFlagForCmd(&keyRemoveSecretFlag, KeyRemoveCmd)
+	})
+}
 
 // KeyRemoveCmd is `singularity key remove <fingerprint>' command
 var KeyRemoveCmd = &cobra.Command{
@@ -29,9 +48,16 @@ var KeyRemoveCmd = &cobra.Command{
 		}
 
 		keyring := sypgp.NewHandle(path, opts...)
-		err := keyring.RemovePubKey(args[0])
-		if err != nil {
-			sylog.Fatalf("Unable to remove public key: %s", err)
+		if secretRemove {
+			err := keyring.RemovePrivKey(args[0])
+			if err != nil {
+				sylog.Fatalf("Unable to remove private key: %s", err)
+			}
+		} else {
+			err := keyring.RemovePubKey(args[0])
+			if err != nil {
+				sylog.Fatalf("Unable to remove public key: %s", err)
+			}
 		}
 	},
 

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -451,7 +451,7 @@ func (c *ctx) singularityKeyRemove(t *testing.T) {
 		},
 		{
 			name:       "remove unknown private key",
-			args:       []string{"remove", "--secret", "0100000000000001"},
+			args:       []string{"remove", "--private", "0100000000000001"},
 			expectExit: 255,
 		},
 		{

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -413,28 +413,130 @@ func (c *ctx) singularityKeyPull(t *testing.T) {
 	}
 }
 
+// singularityKeyRemove will import a private-public key pair. It
+// will then try to remove a couple of unrecognized (=wrong fingerprint)
+// keys from the public and private keyrings, respectively, and check that
+// the actual, previously imported keys are still in the keyring and were
+// unaffected. Lastly, it will try to remove the imported keys using the
+// correct fingerprints, and check they are successfully removed.
+// Note that removing keys from the global keyring is tested separately,
+// in the globalKeyring() method.
 func (c *ctx) singularityKeyRemove(t *testing.T) {
+	keyMap := map[string]string{
+		"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
+	}
+
 	tests := []struct {
-		name          string
-		cmdArgs       []string
-		expectedExit  int
-		expectedRegex string
+		name           string
+		args           []string
+		consoleOps     []string
+		stdout         string
+		expectExit     int
+		otherResultOps []e2e.SingularityCmdResultOp
 	}{
 		{
-			name:          "remove help",
-			cmdArgs:       []string{"--help"},
-			expectedExit:  0,
-			expectedRegex: `^Remove a local public key from your local or the global keyring`,
+			name:       "remove help",
+			args:       []string{"--help"},
+			stdout:     "Remove a local public key from your local or the global keyring",
+			expectExit: 0,
 		},
+		{
+			name: "import private key in remove test",
+			args: []string{"import", "testdata/ecl-pgpkeys/key1.asc"},
+			consoleOps: []string{
+				"e2e", // The password to decrypt the key
+			},
+			stdout:     "successfully added to the private keyring",
+			expectExit: 0,
+		},
+		{
+			name:       "remove unknown private key",
+			args:       []string{"remove", "--secret", "0100000000000001"},
+			expectExit: 255,
+		},
+		{
+			name:       "remove unknown private key secret synonym",
+			args:       []string{"remove", "--secret", "0100000000000001"},
+			expectExit: 255,
+			// This is still useful to test, because if the synonym isn't
+			// recognized, we'd get an exit code of 1 rather than 255.
+		},
+		{
+			name:       "remove unknown public key",
+			args:       []string{"remove", "0100000000000001"},
+			expectExit: 255,
+		},
+		{
+			name: "list public pre-remove",
+			args: []string{"list"},
+			otherResultOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, keyMap["key1"]),
+			},
+			expectExit: 0,
+		},
+		{
+			name:       "remove public key",
+			args:       []string{"remove", keyMap["key1"]},
+			expectExit: 0,
+		},
+		{
+			name:       "remove already-removed public key",
+			args:       []string{"remove", keyMap["key1"]},
+			expectExit: 255,
+		},
+		{
+			name: "list public post-remove",
+			args: []string{"list"},
+			otherResultOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.UnwantedContainMatch, keyMap["key1"]),
+			},
+			expectExit: 0,
+		},
+		{
+			name: "list private pre-remove",
+			args: []string{"list", "--private"},
+			otherResultOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, keyMap["key1"]),
+			},
+			expectExit: 0,
+		},
+		{
+			name:       "remove private key",
+			args:       []string{"remove", "--private", keyMap["key1"]},
+			expectExit: 0,
+		},
+		{
+			name:       "remove already-removed private key",
+			args:       []string{"remove", "--private", keyMap["key1"]},
+			expectExit: 255,
+		},
+		{
+			name: "list private post-remove",
+			args: []string{"list", "--private"},
+			otherResultOps: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.UnwantedContainMatch, keyMap["key1"]),
+			},
+			expectExit: 0,
+		},
+		// {
+		// 	name:    "remove private from global",
+		// 	command: "key remove",
+		// 	profile: e2e.RootProfile,
+		// 	args:    []string{"--private", "--global", keyMap["key1"]},
+		// 	exit:    255,
+		// },
 	}
+	c.singularityResetKeyring(t) // Remove the tmp keyring
 	for _, tt := range tests {
+		resultOps := append([]e2e.SingularityCmdResultOp{e2e.ExpectOutput(e2e.ContainMatch, tt.stdout)}, tt.otherResultOps...)
 		c.env.RunSingularity(
 			t,
-			e2e.WithProfile(e2e.UserProfile),
 			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
 			e2e.WithCommand("key"),
-			e2e.WithArgs(append([]string{"remove"}, tt.cmdArgs...)...),
-			e2e.ExpectExit(tt.expectedExit, e2e.ExpectOutput(e2e.RegexMatch, tt.expectedRegex)),
+			e2e.WithArgs(tt.args...),
+			e2e.ConsoleRun(buildConsoleLines(tt.consoleOps...)...),
+			e2e.ExpectExit(tt.expectExit, resultOps...),
 		)
 	}
 }
@@ -578,6 +680,13 @@ func (c *ctx) globalKeyring(t *testing.T) {
 			command: "key remove",
 			profile: e2e.RootProfile,
 			args:    []string{"--global", "0100000000000001"},
+			exit:    255,
+		},
+		{
+			name:    "remove private from global",
+			command: "key remove",
+			profile: e2e.RootProfile,
+			args:    []string{"--private", "--global", keyMap["key1"]},
 			exit:    255,
 		},
 		{

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -518,13 +518,6 @@ func (c *ctx) singularityKeyRemove(t *testing.T) {
 			},
 			expectExit: 0,
 		},
-		// {
-		// 	name:    "remove private from global",
-		// 	command: "key remove",
-		// 	profile: e2e.RootProfile,
-		// 	args:    []string{"--private", "--global", keyMap["key1"]},
-		// 	exit:    255,
-		// },
 	}
 	c.singularityResetKeyring(t) // Remove the tmp keyring
 	for _, tt := range tests {

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -485,6 +485,10 @@ func removeKey(list openpgp.EntityList, fingerprint string) openpgp.EntityList {
 
 // RemovePrivKey will delete a secret key matching toDelete
 func (keyring *Handle) RemovePrivKey(toDelete string) error {
+	if keyring.global {
+		return fmt.Errorf("global keyring only holds public keys")
+	}
+
 	// read all the local private keys
 	elist, err := loadKeyring(keyring.SecretPath())
 	switch {

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -384,10 +384,11 @@ func (keyring *Handle) appendPubKey(e *openpgp.Entity) error {
 
 // storePrivKeyring overwrites the private keyring with the listed keys
 func (keyring *Handle) storePrivKeyring(keys openpgp.EntityList) error {
-	mode := os.FileMode(0o600)
 	if keyring.global {
-		mode = os.FileMode(0o644)
+		return fmt.Errorf("private keys cannot be stored in global keyring")
 	}
+
+	mode := os.FileMode(0o600)
 
 	f, err := createOrTruncateFile(keyring.SecretPath(), mode)
 	if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Added `--secret` to the `remove` subcommand for keys. Also added `--private` as a synonym of `--secret`, as it's arguably more common to talk about 'public' / 'private', than it is to use 'secret' (despite e.g. GPG using 'secret' in commands).

For the sake of consistency, added `-p`/`--private` synonyms to `key list` and `key export`, as well.

Added e2e testing for  various conditions involving `key remove`. Also added `--private` condition to `key remove` test in `globalKeyring` (which should fail, since `key remove --private --global` is an illicit combination).

### This fixes or addresses the following GitHub issues:

 - Fixes #928 

