### PR TITLE
oci: Enable --writable-tmpfs behaviour by default (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Changes Since Last Release
 
+### Changed defaults / behaviours
+
+- `--oci` mode now provides a writable container by default, using a tmpfs
+  overlay. This improves parity with `--compat` mode in the native runtime, as
+  `--compat` enables `--writable-tmpfs`.
+
 ## Bug Fixes
 
 - Ensure the `allow kernel squashfs` directive in `singularity.conf` applies to

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting Jason Tuschen (tusch@sylabs.io). All complaints will be
+reported by contacting Jason Tuschen (<tusch@sylabs.io>). All complaints will be
 reviewed and investigated and will result in a response that is deemed necessary
 and appropriate to the circumstances. The project team is obligated to maintain
 confidentiality with regard to the reporter of an incident. Further details of

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,6 @@ SingularityCE follows the Sylabs Security Policy available at:
 ## Reporting a Vulnerability
 
 If you have found a vulnerability in SingularityCE, please review the policy
-linked above and then contact security@sylabs.io
+linked above and then contact <security@sylabs.io>
 
 PGP encrypted email is accepted, with key details at the link above.

--- a/docs/content.go
+++ b/docs/content.go
@@ -976,6 +976,9 @@ Enterprise Performance Computing (EPC)`
   $ singularity oci attach mycontainer
   $ singularity oci delete mycontainer`
 
+	// Internal oci launcher use only - no user-facing docs
+	OciRunWrappedUse string = `run-wrapped -b <bundle_path> [run options...] <container_ID>`
+
 	OciUpdateUse   string = `update [update options...] <container_ID>`
 	OciUpdateShort string = `Update container cgroups resources (root user only)`
 	OciUpdateLong  string = `

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2516,11 +2516,12 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		// OCI Runtime Mode
 		//
-		"ociRun":     c.actionOciRun,     // singularity run --oci
-		"ociExec":    c.actionOciExec,    // singularity exec --oci
-		"ociShell":   c.actionOciShell,   // singularity shell --oci
-		"ociNetwork": c.actionOciNetwork, // singularity exec --oci --net
-		"ociBinds":   c.actionOciBinds,   // singularity exec --oci --bind / --mount
-		"ociIDMaps":  c.actionOciIDMaps,  // check uid/gid mapping on host for --oci as user / --fakeroot
+		"ociRun":     c.actionOciRun,        // singularity run --oci
+		"ociExec":    c.actionOciExec,       // singularity exec --oci
+		"ociShell":   c.actionOciShell,      // singularity shell --oci
+		"ociNetwork": c.actionOciNetwork,    // singularity exec --oci --net
+		"ociBinds":   c.actionOciBinds,      // singularity exec --oci --bind / --mount
+		"ociIDMaps":  c.actionOciIDMaps,     // check uid/gid mapping on host for --oci as user / --fakeroot
+		"ociCompat":  np(c.actionOciCompat), // --oci equivalence to native mode --compat
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -674,5 +675,62 @@ func (c actionTests) actionOciIDMaps(t *testing.T) {
 				}),
 			)
 		})
+	}
+}
+
+// actionOCICompat checks that the --oci mode has the behavior that the native mode gains from the --compat flag.
+// Must be run in sequential section as it modifies host process umask.
+func (c actionTests) actionOciCompat(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	type test struct {
+		name     string
+		args     []string
+		exitCode int
+		expect   e2e.SingularityCmdResultOp
+	}
+
+	tests := []test{
+		{
+			name:     "containall",
+			args:     []string{imageRef, "sh", "-c", "ls -lah $HOME"},
+			exitCode: 0,
+			expect:   e2e.ExpectOutput(e2e.ContainMatch, "total 0"),
+		},
+		{
+			name:     "writable-tmpfs",
+			args:     []string{imageRef, "sh", "-c", "touch /test"},
+			exitCode: 0,
+		},
+		{
+			name:     "no-init",
+			args:     []string{imageRef, "sh", "-c", "ps"},
+			exitCode: 0,
+			expect:   e2e.ExpectOutput(e2e.UnwantedContainMatch, "sinit"),
+		},
+		{
+			name:     "no-umask",
+			args:     []string{imageRef, "sh", "-c", "umask"},
+			exitCode: 0,
+			expect:   e2e.ExpectOutput(e2e.ContainMatch, "0022"),
+		},
+	}
+
+	oldUmask := syscall.Umask(0)
+	defer syscall.Umask(oldUmask)
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(
+				tt.exitCode,
+				tt.expect,
+			),
+		)
 	}
 }

--- a/internal/app/singularity/oci_linux.go
+++ b/internal/app/singularity/oci_linux.go
@@ -42,6 +42,15 @@ func OciRun(ctx context.Context, containerID string, args *OciArgs) error {
 	return oci.Run(ctx, containerID, args.BundlePath, args.PidFile, systemdCgroups)
 }
 
+// OciRun runs a container via the OCI runtime, wrapped with prep / cleanup steps.
+func OciRunWrapped(ctx context.Context, containerID string, args *OciArgs) error {
+	systemdCgroups, err := systemdCgroups()
+	if err != nil {
+		return err
+	}
+	return oci.RunWrapped(ctx, containerID, args.BundlePath, args.PidFile, systemdCgroups)
+}
+
 // OciCreate creates a container from an OCI bundle
 func OciCreate(containerID string, args *OciArgs) error {
 	systemdCgroups, err := systemdCgroups()

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -77,7 +77,7 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "Writable")
 	}
 	if lo.WritableTmpfs {
-		badOpt = append(badOpt, "WritableTmpfs")
+		sylog.Infof("--oci mode uses --writable-tmpfs by default")
 	}
 	if len(lo.OverlayPaths) > 0 {
 		badOpt = append(badOpt, "OverlayPaths")
@@ -461,12 +461,12 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	}
 
 	if os.Getuid() == 0 {
-		// Direct execution of runc/crun run.
-		err = Run(ctx, id.String(), b.Path(), "", l.singularityConf.SystemdCgroups)
+		// Execution of runc/crun run, wrapped with prep / cleanup.
+		err = RunWrapped(ctx, id.String(), b.Path(), "", l.singularityConf.SystemdCgroups)
 	} else {
 		// Reexec singularity oci run in a userns with mappings.
 		// Note - the oci run command will pull out the SystemdCgroups setting from config.
-		err = RunNS(ctx, id.String(), b.Path(), "")
+		err = RunWrappedNS(ctx, id.String(), b.Path(), "")
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -35,8 +35,8 @@ func minimalSpec() specs.Spec {
 	}
 	config.Root = &specs.Root{
 		Path: "rootfs",
-		// TODO - support writable-tmpfs / writable
-		Readonly: true,
+		// TODO - support read-only. At present we always have a writable tmpfs overlay, like native runtime --compat.
+		Readonly: false,
 	}
 	config.Process = &specs.Process{
 		Terminal: true,

--- a/pkg/ocibundle/tools/overlay_linux.go
+++ b/pkg/ocibundle/tools/overlay_linux.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 )
 
-// CreateOverlay creates a writable overlay
+// CreateOverlay creates a writable overlay based on a directory.
 func CreateOverlay(bundlePath string) error {
 	var err error
 
@@ -45,18 +45,57 @@ func CreateOverlay(bundlePath string) error {
 		return fmt.Errorf("failed to remount %s: %s", overlayDir, err)
 	}
 
+	err = prepareOverlay(bundlePath, overlayDir)
+	return err
+}
+
+// CreateOverlay creates a writable overlay based on a tmpfs.
+func CreateOverlayTmpfs(bundlePath string, sizeMiB int) error {
+	var err error
+
+	oldumask := syscall.Umask(0)
+	defer syscall.Umask(oldumask)
+
+	overlayDir := filepath.Join(bundlePath, "overlay")
+	if err = os.Mkdir(overlayDir, 0o700); err != nil {
+		return fmt.Errorf("failed to create %s: %s", overlayDir, err)
+	}
+	// delete overlay directory in case of error
+	defer func() {
+		if err != nil {
+			os.RemoveAll(overlayDir)
+		}
+	}()
+
+	options := fmt.Sprintf("mode=1777,size=%dm", sizeMiB)
+	err = syscall.Mount("tmpfs", overlayDir, "tmpfs", syscall.MS_NODEV, options)
+	if err != nil {
+		return fmt.Errorf("failed to bind %s: %s", overlayDir, err)
+	}
+	// best effort to cleanup mount
+	defer func() {
+		if err != nil {
+			syscall.Unmount(overlayDir, syscall.MNT_DETACH)
+		}
+	}()
+
+	err = prepareOverlay(bundlePath, overlayDir)
+	return err
+}
+
+func prepareOverlay(bundlePath, overlayDir string) error {
 	upperDir := filepath.Join(overlayDir, "upper")
-	if err = os.Mkdir(upperDir, 0o755); err != nil {
+	if err := os.Mkdir(upperDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create %s: %s", upperDir, err)
 	}
 	workDir := filepath.Join(overlayDir, "work")
-	if err = os.Mkdir(workDir, 0o700); err != nil {
+	if err := os.Mkdir(workDir, 0o700); err != nil {
 		return fmt.Errorf("failed to create %s: %s", workDir, err)
 	}
 	rootFsDir := RootFs(bundlePath).Path()
 
 	options := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", rootFsDir, upperDir, workDir)
-	if err = syscall.Mount("overlay", rootFsDir, "overlay", 0, options); err != nil {
+	if err := syscall.Mount("overlay", rootFsDir, "overlay", 0, options); err != nil {
 		return fmt.Errorf("failed to mount %s: %s", overlayDir, err)
 	}
 	return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1622

The `--oci` mode intends to follow behaviour that the native runtime implements when run with `--compat`.

One missing aspect is that `--compat` sets `--writable-tmpfs`, where the container rootfs is made writable with a tmpfs backed overlay.

This PR:

- Introduces a simple wrapping of the `oci run` sub-command as `oci run-wrapped`. This hidden command implements prep / cleanup steps that must take place in a userns for non-root `--oci` execution.
- Switches the oci launcher to calling `oci run-wrapped` instead of `oci-run`.
- Adds a tmpfs based overlay creation function for OCI bundles.
- Includes the tmpfs overlay creation in the `oci run-wrapped` flow.
- Copies the native runtime `--compat` e2e tests to OCI mode.

### This fixes or addresses the following GitHub issues:

 - Fixes #1621 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
