### PR TITLE
Fix mount ordering between image and user binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   regardless of the value passed to `--home`). With this change, both value of
   `HOME` and the contents of `/etc/passwd` in the container will reflect the
   value passed to `--home`.
+- Bind mounts are now performed in the order of their occurrence in the
+  comma-separated list given to the `-B`/`--bind` flag, or given as the value of
+  the `SINGULARITY_BIND` environment variable. (Previously, image-mounts were
+  always performed first, regardless of the order of items in the
+  comma-separated list.)
 
 ### New Features & Functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,9 @@
   regardless of the value passed to `--home`). With this change, both value of
   `HOME` and the contents of `/etc/passwd` in the container will reflect the
   value passed to `--home`.
-- Bind mounts are now performed in the order of their occurrence in the
-  comma-separated list given to the `-B`/`--bind` flag, or given as the value of
-  the `SINGULARITY_BIND` environment variable. (Previously, image-mounts were
-  always performed first, regardless of the order of items in the
-  comma-separated list.)
+- Bind mounts are now performed in the order of their occurrence on the command
+  line, or within the value of the `SINGULARITY_BIND` environment variable.
+  (Previously, image-mounts were always performed first, regardless of order.)
 
 ### New Features & Functionality
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1872,6 +1872,11 @@ func (c actionTests) bindImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	scratchDir := filepath.Join(testdir, "scratch")
+	if err := os.MkdirAll(filepath.Join(scratchDir, "bin"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
 	cleanup := func(t *testing.T) {
 		if t.Failed() {
 			t.Logf("Not removing directory %s for test %s", testdir, t.Name())
@@ -2149,6 +2154,29 @@ func (c actionTests) bindImage(t *testing.T) {
 				"--bind", c.env.ImagePath + ":/rootfs:id=4",
 				c.env.ImagePath,
 				"test", "-d", "/rootfs/etc",
+			},
+			exit: 0,
+		},
+		// check ordering between image and user bind
+		{
+			name:    "SquashfsBeforeScratch",
+			profile: e2e.UserProfile,
+			args: []string{
+				"--bind", sifSquashImage + ":/scratch/bin:image-src=/",
+				"--bind", scratchDir + ":/scratch",
+				c.env.ImagePath,
+				"test", "-f", filepath.Join("/scratch/bin", squashMarkerFile),
+			},
+			exit: 1,
+		},
+		{
+			name:    "ScratchBeforeSquashfs",
+			profile: e2e.UserProfile,
+			args: []string{
+				"--bind", scratchDir + ":/scratch",
+				"--bind", sifSquashImage + ":/scratch/bin:image-src=/",
+				c.env.ImagePath,
+				"test", "-f", filepath.Join("/scratch/bin", squashMarkerFile),
 			},
 			exit: 0,
 		},


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bind mounts are now performed in the order of their occurrence in the comma-separated list given to the `-B`/`--bind` flag, or given as the value of the `SINGULARITY_BIND` environment variable. (Previously, image-mounts were always performed first, regardless of the order of items in the comma-separated list.)

(Cherry-picked from [apptainer/apptainer#188](https://github.com/apptainer/apptainer/pull/188) with expanded CHANGELOG comment.)

### This fixes or addresses the following GitHub issues:

 - Fixes #1604 

