### PR TITLE
oci: fix to not override HOME when container specifies USER + e2e test (release-3.11)

### DIFF
--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -47,8 +47,10 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, imag
 	// --env flag can override --env-file and SINGULARITYENV_
 	rtEnv = mergeMap(rtEnv, l.cfg.Env)
 
-	// Ensure HOME points to the required home directory, even if it is a custom one.
-	rtEnv["HOME"] = l.cfg.HomeDir
+	// Ensure HOME points to the required home directory, even if it is a custom one, unless the container explicitly specifies its USER, in which case we don't want to touch HOME.
+	if imgSpec.Config.User == "" {
+		rtEnv["HOME"] = l.cfg.HomeDir
+	}
 
 	cwd, err := l.getProcessCwd()
 	if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1594 

In OCI mode, avoid overriding container's HOME environment variable if container specifies its own USER.

Also add e2e test of the above.

### This fixes or addresses the following GitHub issues:

 - Fixes #1593 

