### PR TITLE
Lookup and store user/group information in stage one prior to creating namespaces (apptainer #1368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
   inheritable / ambient capabilites, matching other OCI runtimes.
 - In OCI-mode, a container run as root, or with `--fakeroot` has OCI default
   effective/permitted capabilities.
+- Lookup and store user/group information in stage one prior to entering any
+  namespaces to fix issue with winbind not correctly lookup user/group
+  information when using user namespace.
 
 ### New Features & Functionality
 
@@ -226,9 +229,6 @@
 - Instances are started in a cgroup, by default, when run as root or when
   unified cgroups v2 with systemd as manager is configured. This allows
   `singularity instance stats` to be supported by default when possible.
-- Lookup and store user/group information in stage one prior to entering any
-  namespaces to fix issue with winbind not correctly lookup user/group information
-  when using user namespace.
 
 ### New features / functionalities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,9 @@
 - Instances are started in a cgroup, by default, when run as root or when
   unified cgroups v2 with systemd as manager is configured. This allows
   `singularity instance stats` to be supported by default when possible.
+- Lookup and store user/group information in stage one prior to entering any
+  namespaces to fix issue with winbind not correctly lookup user/group information
+  when using user namespace.
 
 ### New features / functionalities
 

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	osuser "os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1456,13 +1457,14 @@ func (c *container) getHomePaths() (source string, dest string, err error) {
 		dest = filepath.Clean(c.engine.EngineConfig.GetHomeDest())
 		source, err = filepath.Abs(filepath.Clean(c.engine.EngineConfig.GetHomeSource()))
 	} else {
-		pw, err := user.CurrentOriginal()
-		if err == nil {
-			source = pw.Dir
-			if c.engine.EngineConfig.GetFakeroot() {
+		source = c.engine.EngineConfig.JSON.UserInfo.Home
+		if source != "" {
+			if c.engine.EngineConfig.GetFakeroot() || os.Getuid() == 0 {
+				// Mount user home directory onto /root for
+				//  any root-mapped namespace
 				dest = "/root"
 			} else {
-				dest = pw.Dir
+				dest = source
 			}
 		}
 	}
@@ -2001,7 +2003,7 @@ func (c *container) addIdentityMount(system *mount.System) error {
 		if err != nil {
 			sylog.Warningf("%s", err)
 		} else {
-			content, err := files.Passwd(passwd, home, uid)
+			content, err := files.Passwd(passwd, home, uid, c)
 			if err != nil {
 				sylog.Warningf("%s", err)
 			} else {
@@ -2024,7 +2026,7 @@ func (c *container) addIdentityMount(system *mount.System) error {
 
 	if c.engine.EngineConfig.File.ConfigGroup {
 		group := filepath.Join(rootfs, "/etc/group")
-		content, err := files.Group(group, uid, c.engine.EngineConfig.GetTargetGID())
+		content, err := files.Group(group, uid, c.engine.EngineConfig.GetTargetGID(), c)
 		if err != nil {
 			sylog.Warningf("%s", err)
 		} else {
@@ -2440,4 +2442,37 @@ func (c *container) getBindFlags(source string, defaultFlags uintptr) (uintptr, 
 	}
 
 	return defaultFlags | addFlags, nil
+}
+
+func (c *container) GetPwUID(uid uint32) (*user.User, error) {
+	if c.engine.EngineConfig.JSON.UserInfo.Username == "" {
+		return nil, osuser.UnknownUserIdError(uid)
+	}
+	return &user.User{
+		Name:  c.engine.EngineConfig.JSON.UserInfo.Username,
+		UID:   uint32(c.engine.EngineConfig.JSON.UserInfo.UID),
+		GID:   uint32(c.engine.EngineConfig.JSON.UserInfo.GID),
+		Gecos: c.engine.EngineConfig.JSON.UserInfo.Gecos,
+		Dir:   c.engine.EngineConfig.JSON.UserInfo.Home,
+		Shell: c.engine.EngineConfig.JSON.UserInfo.Shell,
+	}, nil
+}
+
+func (c *container) GetGrGID(gid uint32) (*user.Group, error) {
+	name, ok := c.engine.EngineConfig.JSON.UserInfo.Groups[int(gid)]
+	if ok {
+		return &user.Group{
+			Name: name,
+			GID:  gid,
+		}, nil
+	}
+	return nil, osuser.UnknownGroupIdError(fmt.Sprintf("%d", gid))
+}
+
+func (c *container) Getgroups() ([]int, error) {
+	gids := make([]int, 0, len(c.engine.EngineConfig.JSON.UserInfo.Groups))
+	for gid := range c.engine.EngineConfig.JSON.UserInfo.Groups {
+		gids = append(gids, gid)
+	}
+	return gids, nil
 }

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1459,9 +1459,9 @@ func (c *container) getHomePaths() (source string, dest string, err error) {
 	} else {
 		source = c.engine.EngineConfig.JSON.UserInfo.Home
 		if source != "" {
-			if c.engine.EngineConfig.GetFakeroot() || os.Getuid() == 0 {
-				// Mount user home directory onto /root for
-				//  any root-mapped namespace
+			if c.engine.EngineConfig.GetFakeroot() {
+				// Mount user home directory onto /root for any root-mapped
+				// namespace
 				dest = "/root"
 			} else {
 				dest = source

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -1,5 +1,7 @@
-// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -128,11 +130,13 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 
 	uid := e.EngineConfig.GetTargetUID()
 	gids := e.EngineConfig.GetTargetGID()
+	useTargetIDs := false
 
 	if os.Getuid() == 0 && (uid != 0 || len(gids) > 0) {
 		starterConfig.SetTargetUID(uid)
 		starterConfig.SetTargetGID(gids)
 		e.EngineConfig.OciConfig.SetProcessNoNewPrivileges(true)
+		useTargetIDs = true
 	}
 
 	if e.EngineConfig.GetInstanceJoin() {
@@ -140,6 +144,8 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 			return err
 		}
 	} else {
+		e.setUserInfo(useTargetIDs)
+
 		if err := e.prepareContainerConfig(starterConfig); err != nil {
 			return err
 		}
@@ -1426,4 +1432,52 @@ func (e *EngineOperations) loadImage(path string, writable bool) (*image.Image, 
 	}
 
 	return imgObject, imgErr
+}
+
+func (e *EngineOperations) setUserInfo(useTargetIDs bool) {
+	var gids []int
+
+	pw, err := user.Current()
+	if err != nil {
+		return
+	}
+
+	e.EngineConfig.JSON.UserInfo.Home = pw.Dir
+
+	if useTargetIDs {
+		pw, err = user.GetPwUID(uint32(e.EngineConfig.GetTargetUID()))
+		if err == nil {
+			e.EngineConfig.JSON.UserInfo.Username = pw.Name
+			e.EngineConfig.JSON.UserInfo.Gecos = pw.Gecos
+			e.EngineConfig.JSON.UserInfo.UID = int(pw.UID)
+			e.EngineConfig.JSON.UserInfo.GID = int(pw.GID)
+		}
+	} else {
+		e.EngineConfig.JSON.UserInfo.Username = pw.Name
+		e.EngineConfig.JSON.UserInfo.Gecos = pw.Gecos
+		e.EngineConfig.JSON.UserInfo.UID = int(pw.UID)
+		e.EngineConfig.JSON.UserInfo.GID = int(pw.GID)
+	}
+
+	e.EngineConfig.JSON.UserInfo.Groups = make(map[int]string)
+
+	if useTargetIDs {
+		gids = e.EngineConfig.GetTargetGID()
+	} else {
+		gids, err = os.Getgroups()
+		if err != nil {
+			return
+		}
+	}
+
+	if pw != nil {
+		gids = append(gids, int(pw.GID))
+	}
+
+	for _, gid := range gids {
+		group, err := user.GetGrGID(uint32(gid))
+		if err == nil {
+			e.EngineConfig.JSON.UserInfo.Groups[gid] = group.Name
+		}
+	}
 }

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -130,7 +130,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 
 	uid := e.EngineConfig.GetTargetUID()
 	gids := e.EngineConfig.GetTargetGID()
-	useTargetIDs := false
+	useTargetIDs := e.EngineConfig.GetFakeroot()
 
 	if os.Getuid() == 0 && (uid != 0 || len(gids) > 0) {
 		starterConfig.SetTargetUID(uid)
@@ -1437,7 +1437,7 @@ func (e *EngineOperations) loadImage(path string, writable bool) (*image.Image, 
 func (e *EngineOperations) setUserInfo(useTargetIDs bool) {
 	var gids []int
 
-	pw, err := user.Current()
+	pw, err := user.CurrentOriginal()
 	if err != nil {
 		return
 	}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -388,7 +388,7 @@ func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
 
 	if l.singularityConf.ConfigPasswd {
 		sylog.Debugf("Updating passwd file: %s", containerPasswd)
-		content, err := files.Passwd(containerPasswd, l.cfg.HomeDir, int(uid), nil)
+		content, err := files.Passwd(containerPasswd, l.homeDest, int(uid), nil)
 		if err != nil {
 			sylog.Warningf("%s", err)
 		} else if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -388,7 +388,7 @@ func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
 
 	if l.singularityConf.ConfigPasswd {
 		sylog.Debugf("Updating passwd file: %s", containerPasswd)
-		content, err := files.Passwd(containerPasswd, l.homeDest, int(uid))
+		content, err := files.Passwd(containerPasswd, l.cfg.HomeDir, int(uid), nil)
 		if err != nil {
 			sylog.Warningf("%s", err)
 		} else if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {
@@ -400,7 +400,7 @@ func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
 
 	if l.singularityConf.ConfigGroup {
 		sylog.Debugf("Updating group file: %s", containerGroup)
-		content, err := files.Group(containerGroup, int(uid), []int{int(gid)})
+		content, err := files.Group(containerGroup, int(uid), []int{int(gid)}, nil)
 		if err != nil {
 			sylog.Warningf("%s", err)
 		} else if err := os.WriteFile(containerGroup, content, 0o755); err != nil {

--- a/internal/pkg/util/fs/files/files_linux_test.go
+++ b/internal/pkg/util/fs/files/files_linux_test.go
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -20,11 +22,11 @@ func TestGroup(t *testing.T) {
 	var gids []int
 	uid := os.Getuid()
 
-	_, err := Group("/fake", uid, gids)
+	_, err := Group("/fake", uid, gids, nil)
 	if err == nil {
 		t.Errorf("should have failed with bad group file")
 	}
-	_, err = Group("/etc/group", uid, gids)
+	_, err = Group("/etc/group", uid, gids, nil)
 	if err != nil {
 		t.Errorf("should have passed with correct group file")
 	}
@@ -37,7 +39,7 @@ func TestGroup(t *testing.T) {
 	defer os.Remove(emptyGroup)
 	f.Close()
 
-	_, err = Group(emptyGroup, uid, gids)
+	_, err = Group(emptyGroup, uid, gids, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/pkg/util/fs/files/passwd.go
+++ b/internal/pkg/util/fs/files/passwd.go
@@ -75,13 +75,17 @@ func Passwd(path string, home string, uid int, customLookup UserGroupLookup) (co
 			return content, fmt.Errorf("failed to parse this /etc/passwd line in container: %#v (%s)", line, err)
 		}
 		if entry.Uid() == uid {
-			userExists = true
 			// If user already exists in container, rebuild their passwd info preserving their original shell value
-			lines[i] = makePasswdLine(pwInfo.Name, pwInfo.UID, pwInfo.GID, pwInfo.Gecos, homeDir, entry.Shell())
+			userExists = true
+			origLine := lines[i]
+			revisedLine := makePasswdLine(pwInfo.Name, pwInfo.UID, pwInfo.GID, pwInfo.Gecos, homeDir, entry.Shell())
+			sylog.Debugf("replacing line in passwd file: %q instead of %q", revisedLine, origLine)
+			lines[i] = revisedLine
 			break
 		}
 	}
 	if !userExists {
+		sylog.Debugf("appending new line to passwd file: %q", userInfo)
 		lines = append(lines, userInfo)
 	}
 

--- a/internal/pkg/util/fs/files/passwd.go
+++ b/internal/pkg/util/fs/files/passwd.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -18,9 +20,15 @@ import (
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
+type UserGroupLookup interface {
+	GetPwUID(uint32) (*user.User, error)
+	GetGrGID(uint32) (*user.Group, error)
+	Getgroups() ([]int, error)
+}
+
 // Passwd creates a passwd template based on content of file provided in path,
 // updates content with current user information and returns content.
-func Passwd(path string, home string, uid int) (content []byte, err error) {
+func Passwd(path string, home string, uid int, customLookup UserGroupLookup) (content []byte, err error) {
 	sylog.Verbosef("Checking for template passwd file: %s", path)
 	if !fs.IsFile(path) {
 		return content, fmt.Errorf("passwd file doesn't exist in container, not updating")
@@ -39,7 +47,12 @@ func Passwd(path string, home string, uid int) (content []byte, err error) {
 	}
 	file.Close()
 
-	pwInfo, err := user.GetPwUID(uint32(uid))
+	getPwUID := user.GetPwUID
+	if customLookup != nil {
+		getPwUID = customLookup.GetPwUID
+	}
+
+	pwInfo, err := getPwUID(uint32(uid))
 	if err != nil {
 		return content, err
 	}

--- a/internal/pkg/util/fs/files/passwd_test.go
+++ b/internal/pkg/util/fs/files/passwd_test.go
@@ -21,7 +21,7 @@ func TestPasswd(t *testing.T) {
 	uid := os.Getuid()
 
 	// Test how Passwd() works with a bad passwd file
-	_, err := Passwd("/fake", "/fake", uid)
+	_, err := Passwd("/fake", "/fake", uid, nil)
 	if err == nil {
 		t.Errorf("should have failed with bad passwd file")
 	}
@@ -34,7 +34,8 @@ func TestPasswd(t *testing.T) {
 	emptyPasswd := f.Name()
 	defer os.Remove(emptyPasswd)
 	f.Close()
-	_, err = Passwd(emptyPasswd, "/home", uid)
+
+	_, err = Passwd(emptyPasswd, "/home", uid, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -43,7 +44,7 @@ func TestPasswd(t *testing.T) {
 	testUID := 0
 	testHomeDir := "/tmp"
 	testGoldenFile := "passwd.root.customhome.golden"
-	bytes, err := Passwd(inputPasswdFilePath, testHomeDir, testUID)
+	bytes, err := Passwd(inputPasswdFilePath, testHomeDir, testUID, nil)
 	if err != nil {
 		t.Errorf("Unexpected error encountered calling Passwd(): %v", err)
 		return

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -1,4 +1,6 @@
 // Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -58,6 +60,16 @@ type FuseMount struct {
 	FromContainer bool      `json:"fromContainer,omitempty"` // is FUSE driver program is run from container or from host
 	Daemon        bool      `json:"daemon,omitempty"`        // is FUSE driver program is run in daemon/background mode
 	Cmd           *exec.Cmd `json:"-"`                       // holds the process exec command when FUSE driver run in foreground mode
+}
+
+type UserInfo struct {
+	Username string         `json:"username,omitempty"`
+	Home     string         `json:"home,omitempty"`
+	UID      int            `json:"uid,omitempty"`
+	GID      int            `json:"gid,omitempty"`
+	Groups   map[int]string `json:"groups,omitempty"`
+	Gecos    string         `json:"gecos,omitempty"`
+	Shell    string         `json:"shell,omitempty"`
 }
 
 // JSONConfig stores engine specific configuration that is allowed to be set by the user.
@@ -127,6 +139,7 @@ type JSONConfig struct {
 	XdgRuntimeDir         string            `json:"xdgRuntimeDir,omitempty"`
 	DbusSessionBusAddress string            `json:"dbusSessionBusAddress,omitempty"`
 	NoEval                bool              `json:"noEval,omitempty"`
+	UserInfo              UserInfo          `json:"userInfo,omitempty"`
 	NoSetgroups           bool              `json:"noSetgroups,omitempty"`
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Lookup and store user/group information in stage one prior to entering any namespaces to fix issue with winbind not correctly lookup user/group information when using user namespace.

This is a pick of https://github.com/apptainer/apptainer/pull/1368

Fixes: #696 