### PR TITLE
fix: correct Stdin wire-up in runc/crun execs (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   not support it.
 - Fix dropped "n" characters on some platforms in definition file stored as part
   of SIF metadata.
+- Pass STDIN to `--oci` containers correctly, to fix piping input to a container.
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2519,6 +2519,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociRun":     c.actionOciRun,        // singularity run --oci
 		"ociExec":    c.actionOciExec,       // singularity exec --oci
 		"ociShell":   c.actionOciShell,      // singularity shell --oci
+		"ociSTDPIPE": c.ociSTDPipe,          // stdin/stdout pipe --oci
 		"ociNetwork": c.actionOciNetwork,    // singularity exec --oci --net
 		"ociBinds":   c.actionOciBinds,      // singularity exec --oci --bind / --mount
 		"ociIDMaps":  c.actionOciIDMaps,     // check uid/gid mapping on host for --oci as user / --fakeroot

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -6,6 +6,7 @@
 package actions
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -736,6 +737,90 @@ func (c actionTests) actionOciCompat(t *testing.T) {
 			e2e.ExpectExit(
 				tt.exitCode,
 				tt.expect,
+			),
+		)
+	}
+}
+
+// ociSTDPipe tests pipe stdin/stdout to singularity actions cmd
+func (c actionTests) ociSTDPipe(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	stdinTests := []struct {
+		name    string
+		command string
+		argv    []string
+		input   string
+		exit    int
+	}{
+		{
+			name:    "TrueSTDIN",
+			command: "exec",
+			argv:    []string{imageRef, "grep", "hi"},
+			input:   "hi",
+			exit:    0,
+		},
+		{
+			name:    "FalseSTDIN",
+			command: "exec",
+			argv:    []string{imageRef, "grep", "hi"},
+			input:   "bye",
+			exit:    1,
+		},
+	}
+
+	var input bytes.Buffer
+
+	for _, tt := range stdinTests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.argv...),
+			e2e.WithStdin(&input),
+			e2e.PreRun(func(t *testing.T) {
+				input.WriteString(tt.input)
+			}),
+			e2e.ExpectExit(tt.exit),
+		)
+		input.Reset()
+	}
+
+	user := e2e.CurrentUser(t)
+	stdoutTests := []struct {
+		name    string
+		command string
+		argv    []string
+		output  string
+		exit    int
+	}{
+		{
+			name:    "PwdPath",
+			command: "exec",
+			argv:    []string{"--pwd", "/etc", imageRef, "pwd"},
+			output:  "/etc",
+			exit:    0,
+		},
+		{
+			name:    "id",
+			command: "exec",
+			argv:    []string{imageRef, "id", "-un"},
+			output:  user.Name,
+			exit:    0,
+		},
+	}
+	for _, tt := range stdoutTests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.argv...),
+			e2e.ExpectExit(
+				tt.exit,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.output),
 			),
 		)
 	}

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -96,7 +96,7 @@ func Exec(containerID string, cmdArgs []string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
+	cmd.Stdin = os.Stdin
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -122,7 +122,6 @@ func Kill(containerID string, killSignal string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -149,12 +148,11 @@ func Pause(containerID string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
 
-// Resume pauses processes in a container
+// Resume un-pauses processes in a container
 func Resume(containerID string, systemdCgroups bool) error {
 	runtimeBin, err := runtime()
 	if err != nil {
@@ -176,7 +174,6 @@ func Resume(containerID string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -216,7 +213,7 @@ func Run(ctx context.Context, containerID, bundlePath, pidFile string, systemdCg
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
+	cmd.Stdin = os.Stdin
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -310,7 +307,6 @@ func Start(containerID string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -337,7 +333,6 @@ func State(containerID string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }
@@ -364,7 +359,6 @@ func Update(containerID, cgFile string, systemdCgroups bool) error {
 	cmd := exec.Command(runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdout
 	sylog.Debugf("Calling %s with args %v", runtimeBin, runtimeArgs)
 	return cmd.Run()
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1714 

When runc/crun is called from oci_runc_linux.go, Stdin was incorrectly connected for the various runc/crun operations.

* Non-interactive operations such as resume / kill don't need Stdin.
* Interactive operations (run/exec) had cmd.Stdin incorrectly set to os.Stdout. This prevented OCI containers from receiving input from pipes, redirection, etc.

This PR fixes these issues and ports action STDPIPE tests to --oci mode. These were previously missed, resulting in https://github.com/sylabs/singularity/issues/1712 not being caught by the e2e suite.

### This fixes or addresses the following GitHub issues:

 - Fixes #1712


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
