### PR TITLE
fix: oci: enter cgroup before executing crun as non-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 - Use `/dev/loop-control` for loop device creation, to avoid issues with recent
   kernel patch where `max_loop` is not set.
 - Use correct target uid/gid for inner id mappings in `--oci` mode.
+- Avoid `runc` cgroup creation error when using `--oci` from a root-owned cgroup
+  (e.g. ssh login session scope).
 
 ## 3.11.1 \[2023-03-14\]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

When executed from a root-owned cgroup, such as the session scope resulting from a bare ssh login, crun will fail to create our requested container cgroup.

If we are running as non-root, create and move into a user-owned cgroup, so that there's a common user-owned ancestor. This avoids the `crun` error.

Note that no workaround is needed for `runc` as it is able to create the requested container cgroup without any issue.

### This fixes or addresses the following GitHub issues:

 - Fixes #1538 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
