### PR TITLE
Allow kernel squashfs / extfs mount to be disabled in singularity.conf (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   `--dns` flag can be used to pass a comma-separated list of DNS servers that
   will be used in the container; if this flag is not used, the container will
   use the same `resolv.conf` settings as the host.
+- Added `allow kernel squashfs` directive to `singularity.conf`. Defaults to
+  `yes`. When set to no, Singularity will not mount squashfs filesystems using
+  the kernel squashfs driver.
+- Added `allow kernel extfs` directive to `singularity.conf`. Defaults to `yes`.
+  When set to no, Singularity will not mount extfs filesystems using the kernel
+  extfs driver.
 
 ### Bug Fixes
 

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -107,6 +107,16 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 		return fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}
 
+	// Authorize permitted kernel mounts
+	if engine.EngineConfig.File.AllowKernelSquashfs {
+		mount.AuthorizeImageFS("squashfs")
+	}
+	if engine.EngineConfig.File.AllowKernelExtfs {
+		mount.AuthorizeImageFS("ext3")
+	}
+	// encryptfs isn't a real kernel fs - it's an internal marker of a LUKS2 encrypted squashfs
+	mount.AuthorizeImageFS("encryptfs")
+
 	c := &container{
 		engine:        engine,
 		rpcOps:        rpcOps,

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -141,11 +141,9 @@ var authorizedTags = map[AuthorizedTag]struct {
 	FinalTag:     {true, 16},
 }
 
-var authorizedImage = map[string]fsContext{
-	"encryptfs": {true},
-	"ext3":      {true},
-	"squashfs":  {true},
-}
+// authorizedImage holds fs types that are authorized for use in loopback image mounts.
+// Nothing is allowed by default. Use AuthorizeImageFS to add.
+var authorizedImage = map[string]fsContext{}
 
 var authorizedFS = map[string]fsContext{
 	"overlay": {true},
@@ -615,7 +613,7 @@ func (p *Points) AddImage(tag AuthorizedTag, source string, dest string, fstype 
 		return fmt.Errorf("ms_bind, ms_rec or ms_remount are not valid flags for image mount points")
 	}
 	if _, ok := authorizedImage[fstype]; !ok {
-		return fmt.Errorf("mount %s image is not authorized", fstype)
+		return fmt.Errorf("%s image mounts are not authorized", fstype)
 	}
 	if sizelimit == 0 {
 		return fmt.Errorf("invalid image size, zero length")
@@ -777,4 +775,10 @@ func (p *Points) SetContext(context string) error {
 // GetContext returns SELinux mount context
 func (p *Points) GetContext() string {
 	return p.context
+}
+
+// AuthorizeImageFS adds the specified filesystem from the authorizedImage list.
+// This means a loopback mount can then be performed from an image file with this filesystem.
+func AuthorizeImageFS(fs string) {
+	authorizedImage[fs] = fsContext{true}
 }

--- a/internal/pkg/util/fs/mount/mount_linux_test.go
+++ b/internal/pkg/util/fs/mount/mount_linux_test.go
@@ -21,6 +21,16 @@ func TestImage(t *testing.T) {
 
 	points := &Points{}
 
+	if err := points.AddImage(RootfsTag, "/fake", "/ext3", "ext3", 0, 0, 10, nil); err == nil {
+		t.Errorf("ext3 image mount succeeded. Should fail before it is authorized.")
+	}
+	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10, nil); err == nil {
+		t.Errorf("squashfs image mount succeeded. Should fail before it is authorized.")
+	}
+
+	AuthorizeImageFS("ext3")
+	AuthorizeImageFS("squashfs")
+
 	if err := points.AddImage(RootfsTag, "", "/fake", "ext3", 0, 0, 10, nil); err == nil {
 		t.Errorf("should have failed with empty source")
 	}

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -42,6 +42,8 @@ type File struct {
 	AllowContainerSquashfs  bool     `default:"yes" authorized:"yes,no" directive:"allow container squashfs"`
 	AllowContainerExtfs     bool     `default:"yes" authorized:"yes,no" directive:"allow container extfs"`
 	AllowContainerDir       bool     `default:"yes" authorized:"yes,no" directive:"allow container dir"`
+	AllowKernelSquashfs     bool     `default:"yes" authorized:"yes,no" directive:"allow kernel squashfs"`
+	AllowKernelExtfs        bool     `default:"yes" authorized:"yes,no" directive:"allow kernel extfs"`
 	AlwaysUseNv             bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
 	UseNvCCLI               bool     `default:"no" authorized:"yes,no" directive:"use nvidia-container-cli"`
 	AlwaysUseRocm           bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
@@ -284,6 +286,20 @@ allow container encrypted = {{ if eq .AllowContainerEncrypted true }}yes{{ else 
 allow container squashfs = {{ if eq .AllowContainerSquashfs true }}yes{{ else }}no{{ end }}
 allow container extfs = {{ if eq .AllowContainerExtfs true }}yes{{ else }}no{{ end }}
 allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }}
+
+# ALLOW KERNEL SQUASHFS: [BOOL]
+# DEFAULT: yes
+# If set to no, Singularity will not perform any kernel mounts of squashfs filesystems.
+# This affects both stand-alone image files and filesystems embedded in a SIF file.
+# Applicable to setuid mode only.
+allow kernel squashfs = {{ if eq .AllowKernelSquashfs true }}yes{{ else }}no{{ end }}
+
+# ALLOW KERNEL EXTFS: [BOOL]
+# DEFAULT: yes
+# If set to no, Singularity will not perform any kernel mounts of extfs filesystems.
+# This affects both stand-alone image files and filesystems embedded in a SIF file.
+# Applicable to setuid mode only.
+allow kernel extfs = {{ if eq .AllowKernelExtfs true }}yes{{ else }}no{{ end }}
 
 # ALLOW NET USERS: [STRING]
 # DEFAULT: NULL


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1600 

In singularity.conf, add two directives `allow kernel squashfs` and `allow kernel extfs` which default to 'yes'. When set to 'no', these directives prevent a squashfs mount or extfs mount from being performed through the kernel. Note that this only happens in setuid mode / as root.

squashfs and extfs mounts are added from the various locations that handle loopback mounting of a filesystem image. The image could be a container rootfs, an overlay, or an image bind. In each case the image may be a standalone file or embedded in a SIF.

The simplest place to gate these mounts is in mount.AddImage, via the existing check that the fs type is authorized as the source for an image mount.

Authorized filesystems for image mounts are held in a package var. At the start of container creation we now explicitly authorize squashfs and extfs, unless disabled by singularity.conf.

Relying on a package scope variable isn't ideal. We have multiple processes at container creation, so the authorization must be performed in the right place. e2e tests have been added to verify overlay, image bind, and container rootfs image flows.

Gating the filesystems earlier in the `PrepareConfig` portion of the runtime is, in my opinion, more liable to errors as the checks would have to be replicated in the multiple places that images are handled.

Ideally the mount.System could perhaps hold the list of allowed / disallowed filesystems, that could be set when it is created. However, this would require a large amount of refactoring to complex and critical code.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
