### PR TITLE
fix: apply allow kernel squashfs directive to encrypted squashfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
 - The `remote status` command will now print the username, realname, and email
   of the logged-in user, if available.
 
+## Bug Fixes
+
+- Ensure the `allow kernel squashfs` directive in `singularity.conf` applies to
+  encrypted squashfs filesystems in a SIF.
+
 ## 3.11.2 \[2023-04-27\]
 
 ### New Features & Functionality

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -628,6 +628,23 @@ func (c configTests) configGlobal(t *testing.T) {
 			directiveValue: "yes",
 			exit:           0,
 		},
+		// Encrypted squashFS rootfs in SIF
+		{
+			name:           "AllowKernelSquashfsNo_Encrypted",
+			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow kernel squashfs",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "AllowKernelSquashfsYes_Encrypted",
+			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow kernel squashfs",
+			directiveValue: "yes",
+			exit:           0,
+		},
 		// ext3 writable overlay in SIF
 		{
 			name:           "AllowKernelExtfsNo_SIF",

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -109,12 +109,11 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 	// Authorize permitted kernel mounts
 	if engine.EngineConfig.File.AllowKernelSquashfs {
 		mount.AuthorizeImageFS("squashfs")
+		mount.AuthorizeImageFS("encrypted_squashfs")
 	}
 	if engine.EngineConfig.File.AllowKernelExtfs {
 		mount.AuthorizeImageFS("ext3")
 	}
-	// encryptfs isn't a real kernel fs - it's an internal marker of a LUKS2 encrypted squashfs
-	mount.AuthorizeImageFS("encryptfs")
 
 	c := &container{
 		engine:        engine,
@@ -744,7 +743,7 @@ func (c *container) mountImage(mnt *mount.Point) error {
 
 	mountType := mnt.Type
 
-	if mountType == "encryptfs" {
+	if mountType == "encrypted_squashfs" {
 		key, err = mount.GetKey(mnt.InternalOptions)
 		if err != nil {
 			return err
@@ -789,7 +788,7 @@ func (c *container) mountImage(mnt *mount.Point) error {
 
 	sylog.Debugf("Mounting loop device %s to %s of type %s\n", path, mnt.Destination, mnt.Type)
 
-	if mountType == "encryptfs" {
+	if mountType == "encrypted_squashfs" {
 		// pass the master processus ID only if a container IPC
 		// namespace was requested because cryptsetup requires
 		// to run in the host IPC namespace
@@ -806,7 +805,6 @@ func (c *container) mountImage(mnt *mount.Point) error {
 
 		path = cryptDev
 
-		// Currently we only support encrypted squashfs file system
 		mountType = "squashfs"
 	}
 
@@ -860,7 +858,7 @@ func (c *container) addRootfsMount(system *mount.System) error {
 	case image.EXT3:
 		mountType = "ext3"
 	case image.ENCRYPTSQUASHFS:
-		mountType = "encryptfs"
+		mountType = "encrypted_squashfs"
 		key = c.engine.EngineConfig.GetEncryptionKey()
 	case image.SANDBOX:
 		sylog.Debugf("Mounting directory rootfs: %v\n", rootfs)


### PR DESCRIPTION
_Don't merge until after release-3.11 -> master merge_


## Description of the Pull Request (PR):

The `allow kernel squashfs` directive was not applied correctly to limit mounts of encrypted squashfs images.

The `encryptfs` mount type is not a generic marker of a LUKS wrapping of a filesystem. It currently signifies only an encrypted squashfs mount, and the mount type is changed from `encryptfs -> squashfs` after the check implemented in `mount.image`.

The need for an encrypted SIF test in the e2e suite was overlooked.

This PR:

* Adds required e2e tests.
* Changes `encryptfs` -> `encrypted_squashfs` for clarity.
* Gates `encrypted_squashfs` images on the `allow kernel squashfs` directive.

### This fixes or addresses the following GitHub issues:

 - Fixes #1614


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
