### PR TITLE
chg minimal Go version in mconfig to 1.18

### DIFF
--- a/mconfig
+++ b/mconfig
@@ -20,7 +20,7 @@ hstld=
 hstranlib=
 hstobjcopy=
 hstgo=
-hstgo_version="1.17"
+hstgo_version="1.18"
 hstgo_opts="go"
 
 tgtcc=


### PR DESCRIPTION
## Description of the Pull Request (PR):

Given that we now have code that relies on Go Generics (ver. 1.18+) even outside of the testing suite (see e.g. #1562), the minimal Go version specified in `mconfig` has been changed from 1.17 to 1.18

