### PR TITLE
oci: Improve testing of overlay cleanup

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2584,14 +2584,15 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		//
 		// OCI Runtime Mode
 		//
-		"ociRun":     c.actionOciRun,        // singularity run --oci
-		"ociExec":    c.actionOciExec,       // singularity exec --oci
-		"ociShell":   c.actionOciShell,      // singularity shell --oci
-		"ociNetwork": c.actionOciNetwork,    // singularity exec --oci --net
-		"ociBinds":   c.actionOciBinds,      // singularity exec --oci --bind / --mount
-		"ociCdi":     c.actionOciCdi,        // singularity exec --oci --cdi
-		"ociIDMaps":  c.actionOciIDMaps,     // check uid/gid mapping on host for --oci as user / --fakeroot
-		"ociCompat":  np(c.actionOciCompat), // --oci equivalence to native mode --compat
-		"ociOverlay": (c.actionOciOverlay),  // --overlay in OCI mode
+		"ociRun":             c.actionOciRun,                 // singularity run --oci
+		"ociExec":            c.actionOciExec,                // singularity exec --oci
+		"ociShell":           c.actionOciShell,               // singularity shell --oci
+		"ociNetwork":         c.actionOciNetwork,             // singularity exec --oci --net
+		"ociBinds":           c.actionOciBinds,               // singularity exec --oci --bind / --mount
+		"ociCdi":             c.actionOciCdi,                 // singularity exec --oci --cdi
+		"ociIDMaps":          c.actionOciIDMaps,              // check uid/gid mapping on host for --oci as user / --fakeroot
+		"ociCompat":          np(c.actionOciCompat),          // --oci equivalence to native mode --compat
+		"ociOverlay":         (c.actionOciOverlay),           // --overlay in OCI mode
+		"ociOverlayTeardown": np(c.actionOciOverlayTeardown), // proper overlay unmounting in OCI mode
 	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

In working on #1659 and #1671 , it emerged that in some scenarios (esp. when running as root), our cleanup of overlay mounts was incomplete. Importantly, that cleanup process intentionally logs errors and proceeds (rather than erroring out), in order to clean up as much as possible even under error conditions; but that means that we can't rely simply on exit codes to detect problems in the cleanup of overlay mounts.

This PR adds an e2e test specifically dedicated to detecting such problems, by running an OCI-mode container as root, and comparing the number of current mounts before & after the run.



