### PR TITLE
fix: oci: explicitly request userns for inner reverse idmap (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   SingularityCE will still prefer `crun` if it has been installed.
 - Use `/dev/loop-control` for loop device creation, to avoid issues with recent
   kernel patch where `max_loop` is not set.
+- Always request inner userns in `--oci` mode without `--fakeroot`, so that
+  inner id mapping is applied correctly.
 
 ## 3.11.1 \[2023-03-14\]
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2466,5 +2466,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociShell":   c.actionOciShell,   // singularity shell --oci
 		"ociNetwork": c.actionOciNetwork, // singularity exec --oci --net
 		"ociBinds":   c.actionOciBinds,   // singularity exec --oci --bind / --mount
+		"ociIDMaps":  c.actionOciIDMaps,  // check uid/gid mapping on host for --oci as user / --fakeroot
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -283,6 +283,11 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 		}
 		spec.Linux.UIDMappings = uidMap
 		spec.Linux.GIDMappings = gidMap
+		// Must add userns to the runc/crun applied config for the inner reverse uid/gid mapping to work.
+		spec.Linux.Namespaces = append(
+			spec.Linux.Namespaces,
+			specs.LinuxNamespace{Type: specs.UserNamespace},
+		)
 	}
 
 	u := specs.User{

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -88,13 +88,22 @@ func IsLink(name string) bool {
 	return info.Mode()&os.ModeSymlink != 0
 }
 
-// IsOwner check if name component is owned by user identified with uid.
+// IsOwner checks if named file is owned by user identified with uid.
 func IsOwner(name string, uid uint32) bool {
 	info, err := os.Stat(name)
 	if err != nil {
 		return false
 	}
 	return info.Sys().(*syscall.Stat_t).Uid == uid
+}
+
+// IsGroup checks if named file is owned by group identified with gid.
+func IsGroup(name string, gid uint32) bool {
+	info, err := os.Stat(name)
+	if err != nil {
+		return false
+	}
+	return info.Sys().(*syscall.Stat_t).Gid == gid
 }
 
 // IsExec check if name component has executable bit permission set.

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -163,7 +163,16 @@ func TestIsOwner(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	if IsOwner("/etc/passwd", 0) != true {
-		t.Errorf("IsOwner returns false for /etc/passwd owner")
+		t.Errorf("IsOwner returns false for /etc/passwd root ownership")
+	}
+}
+
+func TestIsGroup(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	if IsGroup("/etc/passwd", 0) != true {
+		t.Errorf("IsGroup returns false for /etc/passwd root group ownership")
 	}
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1518 

When running in --oci mode as a normal user, Singularity sets up an outer userns that provides an unprivileged root. When --fakeroot is not also requested, runc / crun then map back to the user's own uid/gid via an inner reverse mapping specified in config.json.

This mapping was not being applied correctly, as a userns was not requested in the config.json for all situations where a reverse mapping was requested.

Ensure that if we specify a mapping in config.json then we request a userns so that it is applied.

Cover this behavior in an e2e-test by writing to a host dir from the container, and checking ownership of the file on the host.

 - Fixes #1517 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
