### PR TITLE
oci: Don't attempt unpriv overlay when not supported (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- In `--oci` mode, do not attempt to use unprivileged overlay on systems that do
+  not support it.
+
 ## 3.11.3 \[2023-05-04\]
 
 ### Changed defaults / behaviours
@@ -8,7 +15,7 @@
   overlay. This improves parity with `--compat` mode in the native runtime, as
   `--compat` enables `--writable-tmpfs`.
 
-## Bug Fixes
+### Bug Fixes
 
 - Ensure the `allow kernel squashfs` directive in `singularity.conf` applies to
   encrypted squashfs filesystems in a SIF.

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -101,6 +101,15 @@ var ociUpdateFromFileFlag = cmdline.Flag{
 	EnvKeys:      []string{"FROM_FILE"},
 }
 
+// --writable-tmpfs (run-wrapped internal option)
+var ociWritableTmpfs = cmdline.Flag{
+	ID:           "ociWritableTmpfs",
+	Value:        &ociArgs.WritableTmpfs,
+	DefaultValue: false,
+	Name:         "writable-tmpfs",
+	Usage:        "Enable writable-tmpfs for oci run-wrapped",
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(OciCmd)
@@ -129,6 +138,8 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&ociKillForceFlag, OciKillCmd)
 		cmdManager.RegisterFlagForCmd(&ociKillSignalFlag, OciKillCmd)
 		cmdManager.RegisterFlagForCmd(&ociUpdateFromFileFlag, OciUpdateCmd)
+
+		cmdManager.RegisterFlagForCmd(&ociWritableTmpfs, OciRunWrappedCmd)
 	})
 }
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
@@ -688,6 +689,7 @@ func (c actionTests) actionOciCompat(t *testing.T) {
 		name     string
 		args     []string
 		exitCode int
+		requires func(t *testing.T)
 		expect   e2e.SingularityCmdResultOp
 	}
 
@@ -702,6 +704,9 @@ func (c actionTests) actionOciCompat(t *testing.T) {
 			name:     "writable-tmpfs",
 			args:     []string{imageRef, "sh", "-c", "touch /test"},
 			exitCode: 0,
+			// 5.13 is the first mainline kernel to support unpriv overlay.
+			// It is backported to various distros, but not easy to identify those.
+			requires: func(t *testing.T) { require.Kernel(t, 5, 13) },
 		},
 		{
 			name:     "no-init",
@@ -724,6 +729,7 @@ func (c actionTests) actionOciCompat(t *testing.T) {
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
+			e2e.PreRun(tt.requires),
 			e2e.WithProfile(e2e.OCIUserProfile),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.args...),

--- a/internal/app/singularity/oci_linux.go
+++ b/internal/app/singularity/oci_linux.go
@@ -22,15 +22,16 @@ import (
 
 // OciArgs contains CLI arguments
 type OciArgs struct {
-	BundlePath   string
-	LogPath      string
-	LogFormat    string
-	PidFile      string
-	FromFile     string
-	KillSignal   string
-	KillTimeout  uint32
-	EmptyProcess bool
-	ForceKill    bool
+	BundlePath    string
+	LogPath       string
+	LogFormat     string
+	PidFile       string
+	FromFile      string
+	KillSignal    string
+	KillTimeout   uint32
+	EmptyProcess  bool
+	ForceKill     bool
+	WritableTmpfs bool
 }
 
 // OciRun runs a container (equivalent to create/start/delete)
@@ -48,7 +49,7 @@ func OciRunWrapped(ctx context.Context, containerID string, args *OciArgs) error
 	if err != nil {
 		return err
 	}
-	return oci.RunWrapped(ctx, containerID, args.BundlePath, args.PidFile, systemdCgroups)
+	return oci.RunWrapped(ctx, containerID, args.BundlePath, args.PidFile, systemdCgroups, args.WritableTmpfs)
 }
 
 // OciCreate creates a container from an OCI bundle


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a system doesn't support unprivileged overlay mounts, do not attempt to use them.

This means that a writable-tmpfs is not used, and a container is read-only, when run on a system such as EL7 or SLES12.

The approach taken here is rather inelegant, but works. We'll address it more neatly on `main` where additional oci overlay handling has been developed.

Note that this PR must be tested both on a system supporting unpriv overlay (e.g. Ubuntu 22.04, RHEL9) and a system that doesn't (RHEL7, SLES12).

### This fixes or addresses the following GitHub issues:

 - Fixes #1676 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
