### PR TITLE
oci: fallback to fuse-overlayfs if kernel doesn't support unprivileged overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
   `<workdir>/scratch` on the host, rather than to tmpfs storage.
 - Added ability to set a custom config directory via the new
   `SINGULARITY_CONFIGDIR` environment variable.
+- If kernel does not support unprivileged overlays, OCI-mode will attempt to use
+  `fuse-overlayfs` and `fusermount` for overlay mounting and unmounting.
 
 ### Bug Fixes
 

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -57,8 +57,12 @@ func FindBin(name string) (path string, err error) {
 	// fuse2fs for OCI-mode bare-image overlay
 	case "fuse2fs":
 		return findOnPath(name)
+	// fuse-overlayfs for mounting overlays without kernel support for
+	// unprivileged overlays
+	case "fuse-overlayfs":
+		return findOnPath(name)
 	default:
-		return "", fmt.Errorf("unknown executable name %q", name)
+		return "", fmt.Errorf("executable name %q is not known to FindBin", name)
 	}
 }
 

--- a/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
@@ -177,10 +177,10 @@ func dirMountUnmount(t *testing.T, olStr string) {
 	}
 
 	if err := item.Mount(); err != nil {
-		t.Fatalf("error encountered while trying to mount dir %q: %s", olStr, err)
+		t.Fatalf("while trying to mount dir %q: %s", olStr, err)
 	}
 	if err := item.Unmount(); err != nil {
-		t.Errorf("error encountered while trying to unmount dir %q: %s", olStr, err)
+		t.Errorf("while trying to unmount dir %q: %s", olStr, err)
 	}
 }
 

--- a/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
@@ -219,10 +219,12 @@ func tryImageRO(t *testing.T, olStr string, typeCode int, typeStr, expectStr str
 
 func TestSquashfsRO(t *testing.T) {
 	require.Command(t, "squashfuse")
+	require.Command(t, "fusermount")
 	tryImageRO(t, filepath.Join("..", "..", "..", "..", "..", "test", "images", "squashfs-for-overlay.img"), image.SQUASHFS, "squashfs", squashfsTestString)
 }
 
 func TestExtfsRO(t *testing.T) {
 	require.Command(t, "fuse2fs")
+	require.Command(t, "fusermount")
 	tryImageRO(t, filepath.Join("..", "..", "..", "..", "..", "test", "images", "extfs-for-overlay.img")+":ro", image.EXT3, "extfs", extfsTestString)
 }

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -222,6 +222,7 @@ func UnprivOverlaysSupported() (bool, error) {
 
 		if err == ErrNoRootlessOverlay {
 			unprivOverlays.kernelSupport = false
+			return
 		}
 
 		unprivOverlays.err = err

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -83,7 +83,7 @@ func check(path string, d dir) error {
 	stfs := &unix.Statfs_t{}
 
 	if err := statfs(path, stfs); err != nil {
-		return fmt.Errorf("could not retrieve underlying filesystem information for %s: %s", path, err)
+		return fmt.Errorf("could not retrieve underlying filesystem information for %s: %w", path, err)
 	}
 
 	fs, ok := incompatibleFs[int64(stfs.Type)]
@@ -142,7 +142,7 @@ var ErrNoRootlessOverlay = errors.New("rootless overlay not supported by kernel"
 func CheckRootless() error {
 	mountBin, err := bin.FindBin("mount")
 	if err != nil {
-		return fmt.Errorf("while looking for mount command: %s", err)
+		return fmt.Errorf("while looking for mount command: %w", err)
 	}
 
 	tmpDir, err := os.MkdirTemp("", "check-overlay")
@@ -257,7 +257,7 @@ func EnsureOverlayDir(dir string, createIfMissing bool, createPerm os.FileMode) 
 
 	// Create the requested dir
 	if err := os.Mkdir(dir, createPerm); err != nil {
-		return fmt.Errorf("failed to create %q: %s", dir, err)
+		return fmt.Errorf("failed to create %q: %w", dir, err)
 	}
 
 	return nil
@@ -268,12 +268,12 @@ func EnsureOverlayDir(dir string, createIfMissing bool, createPerm os.FileMode) 
 func DetachAndDelete(overlayDir string) error {
 	sylog.Debugf("Detaching overlayDir %q", overlayDir)
 	if err := syscall.Unmount(overlayDir, syscall.MNT_DETACH); err != nil {
-		return fmt.Errorf("failed to unmount %s: %s", overlayDir, err)
+		return fmt.Errorf("failed to unmount %s: %w", overlayDir, err)
 	}
 
 	sylog.Debugf("Removing overlayDir %q", overlayDir)
 	if err := os.RemoveAll(overlayDir); err != nil {
-		return fmt.Errorf("failed to remove %s: %s", overlayDir, err)
+		return fmt.Errorf("failed to remove %s: %w", overlayDir, err)
 	}
 	return nil
 }
@@ -282,7 +282,7 @@ func DetachAndDelete(overlayDir string) error {
 func DetachMount(dir string) error {
 	sylog.Debugf("Calling syscall.Unmount() to detach %q", dir)
 	if err := syscall.Unmount(dir, syscall.MNT_DETACH); err != nil {
-		return fmt.Errorf("failed to detach %s: %s", dir, err)
+		return fmt.Errorf("failed to detach %s: %w", dir, err)
 	}
 
 	return nil
@@ -295,7 +295,7 @@ func UnmountWithFuse(dir string) error {
 	if err != nil {
 		// We should not be creating FUSE-based mounts in the first place
 		// without checking that fusermount is available.
-		return fmt.Errorf("internal error: FUSE-based mount created without fusermount installed: %s", err)
+		return fmt.Errorf("fusermount not available while trying to perform unmount: %w", err)
 	}
 	sylog.Debugf("Executing FUSE unmount command: %s -u %s", fusermountCmd, dir)
 	execCmd := exec.Command(fusermountCmd, "-u", dir)

--- a/internal/pkg/util/fs/overlay/overlay_set_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_set_linux.go
@@ -7,10 +7,13 @@ package overlay
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"syscall"
 
 	"github.com/samber/lo"
+	"github.com/sylabs/singularity/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
@@ -39,6 +42,15 @@ type Set struct {
 // directory.
 func (s Set) Mount(rootFsDir string) error {
 	// Perform identity mounts for this Set
+	dups := lo.FindDuplicatesBy(s.ReadonlyOverlays, func(item *Item) string {
+		return item.SourcePath
+	})
+	if len(dups) > 0 {
+		return fmt.Errorf("duplicate overlays detected: %v", lo.Map(dups, func(item *Item, _ int) string {
+			return item.SourcePath
+		}))
+	}
+
 	if err := s.performIndividualMounts(); err != nil {
 		return err
 	}
@@ -49,7 +61,16 @@ func (s Set) Mount(rootFsDir string) error {
 
 // UnmountOverlay ummounts a Set from a specified rootfs directory.
 func (s Set) Unmount(rootFsDir string) error {
-	if err := DetachMount(rootFsDir); err != nil {
+	unmounterFunc := DetachMount
+	unprivOls, err := UnprivOverlaysSupported()
+	if err != nil {
+		return fmt.Errorf("error encountered while checking for unprivileged overlay support in kernel: %s", err)
+	}
+	if !unprivOls {
+		unmounterFunc = UnmountWithFuse
+	}
+
+	if err := unmounterFunc(rootFsDir); err != nil {
 		return err
 	}
 
@@ -80,9 +101,36 @@ func (s Set) performIndividualMounts() error {
 func (s Set) performFinalMount(rootFsDir string) error {
 	// Try to perform actual mount
 	options := s.options(rootFsDir)
-	sylog.Debugf("Mounting overlay with rootFsDir %q, options: %q", rootFsDir, options)
-	if err := syscall.Mount("overlay", rootFsDir, "overlay", syscall.MS_NODEV, options); err != nil {
-		return fmt.Errorf("failed to mount %s: %s", rootFsDir, err)
+	unprivOls, err := UnprivOverlaysSupported()
+	if err != nil {
+		return fmt.Errorf("error encountered while checking for unprivileged overlay support in kernel: %s", err)
+	}
+
+	if unprivOls {
+		sylog.Debugf("Mounting overlay (via syscall) with rootFsDir %q, options: %q", rootFsDir, options)
+		if err := syscall.Mount("overlay", rootFsDir, "overlay", syscall.MS_NODEV, options); err != nil {
+			return fmt.Errorf("failed to mount %s: %s", rootFsDir, err)
+		}
+	} else {
+		fuseOlFsCmd, err := bin.FindBin("fuse-overlayfs")
+		if err != nil {
+			return fmt.Errorf("kernel does not support unprivileged overlays, and fuse-overlayfs not installed: %s", err)
+		}
+
+		// Even though fusermount is not needed for this step, we shouldn't perform
+		// the mount unless we have the necessary tools to eventually unmount it
+		_, err = bin.FindBin("fusermount")
+		if err != nil {
+			return fmt.Errorf("kernel does not support unprivileged overlays, and using fuse-overlayfs fallback requires fusermount to be installed: %s", err)
+		}
+
+		sylog.Debugf("Mounting overlay (via fuse-overlayfs) with rootFsDir %q, options: %q", rootFsDir, options)
+		execCmd := exec.Command(fuseOlFsCmd, "-o", options, rootFsDir)
+		execCmd.Stderr = os.Stderr
+		_, err = execCmd.Output()
+		if err != nil {
+			return fmt.Errorf("failed to mount %s: %s", rootFsDir, err)
+		}
 	}
 
 	return nil

--- a/internal/pkg/util/fs/overlay/overlay_set_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_set_linux_test.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 )
 
 func addROItemOrFatal(t *testing.T, s *Set, olStr string) *Item {
@@ -22,48 +24,136 @@ func addROItemOrFatal(t *testing.T, s *Set, olStr string) *Item {
 	return i
 }
 
+// wrapOverlayTest takes a testing function and wraps it in code that checks if
+// the kernel has support for unprivileged overlays. If it does, the underlying
+// function will be run twice, once with using kernel overlays and once using
+// fuse-overlayfs (if present). Otherwise, only the latter option will be
+// attempted.
+func wrapOverlayTest(f func(t *testing.T)) func(t *testing.T) {
+	unprivOls, unprivOlsErr := UnprivOverlaysSupported()
+	return func(t *testing.T) {
+		if unprivOlsErr != nil {
+			t.Fatalf("error encountered while checking for unprivileged overlay support in kernel: %s", unprivOlsErr)
+		}
+
+		fuseOverlayFunc := func(t *testing.T) {
+			require.Command(t, "fuse-overlayfs")
+			require.Command(t, "fusermount")
+			f(t)
+		}
+
+		if unprivOls {
+			t.Run("kerneloverlay", f)
+			unprivOverlays.kernelSupport = false
+		}
+
+		t.Run("fuseoverlayfs", fuseOverlayFunc)
+		unprivOverlays.kernelSupport = unprivOls
+	}
+}
+
 func TestAllTypesAtOnce(t *testing.T) {
-	s := Set{}
+	wrapOverlayTest(func(t *testing.T) {
+		s := Set{}
 
-	tmpRODir := mkTempDirOrFatal(t)
-	addROItemOrFatal(t, &s, tmpRODir+":ro")
+		tmpRODir := mkTempDirOrFatal(t)
+		addROItemOrFatal(t, &s, tmpRODir+":ro")
 
-	squashfsSupported := false
-	if _, err := exec.LookPath("squashfs"); err == nil {
-		squashfsSupported = true
-		addROItemOrFatal(t, &s, filepath.Join("..", "..", "..", "..", "..", "test", "images", "squashfs-for-overlay.img"))
-	}
+		squashfsSupported := false
+		if _, err := exec.LookPath("squashfs"); err == nil {
+			squashfsSupported = true
+			addROItemOrFatal(t, &s, filepath.Join("..", "..", "..", "..", "..", "test", "images", "squashfs-for-overlay.img"))
+		}
 
-	extfsSupported := false
-	if _, err := exec.LookPath("fuse2fs"); err == nil {
-		extfsSupported = true
-		addROItemOrFatal(t, &s, filepath.Join("..", "..", "..", "..", "..", "test", "images", "extfs-for-overlay.img")+":ro")
-	}
+		extfsSupported := false
+		if _, err := exec.LookPath("fuse2fs"); err == nil {
+			extfsSupported = true
+			addROItemOrFatal(t, &s, filepath.Join("..", "..", "..", "..", "..", "test", "images", "extfs-for-overlay.img")+":ro")
+		}
 
-	tmpRWDir := mkTempDirOrFatal(t)
-	i, err := NewItemFromString(tmpRWDir)
-	if err != nil {
-		t.Fatalf("failed to create writable-dir overlay item (%q): %s", tmpRWDir, err)
-	}
-	s.WritableOverlay = i
+		tmpRWDir := mkTempDirOrFatal(t)
+		i, err := NewItemFromString(tmpRWDir)
+		if err != nil {
+			t.Fatalf("failed to create writable-dir overlay item (%q): %s", tmpRWDir, err)
+		}
+		s.WritableOverlay = i
 
-	rootfsDir := mkTempDirOrFatal(t)
-	if err := s.Mount(rootfsDir); err != nil {
-		t.Fatalf("failed to mount overlay set: %s", err)
-	}
-	t.Cleanup(func() {
-		s.Unmount(rootfsDir)
-	})
+		rootfsDir := mkTempDirOrFatal(t)
+		if err := s.Mount(rootfsDir); err != nil {
+			t.Fatalf("failed to mount overlay set: %s", err)
+		}
+		t.Cleanup(func() {
+			if t.Failed() {
+				s.Unmount(rootfsDir)
+			}
+		})
 
-	var expectStr string
-	if extfsSupported {
-		expectStr = extfsTestString
-	} else if squashfsSupported {
-		expectStr = squashfsTestString
-	}
+		var expectStr string
+		if extfsSupported {
+			expectStr = extfsTestString
+		} else if squashfsSupported {
+			expectStr = squashfsTestString
+		}
 
-	if squashfsSupported || extfsSupported {
+		if squashfsSupported || extfsSupported {
+			testFileMountedPath := filepath.Join(rootfsDir, testFilePath)
+			data, err := os.ReadFile(testFileMountedPath)
+			if err != nil {
+				t.Fatalf("error while trying to read from file %q: %s", testFileMountedPath, err)
+			}
+			foundStr := string(data)
+			if foundStr != expectStr {
+				t.Errorf("incorrect file contents in mounted overlay set: expected %q, but found: %q", expectStr, foundStr)
+			}
+		}
+
+		if err := s.Unmount(rootfsDir); err != nil {
+			t.Errorf("error encountered while trying to unmount overlay set: %s", err)
+		}
+	})(t)
+}
+
+func TestPersistentWriteToDir(t *testing.T) {
+	wrapOverlayTest(func(t *testing.T) {
+		tmpRWDir := mkTempDirOrFatal(t)
+		i, err := NewItemFromString(tmpRWDir)
+		if err != nil {
+			t.Fatalf("failed to create writable-dir overlay item (%q): %s", tmpRWDir, err)
+		}
+		s := Set{WritableOverlay: i}
+
+		rootfsDir := mkTempDirOrFatal(t)
+
+		// This cleanup will serve adequately for both iterations of the overlay-set
+		// mounting, below. If it happens to get called while the set is not
+		// mounted, it should fail silently.
+		t.Cleanup(func() {
+			if t.Failed() {
+				s.Unmount(rootfsDir)
+			}
+		})
+
+		// Mount the overlay set, write a string to a file, and unmount.
+		if err := s.Mount(rootfsDir); err != nil {
+			t.Fatalf("failed to mount overlay set: %s", err)
+		}
+		expectStr := "my_test_string"
+		bytes := []byte(expectStr)
+		testFilePath := "my_test_file"
 		testFileMountedPath := filepath.Join(rootfsDir, testFilePath)
+		if err := os.WriteFile(testFileMountedPath, bytes, 0o644); err != nil {
+			t.Fatalf("error encountered while trying to write file inside mounted overlay-set: %s", err)
+		}
+
+		if err := s.Unmount(rootfsDir); err != nil {
+			t.Fatalf("error encountered while trying to unmount overlay set: %s", err)
+		}
+
+		// Mount the same set again, and check that we see the file with the
+		// expected contents.
+		if err := s.Mount(rootfsDir); err != nil {
+			t.Fatalf("failed to mount overlay set: %s", err)
+		}
 		data, err := os.ReadFile(testFileMountedPath)
 		if err != nil {
 			t.Fatalf("error while trying to read from file %q: %s", testFileMountedPath, err)
@@ -72,101 +162,51 @@ func TestAllTypesAtOnce(t *testing.T) {
 		if foundStr != expectStr {
 			t.Errorf("incorrect file contents in mounted overlay set: expected %q, but found: %q", expectStr, foundStr)
 		}
-	}
-
-	if err := s.Unmount(rootfsDir); err != nil {
-		t.Errorf("error encountered while trying to unmount overlay set: %s", err)
-	}
-}
-
-func TestPersistentWriteToDir(t *testing.T) {
-	tmpRWDir := mkTempDirOrFatal(t)
-	i, err := NewItemFromString(tmpRWDir)
-	if err != nil {
-		t.Fatalf("failed to create writable-dir overlay item (%q): %s", tmpRWDir, err)
-	}
-	s := Set{WritableOverlay: i}
-
-	rootfsDir := mkTempDirOrFatal(t)
-
-	// This cleanup will serve adequately for both iterations of the overlay-set
-	// mounting, below. If it happens to get called while the set is not
-	// mounted, it should fail silently.
-	t.Cleanup(func() {
-		s.Unmount(rootfsDir)
-	})
-
-	// Mount the overlay set, write a string to a file, and unmount.
-	if err := s.Mount(rootfsDir); err != nil {
-		t.Fatalf("failed to mount overlay set: %s", err)
-	}
-	expectStr := "my_test_string"
-	bytes := []byte(expectStr)
-	testFilePath := "my_test_file"
-	testFileMountedPath := filepath.Join(rootfsDir, testFilePath)
-	if err := os.WriteFile(testFileMountedPath, bytes, 0o644); err != nil {
-		t.Fatalf("error encountered while trying to write file inside mounted overlay-set: %s", err)
-	}
-
-	if err := s.Unmount(rootfsDir); err != nil {
-		t.Fatalf("error encountered while trying to unmount overlay set: %s", err)
-	}
-
-	// Mount the same set again, and check that we see the file with the
-	// expected contents.
-	if err := s.Mount(rootfsDir); err != nil {
-		t.Fatalf("failed to mount overlay set: %s", err)
-	}
-	data, err := os.ReadFile(testFileMountedPath)
-	if err != nil {
-		t.Fatalf("error while trying to read from file %q: %s", testFileMountedPath, err)
-	}
-	foundStr := string(data)
-	if foundStr != expectStr {
-		t.Errorf("incorrect file contents in mounted overlay set: expected %q, but found: %q", expectStr, foundStr)
-	}
-	if err := s.Unmount(rootfsDir); err != nil {
-		t.Errorf("error encountered while trying to unmount overlay set: %s", err)
-	}
+		if err := s.Unmount(rootfsDir); err != nil {
+			t.Errorf("error encountered while trying to unmount overlay set: %s", err)
+		}
+	})(t)
 }
 
 func TestDuplicateItemsInSet(t *testing.T) {
-	var rootfsDir string
-	var rwI *Item
-	var err error
+	wrapOverlayTest(func(t *testing.T) {
+		var rootfsDir string
+		var rwI *Item
+		var err error
 
-	s := Set{}
+		s := Set{}
 
-	// First, test mounting of an overlay set with only readonly items, one of
-	// which is a duplicate of another.
-	addROItemOrFatal(t, &s, mkTempDirOrFatal(t)+":ro")
-	roI2 := addROItemOrFatal(t, &s, mkTempDirOrFatal(t)+":ro")
-	addROItemOrFatal(t, &s, mkTempDirOrFatal(t)+":ro")
-	addROItemOrFatal(t, &s, roI2.SourcePath+":ro")
-	addROItemOrFatal(t, &s, mkTempDirOrFatal(t)+":ro")
+		// First, test mounting of an overlay set with only readonly items, one of
+		// which is a duplicate of another.
+		addROItemOrFatal(t, &s, mkTempDirOrFatal(t)+":ro")
+		roI2 := addROItemOrFatal(t, &s, mkTempDirOrFatal(t)+":ro")
+		addROItemOrFatal(t, &s, mkTempDirOrFatal(t)+":ro")
+		addROItemOrFatal(t, &s, roI2.SourcePath+":ro")
+		addROItemOrFatal(t, &s, mkTempDirOrFatal(t)+":ro")
 
-	rootfsDir = mkTempDirOrFatal(t)
-	if err := s.Mount(rootfsDir); err == nil {
-		t.Errorf("unexpected success: Mounting overlay.Set with duplicate (%q) should have failed", roI2.SourcePath)
-		if err := s.Unmount(rootfsDir); err != nil {
-			t.Fatalf("could not unmount erroneous successful mount of overlay set: %s", err)
+		rootfsDir = mkTempDirOrFatal(t)
+		if err := s.Mount(rootfsDir); err == nil {
+			t.Errorf("unexpected success: Mounting overlay.Set with duplicate (%q) should have failed", roI2.SourcePath)
+			if err := s.Unmount(rootfsDir); err != nil {
+				t.Fatalf("could not unmount erroneous successful mount of overlay set: %s", err)
+			}
 		}
-	}
 
-	// Next, test mounting of an overlay set with a writable item as well as
-	// several readonly items, one of which is a duplicate of another.
-	tmpRWDir := mkTempDirOrFatal(t)
-	rwI, err = NewItemFromString(tmpRWDir)
-	if err != nil {
-		t.Fatalf("failed to create writable-dir overlay item (%q): %s", tmpRWDir, err)
-	}
-	s.WritableOverlay = rwI
-
-	rootfsDir = mkTempDirOrFatal(t)
-	if err := s.Mount(rootfsDir); err == nil {
-		t.Errorf("unexpected success: Mounting overlay.Set with duplicate file/dir (%q) should have failed", roI2.SourcePath)
-		if err := s.Unmount(rootfsDir); err != nil {
-			t.Fatalf("could not unmount erroneous successful mount of overlay set: %s", err)
+		// Next, test mounting of an overlay set with a writable item as well as
+		// several readonly items, one of which is a duplicate of another.
+		tmpRWDir := mkTempDirOrFatal(t)
+		rwI, err = NewItemFromString(tmpRWDir)
+		if err != nil {
+			t.Fatalf("failed to create writable-dir overlay item (%q): %s", tmpRWDir, err)
 		}
-	}
+		s.WritableOverlay = rwI
+
+		rootfsDir = mkTempDirOrFatal(t)
+		if err := s.Mount(rootfsDir); err == nil {
+			t.Errorf("unexpected success: Mounting overlay.Set with duplicate (%q) should have failed", roI2.SourcePath)
+			if err := s.Unmount(rootfsDir); err != nil {
+				t.Fatalf("could not unmount erroneous successful mount of overlay set: %s", err)
+			}
+		}
+	})(t)
 }

--- a/internal/pkg/util/fs/overlay/overlay_set_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_set_linux_test.go
@@ -33,7 +33,7 @@ func wrapOverlayTest(f func(t *testing.T)) func(t *testing.T) {
 	unprivOls, unprivOlsErr := UnprivOverlaysSupported()
 	return func(t *testing.T) {
 		if unprivOlsErr != nil {
-			t.Fatalf("error encountered while checking for unprivileged overlay support in kernel: %s", unprivOlsErr)
+			t.Fatalf("while checking for unprivileged overlay support in kernel: %s", unprivOlsErr)
 		}
 
 		fuseOverlayFunc := func(t *testing.T) {
@@ -108,7 +108,7 @@ func TestAllTypesAtOnce(t *testing.T) {
 		}
 
 		if err := s.Unmount(rootfsDir); err != nil {
-			t.Errorf("error encountered while trying to unmount overlay set: %s", err)
+			t.Errorf("while trying to unmount overlay set: %s", err)
 		}
 	})(t)
 }
@@ -142,11 +142,11 @@ func TestPersistentWriteToDir(t *testing.T) {
 		testFilePath := "my_test_file"
 		testFileMountedPath := filepath.Join(rootfsDir, testFilePath)
 		if err := os.WriteFile(testFileMountedPath, bytes, 0o644); err != nil {
-			t.Fatalf("error encountered while trying to write file inside mounted overlay-set: %s", err)
+			t.Fatalf("while trying to write file inside mounted overlay-set: %s", err)
 		}
 
 		if err := s.Unmount(rootfsDir); err != nil {
-			t.Fatalf("error encountered while trying to unmount overlay set: %s", err)
+			t.Fatalf("while trying to unmount overlay set: %s", err)
 		}
 
 		// Mount the same set again, and check that we see the file with the
@@ -163,7 +163,7 @@ func TestPersistentWriteToDir(t *testing.T) {
 			t.Errorf("incorrect file contents in mounted overlay set: expected %q, but found: %q", expectStr, foundStr)
 		}
 		if err := s.Unmount(rootfsDir); err != nil {
-			t.Errorf("error encountered while trying to unmount overlay set: %s", err)
+			t.Errorf("while trying to unmount overlay set: %s", err)
 		}
 	})(t)
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

If kernel doesn't support unprivileged overlay mounts, fallback to trying to use `fuse-overlayfs` and `fusermount` for overlay mounting and unmounting.

### This fixes or addresses the following GitHub issues:

 - Fixes #1727 

