### PR TITLE
loop: refactor to use x/sys/unix

### DIFF
--- a/internal/pkg/build/sources/packer_ext3.go
+++ b/internal/pkg/build/sources/packer_ext3.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/archive"
 	"github.com/sylabs/singularity/pkg/util/loop"
+	"golang.org/x/sys/unix"
 )
 
 // Ext3Packer holds the locations of where to back from and to, as well as image offset info
@@ -38,10 +39,10 @@ func (p *Ext3Packer) Pack(context.Context) (*types.Bundle, error) {
 
 // unpackExt3 mounts the ext3 image using a loop device and then copies its contents to the bundle
 func unpackExt3(b *types.Bundle, img *image.Image) error {
-	info := &loop.Info64{
+	info := &unix.LoopInfo64{
 		Offset:    img.Partitions[0].Offset,
-		SizeLimit: img.Partitions[0].Size,
-		Flags:     loop.FlagsAutoClear,
+		Sizelimit: img.Partitions[0].Size,
+		Flags:     unix.LO_FLAGS_AUTOCLEAR,
 	}
 
 	var number int

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -37,7 +37,6 @@ import (
 	singularity "github.com/sylabs/singularity/pkg/runtime/engine/singularity/config"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
-	"github.com/sylabs/singularity/pkg/util/loop"
 	"github.com/sylabs/singularity/pkg/util/namespaces"
 	"github.com/sylabs/singularity/pkg/util/singularityconf"
 	"github.com/sylabs/singularity/pkg/util/slice"
@@ -757,16 +756,16 @@ func (c *container) mountImage(mnt *mount.Point) error {
 	}
 
 	attachFlag := os.O_RDWR
-	loopFlags := uint32(loop.FlagsAutoClear)
+	loopFlags := uint32(unix.LO_FLAGS_AUTOCLEAR)
 
 	if flags&syscall.MS_RDONLY == 1 {
-		loopFlags |= loop.FlagsReadOnly
+		loopFlags |= unix.LO_FLAGS_READ_ONLY
 		attachFlag = os.O_RDONLY
 	}
 
-	info := &loop.Info64{
+	info := &unix.LoopInfo64{
 		Offset:    offset,
-		SizeLimit: sizelimit,
+		Sizelimit: sizelimit,
 		Flags:     loopFlags,
 	}
 

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sylabs/singularity/pkg/util/loop"
+	"golang.org/x/sys/unix"
 )
 
 // MkdirArgs defines the arguments to mkdir.
@@ -25,7 +25,7 @@ type MkdirArgs struct {
 type LoopArgs struct {
 	Image      string
 	Mode       int
-	Info       loop.Info64
+	Info       unix.LoopInfo64
 	MaxDevices int
 	Shared     bool
 }

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -11,7 +11,7 @@ import (
 	"os"
 
 	args "github.com/sylabs/singularity/internal/pkg/runtime/engine/singularity/rpc"
-	"github.com/sylabs/singularity/pkg/util/loop"
+	"golang.org/x/sys/unix"
 )
 
 // RPC holds the state necessary for remote procedure calls.
@@ -77,7 +77,7 @@ func (t *RPC) Chroot(root string, method string) (int, error) {
 }
 
 // LoopDevice calls the loop device RPC using the supplied arguments.
-func (t *RPC) LoopDevice(image string, mode int, info loop.Info64, maxDevices int, shared bool) (int, error) {
+func (t *RPC) LoopDevice(image string, mode int, info unix.LoopInfo64, maxDevices int, shared bool) (int, error) {
 	arguments := &args.LoopArgs{
 		Image:      image,
 		Mode:       mode,

--- a/internal/pkg/util/crypt/crypt_dev.go
+++ b/internal/pkg/util/crypt/crypt_dev.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -21,6 +21,7 @@ import (
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/fs/lock"
 	"github.com/sylabs/singularity/pkg/util/loop"
+	"golang.org/x/sys/unix"
 )
 
 // Device describes a crypt device
@@ -43,10 +44,10 @@ func createLoop(path string, offset, size uint64) (string, error) {
 	loopDev := &loop.Device{
 		MaxLoopDevices: loop.GetMaxLoopDevices(),
 		Shared:         true,
-		Info: &loop.Info64{
-			SizeLimit: size,
+		Info: &unix.LoopInfo64{
+			Sizelimit: size,
 			Offset:    offset,
-			Flags:     loop.FlagsAutoClear,
+			Flags:     unix.LO_FLAGS_AUTOCLEAR,
 		},
 	}
 	idx := 0

--- a/pkg/ocibundle/tools/loop.go
+++ b/pkg/ocibundle/tools/loop.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"github.com/sylabs/singularity/pkg/util/loop"
+	"golang.org/x/sys/unix"
 )
 
 // CreateLoop associates a file to loop device and returns
@@ -19,10 +20,10 @@ func CreateLoop(file *os.File, offset, size uint64) (string, io.Closer, error) {
 	loopDev := &loop.Device{
 		MaxLoopDevices: loop.GetMaxLoopDevices(),
 		Shared:         true,
-		Info: &loop.Info64{
-			SizeLimit: size,
+		Info: &unix.LoopInfo64{
+			Sizelimit: size,
 			Offset:    offset,
-			Flags:     loop.FlagsAutoClear | loop.FlagsReadOnly,
+			Flags:     unix.LO_FLAGS_AUTOCLEAR | unix.LO_FLAGS_READ_ONLY,
 		},
 	}
 	idx := 0

--- a/pkg/util/loop/loop_test.go
+++ b/pkg/util/loop/loop_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,15 +12,16 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"golang.org/x/sys/unix"
 )
 
 func TestLoop(t *testing.T) {
 	test.EnsurePrivilege(t)
 
-	var i1 *Info64
+	var i1 *unix.LoopInfo64
 
-	info := &Info64{
-		Flags: FlagsAutoClear | FlagsReadOnly,
+	info := &unix.LoopInfo64{
+		Flags: unix.LO_FLAGS_AUTOCLEAR | unix.LO_FLAGS_READ_ONLY,
 	}
 	loopDevOne := &Device{
 		MaxLoopDevices: GetMaxLoopDevices(),


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use x/sys/unix wrappers for ioctl operations.

Use x/sys/unix types and flag constants.

Not for backport. Changes public things under pkg

### This fixes or addresses the following GitHub issues:

 - Fixes #1505

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
