### PR TITLE
Set custom configuration directory via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@
   specified, but all but one must be read-only (`--overlay <dir>:ro`).
 - The `tap` CNI plugin, new to github.com/containernetworking/plugins v1.3.0,
   is now provided.
+- OCI-mode now supports the `--workdir <workdir>` option. If this option is
+  specified, `/tmp` and `/var/tmp` will be mapped, respectively, to
+  `<workdir>/tmp` and `<workdir>/var_tmp` on the host, rather than to tmpfs
+  storage. If `--scratch <scratchdir>` is used in conjunction with `--workdir`,
+  scratch directories will be mapped to subdirectories nested under
+  `<workdir>/scratch` on the host, rather than to tmpfs storage.
 - Added ability to set a custom config directory via the new
   `SINGULARITY_CONFIGDIR` environment variable.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
   specified, but all but one must be read-only (`--overlay <dir>:ro`).
 - The `tap` CNI plugin, new to github.com/containernetworking/plugins v1.3.0,
   is now provided.
+- Added ability to set a custom config directory via the new
+  `SINGULARITY_CONFIGDIR` environment variable.
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -70,6 +70,7 @@ The following have contributed code and/or documentation to this repository.
 - Lars Quentin <lars@lquenti.de>
 - Maciej Sieczka <msieczka@sieczka.org>
 - Marcelo Magallon <marcelo@sylabs.io>
+- Marco Rubin <marco.rubin@protonmail.com>
 - Mark Egan-Fuller <markeganfuller@googlemail.com>
 - Matt Wiens <mwiens91@gmail.com>
 - Michael Bauer <m@sylabs.io>, <bauerm@umich.edu>

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -263,10 +263,10 @@ func (c ctx) testSingularityConfigDir(t *testing.T) {
 	// Test plan:
 	//
 	// - create a temporary directory to be the configuration directory
-	// - set the SINGULARITY_CONFIGDIR environment variable
-	//   to that temporary directory
 	// - run 'singularity remote list' to create the remote.yaml
-	//   file inside the configuration directory
+	//   file inside the configuration directory, with the
+	//   SINGULARITY_CONFIGDIR environment variables set to that temporary
+	//   directory
 	// - assert that the file has been created
 	//
 	// If the file is in the temporary directory, it means
@@ -276,13 +276,13 @@ func (c ctx) testSingularityConfigDir(t *testing.T) {
 	configDir, cleanup := setupTemporaryDir(t, c.env.TestDir, "config-dir")
 	defer cleanup(t)
 
-	os.Setenv("SINGULARITY_CONFIGDIR", configDir)
-
+	environ := append(os.Environ(), fmt.Sprintf("SINGULARITY_CONFIGDIR=%s", configDir))
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("remote"),
 		e2e.WithArgs("list"),
+		e2e.WithEnv(environ),
 		e2e.ExpectExit(0),
 	)
 

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -270,11 +270,24 @@ func (c ctx) testSingularitySypgpDir(t *testing.T) {
 }
 
 func (c ctx) testSingularityConfigDir(t *testing.T) {
+	// Test plan:
+	//
+	// - create a temporary directory to be the configuration directory
+	// - set the SINGULARITY_CONFIGDIR environment variable
+	//   to that temporary directory
+	// - run 'singularity remote list' to create the remote.yaml
+	//   file inside the configuration directory
+	// - assert that the file has been created
+	//
+	// If the file is in the temporary directory, it means
+	// singularity followed the SINGULARITY_CONFIGDIR environment
+	// variable (checked in pkg/syfs) to set the configuration directory.
+
 	configDir, cleanup := setupTemporaryDir(t, c.env.TestDir, "config-dir")
 	defer cleanup(t)
-	
+
 	os.Setenv("SINGULARITY_CONFIGDIR", configDir)
-	
+
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -282,7 +295,7 @@ func (c ctx) testSingularityConfigDir(t *testing.T) {
 		e2e.WithArgs("list"),
 		e2e.ExpectExit(0),
 	)
-	
+
 	remotePath := filepath.Join(configDir, "remote.yaml")
 	if _, err := os.Stat(remotePath); os.IsNotExist(err) {
 		t.Fatalf("failed to find remote.yaml (expected: %s)", remotePath)
@@ -300,6 +313,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"SINGULARITY_CACHEDIR":      c.testSingularityCacheDir,
 		"singularity disable cache": c.testSingularityDisableCache,
 		"SINGULARITY_SYPGPDIR":      c.testSingularitySypgpDir,
-		"SINGULARITY_CONFIGDIR":     c.testSingularityConfigDir,
+		"config directory":          c.testSingularityConfigDir,
 	}
 }

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -6,6 +6,7 @@
 package cmdenvvars
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -259,16 +259,6 @@ func (c ctx) testSingularitySypgpDir(t *testing.T) {
 	}
 }
 
-func (c ctx) testSingularitySypgpDir(t *testing.T) {
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("key"),
-		e2e.WithArgs("list"),
-		e2e.ExpectExit(0),
-	)
-}
-
 func (c ctx) testSingularityConfigDir(t *testing.T) {
 	// Test plan:
 	//

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -259,6 +259,36 @@ func (c ctx) testSingularitySypgpDir(t *testing.T) {
 	}
 }
 
+func (c ctx) testSingularitySypgpDir(t *testing.T) {
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("key"),
+		e2e.WithArgs("list"),
+		e2e.ExpectExit(0),
+	)
+}
+
+func (c ctx) testSingularityConfigDir(t *testing.T) {
+	configDir, cleanup := setupTemporaryDir(t, c.env.TestDir, "config-dir")
+	defer cleanup(t)
+	
+	os.Setenv("SINGULARITY_CONFIGDIR", configDir)
+	
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("remote"),
+		e2e.WithArgs("list"),
+		e2e.ExpectExit(0),
+	)
+	
+	remotePath := filepath.Join(configDir, "remote.yaml")
+	if _, err := os.Stat(remotePath); os.IsNotExist(err) {
+		t.Fatalf("failed to find remote.yaml (expected: %s)", remotePath)
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
@@ -270,5 +300,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"SINGULARITY_CACHEDIR":      c.testSingularityCacheDir,
 		"singularity disable cache": c.testSingularityDisableCache,
 		"SINGULARITY_SYPGPDIR":      c.testSingularitySypgpDir,
+		"SINGULARITY_CONFIGDIR":     c.testSingularityConfigDir,
 	}
 }

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -48,7 +48,6 @@ func configDir() string {
 	if configDir != "" {
 		return configDir
 	}
-	sylog.Infof("Environment variable %s is not set", configDirEnv)
 
 	user, err := user.Current()
 	if err == nil {

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -23,6 +23,7 @@ const (
 	RemoteCache    = "remote-cache"
 	DockerConfFile = "docker-config.json"
 	singularityDir = ".singularity"
+	configDirEnv   = "SINGULARITY_CONFIGDIR"
 )
 
 // cache contains the information for the current user
@@ -43,26 +44,25 @@ func ConfigDir() string {
 }
 
 func configDir() string {
-	configDir := os.Getenv("SINGULARITY_CONFIGDIR")
-	if configDir == "" {
-		sylog.Warningf("Environment variable SINGULARITY_CONFIGDIR is not set")
+	configDir := os.Getenv(configDirEnv)
+	if configDir != "" {
+		return configDir
+	}
+	sylog.Infof("Environment variable %s is not set", configDirEnv)
 
-		user, err := user.Current()
-		if err != nil {
-			sylog.Warningf("Could not lookup the current user's information: %s", err)
-
-			cwd, err := os.Getwd()
-			if err != nil {
-				sylog.Warningf("Could not get current working directory: %s", err)
-				return singularityDir
-			}
-
-			return filepath.Join(cwd, singularityDir)
-		}
-
+	user, err := user.Current()
+	if err == nil {
 		return filepath.Join(user.HomeDir, singularityDir)
 	}
-	return configDir
+	sylog.Warningf("Could not lookup the current user's information: %s", err)
+
+	cwd, err := os.Getwd()
+	if err == nil {
+		return filepath.Join(cwd, singularityDir)
+	}
+	sylog.Warningf("Could not get current working directory: %s", err)
+	
+	return singularityDir
 }
 
 func RemoteConf() string {

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -46,7 +46,7 @@ func configDir() string {
 	configDir := os.Getenv("SINGULARITY_CONFIGDIR")
 	if configDir == "" {
 		sylog.Warningf("Environment variable SINGULARITY_CONFIGDIR is not set")
-		
+
 		user, err := user.Current()
 		if err != nil {
 			sylog.Warningf("Could not lookup the current user's information: %s", err)

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -50,18 +50,19 @@ func configDir() string {
 	}
 
 	user, err := user.Current()
-	if err == nil {
-		return filepath.Join(user.HomeDir, singularityDir)
-	}
-	sylog.Warningf("Could not lookup the current user's information: %s", err)
+	if err != nil {
+		sylog.Warningf("Could not lookup the current user's information: %s", err)
 
-	cwd, err := os.Getwd()
-	if err == nil {
+		cwd, err := os.Getwd()
+		if err != nil {
+			sylog.Warningf("Could not get current working directory: %s", err)
+			return singularityDir
+		}
+
 		return filepath.Join(cwd, singularityDir)
 	}
-	sylog.Warningf("Could not get current working directory: %s", err)
-	
-	return singularityDir
+
+	return filepath.Join(user.HomeDir, singularityDir)
 }
 
 func RemoteConf() string {

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -43,20 +43,26 @@ func ConfigDir() string {
 }
 
 func configDir() string {
-	user, err := user.Current()
-	if err != nil {
-		sylog.Warningf("Could not lookup the current user's information: %s", err)
-
-		cwd, err := os.Getwd()
+	configDir := os.Getenv("SINGULARITY_CONFIGDIR")
+	if configDir == "" {
+		sylog.Warningf("Environment variable SINGULARITY_CONFIGDIR is not set")
+		
+		user, err := user.Current()
 		if err != nil {
-			sylog.Warningf("Could not get current working directory: %s", err)
-			return singularityDir
+			sylog.Warningf("Could not lookup the current user's information: %s", err)
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				sylog.Warningf("Could not get current working directory: %s", err)
+				return singularityDir
+			}
+
+			return filepath.Join(cwd, singularityDir)
 		}
 
-		return filepath.Join(cwd, singularityDir)
+		return filepath.Join(user.HomeDir, singularityDir)
 	}
-
-	return filepath.Join(user.HomeDir, singularityDir)
+	return configDir
 }
 
 func RemoteConf() string {


### PR DESCRIPTION
This PR adds a new check for the configuration directory via the `SINGULARITY_CONFIGDIR` environment variable, which is checked before the current user's home directory in `sysfs.configDir()`. This is useful if one does not want `.singularity` in their home directory, and can be used to enforce the XDG config directory of the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) defining `SINGULARITY_CONFIGDIR=$XDG_CONFIG_HOME/singularity`.
This environment variable complements `SINGULARITY_CACHEDIR`, which can be used to do the same for the XDG cache directory with `SINGULARITY_CACHEDIR=$XDG_CACHE_HOME/singularity`.
