### PR TITLE
fix: singularity.conf default root capabilities comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
   in `--oci` mode.
 - Honour `mount proc` / `mount sys` / `mount tmp` / `mount home` directives from
   `singularity.conf` in `--oci` mode.
+- Corrected `singularity.conf` comment, to refer to correct file as source
+  of default capabilities when `root default capabilities = file`.
 
 ## 3.11.1 \[2023-03-14\]
 

--- a/etc/conf/testdata/test_1.out.correct
+++ b/etc/conf/testdata/test_1.out.correct
@@ -199,10 +199,11 @@ always use nv = no
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/singularity/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/singularity/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = full
 

--- a/etc/conf/testdata/test_2.in
+++ b/etc/conf/testdata/test_2.in
@@ -199,10 +199,11 @@ always use nv = no
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/singularity/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/singularity/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = full
 

--- a/etc/conf/testdata/test_2.out.correct
+++ b/etc/conf/testdata/test_2.out.correct
@@ -199,10 +199,11 @@ always use nv = no
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/singularity/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/singularity/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = full
 

--- a/etc/conf/testdata/test_3.in
+++ b/etc/conf/testdata/test_3.in
@@ -190,10 +190,11 @@ always use nv = no
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/singularity/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/singularity/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = full
 

--- a/etc/conf/testdata/test_3.out.correct
+++ b/etc/conf/testdata/test_3.out.correct
@@ -199,10 +199,11 @@ always use nv = no
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/singularity/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/singularity/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = full
 

--- a/etc/conf/testdata/test_default.tmpl
+++ b/etc/conf/testdata/test_default.tmpl
@@ -210,10 +210,11 @@ always use nv = {{ if eq .AlwaysUseNv true }}yes{{ else }}no{{ end }}
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/singularity/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/singularity/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = {{ .RootDefaultCapabilities }}
 

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -345,7 +345,8 @@ always use rocm = {{ if eq .AlwaysUseRocm true }}yes{{ else }}no{{ end }}
 # DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/singularity/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/singularity/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = {{ .RootDefaultCapabilities }}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Corrected `singularity.conf` comment, to refer to correct file as source of default capabilities when `root default capabilities = file`.

### This fixes or addresses the following GitHub issues:

 - Fixes #1583 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
