### PR TITLE
fix: address cgroups v1 device related e2e test failures (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   `<library>.so[.version]` files are listed by `ldconfig -p`.
 - Fix systemd cgroup manager error when running a container as a non-root
   user with `--oci`, on systems with cgroups v1 and `runc`.
+- Fix joining cgroup of instance started as root, with cgroups v1,
+  non-default cgroupfs manager, and no device rules.
 
 ### Changed defaults / behaviours
 

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -426,8 +426,11 @@ var resourceFlagTests = []resourceFlagTest{
 		args:            []string{"--blkio-weight", "50"},
 		expectErrorCode: 0,
 		controllerV1:    "blkio",
-		// This is the new path. Older kernels may have only `blkio.weight`
-		resourceV1:   "blkio.bfq.weight",
+		// Could be `blkio.bfq.weight` if bfq is available. However, under
+		// cgroups v1 older crun will not set blkio.bfq.weight, so only test
+		// with blkio.weight.
+		// Ref: https://github.com/containers/crun/issues/1157
+		resourceV1:   "blkio.weight",
 		expectV1:     "50",
 		delegationV2: "io",
 		resourceV2:   "io.bfq.weight",

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -131,7 +131,7 @@ func (m *Manager) UpdateFromSpec(resources *specs.LinuxResources) (err error) {
 	opts := &lcspecconv.CreateOpts{
 		CgroupName:       m.group,
 		UseSystemdCgroup: false,
-		RootlessCgroups:  false,
+		RootlessCgroups:  os.Getuid() != 0,
 		Spec:             spec,
 	}
 
@@ -140,10 +140,10 @@ func (m *Manager) UpdateFromSpec(resources *specs.LinuxResources) (err error) {
 		return fmt.Errorf("could not create cgroup config: %w", err)
 	}
 
-	// runc/libcontainer/cgroups for v2 defaults to a deny-all policy, while
+	// runc/libcontainer/cgroups defaults to a deny-all policy, while
 	// singularity has always allowed access to devices by default. If no device
 	// rules are provided in the spec, then skip setting them so the deny-all is
-	// not applied.
+	// not applied when we update the cgroup.
 	if len(resources.Devices) == 0 {
 		lcConfig.SkipDevices = true
 	}
@@ -308,12 +308,15 @@ func newManager(resources *specs.LinuxResources, group string, systemd bool) (ma
 		return nil, fmt.Errorf("could not create cgroup config: %w", err)
 	}
 
-	// runc/libcontainer/cgroups for v2 defaults to a deny-all policy, while
-	// singularity has always allowed access to devices by default. If no device
-	// rules are provided in the spec, then skip setting them so the deny-all is
-	// not applied.
+	// runc/libcontainer/cgroups defaults to a deny-all policy, while
+	// singularity has always allowed access to devices by default.
 	if len(resources.Devices) == 0 {
-		lcConfig.SkipDevices = true
+		resources.Devices = []specs.LinuxDeviceCgroup{
+			{
+				Allow:  true,
+				Access: "rwm",
+			},
+		}
 	}
 
 	cgroup, err := lcmanager.New(lcConfig)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1430

*fix: Never skip device cgroup creation*

If a container is being run with a cgroups LinuxResources config that doesn't include any device rules, then the device cgroup creation was skipped. Singularity has historically had default-allow, while runc/libcontainer/cgroups is default deny.

Under cgroups v1 with cgroupfs manager we need the device cgroup for PID -> cgroup lookup at instance join, so don't skip it... use an explicit allow rule instead.

At update, we still skip if there are no resources provided, so we don't update to a default allow, or deny.

Also set rootless flag on update properly, so that we avoid warnings / errors with rootless cgroups where device limits don't apply.

*e2e: Only test blkio.weight on cgroups v1, not blkio.bfq.weight*

crun has an issue where on cgroups v1 it won't handle blkio.weight -> blkio.bfq.weight on systems that use bfq.

Only test with blkio.weight present, so we avoid failure due to this issue.

### This fixes or addresses the following GitHub issues:

 - Fixes #1418
 - Fixes #1419


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
