### PR TITLE
Add xino=on for writable overlay mount points (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Changes Since Last Release
 
+### Changed defaults / behaviours
+
+- Add `xino=on` mount option for writable kernel overlay mount points to fix
+  inode numbers consistency after kernel cache flush (not applicable to
+  fuse-overlayfs).
+
 ### New Features & Functionality
 
 - The `tap` CNI plugin, new to github.com/containernetworking/plugins v1.3.0,

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -693,6 +693,10 @@ mount:
 				sylog.Verbosef("Overlay mount failed with %s, mounting with index=off", err)
 				optsString = fmt.Sprintf("%s,index=off", optsString)
 				goto mount
+			} else if mnt.Type == "overlay" && err == syscall.EINVAL {
+				sylog.Verbosef("Overlay mount failed with %s, mounting without xino option", err)
+				optsString = strings.Replace(optsString, ",xino=on", "", -1)
+				goto mount
 			}
 			// mount error for other filesystems is considered fatal
 			return fmt.Errorf("can't mount %s filesystem to %s: %s", mnt.Type, mnt.Destination, err)

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -692,7 +692,7 @@ func (p *Points) AddOverlay(tag AuthorizedTag, dest string, flags uintptr, lower
 		if !strings.HasPrefix(workdir, "/") {
 			return fmt.Errorf("workdir must be an absolute path")
 		}
-		options = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerdir, upperdir, workdir)
+		options = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,xino=on", lowerdir, upperdir, workdir)
 	} else {
 		options = fmt.Sprintf("lowerdir=%s", lowerdir)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1753 

Add `xino=on` mount option for writable kernel overlay mount points to fix inode numbers consistency after kernel cache flush. This is not applicable to mounts done using `fuse-overlayfs`.

This is a pick of https://github.com/apptainer/apptainer/pull/1278

