### PR TITLE
add missing copyright info to mount_linux.go, overlay_set_linux.go

### DIFF
--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/util/fs/overlay/overlay_set_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_set_linux.go
@@ -1,4 +1,6 @@
 // Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes incomplete copyright info on files touched by PR #1753 

