### PR TITLE
oci: support --home (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 - OCI mode now supports `--scratch` (shorthand: `-S`) to mount a tmpfs scratch
   directory in the container.
 - Support `--pwd` in OCI mode.
+- OCI mode now supports `--home`. Supplying a single location (e.g.
+  `--home /myhomedir`) will result in a new tmpfs directory being created at the
+  specified location inside the container, and that dir being set as the
+  in-container user's home dir. Supplying two locations separated by a colon
+  (e.g. `--home /home/user:/myhomedir`) will result in the first location on the
+  host being bind-mounted as the second location in-container, and set as
+  the in-container user's home dir.
 
 ### Bug Fixes
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -92,7 +92,11 @@ func (c actionTests) actionExec(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testdata)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.RemoveAll(testdata)
+		}
+	})
 
 	testdataTmp := filepath.Join(testdata, "tmp")
 	if err := os.Mkdir(testdataTmp, 0o755); err != nil {
@@ -221,7 +225,10 @@ func (c actionTests) actionExec(t *testing.T) {
 		},
 		{
 			name: "Home",
-			argv: []string{"--home", testdata, c.env.ImagePath, "test", "-f", tmpfile.Name()},
+			argv: []string{"--home", "/myhomeloc", c.env.ImagePath, "env"},
+			wantOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `\bHOME=/myhomeloc\b`),
+			},
 			exit: 0,
 		},
 		{

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -89,6 +89,32 @@ func (c actionTests) actionOciExec(t *testing.T) {
 
 	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
+	// Create a temp testfile
+	testdata, err := fs.MakeTmpDir(c.env.TestDir, "testdata", 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.RemoveAll(testdata)
+		}
+	})
+
+	testdataTmp := filepath.Join(testdata, "tmp")
+	if err := os.Mkdir(testdataTmp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a temp testfile
+	tmpfile, err := fs.MakeTmpFile(testdataTmp, "testSingularityExec.", 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpfile.Close()
+
+	basename := filepath.Base(tmpfile.Name())
+	homePath := filepath.Join("/home", basename)
+
 	tests := []struct {
 		name         string
 		argv         []string
@@ -134,6 +160,30 @@ func (c actionTests) actionOciExec(t *testing.T) {
 		{
 			name: "TouchHome",
 			argv: []string{imageRef, "/bin/sh", "-c", "touch $HOME"},
+			exit: 0,
+		},
+		{
+			name: "Home",
+			argv: []string{"--home", "/myhomeloc", imageRef, "sh", "-c", "env; mount"},
+			wantOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.RegexMatch, `\bHOME=/myhomeloc\b`),
+				e2e.ExpectOutput(e2e.RegexMatch, `\btmpfs on /myhomeloc\b`),
+			},
+			exit: 0,
+		},
+		{
+			name: "HomePath",
+			argv: []string{"--home", testdataTmp + ":/home", imageRef, "test", "-f", homePath},
+			exit: 0,
+		},
+		{
+			name: "HomeTmp",
+			argv: []string{"--home", "/tmp", imageRef, "true"},
+			exit: 0,
+		},
+		{
+			name: "HomeTmpExplicit",
+			argv: []string{"--home", "/tmp:/home", imageRef, "true"},
 			exit: 0,
 		},
 		{
@@ -317,10 +367,15 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 	canaryDirBind := hostCanaryDir + ":" + contCanaryDir
 	canaryDirMount := "type=bind,source=" + hostCanaryDir + ",destination=" + contCanaryDir
 
+	hostHomeDir := filepath.Join(workspace, "home")
+
 	createWorkspaceDirs := func(t *testing.T) {
 		e2e.Privileged(func(t *testing.T) {
 			if err := os.RemoveAll(hostCanaryDir); err != nil && !os.IsNotExist(err) {
 				t.Fatalf("failed to delete canary_dir: %s", err)
+			}
+			if err := os.RemoveAll(hostHomeDir); err != nil && !os.IsNotExist(err) {
+				t.Fatalf("failed to delete workspace home: %s", err)
 			}
 		})(t)
 
@@ -332,6 +387,9 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 		}
 		if err := os.Chmod(hostCanaryFile, 0o777); err != nil {
 			t.Fatalf("failed to apply permissions on canary_file: %s", err)
+		}
+		if err := fs.Mkdir(hostHomeDir, 0o777); err != nil {
+			t.Fatalf("failed to create workspace home directory: %s", err)
 		}
 	}
 
@@ -490,6 +548,28 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 				"test", "-f", "/scratch/dir/file",
 			},
 			exit: 0,
+		},
+		{
+			name: "CustomHomeOneToOne",
+			args: []string{
+				"--home", hostHomeDir + ":" + hostHomeDir,
+				"--bind", hostCanaryDir + ":" + filepath.Join(hostHomeDir, "canary121RO"),
+				imageRef,
+				"test", "-f", filepath.Join(hostHomeDir, "canary121RO/file"),
+			},
+			postRun: checkHostDir(filepath.Join(hostHomeDir, "canary121RO")),
+			exit:    0,
+		},
+		{
+			name: "CustomHomeBind",
+			args: []string{
+				"--home", hostHomeDir + ":/home/e2e",
+				"--bind", hostCanaryDir + ":/home/e2e/canaryRO",
+				imageRef,
+				"test", "-f", "/home/e2e/canaryRO/file",
+			},
+			postRun: checkHostDir(filepath.Join(hostHomeDir, "canaryRO")),
+			exit:    0,
 		},
 		// For the --mount variants we are really just verifying the CLI
 		// acceptance of one or more --mount flags. Translation from --mount

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -104,7 +104,7 @@ func (r *SingularityCmdResult) expectMatch(mt MatchType, stream streamType, patt
 		// get rid of the trailing newline
 		if strings.TrimSuffix(output, "\n") != pattern {
 			return errors.Errorf(
-				"Command %q:\nExpect %s stream exact match:\n%s\nCommand %s output:\n%s",
+				"Command %q:\nExpect %s stream exact match:\n%s\nCommand %s stream:\n%s",
 				r.FullCmd, streamName, pattern, streamName, output,
 			)
 		}
@@ -118,7 +118,7 @@ func (r *SingularityCmdResult) expectMatch(mt MatchType, stream streamType, patt
 	case UnwantedExactMatch:
 		if strings.TrimSuffix(output, "\n") == pattern {
 			return errors.Errorf(
-				"Command %q:\nExpect %s stream not matching:\n%s\nCommand %s output:\n%s",
+				"Command %q:\nExpect %s stream not matching:\n%s\nCommand %s stream:\n%s",
 				r.FullCmd, streamName, pattern, streamName, output,
 			)
 		}
@@ -132,7 +132,7 @@ func (r *SingularityCmdResult) expectMatch(mt MatchType, stream streamType, patt
 		}
 		if !matched {
 			return errors.Errorf(
-				"Command %q:\nExpect %s stream match regular expression:\n%s\nCommand %s output:\n%s",
+				"Command %q:\nExpect %s stream match regular expression:\n%s\nCommand %s stream:\n%s",
 				r.FullCmd, streamName, pattern, streamName, output,
 			)
 		}

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -656,8 +656,8 @@ func (l *Launcher) setHome() error {
 
 	// Handle any user request to override the home directory source/dest
 	homeSlice := strings.Split(l.cfg.HomeDir, ":")
-	if len(homeSlice) > 2 || len(homeSlice) == 0 {
-		return fmt.Errorf("home argument has incorrect number of elements: %v", len(homeSlice))
+	if len(homeSlice) < 1 || len(homeSlice) > 2 {
+		return fmt.Errorf("home argument has incorrect number of elements: %v", homeSlice)
 	}
 	l.engineConfig.SetHomeSource(homeSlice[0])
 	if len(homeSlice) == 1 {

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -47,6 +47,9 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, imag
 	// --env flag can override --env-file and SINGULARITYENV_
 	rtEnv = mergeMap(rtEnv, l.cfg.Env)
 
+	// Ensure HOME points to the required home directory, even if it is a custom one.
+	rtEnv["HOME"] = l.cfg.HomeDir
+
 	cwd, err := l.getProcessCwd()
 	if err != nil {
 		return nil, err

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/sylabs/singularity/internal/pkg/util/env"
 	"github.com/sylabs/singularity/internal/pkg/util/shell/interpreter"
-	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"golang.org/x/term"
 )
 
@@ -94,20 +93,13 @@ func getProcessArgs(imageSpec imgspecv1.Image, process string, args []string) []
 
 // getProcessCwd computes the Cwd that the container process should start in.
 // Currently this is the user's tmpfs home directory (see --containall).
+// Because this is called after mounts have already been computed, we can count on l.cfg.HomeDir containing the right value, incorporating any custom home dir overrides (i.e., --home).
 func (l *Launcher) getProcessCwd() (dir string, err error) {
-	if len(l.cfg.PwdPath) > 1 {
+	if len(l.cfg.PwdPath) > 0 {
 		return l.cfg.PwdPath, nil
 	}
 
-	if l.cfg.Fakeroot {
-		return "/root", nil
-	}
-
-	pw, err := user.CurrentOriginal()
-	if err != nil {
-		return "", err
-	}
-	return pw.Dir, nil
+	return l.cfg.HomeDir, nil
 }
 
 // getReverseUserMaps returns uid and gid mappings that re-map container uid to target


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1500 

Adds support for `--home` in OCI mode.

Specifically, supplying a single location (e.g. `--home /myhomedir`) will result in a new tmpfs directory being created at the specified location inside the container, and that dir being set as the in-container user's home dir. Supplying two locations separated by a colon (e.g. `--home /home/user:/myhomedir`) will result in the first location on the host being bind-mounted as the second location in-container, and set as the in-container user's home dir.

### Testing notes

Added e2e tests in e2e/actions/oci.go to largely mirror how we test the corresponding native-mode functionality, with the caveat that the tests now look for a tmpfs mounted dir inside the container when appropriate. Also made a minor improvement inside the native-mode `--home` tests, to make sure we have `$HOME` correctly set in the environment (and not just that we start the container in the right directory).

### This fixes or addresses the following GitHub issues:

 - Fixes #1473 

