### PR TITLE
fix: support and test yum bootstrap on newer distros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
   removal of a private key by fingerprint.
 - Added `--private` as a synonym for `--secret` in `key list`, `key export`, and
   `key remove` subcommands.
+- Add `setopt` definition file header for the `yum` bootstrap agent. The
+  `setopt` value is passed to `yum / dnf` using the `--setopt` flag. This
+  permits setting e.g. `install_weak_deps=False` to bootstrap recent versions of
+  Fedora, where `systemd` (a weak dependency) cannot install correctly in the
+  container. See `examples/Fedora` for an example defintion file.
+- Warn user that a `yum` bootstrap of an older distro may fail if the host rpm
+  `_db_backend` is not `bdb`.
 
 ### Bug Fixes
 
@@ -21,6 +28,10 @@
   `<library>.so[.version]` files are listed by `ldconfig -p`.
 - Fix systemd cgroup manager error when running a container as a non-root
   user with `--oci`, on systems with cgroups v1 and `runc`.
+
+### Changed defaults / behaviours
+
+- Show standard output of yum bootstrap if log level is verbose or higher.
 
 ## 3.11.0 \[2023-02-10\]
 

--- a/e2e/internal/e2e/home.go
+++ b/e2e/internal/e2e/home.go
@@ -19,14 +19,6 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 )
 
-// rpmMacrosContent contains required content to
-// place in $HOME/.rpmmacros file for yum bootstrap
-// build
-var rpmMacrosContent = `
-%_var /var
-%_dbpath %{_var}/lib/rpm
-`
-
 // SetupHomeDirectories creates temporary home directories for
 // privileged and unprivileged users and bind mount those directories
 // on top of real ones. It's possible because e2e tests are executed
@@ -128,18 +120,6 @@ func SetupHomeDirectories(t *testing.T) {
 		if err := os.Chdir(cwd); err != nil {
 			err = errors.Wrapf(err, "change working directory to %s", cwd)
 			t.Fatalf("failed to change working directory: %+v", err)
-		}
-
-		// create .rpmmacros files for yum bootstrap builds
-		macrosFile := filepath.Join(unprivSessionHome, ".rpmmacros")
-		if err := os.WriteFile(macrosFile, []byte(rpmMacrosContent), 0o444); err != nil {
-			err = errors.Wrapf(err, "writing macros file at %s", macrosFile)
-			t.Fatalf("could not write macros file: %+v", err)
-		}
-		macrosFile = filepath.Join(privSessionHome, ".rpmmacros")
-		if err := os.WriteFile(macrosFile, []byte(rpmMacrosContent), 0o444); err != nil {
-			err = errors.Wrapf(err, "writing macros file at %s", macrosFile)
-			t.Fatalf("could not write macros file: %+v", err)
 		}
 	})(t)
 }

--- a/examples/almalinux-arm64/Singularity
+++ b/examples/almalinux-arm64/Singularity
@@ -1,0 +1,11 @@
+BootStrap: yum
+OSVersion: 9
+MirrorURL: http://repo.almalinux.org/almalinux/%{OSVERSION}/BaseOS/aarch64/os
+Include: dnf
+
+%runscript
+    echo "This is what happens when you run the container..."
+
+%post
+    echo "Hello from inside the container"
+    dnf -y install vim-minimal

--- a/examples/almalinux/Singularity
+++ b/examples/almalinux/Singularity
@@ -1,0 +1,11 @@
+BootStrap: yum
+OSVersion: 9
+MirrorURL: http://repo.almalinux.org/almalinux/%{OSVERSION}/BaseOS/x86_64/os
+Include: dnf
+
+%runscript
+    echo "This is what happens when you run the container..."
+
+%post
+    echo "Hello from inside the container"
+    dnf -y install vim-minimal

--- a/examples/fedora-arm64/Singularity
+++ b/examples/fedora-arm64/Singularity
@@ -1,0 +1,12 @@
+BootStrap: yum
+OSVersion: 37
+MirrorURL: http://dfw.mirror.rackspace.com/fedora/releases/%{OSVERSION}/Everything/aarch64/os/
+Include: fedora-release-container dnf
+Setopt: install_weak_deps=False
+
+%runscript
+    echo "This is what happens when you run the container..."
+
+%post
+    echo "Hello from inside the container"
+    dnf -y install vim-minimal

--- a/examples/fedora/Singularity
+++ b/examples/fedora/Singularity
@@ -1,0 +1,12 @@
+BootStrap: yum
+OSVersion: 37
+MirrorURL: http://dfw.mirror.rackspace.com/fedora/releases/%{OSVERSION}/Everything/x86_64/os/
+Include: fedora-release-container dnf
+Setopt: install_weak_deps=False
+
+%runscript
+    echo "This is what happens when you run the container..."
+
+%post
+    echo "Hello from inside the container"
+    dnf -y install vim-minimal

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -6,8 +6,6 @@
 package sources
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -19,6 +17,7 @@ import (
 	"syscall"
 
 	"github.com/sylabs/singularity/internal/pkg/util/bin"
+	"github.com/sylabs/singularity/internal/pkg/util/rpm"
 	"github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
@@ -36,6 +35,7 @@ type YumConveyor struct {
 	osversion string
 	include   string
 	gpg       string
+	setopt    string
 }
 
 // YumConveyorPacker only needs to hold the conveyor to have the needed data to pack
@@ -78,13 +78,19 @@ func (c *YumConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
 		return fmt.Errorf("while copying pseudo devices: %v", err)
 	}
 
-	args := []string{`--noplugins`, `-c`, filepath.Join(c.b.RootfsPath, yumConf), `--installroot`, c.b.RootfsPath, `--releasever=` + c.osversion, `-y`, `install`}
+	args := []string{`--noplugins`, `-c`, filepath.Join(c.b.RootfsPath, yumConf), `--installroot`, c.b.RootfsPath, `--releasever=` + c.osversion, `-y`}
+	if c.setopt != "" {
+		args = append(args, "--setopt", c.setopt)
+	}
+	args = append(args, "install")
 	args = append(args, strings.Fields(c.include)...)
 
 	// Do the install
-	sylog.Debugf("\n\tInstall Command Path: %s\n\tDetected Arch: %s\n\tOSVersion: %s\n\tMirrorURL: %s\n\tUpdateURL: %s\n\tIncludes: %s\n", installCommandPath, runtime.GOARCH, c.osversion, c.mirrorurl, c.updateurl, c.include)
+	sylog.Debugf("\n\tInstall Command Path: %s\n\tDetected Arch: %s\n\tOSVersion: %s\n\tMirrorURL: %s\n\tUpdateURL: %s\n\tIncludes: %s\n\tSetopt: %s\n", installCommandPath, runtime.GOARCH, c.osversion, c.mirrorurl, c.updateurl, c.include, c.setopt)
 	cmd := exec.Command(installCommandPath, args...)
-	// cmd.Stdout = os.Stdout
+	if sylog.GetLevel() >= int(sylog.VerboseLevel) {
+		cmd.Stdout = os.Stdout
+	}
 	cmd.Stderr = os.Stderr
 	if err = cmd.Run(); err != nil {
 		return fmt.Errorf("while bootstrapping: %v", err)
@@ -112,44 +118,30 @@ func (cp *YumConveyorPacker) Pack(context.Context) (b *types.Bundle, err error) 
 }
 
 func (c *YumConveyor) getRPMPath() (err error) {
-	var output, stderr bytes.Buffer
-
 	c.rpmPath, err = bin.FindBin("rpm")
 	if err != nil {
 		return fmt.Errorf("rpm is not in path: %v", err)
 	}
 
-	cmd := exec.Command("rpm", "--showrc")
-	cmd.Stdout = &output
-	cmd.Stderr = &stderr
-
-	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("%v: %v", err, stderr.String())
+	rpmDBBackend, err := rpm.GetMacro("_db_backend")
+	if err != nil {
+		return err
+	}
+	if rpmDBBackend != "bdb" {
+		sylog.Warningf("Your host system is using the %s RPM database backend.", rpmDBBackend)
+		sylog.Warningf("Bootstrapping of older distributions that use the bdb backend will fail.")
 	}
 
-	rpmDBPath := ""
-	scanner := bufio.NewScanner(&output)
-	scanner.Split(bufio.ScanLines)
-
-	for scanner.Scan() {
-		// search for dbpath from showrc output
-		if strings.Contains(scanner.Text(), "_dbpath\t") {
-			// second field in the string is the path
-			rpmDBPath = strings.Fields(scanner.Text())[2]
-		}
+	rpmDBPath, err := rpm.GetMacro("_dbpath")
+	if err != nil {
+		return err
 	}
-
-	if rpmDBPath == "" {
-		return fmt.Errorf("could not find dbpath")
-	}
-
 	// %{_var}/lib/rpm is the 'traditional' dbpath
-	if rpmDBPath != `%{_var}/lib/rpm` {
+	if rpmDBPath != `/var/lib/rpm` {
 		// Fedora 36 now uses a different rpm dbpath, and may fail to bootstrap older distros
-		if rpmDBPath == `%{_usr}/lib/sysimage/rpm` {
+		if rpmDBPath == `/usr/lib/sysimage/rpm` {
 			sylog.Warningf("Your host system is using a new RPM database path: %v", rpmDBPath)
-			sylog.Warningf("Bootstrapping older distributions may require an ~/.rpmmacros file containing:\n" +
-				"\t\t_dbpath %%{_var}/lib/rpm\n")
+			sylog.Warningf("Bootstrapping of older distributions that use /var/lib/rpm will fail.")
 		} else {
 			// If we're on a 'foreign' system, with neither old or new paths, and ~/.rpmmacros will be required.
 			return fmt.Errorf("RPM database is using a non-standard path: %s\n"+
@@ -159,7 +151,7 @@ func (c *YumConveyor) getRPMPath() (err error) {
 				"Place the following lines into the '.rpmmacros' file:\n"+
 				"%s\n"+
 				"%s\n"+
-				"After creating the file, re-run the bootstrap.\n"+
+				"After creating the file, re-run the bootstrap.\n",
 				rpmDBPath, os.Getenv("HOME"), `%_var /var`, `%_dbpath %{_var}/lib/rpm`)
 		}
 	}
@@ -203,6 +195,8 @@ func (c *YumConveyor) getBootstrapOptions() (err error) {
 	include = `/etc/redhat-release coreutils ` + include
 
 	c.include = include
+
+	c.setopt = c.b.Recipe.Header["setopt"]
 
 	return nil
 }

--- a/internal/pkg/build/sources/conveyorPacker_yum_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum_test.go
@@ -25,6 +25,8 @@ func TestYumConveyor(t *testing.T) {
 	// TODO - Centos puts non-amd64 at a different mirror location
 	// need multiple def files to test on other archs
 	require.Arch(t, "amd64")
+	require.RPMMacro(t, "_db_backend", "bdb")
+	require.RPMMacro(t, "_dbpath", "/var/lib/rpm")
 
 	if testing.Short() {
 		t.SkipNow()
@@ -69,6 +71,8 @@ func TestYumPacker(t *testing.T) {
 	// TODO - Centos puts non-amd64 at a different mirror location
 	// need multiple def files to test on other archs
 	require.Arch(t, "amd64")
+	require.RPMMacro(t, "_db_backend", "bdb")
+	require.RPMMacro(t, "_dbpath", "/var/lib/rpm")
 
 	if testing.Short() {
 		t.SkipNow()

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -22,6 +22,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/security/seccomp"
+	"github.com/sylabs/singularity/internal/pkg/util/rpm"
 	"github.com/sylabs/singularity/pkg/network"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
 	"github.com/sylabs/singularity/pkg/util/slice"
@@ -342,4 +343,15 @@ func Kernel(t *testing.T, reqMajor, reqMinor int) {
 	}
 
 	t.Skipf("Kernel %d.%d found, but %d.%d required", major, minor, reqMajor, reqMinor)
+}
+
+func RPMMacro(t *testing.T, name, value string) {
+	eval, err := rpm.GetMacro(name)
+	if err != nil {
+		t.Skipf("Couldn't get value of %s: %s", name, err)
+	}
+
+	if eval != value {
+		t.Skipf("Need %s as value of %s, got %s", value, name, eval)
+	}
 }

--- a/internal/pkg/util/rpm/rpm.go
+++ b/internal/pkg/util/rpm/rpm.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package rpm
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+var ErrMacroUndefined = errors.New("macro is not defined")
+
+// GetMacro returns the value of the provided macro name
+func GetMacro(name string) (value string, err error) {
+	rpm, err := exec.LookPath("rpm")
+	if err != nil {
+		return "", fmt.Errorf("rpm command not found: %w", err)
+	}
+
+	args := []string{"--eval", "%{" + name + "}"}
+	cmd := exec.Command(rpm, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("while looking up value of rpm macro %s: %s", name, err)
+	}
+
+	eval := strings.TrimSuffix(string(out), "\n")
+	if eval == "%{"+name+"}" {
+		return "", ErrMacroUndefined
+	}
+	return eval, nil
+}

--- a/internal/pkg/util/rpm/rpm_test.go
+++ b/internal/pkg/util/rpm/rpm_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package rpm
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestGetMacro(t *testing.T) {
+	_, err := exec.LookPath("rpm")
+	if err != nil {
+		t.Skipf("rpm command not found in $PATH")
+	}
+
+	tests := []struct {
+		name      string
+		macroName string
+		wantValue string
+		wantErr   error
+	}{
+		{
+			name:      "_host_os",
+			macroName: "_host_os",
+			wantValue: "linux",
+			wantErr:   nil,
+		},
+		{
+			name:      "not defined",
+			macroName: "_not_a_macro_abc_123",
+			wantValue: "",
+			wantErr:   ErrMacroUndefined,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotValue, err := GetMacro(tt.macroName)
+			if err != tt.wantErr {
+				t.Errorf("GetMacro() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("GetMacro() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -583,4 +583,5 @@ var validHeaders = map[string]bool{
 	"modules":      true,
 	"otherurl&n":   true,
 	"fingerprints": true,
+	"setopt":       true,
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

The yum bootstrap is fragile, as over time rpm has changed both the format of its database, and the location of the database. This means that newer RPM distros (EL9, recent Fedora) cannot bootstrap older ones successfully.

* Refactor code checking for rpm macro values.
* Check for host `_db_backend` value `sqlite` and warn that older distros using `bdb` cannot be bootstrapped in this case.
* Add a `setopt` def file header, which will pass the value to yum/dnf via the `--setopt` flag. This allows specifying `install_weak_deps=False`, which is necessary to bootstrap a minimal Fedora with no systemd (which fails to install).
* Add examples and gated e2e tests so that we test bootstrapping CentOS 7, AlmaLinux 9, or Fedora 37, depending on what the host rpm setup will support.
* Don't create an `.rpmmacros` file for the e2e-tests to try and force bootstrap on 'foreign' distributions. This is no longer effective with the database format mistmatch issue, and blocks testing a Fedora bootstrap.
* Show standard output of yum/dnf bootstrap if log level is verbose or higher (permits debugging bootstraps more easily).

### This fixes or addresses the following GitHub issues:

 - Fixes #1105 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
