### PR TITLE
fix: remove library http client timeout

### DIFF
--- a/internal/pkg/remote/endpoint/client.go
+++ b/internal/pkg/remote/endpoint/client.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	golog "github.com/go-log/log"
 	keyclient "github.com/sylabs/scs-key-client/client"
@@ -100,10 +99,11 @@ func (ep *Config) LibraryClientConfig(uri string) (*libclient.Config, error) {
 	isDefault := uri == ""
 
 	config := &libclient.Config{
-		BaseURL:    uri,
-		UserAgent:  useragent.Value(),
-		Logger:     (golog.Logger)(sylog.DebugLogger{}),
-		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		BaseURL:   uri,
+		UserAgent: useragent.Value(),
+		Logger:    (golog.Logger)(sylog.DebugLogger{}),
+		// TODO - probably should establish an appropriate client timeout here.
+		HTTPClient: &http.Client{},
 	}
 
 	if isDefault {


### PR DESCRIPTION
## Description of the Pull Request (PR):

The timeout added to the library http client in #1490 caused library pull failures.

There probably should be a sensibly large timeout here, to accommodate large pulls. The code path down through scs-library-client needs to be reviewed and considered to set an appropriate value.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
