### PR TITLE
fix: apply allow kernel squashfs directive to encrypted squashfs (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+## Bug Fixes
+
+- Ensure the `allow kernel squashfs` directive in `singularity.conf` applies to
+  encrypted squashfs filesystems in a SIF.
+
 ## 3.11.2 \[2023-04-27\]
 
 ### New Features & Functionality

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -628,6 +628,23 @@ func (c configTests) configGlobal(t *testing.T) {
 			directiveValue: "yes",
 			exit:           0,
 		},
+		// Encrypted squashFS rootfs in SIF
+		{
+			name:           "AllowKernelSquashfsNo_Encrypted",
+			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow kernel squashfs",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "AllowKernelSquashfsYes_Encrypted",
+			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow kernel squashfs",
+			directiveValue: "yes",
+			exit:           0,
+		},
 		// ext3 writable overlay in SIF
 		{
 			name:           "AllowKernelExtfsNo_SIF",


### PR DESCRIPTION
_Don't merge until after release-3.11 -> master merge_

## Description of the Pull Request (PR):

Pick #1617

The `allow kernel squashfs` directive was not applied correctly to limit mounts of encrypted squashfs images.

The `encryptfs` mount type is not a generic marker of a LUKS wrapping of a filesystem. It currently signifies only an encrypted squashfs mount, and the mount type is changed from `encryptfs -> squashfs` after the check implemented in `mount.image`.

The need for an encrypted SIF test in the e2e suite was overlooked.

This PR:

* Adds required e2e tests.
* Changes `encryptfs` -> `encrypted_squashfs` for clarity.
* Gates `encrypted_squashfs` images on the `allow kernel squashfs` directive.

### This fixes or addresses the following GitHub issues:

 - Fixes #1614 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
