### PR TITLE
Go version in CircleCI config 1.20.3 -> 1.20.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.20.3'
+    default: '1.20.4'
 
 executors:
   node:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Change version of Go in CircleCI config (.circleci/config.yml) from 1.20.3 to 1.20.4

