### PR TITLE
add get login password command (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - The `tap` CNI plugin, new to github.com/containernetworking/plugins v1.3.0,
   is now provided.
+- Added `remote get-login-password` subcommand that allows the user to
+  retrieve a CLI token to interact with the OCI registry of a
+  Singularity Enterprise instance.
 
 ### Bug Fixes
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,6 +55,7 @@ The following have contributed code and/or documentation to this repository.
 - Ian Kaneshiro <ian@ctrliq.com>, <iankane@umich.edu>
 - Jack Morrison <morrisonjc@ornl.gov>, <jack@rescale.com>
 - Jacob Chappell <chappellind@gmail.com>, <jacob.chappell@uky.edu>
+- Jarrett Dixon <jarrett@sylabs.io>
 - Jarrod Johnson <jjohnson2@lenovo.com>
 - Jason Stover <jms@sylabs.io>, <jason.stover@gmail.com>
 - Jeff Kriske <jekriske@gmail.com>

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -7,6 +7,7 @@
 package cli
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -174,6 +175,7 @@ func init() {
 		cmdManager.RegisterSubCmd(RemoteCmd, RemoteStatusCmd)
 		cmdManager.RegisterSubCmd(RemoteCmd, RemoteAddKeyserverCmd)
 		cmdManager.RegisterSubCmd(RemoteCmd, RemoteRemoveKeyserverCmd)
+		cmdManager.RegisterSubCmd(RemoteCmd, RemoteGetLoginPasswordCmd)
 
 		// default location of the remote.yaml file is the user directory
 		cmdManager.RegisterFlagForCmd(&remoteConfigFlag, RemoteCmd)
@@ -228,6 +230,33 @@ func setKeyserver(_ *cobra.Command, _ []string) {
 	if uint32(os.Getuid()) != 0 {
 		sylog.Fatalf("Unable to modify keyserver configuration: not root user")
 	}
+}
+
+// RemoteGetLoginPasswordCmd singularity remote get-login-password
+var RemoteGetLoginPasswordCmd = &cobra.Command{
+	DisableFlagsInUseLine: true,
+
+	Use:     docs.RemoteGetLoginPasswordUse,
+	Short:   docs.RemoteGetLoginPasswordShort,
+	Long:    docs.RemoteGetLoginPasswordLong,
+	Example: docs.RemoteGetLoginPasswordExample,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		defaultConfig := ""
+
+		config, err := getLibraryClientConfig(defaultConfig)
+		if err != nil {
+			sylog.Errorf("Error initializing config: %v", err)
+		}
+
+		password, err := singularity.RemoteGetLoginPassword(config)
+		if err != nil {
+			sylog.Errorf("error: %v", err)
+		}
+		if password != "" {
+			fmt.Println(password)
+		}
+	},
 }
 
 // RemoteAddCmd singularity remote add [remoteName] [remoteURI]

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -8,6 +8,7 @@ package docs
 
 // Global content for help and man pages
 const (
+
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -42,6 +43,13 @@ const (
 
     $ singularity help remote list
     $ singularity remote list`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// remote get-login-password
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RemoteGetLoginPasswordUse     string = `get-login-password`
+	RemoteGetLoginPasswordShort   string = `Retrieves the cli secret for the currently logged in user`
+	RemoteGetLoginPasswordLong    string = `The 'remote get-login-password' command allows you to retrieve the cli secret for the currently user.`
+	RemoteGetLoginPasswordExample string = `$ singularity remote get-login-password | docker login -u user --password-stdin https://harbor.sylabs.io`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote add command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/internal/app/singularity/remote_get_login_password.go
+++ b/internal/app/singularity/remote_get_login_password.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+package singularity
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	scslibclient "github.com/sylabs/scs-library-client/client"
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+// RemoteGetLoginPassword retrieves cli token from oci library shim
+func RemoteGetLoginPassword(config *scslibclient.Config) (string, error) {
+	client := http.Client{Timeout: 5 * time.Second}
+	path := "/v1/rbac/users/current"
+	endPoint := config.BaseURL + path
+
+	req, err := http.NewRequest(http.MethodGet, endPoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("error creating new request: %v", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", config.AuthToken))
+	res, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error making request: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		sylog.Debugf("Status Code: %v", res.StatusCode)
+		if res.StatusCode == http.StatusUnauthorized {
+			return "", fmt.Errorf("must be logged in to retrieve token")
+		}
+		return "", fmt.Errorf("status is not ok: %v", res.StatusCode)
+	}
+
+	var u oUser
+	err = json.NewDecoder(res.Body).Decode(&u)
+	if err != nil {
+		return "", fmt.Errorf("error decoding json response: %v", err)
+	}
+
+	if u.OidcUserMeta.Secret == "" {
+		return "", fmt.Errorf("user does not have cli token set")
+	}
+
+	return u.OidcUserMeta.Secret, nil
+}
+
+type oidcUserMeta struct {
+	Secret string `json:"secret"`
+}
+
+type oUser struct {
+	OidcUserMeta oidcUserMeta `json:"oidc_user_meta"`
+}

--- a/internal/app/singularity/remote_get_login_password_test.go
+++ b/internal/app/singularity/remote_get_login_password_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+package singularity
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	scslibclient "github.com/sylabs/scs-library-client/client"
+	"gotest.tools/v3/assert"
+)
+
+const (
+	validToken   = "validToken"
+	invalidToken = "not valid"
+)
+
+func TestRemoteGetLoginPassword(t *testing.T) {
+	tests := []struct {
+		name      string
+		password  string
+		authToken string
+		jsonResp  string
+		shallPass bool
+	}{
+		{
+			name:      "happy path",
+			shallPass: true,
+			authToken: validToken,
+			jsonResp: `{
+							"admin_role_in_auth": false,
+							"comment": "Onboarded via OIDC provider",
+							"creation_time": "2023-02-01T21:37:31.626Z",
+							"email": "user@sylabs.io",
+							"oidc_user_meta": {
+								"creation_time": "2023-02-01T21:37:31.626Z",
+								"id": 1,
+								"secret": "secretsecretsecret",
+								"subiss": "subissidhttps://hydra.se.k3s/",
+								"update_time": "2023-02-20T23:26:39.841Z",
+								"user_id": 3
+							},
+							"realname": "sylabs-user",
+							"sysadmin_flag": true,
+							"update_time": "2023-02-07T18:25:40.732Z",
+							"user_id": 3,
+							"username": "sylabs-user"
+						} `,
+			password: "secretsecretsecret",
+		},
+		{
+			name:      "invalid token",
+			shallPass: false,
+			authToken: invalidToken,
+			password:  "",
+		},
+		{
+			name:      "empty json response",
+			shallPass: false,
+			authToken: validToken,
+			password:  "",
+			jsonResp:  "{}",
+		},
+		{
+			name:      "invalid json response",
+			shallPass: false,
+			authToken: validToken,
+			password:  "",
+			jsonResp:  "random non json text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				isTokenValid := r.Header.Get("Authorization") == "Bearer "+validToken
+
+				if r.URL.Path == "/v1/rbac/users/current" && isTokenValid {
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprintln(w, tt.jsonResp)
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+					fmt.Fprintln(w, "Not found")
+
+				}
+			}))
+			defer srv.Close()
+
+			config := &scslibclient.Config{
+				BaseURL:   srv.URL,
+				AuthToken: tt.authToken,
+			}
+			actual, err := RemoteGetLoginPassword(config)
+			assert.Equal(t, actual, tt.password)
+			if tt.shallPass == true && err != nil {
+				t.Fatalf("valid case failed: %s\n", err)
+			}
+
+			if tt.shallPass == false && err == nil {
+				t.Fatal("invalid case passed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Pick #1348

This PR adds a get login password command that allows users to retrieve the cli token from the currently logged in user.

This enables the workflow to pipe the cli secret directly into docker login flow from reading std-in. This workflow is recommended to prevent the password from ending up in a shell's history or log-files

Example usage:

singularity remote get-login-password | docker login --username foo --password-stdin