### PR TITLE
e2e: fix: don't panic if OCSP responder cannot start (release-3.11)

### DIFF
--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -30,13 +30,18 @@ func (c *ctx) verify(t *testing.T) {
 	intPath := filepath.Join("..", "test", "certs", "intermediate.pem")
 	rootPath := filepath.Join("..", "test", "certs", "root.pem")
 
-	c.startOCSPResponder(priKeyPath, rootPath)
+	ocspOk := true
+	if err := c.startOCSPResponder(priKeyPath, rootPath); err != nil {
+		t.Errorf("OCSP responder could not start: %s", err)
+		ocspOk = false
+	}
 
 	tests := []struct {
 		name       string
 		envs       []string
 		flags      []string
 		imagePath  string
+		needOCSP   bool
 		expectCode int
 		expectOps  []e2e.SingularityCmdResultOp
 	}{
@@ -172,6 +177,7 @@ func (c *ctx) verify(t *testing.T) {
 				"--ocsp-verify",
 			},
 			imagePath:  filepath.Join("..", "test", "images", "one-group-signed-dsse.sif"),
+			needOCSP:   true,
 			expectCode: 255,
 			expectOps: []e2e.SingularityCmdResultOp{
 				// Expect OCSP to fail due to https://github.com/sylabs/singularity/issues/1152
@@ -187,6 +193,7 @@ func (c *ctx) verify(t *testing.T) {
 				"SINGULARITY_VERIFY_OCSP=true",
 			},
 			imagePath:  filepath.Join("..", "test", "images", "one-group-signed-dsse.sif"),
+			needOCSP:   true,
 			expectCode: 255,
 			expectOps: []e2e.SingularityCmdResultOp{
 				// Expect OCSP to fail due to https://github.com/sylabs/singularity/issues/1152
@@ -201,6 +208,7 @@ func (c *ctx) verify(t *testing.T) {
 				"--ocsp-verify",
 			},
 			imagePath:  filepath.Join("..", "test", "images", "one-group-signed-dsse.sif"),
+			needOCSP:   true,
 			expectCode: 255,
 			expectOps: []e2e.SingularityCmdResultOp{
 				e2e.ExpectError(e2e.ContainMatch, "Failed to verify container: x509: certificate specifies an incompatible key usage"),
@@ -214,6 +222,11 @@ func (c *ctx) verify(t *testing.T) {
 	for _, tt := range tests {
 		c.RunSingularity(t,
 			e2e.AsSubtest(tt.name),
+			e2e.PreRun(func(t *testing.T) {
+				if tt.needOCSP && !ocspOk {
+					t.Skip("OCSP responder not available")
+				}
+			}),
 			e2e.WithProfile(e2e.UserProfile),
 			e2e.WithEnv(tt.envs),
 			e2e.WithCommand("verify"),
@@ -233,7 +246,9 @@ func (c *ctx) importPGPKeypairs(t *testing.T) {
 	)
 }
 
-func (c *ctx) startOCSPResponder(rootKeyPath string, rootCertPath string) {
+func (c *ctx) startOCSPResponder(rootKeyPath string, rootCertPath string) error {
+	responderErr := make(chan error, 1)
+
 	// initiate OCSP responder to validate the singularity certificate chain
 	go func() {
 		args := ocspresponder.ResponderArgs{
@@ -245,11 +260,17 @@ func (c *ctx) startOCSPResponder(rootKeyPath string, rootCertPath string) {
 		}
 
 		if err := ocspresponder.StartOCSPResponder(args); err != nil {
-			panic(fmt.Errorf("responder initialization has failed due to '%s'", err))
+			responderErr <- fmt.Errorf("responder initialization has failed due to '%s'", err)
 		}
 	}()
 
-	time.Sleep(5 * time.Second)
+	// Assume if there's no error after 5 seconds then the responder is running.
+	select {
+	case err := <-responderErr:
+		return err
+	case <-time.After(5 * time.Second):
+		return nil
+	}
 }
 
 // E2ETests is the main func to trigger the test suite


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1421

In the e2e VERIFY tests, if the openssl OCSP responder fails to start we now error, and skip the OCSP subtests.

Prior to this change a panic occured, causing other tests not to be run.

Responder startup failure has been observed on SLES 12, where not all the key algorithms we are using are supported by the openssl version that's available.

We do want to test the different key algorithms are handled in our code, so lets leave this as a reported test error for now, rather than gating the test on openssl version.

### This fixes or addresses the following GitHub issues:

 - Fixes #1417


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
