### PR TITLE
Prepare 3.11.1 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.20'
+    default: '1.20.2'
 
 executors:
   node:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # SingularityCE Changelog
 
-## Changes Since Last Release
+## 3.11.1 \[2023-03-14\]
 
 ### New Features & Functionality
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -146,11 +146,11 @@ cd singularity
 By default your clone will be on the `main` branch which is where development
 of SingularityCE happens. To build a specific version of SingularityCE, check
 out a [release tag](https://github.com/sylabs/singularity/tags) before
-compiling. E.g. to build the 3.11.0 release, checkout the
-`v3.11.0` tag:
+compiling. E.g. to build the 3.11.1 release, checkout the
+`v3.11.1` tag:
 
 ```sh
-git checkout --recurse-submodules v3.11.0
+git checkout --recurse-submodules v3.11.1
 ```
 
 ## Compiling SingularityCE
@@ -201,7 +201,7 @@ build and install the RPM like this:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-export VERSION=3.11.0  # this is the singularity version, change as you need
+export VERSION=3.11.1  # this is the singularity version, change as you need
 
 # Fetch the source
 wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-ce-${VERSION}.tar.gz

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -88,7 +88,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.20 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.20.2 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump to Go 1.20.2 for CI builds.

Bump version numbers in changelog, install docs.