### PR TITLE
fix: add missing cast in memoryusage calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Fix dropped "n" characters on some platforms in definition file stored as part
   of SIF metadata.
 - Pass STDIN to `--oci` containers correctly, to fix piping input to a container.
+- Fix memory usage calculation during singularity compilation on RaspberryPi.
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 - Fix dropped "n" characters on some platforms in definition file stored as part
   of SIF metadata.
 - Pass STDIN to `--oci` containers correctly, to fix piping input to a container.
-- Fix memory usage calculation during singularity compilation on RaspberryPi.
+- Fix compilation on 32-bit systems.
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -111,4 +111,5 @@ The following have contributed code and/or documentation to this repository.
 - Yinuo Chen <ynchen2829@utexas.edu>
 - Onur Yılmaz <csonuryilmaz@gmail.com>
 - Pranathi Locula <locula@deshaw.com>
+- Filip Gorczyca <filip.gorczyca141@gmail.com>
 ```

--- a/internal/app/singularity/instance_linux.go
+++ b/internal/app/singularity/instance_linux.go
@@ -171,7 +171,7 @@ func calculateMemoryUsage(stats *libcgroups.MemoryStats) (float64, float64, floa
 		in := &syscall.Sysinfo_t{}
 		err := syscall.Sysinfo(in)
 		if err == nil {
-			memLimit = in.Totalram * uint64(in.Unit)
+			memLimit = uint64(in.Totalram) * uint64(in.Unit)
 		}
 	}
 	if memLimit != 0 {

--- a/internal/app/singularity/instance_linux.go
+++ b/internal/app/singularity/instance_linux.go
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Adds explicit cast to `uint64` of `Totalram` field in SysInfo system call. This solves a compilation problem on certain versions of Raspberry PI.

This is a pick of https://github.com/apptainer/apptainer/pull/1347