### PR TITLE
oci: fix --home when running as root or fakeroot

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -173,10 +173,6 @@ func (c actionTests) actionOciExec(t *testing.T) {
 				e2e.ExpectOutput(e2e.RegexMatch, `\bHOME=/myhomeloc\b`),
 				e2e.ExpectOutput(e2e.RegexMatch, `\btmpfs on /myhomeloc\b`),
 			},
-			skipProfiles: map[string]bool{
-				e2e.OCIRootProfile.String():     true,
-				e2e.OCIFakerootProfile.String(): true,
-			},
 			exit: 0,
 		},
 		{

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -40,6 +40,9 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, imag
 	// --env flag can override --env-file and SINGULARITYENV_
 	rtEnv = mergeMap(rtEnv, l.cfg.Env)
 
+	// Ensure HOME points to the required home directory, even if it is a custom one.
+	rtEnv["HOME"] = l.cfg.HomeDir
+
 	cwd, err := l.getProcessCwd()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix `--home` functionality in OCI-mode, so it works even when running as root (e.g. under `sudo`) or when running with `--fakeroot`.

### This fixes or addresses the following GitHub issues:

 - Fixes #1529 

### Related PRs

#1531 describes a more fundamental change to the way custom /etc/passwd information is handled in singularity, which would reduce the likelihood of problems like the one described here arising in the first place.