### PR TITLE
fix: Remove files with restrictive perms from --oci temp rootfs

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -955,6 +955,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("issue 4524", c.issue4524)
 			t.Run("issue 1286", c.issue1286)
 			t.Run("issue 1528", c.issue1528)
+			t.Run("issue 1586", c.issue1586)
 		},
 		// Tests that are especially slow, or run against a local docker
 		// registry, can be run in parallel, with `--disable-cache` used within

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/cache"
 	"github.com/sylabs/singularity/internal/pkg/cgroups"
 	"github.com/sylabs/singularity/internal/pkg/runtime/launcher"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/internal/pkg/util/fs/files"
 	"github.com/sylabs/singularity/pkg/ocibundle"
 	"github.com/sylabs/singularity/pkg/ocibundle/native"
@@ -424,7 +425,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	}
 	defer func() {
 		sylog.Debugf("Removing OCI bundle at: %s", bundleDir)
-		if err := os.RemoveAll(bundleDir); err != nil {
+		if err := fs.ForceRemoveAll(bundleDir); err != nil {
 			sylog.Errorf("Couldn't remove OCI bundle %s: %v", bundleDir, err)
 		}
 	}()


### PR DESCRIPTION
## Description of the Pull Request (PR):

When we run a container in `--oci` mode, we have a temporary rootfs that must be removed when the container exits.

A container can contain files / dirs with restrictive permissions that prevent direct removal.

Use fs.ForceRemoveAll, which will chmod & remove anything that os.RemoveAll is unable to remove.


### This fixes or addresses the following GitHub issues:

 - Fixes #1586


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
