### PR TITLE
Drop Ubuntu 18.04 (EOL)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,6 @@ executors:
   almalinux9:
     docker:
       - image: almalinux:9
-  ubuntu1804:
-    docker:
-      - image: ubuntu:18.04
   ubuntu2004:
     docker:
       - image: ubuntu:20.04
@@ -376,7 +373,7 @@ workflows:
       - build-deb:
           matrix:
             parameters:
-              e: ["ubuntu1804", "ubuntu2004", "ubuntu2204"]
+              e: ["ubuntu2004", "ubuntu2204"]
           filters:
             branches:
               only:
@@ -398,7 +395,7 @@ workflows:
       - build-deb:
           matrix:
             parameters:
-              e: ["ubuntu1804", "ubuntu2004", "ubuntu2204"]
+              e: ["ubuntu2004", "ubuntu2204"]
           filters:
             branches:
               ignore: /.*/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,25 +29,6 @@ sudo apt-get install -y \
     wget
 ```
 
-On Ubuntu 18.04:
-
-```sh
-# Ensure repositories are up-to-date
-sudo apt-get update
-# Install debian packages for dependencies
-sudo apt-get install -y \
-    build-essential \
-    libseccomp-dev \
-    libglib2.0-dev \
-    pkg-config \
-    squashfs-tools \
-    cryptsetup \
-    runc \
-    uidmap \
-    git \
-    wget
-```
-
 On CentOS/RHEL 8 and above:
 
 ```sh

--- a/examples/ubuntu/Singularity
+++ b/examples/ubuntu/Singularity
@@ -1,5 +1,5 @@
 BootStrap: debootstrap
-OSVersion: trusty
+OSVersion: jammy
 MirrorURL: http://us.archive.ubuntu.com/ubuntu/
 
 

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
@@ -35,7 +35,7 @@ func TestDebootstrapConveyor(t *testing.T) {
 
 	b.Recipe.Header = map[string]string{
 		"bootstrap": "debootstrap",
-		"osversion": "bionic",
+		"osversion": "jammy",
 		"mirrorurl": "http://us.archive.ubuntu.com/ubuntu/",
 		"include":   "apt python ",
 	}
@@ -68,7 +68,7 @@ func TestDebootstrapPacker(t *testing.T) {
 
 	b.Recipe.Header = map[string]string{
 		"bootstrap": "debootstrap",
-		"osversion": "bionic",
+		"osversion": "jammy",
 		"mirrorurl": "http://us.archive.ubuntu.com/ubuntu/",
 		"include":   "apt python ",
 	}


### PR DESCRIPTION
_Merge after 2024-04-30_

**ci: Drop Ubuntu 18.04 package builds**
    
Ubuntu 18.04 is EOL 2023-04-30

**Bump example / debootstrap tests to Ubuntu jammy**
    
Ensure we are using a currently supported Ubuntu in our example definition file, and debootstrap test code.
