### PR TITLE
fix: oci: Don't create cgroup for crun on v1 / cgroupfs (release-3.11)

### DIFF
--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	lccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/cache"
@@ -487,9 +488,10 @@ func (l *Launcher) getCgroup() (path string, resources *specs.LinuxResources, er
 	return path, resources, nil
 }
 
-// crunNestCgroup will check whether we are using crun, and enter a cgroup if running as a non-root user.
-// This is required to satisfy a common user-owned ancestor cgroup requirement on e.g. bare ssh logins.
-// See: https://github.com/sylabs/singularity/issues/1538
+// crunNestCgroup will check whether we are using crun, and enter a cgroup if
+// running as a non-root user under cgroups v2, with systemd. This is required
+// to satisfy a common user-owned ancestor cgroup requirement on e.g. bare ssh
+// logins. See: https://github.com/sylabs/singularity/issues/1538
 func (l *Launcher) crunNestCgroup() error {
 	r, err := runtime()
 	if err != nil {
@@ -503,6 +505,12 @@ func (l *Launcher) crunNestCgroup() error {
 
 	// No workaround required if we are run as root.
 	if os.Getuid() == 0 {
+		return nil
+	}
+
+	// We can only create a new cgroup under cgroups v2 with systemd as manager.
+	// Generally we won't hit the issue that needs a workaround under cgroups v1, so no-op instead of a warning here.
+	if !(lccgroups.IsCgroup2UnifiedMode() && l.singularityConf.SystemdCgroups) {
 		return nil
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1570

If we are running under cgroups v1 or with the cgroupfs manager (i.e. not systemd as cgroup manager), do not attempt to enter a cgroup at startup with crun. We cannot create a cgroup unprivileged in this situation.

Under cgroups v1, crun will not perform the cgroups manipulation that leads to the issue we worked around in #1539. Any other issue with the cgroup that we are in at launch cannot be rectified, either.


### This fixes or addresses the following GitHub issues:

 - Fixes #1569 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
