### PR TITLE
more robust way of setting IFS to newline (#1708) (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - In `--oci` mode, do not attempt to use unprivileged overlay on systems that do
   not support it.
+- Fix dropped "n" characters on some platforms in definition file stored as part
+  of SIF metadata.
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -242,7 +242,8 @@ func newCommand(allData bool, appName string, img *image.Image) *command {
 	cat_file() {
 		echo "%[3]s $1:$2"
 
-		local IFS=$'\n'
+		local IFS="
+"
 		while read -r content; do
 			printf "%%s\n" "$content"
 		done < "$2"

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -1013,6 +1013,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		// Regressions
 		"issue 4943": c.issue4943,
 		"issue 5172": c.issue5172,
-		"issue 274":  c.issue274, // https://github.com/sylabs/singularity/issues/274
+		"issue 274":  c.issue274,  // https://github.com/sylabs/singularity/issues/274
+		"issue 1704": c.issue1704, // https://github.com/sylabs/singularity/issues/1704
 	}
 }

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -178,6 +179,48 @@ From: continuumio/miniconda3:latest
 			e2e.ExpectOutput(e2e.ContainMatch, "active environment : env"),
 			e2e.ExpectError(e2e.ExactMatch, ""),
 		),
+	)
+}
+
+// https://github.com/sylabs/singularity/issues/1704 Ensure that trailing "n"s
+// aren't lopped off by the internal sandbox inspect call that is part of the
+// SIF-building process.
+func (c ctx) issue1704(t *testing.T) {
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue1704-", "")
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
+
+	defPath := filepath.Join("..", "test", "defs", "issue1704.def")
+	sifPath := filepath.Join(tmpDir, "issue1704.sif")
+	bytes, err := os.ReadFile(defPath)
+	if err != nil {
+		t.Fatalf("could not read contents of def file %q: %s", defPath, err)
+	}
+	defFileContents := string(bytes)
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("Build"),
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(sifPath, defPath),
+		e2e.ExpectExit(0),
+	)
+
+	if t.Failed() {
+		return
+	}
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("Inspect"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("inspect"),
+		e2e.WithArgs("-d", sifPath),
+		e2e.ExpectExit(0, e2e.ExpectOutput(e2e.ContainMatch, strings.TrimSpace(defFileContents))),
 	)
 }
 

--- a/test/defs/issue1704.def
+++ b/test/defs/issue1704.def
@@ -1,0 +1,10 @@
+BootStrap: docker
+From: ubuntu:22.04
+
+%setup
+    #an
+    #abn
+    #nn
+    #ann
+    #nan
+    #anan


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1708 

As part of the function of `singularity inspect`, an ad-hoc shell script is set up, by concatenating programmatically-generated snippets of shell code. One of these snippets, created in cmd/internal/cli/inspect.go:227, includes a line whose function is to set IFS (the Input Field Separator) _back_ to newline in the scope of the `cat_file()` function, despite being set to ":" (colon) in the global scope (cmd/internal/cli/inspect.go:256).

However, the way this was done until now uses escaping of the newline, as follows: `local IFS=$'\n'`
This escaping apparently doesn't work on certain platforms, resulting in the relevant input being split using the character "n" as the relevant delimiter, rather than using newlines.

I have verified that it fails on Debian 11 "bullseye" on amd64, and the user who reported #1704 encountered the same thing on Ubuntu 22.04 "jammy" on amd64. There is a newer syntax for this - `local IFS=$'...'` - but there is a worry this won't work on older systems; see discussion in [this](https://stackoverflow.com/questions/16831429/when-setting-ifs-to-split-on-newlines-why-is-it-necessary-to-include-a-backspac) StackOverflow post. In the same post, however, it is mentioned that there is a rather simple and possibly more robust way to achieve the same effect, namely, to use a literal newline between double-quotes:

```
      <clipped>
      local IFS="
"
      <clipped>
```

This PR replaces the previous implementation, using `$'\n'`, with the one above.

### This fixes or addresses the following GitHub issues:

 - Fixes #1704 

