### PR TITLE
oci: support --workdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@
   specified, but all but one must be read-only (`--overlay <dir>:ro`).
 - The `tap` CNI plugin, new to github.com/containernetworking/plugins v1.3.0,
   is now provided.
+- OCI-mode now supports the `--workdir <workdir>` option. If this option is
+  specified, `/tmp` and `/var/tmp` will be mapped, respectively, to
+  `<workdir>/tmp` and `<workdir>/var_tmp` on the host, rather than to tmpfs
+  storage. If `--scratch <scratchdir>` is used in conjunction with `--workdir`,
+  scratch directories will be mapped to subdirectories nested under
+  `<workdir>/scratch` on the host, rather than to tmpfs storage.
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -169,7 +169,7 @@ var actionWorkdirFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "workdir",
 	ShortHand:    "W",
-	Usage:        "working directory to be used for /tmp, /var/tmp and $HOME (if -c/--contain was also used)",
+	Usage:        "working directory to be used for /tmp and /var/tmp (if -c/--contain was also used)",
 	EnvKeys:      []string{"WORKDIR"},
 	Tag:          "<path>",
 }

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -1127,33 +1127,7 @@ func (c actionTests) actionBinds(t *testing.T) {
 	hostWorkDir := filepath.Join(workspace, "workdir")
 
 	createWorkspaceDirs := func(t *testing.T) {
-		e2e.Privileged(func(t *testing.T) {
-			if err := os.RemoveAll(hostCanaryDir); err != nil && !os.IsNotExist(err) {
-				t.Fatalf("failed to delete canary_dir: %s", err)
-			}
-			if err := os.RemoveAll(hostHomeDir); err != nil && !os.IsNotExist(err) {
-				t.Fatalf("failed to delete workspace home: %s", err)
-			}
-			if err := os.RemoveAll(hostWorkDir); err != nil && !os.IsNotExist(err) {
-				t.Fatalf("failed to delete workspace work: %s", err)
-			}
-		})(t)
-
-		if err := fs.Mkdir(hostCanaryDir, 0o777); err != nil {
-			t.Fatalf("failed to create canary_dir: %s", err)
-		}
-		if err := fs.Touch(hostCanaryFile); err != nil {
-			t.Fatalf("failed to create canary_file: %s", err)
-		}
-		if err := os.Chmod(hostCanaryFile, 0o777); err != nil {
-			t.Fatalf("failed to apply permissions on canary_file: %s", err)
-		}
-		if err := fs.Mkdir(hostHomeDir, 0o777); err != nil {
-			t.Fatalf("failed to create workspace home directory: %s", err)
-		}
-		if err := fs.Mkdir(hostWorkDir, 0o777); err != nil {
-			t.Fatalf("failed to create workspace work directory: %s", err)
-		}
+		workspaceDirsGenerator(t, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile)
 	}
 
 	// convert test image to sandbox

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1127,7 +1127,7 @@ func (c actionTests) actionBinds(t *testing.T) {
 	hostWorkDir := filepath.Join(workspace, "workdir")
 
 	createWorkspaceDirs := func(t *testing.T) {
-		workspaceDirsGenerator(t, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile)
+		mkWorkspaceDirs(t, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile)
 	}
 
 	// convert test image to sandbox

--- a/e2e/actions/common.go
+++ b/e2e/actions/common.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package actions
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
+)
+
+func workspaceDirsGenerator(t *testing.T, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile string) {
+	e2e.Privileged(func(t *testing.T) {
+		if err := os.RemoveAll(hostCanaryDir); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("failed to delete canary_dir: %s", err)
+		}
+		if err := os.RemoveAll(hostHomeDir); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("failed to delete workspace home: %s", err)
+		}
+		if err := os.RemoveAll(hostWorkDir); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("failed to delete workspace home: %s", err)
+		}
+	})(t)
+
+	if err := fs.Mkdir(hostCanaryDir, 0o777); err != nil {
+		t.Fatalf("failed to create canary_dir: %s", err)
+	}
+	if err := fs.Touch(hostCanaryFile); err != nil {
+		t.Fatalf("failed to create canary_file: %s", err)
+	}
+	if err := os.Chmod(hostCanaryFile, 0o777); err != nil {
+		t.Fatalf("failed to apply permissions on canary_file: %s", err)
+	}
+	if err := fs.Mkdir(hostHomeDir, 0o777); err != nil {
+		t.Fatalf("failed to create workspace home directory: %s", err)
+	}
+	if err := fs.Mkdir(hostWorkDir, 0o777); err != nil {
+		t.Fatalf("failed to create workspace home directory: %s", err)
+	}
+}

--- a/e2e/actions/common.go
+++ b/e2e/actions/common.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
-func workspaceDirsGenerator(t *testing.T, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile string) {
+func mkWorkspaceDirs(t *testing.T, hostCanaryDir, hostHomeDir, hostWorkDir, hostCanaryFile string) {
 	e2e.Privileged(func(t *testing.T) {
 		if err := os.RemoveAll(hostCanaryDir); err != nil && !os.IsNotExist(err) {
 			t.Fatalf("failed to delete canary_dir: %s", err)

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -81,10 +81,6 @@ func checkOpts(lo launcher.Options) error {
 	if lo.WritableTmpfs {
 		sylog.Infof("--oci mode uses --writable-tmpfs by default")
 	}
-	if lo.WorkDir != "" {
-		badOpt = append(badOpt, "WorkDir")
-	}
-
 	if lo.NoHome {
 		badOpt = append(badOpt, "NoHome")
 	}

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/internal/pkg/util/gpu"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"github.com/sylabs/singularity/pkg/sylog"
@@ -32,7 +33,9 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 	if err := l.addDevMounts(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring devpts mount: %w", err)
 	}
-	l.addTmpMounts(mounts)
+	if err := l.addTmpMounts(mounts); err != nil {
+		return nil, fmt.Errorf("while configuring tmp mounts: %w", err)
+	}
 	if err := l.addHomeMount(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring home mount: %w", err)
 	}
@@ -57,16 +60,73 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 }
 
 // addTmpMounts adds tmpfs mounts for /tmp and /var/tmp in the container.
-func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) {
+func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) error {
+	const (
+		tmpDest    = "/tmp"
+		vartmpDest = "/var/tmp"
+	)
+
 	if !l.singularityConf.MountTmp {
 		sylog.Debugf("Skipping mount of /tmp due to singularity.conf")
-		return
+		return nil
 	}
 
+	if len(l.cfg.WorkDir) > 0 {
+		sylog.Debugf("WorkDir specification provided: %s", l.cfg.WorkDir)
+		const (
+			tmpSrcSubdir    = "tmp"
+			vartmpSrcSubdir = "var_tmp"
+		)
+
+		workdir, err := filepath.Abs(filepath.Clean(l.cfg.WorkDir))
+		if err != nil {
+			sylog.Warningf("Can't determine absolute path of workdir %s", l.cfg.WorkDir)
+		}
+
+		tmpSrc := filepath.Join(workdir, tmpSrcSubdir)
+		vartmpSrc := filepath.Join(workdir, vartmpSrcSubdir)
+
+		if err := fs.Mkdir(tmpSrc, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create %s: %s", tmpSrc, err)
+		}
+		if err := fs.Mkdir(vartmpSrc, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create %s: %s", vartmpSrc, err)
+		}
+
+		*mounts = append(*mounts,
+
+			specs.Mount{
+				Destination: tmpDest,
+				Type:        "none",
+				Source:      tmpSrc,
+				Options: []string{
+					"rbind",
+					"nosuid",
+					"relatime",
+					"mode=777",
+				},
+			},
+			specs.Mount{
+				Destination: vartmpDest,
+				Type:        "none",
+				Source:      vartmpSrc,
+				Options: []string{
+					"rbind",
+					"nosuid",
+					"relatime",
+					"mode=777",
+				},
+			},
+		)
+
+		return nil
+	}
+
+	sylog.Debugf(("No workdir specification provided. Proceeding with tmpfs mounts for /tmp and /var/tmp"))
 	*mounts = append(*mounts,
 
 		specs.Mount{
-			Destination: "/tmp",
+			Destination: tmpDest,
 			Type:        "tmpfs",
 			Source:      "tmpfs",
 			Options: []string{
@@ -77,7 +137,7 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) {
 			},
 		},
 		specs.Mount{
-			Destination: "/var/tmp",
+			Destination: vartmpDest,
 			Type:        "tmpfs",
 			Source:      "tmpfs",
 			Options: []string{
@@ -86,7 +146,10 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) {
 				"mode=777",
 				fmt.Sprintf("size=%dm", l.singularityConf.SessiondirMaxSize),
 			},
-		})
+		},
+	)
+
+	return nil
 }
 
 // addDevMounts adds mounts to assemble a minimal /dev in the container.
@@ -264,20 +327,50 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 
 // addScratchMounts adds tmpfs mounts for scratch directories in the container.
 func (l *Launcher) addScratchMounts(mounts *[]specs.Mount) error {
-	for _, s := range l.cfg.ScratchDirs {
-		*mounts = append(*mounts,
-			specs.Mount{
-				Destination: s,
-				Type:        "tmpfs",
-				Source:      "tmpfs",
-				Options: []string{
-					"nosuid",
-					"relatime",
-					"nodev",
-					fmt.Sprintf("size=%dm", l.singularityConf.SessiondirMaxSize),
+	const scratchContainerDirName = "/scratch"
+
+	if len(l.cfg.WorkDir) > 0 {
+		scratchContainerDirPath := filepath.Join(l.cfg.WorkDir, scratchContainerDirName)
+		if err := fs.Mkdir(scratchContainerDirPath, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create %s: %s", scratchContainerDirPath, err)
+		}
+
+		for _, s := range l.cfg.ScratchDirs {
+			scratchDirPath := filepath.Join(scratchContainerDirPath, s)
+			if err := fs.Mkdir(scratchDirPath, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+				return fmt.Errorf("failed to create %s: %s", scratchDirPath, err)
+			}
+
+			*mounts = append(*mounts,
+				specs.Mount{
+					Destination: s,
+					Type:        "",
+					Source:      scratchDirPath,
+					Options: []string{
+						"rbind",
+						"nosuid",
+						"relatime",
+						"nodev",
+					},
 				},
-			},
-		)
+			)
+		}
+	} else {
+		for _, s := range l.cfg.ScratchDirs {
+			*mounts = append(*mounts,
+				specs.Mount{
+					Destination: s,
+					Type:        "tmpfs",
+					Source:      "tmpfs",
+					Options: []string{
+						"nosuid",
+						"relatime",
+						"nodev",
+						fmt.Sprintf("size=%dm", l.singularityConf.SessiondirMaxSize),
+					},
+				},
+			)
+		}
 	}
 
 	return nil

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -330,7 +330,11 @@ func (l *Launcher) addScratchMounts(mounts *[]specs.Mount) error {
 	const scratchContainerDirName = "/scratch"
 
 	if len(l.cfg.WorkDir) > 0 {
-		scratchContainerDirPath := filepath.Join(l.cfg.WorkDir, scratchContainerDirName)
+		workdir, err := filepath.Abs(filepath.Clean(l.cfg.WorkDir))
+		if err != nil {
+			sylog.Warningf("Can't determine absolute path of workdir %s", l.cfg.WorkDir)
+		}
+		scratchContainerDirPath := filepath.Join(workdir, scratchContainerDirName)
 		if err := fs.Mkdir(scratchContainerDirPath, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
 			return fmt.Errorf("failed to create %s: %s", scratchContainerDirPath, err)
 		}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Provides support for `--workdir` in OCI-mode.

Specifying `--workdir <dir>` means that `/tmp` and `/var/tmp` will be mapped, respectively, to `<workdir>/tmp` and `<workdir>/var_tmp` on the host, rather than to tmpfs storage. If `--scratch <scratchdir>` is used in conjunction with `--workdir`, scratch directories will be mapped to subdirectories nested under `<workdir>/scratch` on the host, rather than to tmpfs storage. (This is line with the behavior of `--scratch` in conjunction with `--workdir` in native mode.)

Also changed the usage string for the `--workdir` option to make it clear that $HOME is unaffected by this option. (The latter can be manipulated separately, using the `--home` option.) This is so both in native mode and OCI mode.

### This fixes or addresses the following GitHub issues:

 - Fixes #1483 

