### PR TITLE
1138 consider gnu vs fhs definition of localstatedir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 ### Changed defaults / behaviours
 
 - Show standard output of yum bootstrap if log level is verbose or higher.
+- When building RPM, we will now use `/var/lib/singularity` (rather than
+  `/var/singularity`) to store local state files.
 
 ## 3.11.0 \[2023-02-10\]
 

--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -102,7 +102,7 @@ container platform designed to be simple, fast, and secure.
         --includedir=%{_includedir} \
         --libdir=%{_libdir} \
         --libexecdir=%{_libexecdir} \
-        --localstatedir=%{_localstatedir} \
+        --localstatedir=%{_sharedstatedir} \
         --sharedstatedir=%{_sharedstatedir} \
         --mandir=%{_mandir} \
         --infodir=%{_infodir}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Changed value of `--localstatedir` in `dist/rpm/singularity-ce.spec.in` to `/var/lib` (by pulling from the macro `%{_sharedstatedir}` instead of `%{_localstatedir}`, as was the case previously).

This brings the behavior of our RPM packaging in line with [current FHS specifications](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s08.html), as well as what Red Hat are now [requiring](https://bugzilla.redhat.com/show_bug.cgi?id=2145834).

This also brings the behavior of RPM builds in line, in this respect, with what we do for `.deb` packaging (see `debian/rules`).

### This fixes or addresses the following GitHub issues:

 - Fixes #1138 

