### PR TITLE
loop: Use LOOP_CTL_ADD instead of mknod for dev creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
   SingularityCE will still prefer `crun` if it has been installed.
 - Always request inner userns in `--oci` mode without `--fakeroot`, so that
   inner id mapping is applied correctly.
+- Use `/dev/loop-control` for loop device creation, to avoid issues with recent
+  kernel patch where `max_loop` is not set.
 
 ## 3.11.1 \[2023-03-14\]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Perform loop device creation via the LOOP_CTL_ADD ioctl against /dev/loop-control.

This avoids hitting an error in the latest kernels that include a change in handling of loop device creation when max_loop is unset.

Our target distros now all provide /dev/loop-control, so we are free to make this change.

Also contains minor fixes to correct an error/debug message, and add an earlier continue in case of failure to open loop device in attachLoop.

### This fixes or addresses the following GitHub issues:

 - Fixes #1499


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
