### PR TITLE
fix: TERM not set in OCI containers (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Use correct target uid/gid for inner id mappings in `--oci` mode.
 - Avoid `runc` cgroup creation error when using `--oci` from a root-owned cgroup
   (e.g. ssh login session scope).
+- Pass host's `TERM` environment variable to container in OCI mode. Can be
+  overridden by setting `SINGULARITYENV_TERM` on host.
 
 ## 3.11.1 \[2023-03-14\]
 

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -954,6 +954,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			// Regressions
 			t.Run("issue 4524", c.issue4524)
 			t.Run("issue 1286", c.issue1286)
+			t.Run("issue 1528", c.issue1528)
 		},
 		// Tests that are especially slow, or run against a local docker
 		// registry, can be run in parallel, with `--disable-cache` used within

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -28,6 +28,13 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, imag
 	// Assemble the runtime & user-requested environment, which will be merged
 	// with the image ENV and set in the container at runtime.
 	rtEnv := defaultEnv(image, bundle)
+
+	// Propagate TERM from host. Doing this here means it can be overridden by SINGULARITYENV_TERM.
+	hostTerm, isHostTermSet := os.LookupEnv("TERM")
+	if isHostTermSet {
+		rtEnv["TERM"] = hostTerm
+	}
+
 	// SINGULARITYENV_ has lowest priority
 	rtEnv = mergeMap(rtEnv, singularityEnvMap())
 	// --env-file can override SINGULARITYENV_


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1553 

Pass host's TERM environment variable to container in OCI mode. Can be overridden by setting SINGULARITYENV_TERM on host.

### This fixes or addresses the following GitHub issues:

 - Fixes #1528


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
