### PR TITLE
oci: fix custom pwd not respected when homedir set (release-3.11)

### DIFF
--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -226,9 +226,11 @@ func Run(t *testing.T) {
 	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
 
 	t.Cleanup(func() {
-		os.Remove(imagePath)
-		os.Remove(ociArchivePath)
-		os.Remove(dockerArchivePath)
+		if !t.Failed() {
+			os.Remove(imagePath)
+			os.Remove(ociArchivePath)
+			os.Remove(dockerArchivePath)
+		}
 	})
 
 	suite := testhelper.NewSuite(t, testenv)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1523 

There was a problem where, in OCI mode, a custom working directory (`--pwd`) would not be respected, and the homedir would be used as the working directory instead.

Interestingly, this was not caught by our e2e tests, which (ultimately) revealed a problem in the way I was handling profiles in the `actionOciExec()` function (e2e/actions/oci.go:228).

This fixes both issues.

