### PR TITLE
oci: support --overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
   `--fakeroot`, for example).
 - The `remote status` command will now print the username, realname, and email
   of the logged-in user, if available.
+- OCI-mode now supports `--overlay <overlay_dir>` flag, to use a directory as an
+  overlay in lieu of a writable tmpfs (which is the default behavior since
+  version 3.11.3). This enables writes to the filesystem to persist across runs
+  of the OCI container. If `<overlay_dir>` does not exist, Singularity will
+  attempt to create it.
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,10 @@
   `--fakeroot`, for example).
 - The `remote status` command will now print the username, realname, and email
   of the logged-in user, if available.
-- OCI-mode now supports `--overlay <overlay_dir>` flag, to use a directory as an
-  overlay in lieu of a writable tmpfs (which is the default behavior since
-  version 3.11.3). This enables writes to the filesystem to persist across runs
-  of the OCI container. If `<overlay_dir>` does not exist, Singularity will
-  attempt to create it.
+- OCI-mode now supports `--overlay <dir>` flag, allowing writes to the
+  filesystem to persist across runs of the OCI container. If specified dir does
+  not exist, Singularity will attempt to create it. Multiple overlays can be
+  specified, but all but one must be read-only (`--overlay <dir>:ro`).
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -36,12 +36,11 @@ var ociBundleFlag = cmdline.Flag{
 // -o|--overlay
 var ociOverlayFlag = cmdline.Flag{
 	ID:           "ociOverlayFlag",
-	Value:        &ociArgs.OverlayPath,
-	DefaultValue: "",
+	Value:        &ociArgs.OverlayPaths,
+	DefaultValue: []string{},
 	Name:         "overlay",
 	ShortHand:    "o",
-	Usage:        "specify an overlay dir to use in lieu of a writeable tmpfs",
-	EnvKeys:      []string{"OVERLAY"},
+	Usage:        "specify an overlay dir to use in lieu of a writable tmpfs",
 	Tag:          "<path>",
 }
 
@@ -135,10 +134,10 @@ func init() {
 		createRunCmd := cmdManager.GetCmdGroup("create_run")
 
 		cmdManager.RegisterFlagForCmd(&ociBundleFlag, createRunCmd...)
-		cmdManager.RegisterFlagForCmd(&ociOverlayFlag, OciRunWrappedCmd)
 		cmdManager.RegisterFlagForCmd(&ociLogPathFlag, createRunCmd...)
 		cmdManager.RegisterFlagForCmd(&ociLogFormatFlag, createRunCmd...)
 		cmdManager.RegisterFlagForCmd(&ociPidFileFlag, createRunCmd...)
+		cmdManager.RegisterFlagForCmd(&ociOverlayFlag, OciRunWrappedCmd)
 		cmdManager.RegisterFlagForCmd(&ociKillForceFlag, OciKillCmd)
 		cmdManager.RegisterFlagForCmd(&ociKillSignalFlag, OciKillCmd)
 		cmdManager.RegisterFlagForCmd(&ociUpdateFromFileFlag, OciUpdateCmd)

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -33,6 +33,18 @@ var ociBundleFlag = cmdline.Flag{
 	EnvKeys:      []string{"BUNDLE"},
 }
 
+// -o|--overlay
+var ociOverlayFlag = cmdline.Flag{
+	ID:           "ociOverlayFlag",
+	Value:        &ociArgs.OverlayPath,
+	DefaultValue: "",
+	Name:         "overlay",
+	ShortHand:    "o",
+	Usage:        "specify an overlay dir to use in lieu of a writeable tmpfs",
+	EnvKeys:      []string{"OVERLAY"},
+	Tag:          "<path>",
+}
+
 // -l|--log-path
 var ociLogPathFlag = cmdline.Flag{
 	ID:           "ociLogPathFlag",
@@ -123,6 +135,7 @@ func init() {
 		createRunCmd := cmdManager.GetCmdGroup("create_run")
 
 		cmdManager.RegisterFlagForCmd(&ociBundleFlag, createRunCmd...)
+		cmdManager.RegisterFlagForCmd(&ociOverlayFlag, OciRunWrappedCmd)
 		cmdManager.RegisterFlagForCmd(&ociLogPathFlag, createRunCmd...)
 		cmdManager.RegisterFlagForCmd(&ociLogFormatFlag, createRunCmd...)
 		cmdManager.RegisterFlagForCmd(&ociPidFileFlag, createRunCmd...)

--- a/docs/content.go
+++ b/docs/content.go
@@ -977,7 +977,7 @@ Enterprise Performance Computing (EPC)`
   $ singularity oci delete mycontainer`
 
 	// Internal oci launcher use only - no user-facing docs
-	OciRunWrappedUse string = `run-wrapped -b <bundle_path> [run options...] <container_ID>`
+	OciRunWrappedUse string = `run-wrapped -b <bundle_path> [-o <overlay_dir>] [run options...] <container_ID>`
 
 	OciUpdateUse   string = `update [update options...] <container_ID>`
 	OciUpdateShort string = `Update container cgroups resources (root user only)`

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2592,5 +2592,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociCdi":     c.actionOciCdi,        // singularity exec --oci --cdi
 		"ociIDMaps":  c.actionOciIDMaps,     // check uid/gid mapping on host for --oci as user / --fakeroot
 		"ociCompat":  np(c.actionOciCompat), // --oci equivalence to native mode --compat
+		"ociOverlay": (c.actionOciOverlay),  // --overlay in OCI mode
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -241,7 +241,7 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			argv: []string{"--home", "/tmp", imageRef, "cat", "/etc/passwd"},
 			exit: 0,
 			wantOutputs: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.RegexMatch, `^root:x:0:0:root:[^:]*:/bin/sh\n`),
+				e2e.ExpectOutput(e2e.RegexMatch, `^root:x:0:0:root:[^:]*:/bin/ash\n`),
 			},
 		},
 	}
@@ -811,7 +811,7 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 
 					// Generate the command to be executed in the container
 					// Start by printing all environment variables, to test using e2e.ContainMatch conditions later
-					execCmd := "/bin/env"
+					execCmd := "/usr/bin/env"
 
 					// Add commands to test the presence of mapped devices.
 					for _, d := range tt.DeviceNodes {
@@ -980,48 +980,92 @@ func (c actionTests) actionOciOverlay(t *testing.T) {
 	e2e.EnsureOCIArchive(t, c.env)
 	imageRef := "oci-archive:" + c.env.OCIArchivePath
 
-	// Create a temporary directory
-	testDir, err := fs.MakeTmpDir(c.env.TestDir, "overlaytestdir", 0o755)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		if !t.Failed() {
-			os.RemoveAll(testDir)
+	for _, profile := range []e2e.Profile{e2e.OCIRootProfile, e2e.OCIFakerootProfile} {
+		testDir, err := fs.MakeTmpDir(c.env.TestDir, "overlaytestdir", 0o755)
+		if err != nil {
+			t.Fatal(err)
 		}
-	})
+		t.Cleanup(func() {
+			if !t.Failed() {
+				os.RemoveAll(testDir)
+			}
+		})
 
-	type test struct {
-		name     string
-		args     []string
-		exitCode int
-		expect   e2e.SingularityCmdResultOp
-	}
+		// Create a few read-only overlay subdirs under testDir
+		for i := 0; i < 3; i++ {
+			dirName := fmt.Sprintf("my_ro_ol_dir%d", i)
+			fullPath := filepath.Join(testDir, dirName)
+			if err = os.Mkdir(fullPath, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if !t.Failed() {
+					os.RemoveAll(fullPath)
+				}
+			})
+			if err = os.WriteFile(
+				filepath.Join(fullPath, fmt.Sprintf("testfile.%d", i)),
+				[]byte(fmt.Sprintf("test_string_%d\n", i)),
+				0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err = os.WriteFile(
+				filepath.Join(fullPath, "maskable_testfile"),
+				[]byte(fmt.Sprintf("maskable_string_%d\n", i)),
+				0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
 
-	tests := []test{
-		{
-			name:     "NewOverlayDir",
-			args:     []string{"--overlay", filepath.Join(testDir, "my_overlay_dir"), imageRef, "sh", "-c", "echo my_test_string > /my_test_file"},
-			exitCode: 0,
-		},
-		{
-			name:     "ExistOverlayDir",
-			args:     []string{"--overlay", filepath.Join(testDir, "my_overlay_dir"), imageRef, "cat", "/my_test_file"},
-			exitCode: 0,
-			expect:   e2e.ExpectOutput(e2e.ExactMatch, "my_test_string"),
-		},
-	}
-	for _, tt := range tests {
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.OCIUserProfile),
-			e2e.WithCommand("exec"),
-			e2e.WithArgs(tt.args...),
-			e2e.ExpectExit(
-				tt.exitCode,
-				tt.expect,
-			),
-		)
+		tests := []struct {
+			name        string
+			args        []string
+			exitCode    int
+			wantOutputs []e2e.SingularityCmdResultOp
+		}{
+			{
+				name:     "NewWritable",
+				args:     []string{"--overlay", filepath.Join(testDir, "my_rw_ol_dir"), imageRef, "sh", "-c", "echo my_test_string > /my_test_file"},
+				exitCode: 0,
+			},
+			{
+				name:     "ExistWritable",
+				args:     []string{"--overlay", filepath.Join(testDir, "my_rw_ol_dir"), imageRef, "cat", "/my_test_file"},
+				exitCode: 0,
+				wantOutputs: []e2e.SingularityCmdResultOp{
+					e2e.ExpectOutput(e2e.ExactMatch, "my_test_string"),
+				},
+			},
+			{
+				name:     "NonExistReadonly",
+				args:     []string{"--overlay", filepath.Join(testDir, "my_ro_ol_dir_nonexistent:ro"), imageRef, "echo", "hi"},
+				exitCode: 255,
+			},
+			{
+				name:     "SeveralReadonly",
+				args:     []string{"--overlay", filepath.Join(testDir, "my_ro_ol_dir2:ro"), "--overlay", filepath.Join(testDir, "my_ro_ol_dir1:ro"), imageRef, "cat", "/testfile.1", "/maskable_testfile"},
+				exitCode: 0,
+				wantOutputs: []e2e.SingularityCmdResultOp{
+					e2e.ExpectOutput(e2e.ContainMatch, "test_string_1"),
+					e2e.ExpectOutput(e2e.ContainMatch, "maskable_string_2"),
+				},
+			},
+		}
+
+		t.Run(profile.String(), func(t *testing.T) {
+			for _, tt := range tests {
+				c.env.RunSingularity(
+					t,
+					e2e.AsSubtest(tt.name),
+					e2e.WithProfile(profile),
+					e2e.WithCommand("exec"),
+					e2e.WithArgs(tt.args...),
+					e2e.ExpectExit(
+						tt.exitCode,
+						tt.wantOutputs...,
+					),
+				)
+			}
+		})
 	}
 }

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -488,28 +488,28 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 		dfd  e2e.DefFileDetails
 	}{
 		{
-			name: "BusyBox",
+			name: "Alpine",
 			exit: 0,
 			dfd: e2e.DefFileDetails{
 				Bootstrap: "docker",
-				From:      c.env.TestRegistry + "/my-busybox",
+				From:      c.env.TestRegistry + "/my-alpine",
 			},
 		},
 		{
-			name: "BusyBoxRegistry",
+			name: "AlpineRegistry",
 			exit: 0,
 			dfd: e2e.DefFileDetails{
 				Bootstrap: "docker",
-				From:      "my-busybox",
+				From:      "my-alpine",
 				Registry:  c.env.TestRegistry,
 			},
 		},
 		{
-			name: "BusyBoxNamespace",
+			name: "AlpineNamespace",
 			exit: 255,
 			dfd: e2e.DefFileDetails{
 				Bootstrap: "docker",
-				From:      "my-busybox",
+				From:      "my-alpine",
 				Registry:  c.env.TestRegistry,
 				Namespace: "not-a-namespace",
 			},

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -82,7 +82,7 @@ func (c ctx) issue5172(t *testing.T) {
 	u := e2e.UserProfile.HostUser(t)
 
 	// create $HOME/.config/containers/registries.conf
-	regImage := "docker://" + c.env.TestRegistry + "/my-busybox"
+	regImage := "docker://" + c.env.TestRegistry + "/my-alpine"
 	regDir := filepath.Join(u.Dir, ".config", "containers")
 	regFile := filepath.Join(regDir, "registries.conf")
 	imagePath := filepath.Join(c.env.TestDir, "issue-5172")

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1550,7 +1550,7 @@ func (c imgBuildTests) buildBindMount(t *testing.T) {
 	}
 }
 
-// testWritableTmpfs checks that we can run the build using a writeable tmpfs in the %test step
+// testWritableTmpfs checks that we can run the build using a writable tmpfs in the %test step
 func (c imgBuildTests) testWritableTmpfs(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -194,9 +194,9 @@ func Run(t *testing.T) {
 
 	// Provision local registry
 	testenv.TestRegistry = e2e.StartRegistry(t, testenv)
-	testenv.TestRegistryImage = fmt.Sprintf("docker://%s/my-busybox:latest", testenv.TestRegistry)
+	testenv.TestRegistryImage = fmt.Sprintf("docker://%s/my-alpine:latest", testenv.TestRegistry)
 
-	// Copy small test image (busybox:latest) into local registry from DockerHub
+	// Copy small test image (alpine:latest) into local registry from DockerHub
 	insecureSource := false
 	insecureValue := os.Getenv("E2E_DOCKER_MIRROR_INSECURE")
 	if insecureValue != "" {
@@ -205,7 +205,7 @@ func Run(t *testing.T) {
 			t.Fatalf("could not convert E2E_DOCKER_MIRROR_INSECURE=%s: %s", insecureValue, err)
 		}
 	}
-	e2e.CopyOCIImage(t, "docker://busybox:latest", testenv.TestRegistryImage, insecureSource, true)
+	e2e.CopyOCIImage(t, "docker://alpine:latest", testenv.TestRegistryImage, insecureSource, true)
 
 	// SIF base test path, built on demand by e2e.EnsureImage
 	imagePath := path.Join(name, "test.sif")

--- a/internal/app/singularity/oci_linux.go
+++ b/internal/app/singularity/oci_linux.go
@@ -50,15 +50,7 @@ func OciRunWrapped(ctx context.Context, containerID string, args *OciArgs) error
 		return err
 	}
 
-	runFunc := func() error {
-		return oci.Run(ctx, containerID, args.BundlePath, args.PidFile, systemdCgroups)
-	}
-
-	if len(args.OverlayPaths) > 0 {
-		return oci.WrapWithOverlays(runFunc, args.BundlePath, args.OverlayPaths)
-	}
-
-	return oci.WrapWithWritableTmpFs(runFunc, args.BundlePath)
+	return oci.RunWrapped(ctx, containerID, args.BundlePath, args.PidFile, args.OverlayPaths, systemdCgroups)
 }
 
 // OciCreate creates a container from an OCI bundle

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -470,22 +470,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 
 	if os.Getuid() == 0 {
 		// Execution of runc/crun run, wrapped with prep / cleanup.
-		if len(l.cfg.OverlayPaths) > 0 {
-			err = WrapWithOverlays(
-				func() error {
-					return Run(ctx, id.String(), b.Path(), "", l.singularityConf.SystemdCgroups)
-				},
-				b.Path(),
-				l.cfg.OverlayPaths,
-			)
-		} else {
-			err = WrapWithWriteableTmpFs(
-				func() error {
-					return Run(ctx, id.String(), b.Path(), "", l.singularityConf.SystemdCgroups)
-				},
-				b.Path(),
-			)
-		}
+		err = l.RunWithOverlays(ctx, id.String(), b.Path())
 	} else {
 		// Reexec singularity oci run in a userns with mappings.
 		// Note - the oci run command will pull out the SystemdCgroups setting from config.
@@ -496,6 +481,18 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		os.Exit(exitErr.ExitCode())
 	}
 	return err
+}
+
+func (l *Launcher) RunWithOverlays(ctx context.Context, containerID, bundleDir string) error {
+	runFunc := func() error {
+		return Run(ctx, containerID, bundleDir, "", l.singularityConf.SystemdCgroups)
+	}
+
+	if len(l.cfg.OverlayPaths) > 0 {
+		return WrapWithOverlays(runFunc, bundleDir, l.cfg.OverlayPaths)
+	}
+
+	return WrapWithWritableTmpFs(runFunc, bundleDir)
 }
 
 // getCgroup will return a cgroup path and resources for the runtime to create.

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -81,9 +81,6 @@ func checkOpts(lo launcher.Options) error {
 	if lo.WritableTmpfs {
 		sylog.Infof("--oci mode uses --writable-tmpfs by default")
 	}
-	if len(lo.OverlayPaths) > 0 {
-		badOpt = append(badOpt, "OverlayPaths")
-	}
 	if lo.WorkDir != "" {
 		badOpt = append(badOpt, "WorkDir")
 	}
@@ -473,11 +470,26 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 
 	if os.Getuid() == 0 {
 		// Execution of runc/crun run, wrapped with prep / cleanup.
-		err = RunWrapped(ctx, id.String(), b.Path(), "", l.singularityConf.SystemdCgroups)
+		if len(l.cfg.OverlayPaths) > 0 {
+			err = WrapWithOverlays(
+				func() error {
+					return Run(ctx, id.String(), b.Path(), "", l.singularityConf.SystemdCgroups)
+				},
+				b.Path(),
+				l.cfg.OverlayPaths,
+			)
+		} else {
+			err = WrapWithWriteableTmpFs(
+				func() error {
+					return Run(ctx, id.String(), b.Path(), "", l.singularityConf.SystemdCgroups)
+				},
+				b.Path(),
+			)
+		}
 	} else {
 		// Reexec singularity oci run in a userns with mappings.
 		// Note - the oci run command will pull out the SystemdCgroups setting from config.
-		err = RunWrappedNS(ctx, id.String(), b.Path(), "")
+		err = RunWrappedNS(ctx, id.String(), b.Path(), l.cfg.OverlayPaths)
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -470,7 +470,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 
 	if os.Getuid() == 0 {
 		// Execution of runc/crun run, wrapped with prep / cleanup.
-		err = l.RunWithOverlays(ctx, id.String(), b.Path())
+		err = RunWrapped(ctx, id.String(), b.Path(), "", l.cfg.OverlayPaths, l.singularityConf.SystemdCgroups)
 	} else {
 		// Reexec singularity oci run in a userns with mappings.
 		// Note - the oci run command will pull out the SystemdCgroups setting from config.
@@ -481,18 +481,6 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 		os.Exit(exitErr.ExitCode())
 	}
 	return err
-}
-
-func (l *Launcher) RunWithOverlays(ctx context.Context, containerID, bundleDir string) error {
-	runFunc := func() error {
-		return Run(ctx, containerID, bundleDir, "", l.singularityConf.SystemdCgroups)
-	}
-
-	if len(l.cfg.OverlayPaths) > 0 {
-		return WrapWithOverlays(runFunc, bundleDir, l.cfg.OverlayPaths)
-	}
-
-	return WrapWithWritableTmpFs(runFunc, bundleDir)
 }
 
 // getCgroup will return a cgroup path and resources for the runtime to create.

--- a/internal/pkg/runtime/launcher/oci/oci_overlay.go
+++ b/internal/pkg/runtime/launcher/oci/oci_overlay.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/sylabs/singularity/pkg/ocibundle/tools"
+	"github.com/sylabs/singularity/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/util/singularityconf"
+)
+
+// WrapWithWritableTmpFs runs a function wrapped with prep / cleanup steps for a writable tmpfs.
+func WrapWithWritableTmpFs(f func() error, bundleDir string) error {
+	// TODO: --oci mode always emulating --compat, which uses --writable-tmpfs.
+	//       Provide a way of disabling this, for a read only rootfs.
+	if err := prepareWritableTmpfs(bundleDir); err != nil {
+		return err
+	}
+
+	err := f()
+
+	// Cleanup actions log errors, but don't return - so we get as much cleanup done as possible.
+	if err := cleanupWritableTmpfs(bundleDir); err != nil {
+		sylog.Errorf("While cleaning up writable tmpfs: %v", err)
+	}
+
+	// Return any error from the actual container payload - preserve exit code.
+	return err
+}
+
+// WrapWithOverlays runs a function wrapped with prep / cleanup steps for overlays.
+func WrapWithOverlays(f func() error, bundleDir string, overlayPaths []string) error {
+	writableOverlayFound := false
+	ovs := tools.OverlaySet{}
+	for _, p := range overlayPaths {
+		writable := true
+		splitted := strings.SplitN(p, ":", 2)
+		barePath := splitted[0]
+		if len(splitted) > 1 {
+			if splitted[1] == "ro" {
+				writable = false
+			}
+		}
+
+		if writable && writableOverlayFound {
+			return fmt.Errorf("you can't specify more than one writable overlay; %#v has already been specified as a writable overlay; use '--overlay %s:ro' instead", ovs.WritableLoc, barePath)
+		}
+		if writable {
+			writableOverlayFound = true
+			ovs.WritableLoc = barePath
+		} else {
+			ovs.ReadonlyLocs = append(ovs.ReadonlyLocs, barePath)
+		}
+	}
+
+	if err := tools.MountOverlay(bundleDir, ovs); err != nil {
+		return err
+	}
+
+	err := f()
+
+	// Cleanup actions log errors, but don't return - so we get as much cleanup done as possible.
+	if err := tools.UnmountRootFSOverlay(bundleDir); err != nil {
+		sylog.Errorf("While unmounting rootfs overlay: %v", err)
+	}
+
+	// Return any error from the actual container payload - preserve exit code.
+	return err
+}
+
+func prepareWritableTmpfs(bundleDir string) error {
+	sylog.Debugf("Configuring writable tmpfs overlay for %s", bundleDir)
+	c := singularityconf.GetCurrentConfig()
+	if c == nil {
+		return fmt.Errorf("singularity configuration is not initialized")
+	}
+	return tools.CreateOverlayTmpfs(bundleDir, int(c.SessiondirMaxSize))
+}
+
+func cleanupWritableTmpfs(bundleDir string) error {
+	sylog.Debugf("Cleaning up writable tmpfs overlay for %s", bundleDir)
+	return tools.DeleteOverlay(bundleDir)
+}
+
+// absolutifyOverlay takes an overlay description string (a path, optionally followed by a colon with an option string, like ":ro" or ":rw"), and replaces any relative path in the description string with an absolute one.
+func absolutifyOverlay(desc string) (string, error) {
+	splitted := strings.SplitN(desc, ":", 2)
+	barePath := splitted[0]
+	absBarePath, err := filepath.Abs(barePath)
+	if err != nil {
+		return "", err
+	}
+	absDesc := absBarePath
+	if len(splitted) > 1 {
+		absDesc += ":" + splitted[1]
+	}
+
+	return absDesc, nil
+}

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -246,9 +246,9 @@ func RunWrappedNS(ctx context.Context, containerID, bundlePath string, overlayPa
 		"-b", absBundle,
 	}
 	for _, p := range overlayPaths {
-		absPath, err := absolutifyOverlay(p)
+		absPath, err := absOverlay(p)
 		if err != nil {
-			return fmt.Errorf("%w: could not convert %#v to absolute path", err, p)
+			return fmt.Errorf("could not convert %q to absolute path: %w", p, err)
 		}
 
 		args = append(args, "--overlay", absPath)

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -25,7 +25,7 @@ type Namespaces struct {
 type Options struct {
 	// Writable marks the container image itself as writable.
 	Writable bool
-	// WriteableTmpfs applies an ephemeral writable overlay to the container.
+	// WritableTmpfs applies an ephemeral writable overlay to the container.
 	WritableTmpfs bool
 	// OverlayPaths holds paths to image or directory overlays to be applied.
 	OverlayPaths []string

--- a/pkg/ocibundle/tools/overlay_linux.go
+++ b/pkg/ocibundle/tools/overlay_linux.go
@@ -12,40 +12,58 @@ import (
 	"syscall"
 )
 
-// CreateOverlay creates a writable overlay based on a directory.
+// CreateOverlay creates a writable overlay based on a directory inside the OCI bundle.
 func CreateOverlay(bundlePath string) error {
-	var err error
-
 	oldumask := syscall.Umask(0)
 	defer syscall.Umask(oldumask)
 
-	overlayDir := filepath.Join(bundlePath, "overlay")
-	if err = os.Mkdir(overlayDir, 0o700); err != nil {
-		return fmt.Errorf("failed to create %s: %s", overlayDir, err)
+	overlayPath := filepath.Join(bundlePath, "overlay")
+	var err error
+	if err = os.Mkdir(overlayPath, 0o700); err != nil {
+		return fmt.Errorf("failed to create %s: %s", overlayPath, err)
 	}
 	// delete overlay directory in case of error
 	defer func() {
 		if err != nil {
-			os.RemoveAll(overlayDir)
+			os.RemoveAll(overlayPath)
 		}
 	}()
 
-	err = syscall.Mount(overlayDir, overlayDir, "", syscall.MS_BIND, "")
+	return CreateOverlayByPath(bundlePath, overlayPath)
+}
+
+// CreateOverlayByPath creates a writable overlay based on a directory whose path is specified in the second argument.
+func CreateOverlayByPath(bundlePath string, overlayPath string) error {
+	var err error
+
+	_, err = os.Stat(overlayPath)
 	if err != nil {
-		return fmt.Errorf("failed to bind %s: %s", overlayDir, err)
+		if os.IsNotExist(err) {
+			err := os.Mkdir(overlayPath, 0o755)
+			if err != nil {
+				return fmt.Errorf("failed to create %s: %s", overlayPath, err)
+			}
+		} else {
+			return err
+		}
+	}
+
+	err = syscall.Mount(overlayPath, overlayPath, "", syscall.MS_BIND, "")
+	if err != nil {
+		return fmt.Errorf("failed to bind %s: %s", overlayPath, err)
 	}
 	// best effort to cleanup mount
 	defer func() {
 		if err != nil {
-			syscall.Unmount(overlayDir, syscall.MNT_DETACH)
+			syscall.Unmount(overlayPath, syscall.MNT_DETACH)
 		}
 	}()
 
-	if err = syscall.Mount("", overlayDir, "", syscall.MS_REMOUNT|syscall.MS_BIND, ""); err != nil {
-		return fmt.Errorf("failed to remount %s: %s", overlayDir, err)
+	if err = syscall.Mount("", overlayPath, "", syscall.MS_REMOUNT|syscall.MS_BIND, ""); err != nil {
+		return fmt.Errorf("failed to remount %s: %s", overlayPath, err)
 	}
 
-	err = prepareOverlay(bundlePath, overlayDir)
+	err = prepareOverlay(bundlePath, overlayPath)
 	return err
 }
 
@@ -84,20 +102,41 @@ func CreateOverlayTmpfs(bundlePath string, sizeMiB int) error {
 }
 
 func prepareOverlay(bundlePath, overlayDir string) error {
+	var err error
+
 	upperDir := filepath.Join(overlayDir, "upper")
-	if err := os.Mkdir(upperDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create %s: %s", upperDir, err)
+	_, err = os.Stat(upperDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err := os.Mkdir(upperDir, 0o755)
+			if err != nil {
+				return fmt.Errorf("failed to create %s: %s", upperDir, err)
+			}
+		} else {
+			return err
+		}
 	}
+
 	workDir := filepath.Join(overlayDir, "work")
-	if err := os.Mkdir(workDir, 0o700); err != nil {
-		return fmt.Errorf("failed to create %s: %s", workDir, err)
+	_, err = os.Stat(workDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err := os.Mkdir(workDir, 0o700)
+			if err != nil {
+				return fmt.Errorf("failed to create %s: %s", workDir, err)
+			}
+		} else {
+			return err
+		}
 	}
+
 	rootFsDir := RootFs(bundlePath).Path()
 
 	options := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", rootFsDir, upperDir, workDir)
 	if err := syscall.Mount("overlay", rootFsDir, "overlay", 0, options); err != nil {
 		return fmt.Errorf("failed to mount %s: %s", overlayDir, err)
 	}
+
 	return nil
 }
 

--- a/pkg/ocibundle/tools/overlay_linux.go
+++ b/pkg/ocibundle/tools/overlay_linux.go
@@ -13,12 +13,16 @@ import (
 	"syscall"
 )
 
+// OverlaySet represents a set of overlay directories which will be overlain on top of some filesystem mount point. The actual mount point atop which these directories will be overlain is not specified in the OverlaySet; it is left implicit, to be chosen by whichever function consumes an OverlaySet. An OverlaySet contains two types of directories: zero or more directories which will be mounted as read-only overlays atop the (implicit) mount point, and one directory which will be mounted as a writable overlay atop all the rest. An empty WritableLoc field indicates that no writable overlay is to be mounted.
 type OverlaySet struct {
+	// List of directories to be mounted as read-only overlays. The mount point atop which these will be mounted is left implicit, to be chosen by whichever function consumes the OverlaySet.
 	ReadonlyLocs []string
-	WritableLoc  string
+
+	// Directory to be mounted as a writable overlay. The mount point atop which this will be mounted is left implicit, to be chosen by whichever function consumes the OverlaySet. Empty value indicates no writable overlay is to be mounted.
+	WritableLoc string
 }
 
-// CreateOverlay creates a writable overlay based on a directory inside the OCI bundle.
+// CreateOverlay creates a writable overlay using a directory inside the OCI bundle.
 func CreateOverlay(bundlePath string) error {
 	oldumask := syscall.Umask(0)
 	defer syscall.Umask(oldumask)
@@ -35,10 +39,111 @@ func CreateOverlay(bundlePath string) error {
 		}
 	}()
 
-	return MountOverlay(bundlePath, OverlaySet{WritableLoc: overlayDir})
+	return ApplyOverlay(
+		RootFs(bundlePath).Path(),
+		OverlaySet{WritableLoc: overlayDir},
+	)
 }
 
-func MountOverlay(bundlePath string, ovs OverlaySet) error {
+// DeleteOverlay deletes an overlay previously created using a directory inside the OCI bundle.
+func DeleteOverlay(bundlePath string) error {
+	overlayDir := filepath.Join(bundlePath, "overlay")
+	rootFsDir := RootFs(bundlePath).Path()
+	return unmountAndDeleteOverlay(rootFsDir, overlayDir)
+}
+
+// CreateOverlay creates a writable overlay using tmpfs.
+func CreateOverlayTmpfs(bundlePath string, sizeMiB int) (string, error) {
+	var err error
+
+	oldumask := syscall.Umask(0)
+	defer syscall.Umask(oldumask)
+
+	overlayDir := filepath.Join(bundlePath, "overlay")
+	err = ensureOverlayDir(overlayDir, true, 0o700)
+	if err != nil {
+		return "", fmt.Errorf("failed to create %s: %s", overlayDir, err)
+	}
+	// delete overlay directory in case of error
+	defer func() {
+		if err != nil {
+			os.RemoveAll(overlayDir)
+		}
+	}()
+
+	options := fmt.Sprintf("mode=1777,size=%dm", sizeMiB)
+	err = syscall.Mount("tmpfs", overlayDir, "tmpfs", syscall.MS_NODEV, options)
+	if err != nil {
+		return "", fmt.Errorf("failed to bind %s: %s", overlayDir, err)
+	}
+	// best effort to cleanup mount
+	defer func() {
+		if err != nil {
+			syscall.Unmount(overlayDir, syscall.MNT_DETACH)
+		}
+	}()
+
+	err = ApplyOverlay(
+		RootFs(bundlePath).Path(),
+		OverlaySet{WritableLoc: overlayDir},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return overlayDir, nil
+}
+
+// DeleteOverlayTmpfs deletes an overlay previously created using tmpfs.
+func DeleteOverlayTmpfs(bundlePath, overlayDir string) error {
+	rootFsDir := RootFs(bundlePath).Path()
+	return unmountAndDeleteOverlay(rootFsDir, overlayDir)
+}
+
+// ApplyOverlay prepares and mounts the specified overlay
+func ApplyOverlay(rootFsDir string, ovs OverlaySet) error {
+	// Prepare internal structure of writable overlay dir, if necessary
+	if len(ovs.WritableLoc) > 0 {
+		if err := ensureOverlayDir(ovs.WritableLoc, true, 0o755); err != nil {
+			return err
+		}
+		if err := prepareWritableOverlay(ovs.WritableLoc); err != nil {
+			return err
+		}
+	}
+
+	// Perform identity mounts for this OverlaySet
+	if err := performIdentityMounts(ovs); err != nil {
+		return err
+	}
+
+	// Perform actual overlay mount
+	return performOverlayMount(rootFsDir, overlayOptions(rootFsDir, ovs))
+}
+
+// UnmountOverlay umounts an overlay
+func UnmountOverlay(rootFsDir string) error {
+	if err := syscall.Unmount(rootFsDir, syscall.MNT_DETACH); err != nil {
+		return fmt.Errorf("failed to unmount %s: %s", rootFsDir, err)
+	}
+
+	return nil
+}
+
+// prepareWritableOverlay ensures that the upper and work subdirs of a writable overlay dir exist, and if not, creates them.
+func prepareWritableOverlay(dir string) error {
+	if err := ensureOverlayDir(upperSubdirOf(dir), true, 0o755); err != nil {
+		return fmt.Errorf("err encountered while preparing upper subdir of overlay dir %q: %w", upperSubdirOf(dir), err)
+	}
+	if err := ensureOverlayDir(workSubdirOf(dir), true, 0o700); err != nil {
+		return fmt.Errorf("err encountered while preparing work subdir of overlay dir %q: %w", workSubdirOf(dir), err)
+	}
+
+	return nil
+}
+
+// performIdentityMounts performs the preparator identity mounts of overlay dirs, typically carried out prior to the actual overlay mount where these dirs are used as lowerdir or upperdir arguments.
+func performIdentityMounts(ovs OverlaySet) error {
 	var err error
 
 	locsToBind := ovs.ReadonlyLocs
@@ -74,43 +179,29 @@ func MountOverlay(bundlePath string, ovs OverlaySet) error {
 		}
 	}
 
-	// Prepare internal structure of overlay dir
-	err = prepareOverlay(bundlePath, ovs)
 	return err
 }
 
-// CreateOverlay creates a writable overlay based on a tmpfs.
-func CreateOverlayTmpfs(bundlePath string, sizeMiB int) error {
-	var err error
+// overlayOptions creates the options string to be used in an overlay mount
+func overlayOptions(rootFsDir string, ovs OverlaySet) string {
+	// Create lowerdir argument of options string
+	lowerDirJoined := strings.Join(append(ovs.ReadonlyLocs, rootFsDir), ":")
 
-	oldumask := syscall.Umask(0)
-	defer syscall.Umask(oldumask)
-
-	overlayDir := filepath.Join(bundlePath, "overlay")
-	if err = ensureOverlayDir(overlayDir, true, 0o700); err != nil {
-		return fmt.Errorf("failed to create %s: %s", overlayDir, err)
+	if len(ovs.WritableLoc) > 0 {
+		return fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDirJoined, upperSubdirOf(ovs.WritableLoc), workSubdirOf(ovs.WritableLoc))
 	}
-	// delete overlay directory in case of error
-	defer func() {
-		if err != nil {
-			os.RemoveAll(overlayDir)
-		}
-	}()
 
-	options := fmt.Sprintf("mode=1777,size=%dm", sizeMiB)
-	err = syscall.Mount("tmpfs", overlayDir, "tmpfs", syscall.MS_NODEV, options)
-	if err != nil {
-		return fmt.Errorf("failed to bind %s: %s", overlayDir, err)
+	return fmt.Sprintf("lowerdir=%s", lowerDirJoined)
+}
+
+// performOverlayMount mounts an overlay atop a given rootfs directory
+func performOverlayMount(rootFsDir, options string) error {
+	// Try to perform actual mount
+	if err := syscall.Mount("overlay", rootFsDir, "overlay", 0, options); err != nil {
+		return fmt.Errorf("failed to mount %s: %s", rootFsDir, err)
 	}
-	// best effort to cleanup mount
-	defer func() {
-		if err != nil {
-			syscall.Unmount(overlayDir, syscall.MNT_DETACH)
-		}
-	}()
 
-	err = prepareOverlay(bundlePath, OverlaySet{WritableLoc: overlayDir})
-	return err
+	return nil
 }
 
 // ensureOverlayDir checks if a directory already exists; if it doesn't, and writable is true, it attempts to create it with the specified permissions.
@@ -140,60 +231,26 @@ func ensureOverlayDir(dir string, createIfMissing bool, createPerm os.FileMode) 
 	return nil
 }
 
-func prepareOverlay(bundlePath string, ovs OverlaySet) error {
-	var err error
-
-	rootFsDir := RootFs(bundlePath).Path()
-	lowerDirJoined := strings.Join(append(ovs.ReadonlyLocs, rootFsDir), ":")
-
-	// Prepare options string for mount
-	var options string
-	if len(ovs.WritableLoc) > 0 {
-		upperDir := filepath.Join(ovs.WritableLoc, "upper")
-		if err = ensureOverlayDir(upperDir, true, 0o755); err != nil {
-			return err
-		}
-
-		workDir := filepath.Join(ovs.WritableLoc, "work")
-		if err = ensureOverlayDir(workDir, true, 0o700); err != nil {
-			return err
-		}
-
-		options = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDirJoined, upperDir, workDir)
-	} else {
-		options = fmt.Sprintf("lowerdir=%s", lowerDirJoined)
-	}
-
-	// Try to perform actual mount
-	if err := syscall.Mount("overlay", rootFsDir, "overlay", 0, options); err != nil {
-		return fmt.Errorf("failed to mount %s: %s", rootFsDir, err)
-	}
-
-	return nil
+func upperSubdirOf(overlayDir string) string {
+	return filepath.Join(overlayDir, "upper")
 }
 
-// DeleteOverlay deletes overlay
-func DeleteOverlay(bundlePath string) error {
-	if err := UnmountRootFSOverlay(bundlePath); err != nil {
+func workSubdirOf(overlayDir string) string {
+	return filepath.Join(overlayDir, "work")
+}
+
+// unmountAndDeleteOverlay unmounts and deletes a previously-created overlay.
+func unmountAndDeleteOverlay(rootFsDir, overlayDir string) error {
+	if err := UnmountOverlay(rootFsDir); err != nil {
 		return err
 	}
 
-	overlayDir := filepath.Join(bundlePath, "overlay")
 	if err := syscall.Unmount(overlayDir, syscall.MNT_DETACH); err != nil {
 		return fmt.Errorf("failed to unmount %s: %s", overlayDir, err)
 	}
+
 	if err := os.RemoveAll(overlayDir); err != nil {
 		return fmt.Errorf("failed to remove %s: %s", overlayDir, err)
-	}
-	return nil
-}
-
-// UnmountRootFSOverlay umounts a rootfs overlay
-func UnmountRootFSOverlay(bundlePath string) error {
-	rootFsDir := RootFs(bundlePath).Path()
-
-	if err := syscall.Unmount(rootFsDir, syscall.MNT_DETACH); err != nil {
-		return fmt.Errorf("failed to unmount %s: %s", rootFsDir, err)
 	}
 
 	return nil

--- a/pkg/ocibundle/tools/overlay_linux.go
+++ b/pkg/ocibundle/tools/overlay_linux.go
@@ -207,8 +207,8 @@ func performOverlayMount(rootFsDir, options string) error {
 // ensureOverlayDir checks if a directory already exists; if it doesn't, and writable is true, it attempts to create it with the specified permissions.
 func ensureOverlayDir(dir string, createIfMissing bool, createPerm os.FileMode) error {
 	_, err := os.Stat(dir)
-	if dir == "" {
-		panic("ensureOverlayDir on empty dir")
+	if len(dir) == 0 {
+		return fmt.Errorf("internal error: ensureOverlayDir() called with empty dir name")
 	}
 
 	if err == nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Support `--overlay <overlay_dir>` flag in OCI-mode (in "action" commands, i.e., run/exec/shell). This allows the user to mount a directory as a filesystem overlay, in lieu of using a writable tmpfs (which is the default behavior since version 3.11.3). This enables writes to the filesystem to persist across runs of the OCI container. If `<overlay_dir>` does not exist, Singularity will attempt to create it.

### This fixes or addresses the following GitHub issues:

 - Fixes #1478 

