### PR TITLE
e2e: fix incorrect arm64->amd64 in CentOS Yum test

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -107,7 +107,7 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 				require.Command(t, "yum")
 				require.RPMMacro(t, "_db_backend", "bdb")
 				require.RPMMacro(t, "_dbpath", "/var/lib/rpm")
-				require.Arch(t, "arm64")
+				require.Arch(t, "amd64")
 			},
 		},
 		{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Corrects an issue in #1420

### This fixes or addresses the following GitHub issues:

 - Fixes #1434


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
