### PR TITLE
oci: support --scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@
 - The `remote status` command will now print the username, realname, and email
   of the logged-in user, if available.
 - OCI mode now supports `--hostname` (requires UTS namespace, therefore this
-  flag will infer `--uts` if running in OCI mode).
+  flag will infer `--uts`).
+- OCI mode now supports `--scratch` (shorthand: `-S`) to mount a tmpfs scratch
+  directory in the container.
 
 ### Bug Fixes
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1143,10 +1143,11 @@ func (c actionTests) actionBinds(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    []string
-		postRun func(*testing.T)
-		exit    int
+		name        string
+		args        []string
+		wantOutputs []e2e.SingularityCmdResultOp
+		postRun     func(*testing.T)
+		exit        int
 	}{
 		{
 			name: "NonExistentSource",
@@ -1457,6 +1458,28 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit:    0,
 		},
 		{
+			name: "IsScratchTmpfs",
+			args: []string{
+				"--scratch", "/name-of-a-scratch",
+				sandbox,
+				"mount",
+			},
+			wantOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `\btmpfs on /name-of-a-scratch\b`),
+			},
+			exit: 0,
+		},
+		{
+			name: "BindOverScratch",
+			args: []string{
+				"--scratch", "/name-of-a-scratch",
+				"--bind", hostCanaryDir + ":/name-of-a-scratch",
+				sandbox,
+				"test", "-f", "/name-of-a-scratch/file",
+			},
+			exit: 0,
+		},
+		{
 			name: "ScratchTmpfsBind",
 			args: []string{
 				"--scratch", "/scratch",
@@ -1518,7 +1541,7 @@ func (c actionTests) actionBinds(t *testing.T) {
 					e2e.WithCommand("exec"),
 					e2e.WithArgs(tt.args...),
 					e2e.PostRun(tt.postRun),
-					e2e.ExpectExit(tt.exit),
+					e2e.ExpectExit(tt.exit, tt.wantOutputs...),
 				)
 			}
 		})

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -82,9 +82,6 @@ func checkOpts(lo launcher.Options) error {
 	if len(lo.OverlayPaths) > 0 {
 		badOpt = append(badOpt, "OverlayPaths")
 	}
-	if len(lo.ScratchDirs) > 0 {
-		badOpt = append(badOpt, "ScratchDirs")
-	}
 	if lo.WorkDir != "" {
 		badOpt = append(badOpt, "WorkDir")
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Support `--scratch` (shorthand: `-S`) for mounting a tmpfs scratch directory in the container in oci mode, just like we do in native mode.

### Testing notes

Added e2e tests for this functionality in oci mode, mirroring and extending the e2e tests for the corresponding native-mode functionality. Added a couple of tests to both modes:

- Test that a scratch-mounted dir is indeed present in the container as a mount with `tmpfs` filesystem
- Test that when a bind-mounted dir shares a path with a scratch-mounted dir, the bind-mounted one will override the scratch-mounted one. (This was already behavior in native mode, though it wasn't being tested, as far as I could tell. Now it's enforced by the e2e tests for each of the two modes.)

### This fixes or addresses the following GitHub issues:

 - Fixes #1482 

