### PR TITLE
fix: oci: reverse uid/gid maps now honour target IDs (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   kernel patch where `max_loop` is not set.
 - Always request inner userns in `--oci` mode without `--fakeroot`, so that
   inner id mapping is applied correctly.
+- Use correct target uid/gid for inner id mappings in `--oci` mode.
 
 ## 3.11.1 \[2023-03-14\]
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -277,7 +277,7 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 	}
 
 	if targetUID != 0 && currentUID != 0 {
-		uidMap, gidMap, err := l.getReverseUserMaps(targetUID, targetGID)
+		uidMap, gidMap, err := getReverseUserMaps(currentUID, targetUID, targetGID)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -104,11 +104,9 @@ func (l *Launcher) getProcessCwd() (dir string, err error) {
 // userns from which the OCI runtime is launched.
 //
 //	e.g. host 1001 -> fakeroot userns 0 -> container targetUID
-func (l *Launcher) getReverseUserMaps(targetUID, targetGID uint32) (uidMap, gidMap []specs.LinuxIDMapping, err error) {
-	uid := uint32(os.Getuid())
-	gid := uint32(os.Getgid())
+func getReverseUserMaps(hostUID, targetUID, targetGID uint32) (uidMap, gidMap []specs.LinuxIDMapping, err error) {
 	// Get user's configured subuid & subgid ranges
-	subuidRange, err := fakeroot.GetIDRange(fakeroot.SubUIDFile, uid)
+	subuidRange, err := fakeroot.GetIDRange(fakeroot.SubUIDFile, hostUID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -116,7 +114,7 @@ func (l *Launcher) getReverseUserMaps(targetUID, targetGID uint32) (uidMap, gidM
 	if subuidRange.Size < 65536 {
 		return nil, nil, fmt.Errorf("subuid range size (%d) must be at least 65536", subuidRange.Size)
 	}
-	subgidRange, err := fakeroot.GetIDRange(fakeroot.SubGIDFile, uid)
+	subgidRange, err := fakeroot.GetIDRange(fakeroot.SubGIDFile, hostUID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -124,22 +122,27 @@ func (l *Launcher) getReverseUserMaps(targetUID, targetGID uint32) (uidMap, gidM
 		return nil, nil, fmt.Errorf("subuid range size (%d) must be at least 65536", subgidRange.Size)
 	}
 
-	if uid < subuidRange.Size {
+	uidMap, gidMap = reverseMapByRange(targetUID, targetGID, *subuidRange, *subgidRange)
+	return uidMap, gidMap, nil
+}
+
+func reverseMapByRange(targetUID, targetGID uint32, subuidRange, subgidRange specs.LinuxIDMapping) (uidMap, gidMap []specs.LinuxIDMapping) {
+	if targetUID < subuidRange.Size {
 		uidMap = []specs.LinuxIDMapping{
 			{
 				ContainerID: 0,
 				HostID:      1,
-				Size:        uid,
+				Size:        targetUID,
 			},
 			{
-				ContainerID: uid,
+				ContainerID: targetUID,
 				HostID:      0,
 				Size:        1,
 			},
 			{
-				ContainerID: uid + 1,
-				HostID:      uid + 1,
-				Size:        subuidRange.Size - uid,
+				ContainerID: targetUID + 1,
+				HostID:      targetUID + 1,
+				Size:        subuidRange.Size - targetUID,
 			},
 		}
 	} else {
@@ -150,29 +153,29 @@ func (l *Launcher) getReverseUserMaps(targetUID, targetGID uint32) (uidMap, gidM
 				Size:        subuidRange.Size,
 			},
 			{
-				ContainerID: uid,
+				ContainerID: targetUID,
 				HostID:      0,
 				Size:        1,
 			},
 		}
 	}
 
-	if gid < subgidRange.Size {
+	if targetGID < subgidRange.Size {
 		gidMap = []specs.LinuxIDMapping{
 			{
 				ContainerID: 0,
 				HostID:      1,
-				Size:        gid,
+				Size:        targetGID,
 			},
 			{
-				ContainerID: gid,
+				ContainerID: targetGID,
 				HostID:      0,
 				Size:        1,
 			},
 			{
-				ContainerID: gid + 1,
-				HostID:      gid + 1,
-				Size:        subgidRange.Size - gid,
+				ContainerID: targetGID + 1,
+				HostID:      targetGID + 1,
+				Size:        subgidRange.Size - targetGID,
 			},
 		}
 	} else {
@@ -183,14 +186,14 @@ func (l *Launcher) getReverseUserMaps(targetUID, targetGID uint32) (uidMap, gidM
 				Size:        subgidRange.Size,
 			},
 			{
-				ContainerID: gid,
+				ContainerID: targetGID,
 				HostID:      0,
 				Size:        1,
 			},
 		}
 	}
 
-	return uidMap, gidMap, nil
+	return uidMap, gidMap
 }
 
 // getProcessEnv combines the image config ENV with the ENV requested at runtime.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1537 

In `getReverseUserMaps`,we were taking `targetUID` and `targetGID` parameters that define the UID and GID the container will be entereed as. However, the mappings returned were based on the current host UID and GID, and not the target IDs.

Ensure that the user maps use the `targetUID` and `targetGID`.

Split the function up so that the core computation of the user maps can be tested. The tests help to explain what the intended functionality here is... which is beneficial as it's somewhat complex.

### This fixes or addresses the following GitHub issues:

 - Fixes #1519


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
