### PR TITLE
oci: fix custom cwd not respected when homedir set

### DIFF
--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -226,9 +226,11 @@ func Run(t *testing.T) {
 	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
 
 	t.Cleanup(func() {
-		os.Remove(imagePath)
-		os.Remove(ociArchivePath)
-		os.Remove(dockerArchivePath)
+		if !t.Failed() {
+			os.Remove(imagePath)
+			os.Remove(ociArchivePath)
+			os.Remove(dockerArchivePath)
+		}
 	})
 
 	suite := testhelper.NewSuite(t, testenv)

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -88,6 +88,10 @@ func getProcessArgs(imageSpec imgspecv1.Image, process string, args []string) []
 // Currently this is the user's tmpfs home directory (see --containall).
 // Because this is called after mounts have already been computed, we can count on l.cfg.HomeDir containing the right value, incorporating any custom home dir overrides (i.e., --home).
 func (l *Launcher) getProcessCwd() (dir string, err error) {
+	if len(l.cfg.CwdPath) > 0 {
+		return l.cfg.CwdPath, nil
+	}
+
 	return l.cfg.HomeDir, nil
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

There was a problem where, in OCI mode, a custom working directory (`--cwd`/`--pwd`) would not be respected, and the homedir would be used as the working directory instead.

Interestingly, this was not caught by our e2e tests, which (ultimately) revealed a problem in the way I was handling profiles in the `actionOciExec()` function (e2e/actions/oci.go:228).

This fixes both issues.

