### PR TITLE
fixed typo (resolve.conf -> resolv.conf)

### DIFF
--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -390,7 +390,7 @@ func (l *Launcher) prepareResolvConf(rootfs string) error {
 
 	stat, err := os.Stat(containerEtc)
 	if os.IsNotExist(err) || !stat.IsDir() {
-		sylog.Warningf("container does not contain an /etc directory; skipping resolve.conf configuration")
+		sylog.Warningf("container does not contain an /etc directory; skipping resolv.conf configuration")
 		return nil
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes a tiny typo ("resolve.conf" -> "resolv.conf") in warning message in internal/pkg/runtime/launcher/oci/launcher_linux.go:393

