### PR TITLE
oci: support --hostname (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Changes Since Last Release
 
+### New Features & Functionality
+
+- OCI mode now supports `--hostname` (requires UTS namespace, therefore this
+  flag will infer `--uts` if running in OCI mode).
+
 ### Bug Fixes
 
 - Require `runc` in RPM packages built on SLES, not `crun`, because `crun` is

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -211,7 +211,7 @@ var actionHostnameFlag = cmdline.Flag{
 	Value:        &hostname,
 	DefaultValue: "",
 	Name:         "hostname",
-	Usage:        "set container hostname",
+	Usage:        "set container hostname. Infers --uts.",
 	EnvKeys:      []string{"HOSTNAME"},
 	Tag:          "<name>",
 }

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -47,7 +47,12 @@ func getCacheHandle(cfg cache.Config) *cache.Handle {
 	return h
 }
 
-// actionPreRun will run replaceURIWithImage and will also do the proper path unsetting
+// actionPreRun will:
+//   - run replaceURIWithImage;
+//   - do the proper path unsetting;
+//   - and implement flag inferences for:
+//     --compat
+//     --hostname
 func actionPreRun(cmd *cobra.Command, args []string) {
 	// For compatibility - we still set USER_PATH so it will be visible in the
 	// container, and can be used there if needed. USER_PATH is not used by
@@ -66,6 +71,11 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 		noInit = true
 		noUmask = true
 		noEval = true
+	}
+
+	// --hostname requires UTS namespace
+	if len(hostname) > 0 {
+		utsNamespace = true
 	}
 }
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -112,9 +112,10 @@ func (c actionTests) actionExec(t *testing.T) {
 	homePath := filepath.Join("/home", basename)
 
 	tests := []struct {
-		name string
-		argv []string
-		exit int
+		name        string
+		argv        []string
+		exit        int
+		wantOutputs []e2e.SingularityCmdResultOp
 	}{
 		{
 			name: "NoCommand",
@@ -253,6 +254,14 @@ func (c actionTests) actionExec(t *testing.T) {
 			argv: []string{"--no-home", c.env.ImagePath, "ls", "-ld", user.Dir},
 			exit: 1,
 		},
+		{
+			name: "Hostname",
+			argv: []string{"--hostname", "whats-in-a-native-name", c.env.ImagePath, "hostname"},
+			exit: 0,
+			wantOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ExactMatch, "whats-in-a-native-name"),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -263,7 +272,7 @@ func (c actionTests) actionExec(t *testing.T) {
 			e2e.WithCommand("exec"),
 			e2e.WithDir("/tmp"),
 			e2e.WithArgs(tt.argv...),
-			e2e.ExpectExit(tt.exit),
+			e2e.ExpectExit(tt.exit, tt.wantOutputs...),
 		)
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -90,9 +90,10 @@ func (c actionTests) actionOciExec(t *testing.T) {
 	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
 	tests := []struct {
-		name string
-		argv []string
-		exit int
+		name        string
+		argv        []string
+		exit        int
+		wantOutputs []e2e.SingularityCmdResultOp
 	}{
 		{
 			name: "NoCommand",
@@ -139,6 +140,14 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			argv: []string{"--uts", imageRef, "true"},
 			exit: 0,
 		},
+		{
+			name: "Hostname",
+			argv: []string{"--hostname", "whats-in-an-oci-name", imageRef, "hostname"},
+			exit: 0,
+			wantOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ExactMatch, "whats-in-an-oci-name"),
+			},
+		},
 	}
 	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {
@@ -150,7 +159,7 @@ func (c actionTests) actionOciExec(t *testing.T) {
 					e2e.WithCommand("exec"),
 					e2e.WithDir("/tmp"),
 					e2e.WithArgs(tt.argv...),
-					e2e.ExpectExit(tt.exit),
+					e2e.ExpectExit(tt.exit, tt.wantOutputs...),
 				)
 			}
 		})

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -210,7 +210,11 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 
 	// If user wants to set a hostname, it requires the UTS namespace.
 	if l.cfg.Hostname != "" {
-		l.cfg.Namespaces.UTS = true
+		// This is a sanity-check; actionPreRun in actions.go should have prevented this scenario from arising.
+		if !l.cfg.Namespaces.UTS {
+			return fmt.Errorf("internal error: trying to set hostname without UTS namespace")
+		}
+
 		l.engineConfig.SetHostname(l.cfg.Hostname)
 	}
 
@@ -295,7 +299,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		if l.cfg.Boot {
 			l.cfg.Namespaces.UTS = true
 			l.cfg.Namespaces.Net = true
-			if l.cfg.Hostname == "" {
+			if len(l.cfg.Hostname) < 1 {
 				l.engineConfig.SetHostname(instanceName)
 			}
 			if !l.cfg.KeepPrivs {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -133,9 +133,6 @@ func checkOpts(lo launcher.Options) error {
 	if len(lo.NetworkArgs) > 0 {
 		badOpt = append(badOpt, "NetworkArgs")
 	}
-	if lo.Hostname != "" {
-		badOpt = append(badOpt, "Hostname")
-	}
 	if lo.DNS != "" {
 		badOpt = append(badOpt, "DNS")
 	}
@@ -214,6 +211,15 @@ func (l *Launcher) createSpec() (*specs.Spec, error) {
 	spec := minimalSpec()
 
 	spec = addNamespaces(spec, l.cfg.Namespaces)
+
+	if len(l.cfg.Hostname) > 0 {
+		// This is a sanity-check; actionPreRun in actions.go should have prevented this scenario from arising.
+		if !l.cfg.Namespaces.UTS {
+			return nil, fmt.Errorf("internal error: trying to set hostname without UTS namespace")
+		}
+
+		spec.Hostname = l.cfg.Hostname
+	}
 
 	mounts, err := l.getMounts()
 	if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1495

Support `--hostname` in OCI mode. Requires UTS namespace, so in OCI mode, `--hostname` will infer `--uts`. Added test in e2e-test suite (e2e/actions/oci.go:148) for this functionality.

### This fixes or addresses the following GitHub issues:

 - Fixes #1474 

