### PR TITLE
fix rel. path --workdir with --scratch, add native and oci e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@
 - Added ability to set a custom config directory via the new
   `SINGULARITY_CONFIGDIR` environment variable.
 
+### Bug Fixes
+
+- Fix interaction between `--workdir` when given relative path and `--scratch`.
+
 ## 3.11.3 \[2023-05-04\]
 
 ### Changed defaults / behaviours

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2501,7 +2501,7 @@ func (c actionTests) relWorkdirScratch(t *testing.T) {
 	testdir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "persistent-overlay-", "")
 	t.Cleanup(func() {
 		if !t.Failed() {
-			cleanup(t)
+			e2e.Privileged(cleanup)
 		}
 	})
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1180,7 +1180,7 @@ func (c actionTests) ociRelWorkdirScratch(t *testing.T) {
 	testdir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "persistent-overlay-", "")
 	t.Cleanup(func() {
 		if !t.Failed() {
-			cleanup(t)
+			e2e.Privileged(cleanup)
 		}
 	})
 

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1870,7 +1870,7 @@ func (c *container) addTmpMount(system *mount.System) error {
 
 			workdir, err := filepath.Abs(filepath.Clean(workdir))
 			if err != nil {
-				sylog.Warningf("Can't determine absolute path of workdir %s", workdir)
+				return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 			}
 
 			tmpSource = filepath.Join(workdir, tmpSource)
@@ -1946,7 +1946,7 @@ func (c *container) addScratchMount(system *mount.System) error {
 	if hasWorkdir {
 		workdir, err = filepath.Abs(filepath.Clean(workdir))
 		if err != nil {
-			sylog.Warningf("Can't determine absolute path of workdir %s", workdir)
+			return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 		}
 		sourceDir := filepath.Join(workdir, scratchSessionDir)
 		if err := fs.MkdirAll(sourceDir, 0o750); err != nil {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1942,9 +1942,12 @@ func (c *container) addScratchMount(system *mount.System) error {
 
 	workdir := c.engine.EngineConfig.GetWorkdir()
 	hasWorkdir := workdir != ""
-
+	var err error
 	if hasWorkdir {
-		workdir = filepath.Clean(workdir)
+		workdir, err = filepath.Abs(filepath.Clean(workdir))
+		if err != nil {
+			sylog.Warningf("Can't determine absolute path of workdir %s", workdir)
+		}
 		sourceDir := filepath.Join(workdir, scratchSessionDir)
 		if err := fs.MkdirAll(sourceDir, 0o750); err != nil {
 			return fmt.Errorf("could not create scratch working directory %s: %s", sourceDir, err)

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -80,7 +80,7 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) error {
 
 		workdir, err := filepath.Abs(filepath.Clean(l.cfg.WorkDir))
 		if err != nil {
-			sylog.Warningf("Can't determine absolute path of workdir %s", l.cfg.WorkDir)
+			return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 		}
 
 		tmpSrc := filepath.Join(workdir, tmpSrcSubdir)
@@ -332,7 +332,7 @@ func (l *Launcher) addScratchMounts(mounts *[]specs.Mount) error {
 	if len(l.cfg.WorkDir) > 0 {
 		workdir, err := filepath.Abs(filepath.Clean(l.cfg.WorkDir))
 		if err != nil {
-			sylog.Warningf("Can't determine absolute path of workdir %s", l.cfg.WorkDir)
+			return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 		}
 		scratchContainerDirPath := filepath.Join(workdir, scratchContainerDirName)
 		if err := fs.Mkdir(scratchContainerDirPath, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes a bug where `--scratch` failed when used in conjunction with `--workdir` if the latter was given a relative (rather than absolute) path.

Also changes the behavior of `--workdir` code so that an error (rather than a warning) is generated if specified workdir cannot be converted to an absolute path.

Lastly, adds e2e tests for this behavior (`--scratch` in conjunction with relative `--workdir`), in both native and OCI modes.

### This fixes or addresses the following GitHub issues:

 - Fixes #1693 

