### PR TITLE
rpm: fix: correct BuildRequires/Requires for SLES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
   retrieve a CLI token to interact with the OCI registry of a
   Singularity Enterprise instance.
 
+### Bug Fixes
+
+- Require `runc` in RPM packages built on SLES, not `crun`, because `crun` is
+  part of the Package Hub community repository that may not be enabled.
+  SingularityCE will still prefer `crun` if it has been installed.
+
 ## 3.11.1 \[2023-03-14\]
 
 ### New Features & Functionality

--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -47,19 +47,19 @@ BuildRequires: make
 # Paths to runtime dependencies detected by mconfig, so must be present at build time.
 BuildRequires: cryptsetup
 %if "%{_target_vendor}" == "suse"
-Requires: squashfs
+BuildRequires: squashfs
 %else
-Requires: squashfs-tools
+BuildRequires: squashfs-tools
 %endif
 # Required for building bundled conmon
 BuildRequires: libseccomp-devel
 BuildRequires: glib2-devel
 
 # crun requirement not satisfied on EL7 or SLES default repos - use runc there.
-%if "%{_target_vendor}" == "suse" || 0%{?rhel} > 7
-Requires: crun
-%else
+%if "%{_target_vendor}" == "suse" || 0%{?rhel} < 8
 Requires: runc
+%else
+Requires: crun
 %endif
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs


### PR DESCRIPTION
## Description of the Pull Request (PR):

* On SLES we intend to require runc, not crun.
* squashfs had a duplicate Requires, instead of a BuildRequires.

### This fixes or addresses the following GitHub issues:

 - Fixes #1453


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
