### PR TITLE
add username & email in 'remote status' output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   OCI mode (`--oci`). Currently supports passing one or more (comma-separated)
   fully-qualified CDI device names, and those devices will then be made
   available inside the container.
+- The `remote status` command will now print the username, realname, and email
+  of the logged-in user, if available.
 
 ### Bug Fixes
 

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -141,10 +141,11 @@ const (
 	RemoteStatusShort string = `Check the status of the singularity services at an endpoint, and your authentication token`
 	RemoteStatusLong  string = `
   The 'remote status' command checks the status of the specified remote endpoint
-  and reports the availability of services and their versions. If no endpoint is
-  specified, it will check the status of the default remote (SylabsCloud). If you
-  have logged in with an authentication token the validity of that token will be
-  checked.`
+  and reports the availability of services and their versions, and reports the
+  user's logged-in status (or lack thereof) on that endpoint. If no endpoint is
+  specified, it will check the status of the default remote (SylabsCloud). If
+  you have logged in with an authentication token the validity of that token
+  will be checked.`
 	RemoteStatusExample string = `
   $ singularity remote status SylabsCloud`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/internal/app/singularity/remote_get_login_password.go
+++ b/internal/app/singularity/remote_get_login_password.go
@@ -17,7 +17,7 @@ import (
 // RemoteGetLoginPassword retrieves cli token from oci library shim
 func RemoteGetLoginPassword(config *scslibclient.Config) (string, error) {
 	client := http.Client{Timeout: 5 * time.Second}
-	path := "/v1/rbac/users/current"
+	path := userServicePath
 	endPoint := config.BaseURL + path
 
 	req, err := http.NewRequest(http.MethodGet, endPoint, nil)
@@ -39,23 +39,15 @@ func RemoteGetLoginPassword(config *scslibclient.Config) (string, error) {
 		return "", fmt.Errorf("status is not ok: %v", res.StatusCode)
 	}
 
-	var u oUser
-	err = json.NewDecoder(res.Body).Decode(&u)
+	var ud userData
+	err = json.NewDecoder(res.Body).Decode(&ud)
 	if err != nil {
 		return "", fmt.Errorf("error decoding json response: %v", err)
 	}
 
-	if u.OidcUserMeta.Secret == "" {
+	if ud.OidcMeta.Secret == "" {
 		return "", fmt.Errorf("user does not have cli token set")
 	}
 
-	return u.OidcUserMeta.Secret, nil
-}
-
-type oidcUserMeta struct {
-	Secret string `json:"secret"`
-}
-
-type oUser struct {
-	OidcUserMeta oidcUserMeta `json:"oidc_user_meta"`
+	return ud.OidcMeta.Secret, nil
 }

--- a/internal/app/singularity/remote_get_login_password_test.go
+++ b/internal/app/singularity/remote_get_login_password_test.go
@@ -79,7 +79,7 @@ func TestRemoteGetLoginPassword(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				isTokenValid := r.Header.Get("Authorization") == "Bearer "+validToken
 
-				if r.URL.Path == "/v1/rbac/users/current" && isTokenValid {
+				if r.URL.Path == userServicePath && isTokenValid {
 					w.Header().Set("Content-Type", "application/json")
 					fmt.Fprintln(w, tt.jsonResp)
 				} else {

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -7,11 +7,14 @@
 package singularity
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"sort"
 	"text/tabwriter"
 
+	scslibclient "github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/pkg/sylog"
@@ -112,6 +115,15 @@ func RemoteStatus(usrConfigFile, name string) (err error) {
 	}
 	tw.Flush()
 
+	libClientConfigURI := ""
+	libClientConfig, err := e.LibraryClientConfig(libClientConfigURI)
+	if err != nil {
+		return fmt.Errorf("could not get library client configuration: %v", err)
+	}
+	if err := printLoggedInIdentity(libClientConfig); err != nil {
+		return err
+	}
+
 	return doTokenCheck(e)
 }
 
@@ -125,6 +137,47 @@ func doStatusCheck(name string, sp endpoint.Service) *status {
 		return &status{name: name, uri: uri, status: "N/A"}
 	}
 	return &status{name: name, uri: uri, status: "OK", version: version}
+}
+
+func printLoggedInIdentity(config *scslibclient.Config) error {
+	path := userServicePath
+	endPoint := config.BaseURL + path
+
+	req, err := http.NewRequest(http.MethodGet, endPoint, nil)
+	if err != nil {
+		return fmt.Errorf("error creating new request: %v", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", config.AuthToken))
+	res, err := config.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making request: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		sylog.Debugf("Status Code: %v", res.StatusCode)
+		if res.StatusCode == http.StatusUnauthorized {
+			// This simply means we are not logged in, which in this context is not an error condition.
+			return nil
+		} else if res.StatusCode == http.StatusNotFound {
+			sylog.Warningf("endpoint for retrieving logged-in user's username/email is not available on the current remote library")
+			return nil
+		} else {
+			return fmt.Errorf("encountered error while trying to retrieve logged-in user's username/email: %v", res.StatusCode)
+		}
+	}
+
+	var ud userData
+	if err := json.NewDecoder(res.Body).Decode(&ud); err != nil {
+		return fmt.Errorf("error decoding json response: %v", err)
+	}
+
+	if len(ud.Username) > 0 {
+		// TODO: Right now, it doesn't seem like the realname field ever contains anything different than the username field, so it would be redundant to print them both. If this ever changes, we can add another %s to the format string and output ud.Realname, as well. (It's already in the struct.)
+		fmt.Printf("\nLogged in as: %s <%s>\n\n", ud.Username, ud.Email)
+	}
+
+	return nil
 }
 
 func doTokenCheck(e *endpoint.Config) error {

--- a/internal/app/singularity/user.go
+++ b/internal/app/singularity/user.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+package singularity
+
+const (
+	userServicePath = "/v1/rbac/users/current"
+)
+
+type userOidcMeta struct {
+	Secret string `json:"secret"`
+}
+
+type userData struct {
+	OidcMeta userOidcMeta `json:"oidc_user_meta"`
+	Email    string       `json:"email"`
+	Realname string       `json:"realname"`
+	Username string       `json:"username"`
+}

--- a/internal/pkg/remote/endpoint/client.go
+++ b/internal/pkg/remote/endpoint/client.go
@@ -8,7 +8,9 @@ package endpoint
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	golog "github.com/go-log/log"
 	keyclient "github.com/sylabs/scs-key-client/client"
@@ -98,9 +100,10 @@ func (ep *Config) LibraryClientConfig(uri string) (*libclient.Config, error) {
 	isDefault := uri == ""
 
 	config := &libclient.Config{
-		BaseURL:   uri,
-		UserAgent: useragent.Value(),
-		Logger:    (golog.Logger)(sylog.DebugLogger{}),
+		BaseURL:    uri,
+		UserAgent:  useragent.Value(),
+		Logger:     (golog.Logger)(sylog.DebugLogger{}),
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
 	}
 
 	if isDefault {


### PR DESCRIPTION
## Description of the Pull Request (PR):

In the `remote status` command, print the logged-in user's username & email address.

### This fixes or addresses the following GitHub issues:

 - Fixes #946 

