### PR TITLE
Enter namespaces earlier in --oci mode. 

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/internal/pkg/util/interactive"
+	"github.com/sylabs/singularity/internal/pkg/util/rootless"
 	"github.com/sylabs/singularity/internal/pkg/util/starter"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"github.com/sylabs/singularity/pkg/build/types"
@@ -73,11 +74,12 @@ func fakerootExec(cmdArgs []string) {
 		sylog.Fatalf("failed to retrieve user information: %s", err)
 	}
 
-	// Append the user's real UID to the environment as _CONTAINERS_ROOTLESS_UID.
+	// Append the user's real UID/GID to the environment as _CONTAINERS_ROOTLESS_UID/GID.
 	// This is required in fakeroot builds that may use containers/image 5.7 and above.
 	// https://github.com/containers/image/issues/1066
 	// https://github.com/containers/image/blob/master/internal/rootless/rootless.go
-	os.Setenv("_CONTAINERS_ROOTLESS_UID", strconv.Itoa(os.Getuid()))
+	os.Setenv(rootless.UIDEnv, strconv.Itoa(os.Getuid()))
+	os.Setenv(rootless.GIDEnv, strconv.Itoa(os.Getgid()))
 
 	engineConfig := &fakerootConfig.EngineConfig{
 		Args:        args,

--- a/internal/pkg/runtime/launcher/oci/oci_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_linux.go
@@ -18,7 +18,7 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/sylabs/singularity/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
-	"github.com/sylabs/singularity/internal/pkg/util/user"
+	"github.com/sylabs/singularity/internal/pkg/util/rootless"
 	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/fs/lock"
@@ -54,14 +54,14 @@ func runtime() (path string, err error) {
 // runtimeStateDir returns path to use for crun/runc's state handling.
 func runtimeStateDir() (path string, err error) {
 	// Ensure we get correct uid for host if we were re-exec'd in id mapped userns
-	pw, err := user.CurrentOriginal()
+	u, err := rootless.GetUser()
 	if err != nil {
 		return "", err
 	}
-	if pw.UID == 0 {
+	if u.Uid == "0" {
 		return "/run/singularity-oci", nil
 	}
-	return fmt.Sprintf("/run/user/%d/singularity-oci", pw.UID), nil
+	return fmt.Sprintf("/run/user/%s/singularity-oci", u.Uid), nil
 }
 
 // stateDir returns the path to container state handled by conmon/singularity
@@ -72,7 +72,7 @@ func stateDir(containerID string) (string, error) {
 		return "", err
 	}
 
-	u, err := user.CurrentOriginal()
+	u, err := rootless.GetUser()
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/runtime/launcher/oci/oci_overlay.go
+++ b/internal/pkg/runtime/launcher/oci/oci_overlay.go
@@ -7,8 +7,6 @@ package oci
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"github.com/sylabs/singularity/internal/pkg/util/fs/overlay"
 	"github.com/sylabs/singularity/pkg/ocibundle/tools"
@@ -93,20 +91,4 @@ func prepareWritableTmpfs(bundleDir string) (string, error) {
 func cleanupWritableTmpfs(bundleDir, overlayDir string) error {
 	sylog.Debugf("Cleaning up writable tmpfs overlay for %s", bundleDir)
 	return tools.DeleteOverlayTmpfs(bundleDir, overlayDir)
-}
-
-// absOverlay takes an overlay description string (a path, optionally followed by a colon with an option string, like ":ro" or ":rw"), and replaces any relative path in the description string with an absolute one.
-func absOverlay(desc string) (string, error) {
-	splitted := strings.SplitN(desc, ":", 2)
-	barePath := splitted[0]
-	absBarePath, err := filepath.Abs(barePath)
-	if err != nil {
-		return "", err
-	}
-	absDesc := absBarePath
-	if len(splitted) > 1 {
-		absDesc += ":" + splitted[1]
-	}
-
-	return absDesc, nil
 }

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -14,12 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
-	"github.com/sylabs/singularity/internal/pkg/buildcfg"
-	fakerootConfig "github.com/sylabs/singularity/internal/pkg/runtime/engine/fakeroot/config"
-	"github.com/sylabs/singularity/internal/pkg/util/starter"
-	"github.com/sylabs/singularity/pkg/runtime/engine/config"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
@@ -218,63 +213,24 @@ func Run(ctx context.Context, containerID, bundlePath, pidFile string, systemdCg
 
 // RunWrapped runs a container via the OCI runtime, wrapped with prep / cleanup steps.
 func RunWrapped(ctx context.Context, containerID, bundlePath, pidFile string, overlayPaths []string, systemdCgroups bool) error {
-	runFunc := func() error {
-		return Run(ctx, containerID, bundlePath, pidFile, systemdCgroups)
-	}
-
-	if len(overlayPaths) > 0 {
-		return WrapWithOverlays(runFunc, bundlePath, overlayPaths)
-	}
-
-	return WrapWithWritableTmpFs(runFunc, bundlePath)
-}
-
-// RunWrappedNS reexecs singularity in a user namespace, with supplied uid/gid mapping, calling oci run.
-func RunWrappedNS(ctx context.Context, containerID, bundlePath string, overlayPaths []string) error {
 	absBundle, err := filepath.Abs(bundlePath)
 	if err != nil {
 		return fmt.Errorf("failed to determine bundle absolute path: %s", err)
 	}
 
-	args := []string{
-		filepath.Join(buildcfg.BINDIR, "singularity"),
-		"oci",
-		"run-wrapped",
-		"-b", absBundle,
-	}
-	for _, p := range overlayPaths {
-		absPath, err := absOverlay(p)
-		if err != nil {
-			return fmt.Errorf("could not convert %q to absolute path: %w", p, err)
-		}
-
-		args = append(args, "--overlay", absPath)
-	}
-	args = append(args, containerID)
-
 	if err := os.Chdir(absBundle); err != nil {
 		return fmt.Errorf("failed to change directory to %s: %s", absBundle, err)
 	}
 
-	sylog.Debugf("Calling fakeroot engine to execute %q", strings.Join(args, " "))
-
-	cfg := &config.Common{
-		EngineName:  fakerootConfig.Name,
-		ContainerID: "fakeroot",
-		EngineConfig: &fakerootConfig.EngineConfig{
-			Envs:    os.Environ(),
-			Args:    args,
-			NoPIDNS: true,
-		},
+	runFunc := func() error {
+		return Run(ctx, containerID, absBundle, pidFile, systemdCgroups)
 	}
 
-	return starter.Run(
-		"Singularity oci userns",
-		cfg,
-		starter.WithStdin(os.Stdin),
-		starter.WithStdout(os.Stdout),
-		starter.WithStderr(os.Stderr),
-	)
+	if len(overlayPaths) > 0 {
+		return WrapWithOverlays(runFunc, absBundle, overlayPaths)
+	}
+
+	return WrapWithWritableTmpFs(runFunc, absBundle)
 }
 
 // Start starts a previously created container

--- a/internal/pkg/runtime/launcher/oci/spec_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux_test.go
@@ -57,9 +57,13 @@ func Test_addNamespaces(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := minimalSpec()
-			newSpec := addNamespaces(spec, tt.ns)
-			newNS := newSpec.Linux.Namespaces
+			ms := minimalSpec()
+			spec := &ms
+			err := addNamespaces(spec, tt.ns)
+			if err != nil {
+				t.Errorf("addNamespaces() returned an unexpected error: %v", err)
+			}
+			newNS := spec.Linux.Namespaces
 			if !reflect.DeepEqual(newNS, tt.wantNS) {
 				t.Errorf("addNamespaces() got %v, want %v", newNS, tt.wantNS)
 			}

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -6,7 +6,10 @@
 package launcher
 
 import (
+	"fmt"
+
 	"github.com/containers/image/v5/types"
+	"github.com/sylabs/singularity/internal/pkg/util/fs/overlay"
 	"github.com/sylabs/singularity/pkg/util/cryptkey"
 )
 
@@ -170,8 +173,16 @@ func OptWritableTmpfs(b bool) Option {
 }
 
 // OptOverlayPaths sets overlay images and directories to apply to the container.
+// Relative paths are resolved to absolute paths at this point.
 func OptOverlayPaths(op []string) Option {
 	return func(lo *Options) error {
+		var err error
+		for i, p := range op {
+			op[i], err = overlay.AbsOverlay(p)
+			if err != nil {
+				return fmt.Errorf("could not convert %q to absolute path: %w", p, err)
+			}
+		}
 		lo.OverlayPaths = op
 		return nil
 	}

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -303,4 +304,20 @@ func UnmountWithFuse(dir string) error {
 	execCmd.Stderr = os.Stderr
 	_, err = execCmd.Output()
 	return err
+}
+
+// AbsOverlay takes an overlay description string (a path, optionally followed by a colon with an option string, like ":ro" or ":rw"), and replaces any relative path in the description string with an absolute one.
+func AbsOverlay(desc string) (string, error) {
+	splitted := strings.SplitN(desc, ":", 2)
+	barePath := splitted[0]
+	absBarePath, err := filepath.Abs(barePath)
+	if err != nil {
+		return "", err
+	}
+	absDesc := absBarePath
+	if len(splitted) > 1 {
+		absDesc += ":" + splitted[1]
+	}
+
+	return absDesc, nil
 }

--- a/internal/pkg/util/rootless/rootless.go
+++ b/internal/pkg/util/rootless/rootless.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package rootless
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	fakerootConfig "github.com/sylabs/singularity/internal/pkg/runtime/engine/fakeroot/config"
+	"github.com/sylabs/singularity/internal/pkg/util/starter"
+	"github.com/sylabs/singularity/pkg/runtime/engine/config"
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+const (
+	NSEnv  = "_SINGULARITY_NAMESPACE"
+	UIDEnv = "_CONTAINERS_ROOTLESS_UID"
+	GIDEnv = "_CONTAINERS_ROOTLESS_GID"
+)
+
+// Getuid retrieves the uid stored in the env var _CONTAINERS_ROOTLESS_UID, or
+// the current euid if the env var is not set.
+func Getuid() (uid int, err error) {
+	u := os.Getenv(UIDEnv)
+	if u != "" {
+		return strconv.Atoi(u)
+	}
+	return os.Geteuid(), nil
+}
+
+// Getgid retrieves the uid stored in the env var _CONTAINERS_ROOTLESS_GID, or
+// the current egid if the env var is not set.
+func Getgid() (uid int, err error) {
+	g := os.Getenv(GIDEnv)
+	if g != "" {
+		return strconv.Atoi(g)
+	}
+	return os.Getegid(), nil
+}
+
+// GetUser retrieves the User struct for the uid stored in the env var
+// _CONTAINERS_ROOTLESS_UID, or the current euid if the env var is not set.
+func GetUser() (*user.User, error) {
+	u := os.Getenv(UIDEnv)
+	if u != "" {
+		return user.LookupId(u)
+	}
+	return user.Current()
+}
+
+// InNS returns true if we are in a namespace created using this package.
+func InNS() bool {
+	_, envSet := os.LookupEnv(NSEnv)
+	return envSet
+}
+
+// ExecWithFakeroot will exec singularity with provided args, in a
+// subuid/gid-mapped fakeroot user namespace. This uses the fakeroot engine.
+func ExecWithFakeroot(args []string) error {
+	singularityBin := []string{
+		filepath.Join(buildcfg.BINDIR, "singularity"),
+	}
+	args = append(singularityBin, args...)
+
+	env := os.Environ()
+	env = append(env, NSEnv+"=TRUE")
+	// Use _CONTAINERS_ROOTLESS_xID naming for these vars as they are required
+	// by our use of containers/image for OCI image handling.
+	env = append(env, UIDEnv+"="+strconv.Itoa(os.Geteuid()))
+	env = append(env, GIDEnv+"="+strconv.Itoa(os.Getegid()))
+
+	sylog.Debugf("Calling fakeroot engine to execute %q", strings.Join(args, " "))
+
+	cfg := &config.Common{
+		EngineName:  fakerootConfig.Name,
+		ContainerID: "fakeroot",
+		EngineConfig: &fakerootConfig.EngineConfig{
+			Envs:        env,
+			Args:        args,
+			NoPIDNS:     true,
+			NoSetgroups: true,
+		},
+	}
+
+	return starter.Exec(
+		"Singularity oci fakeroot",
+		cfg,
+	)
+}
+
+// RunInMountNS will run singularity with provided args, in a mount
+// namespace only.
+func RunInMountNS(args []string) error {
+	singularityBin := filepath.Join(buildcfg.BINDIR, "singularity")
+
+	env := os.Environ()
+	env = append(env, NSEnv+"=TRUE")
+
+	cmd := exec.Command(singularityBin, args...)
+	cmd.Env = env
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	// Unshare mount namespace
+	cmd.SysProcAttr.Unshareflags = syscall.CLONE_NEWNS
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		os.Exit(exitErr.ExitCode())
+	}
+	return err
+}

--- a/internal/pkg/util/rootless/rootless_test.go
+++ b/internal/pkg/util/rootless/rootless_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package rootless
+
+import (
+	"os"
+	"os/user"
+	"reflect"
+	"testing"
+)
+
+//nolint:dupl
+func TestGetuid(t *testing.T) {
+	tests := []struct {
+		name    string
+		setEnv  bool
+		envVal  string
+		wantUID int
+		wantErr bool
+	}{
+		{
+			name:    "unset",
+			setEnv:  false,
+			envVal:  "",
+			wantUID: os.Geteuid(),
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			setEnv:  true,
+			envVal:  "",
+			wantUID: os.Geteuid(),
+			wantErr: false,
+		},
+		{
+			name:    "valid",
+			setEnv:  true,
+			envVal:  "123",
+			wantUID: 123,
+			wantErr: false,
+		},
+		{
+			name:    "invalid",
+			setEnv:  true,
+			envVal:  "abc",
+			wantUID: 0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				os.Setenv(UIDEnv, tt.envVal)
+				defer os.Unsetenv(UIDEnv)
+			}
+			gotUID, err := Getuid()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Getuid() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotUID != tt.wantUID {
+				t.Errorf("Getuid() = %v, want %v", gotUID, tt.wantUID)
+			}
+		})
+	}
+}
+
+//nolint:dupl
+func TestGetgid(t *testing.T) {
+	tests := []struct {
+		name    string
+		setEnv  bool
+		envVal  string
+		wantGID int
+		wantErr bool
+	}{
+		{
+			name:    "unset",
+			setEnv:  false,
+			envVal:  "",
+			wantGID: os.Getegid(),
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			setEnv:  true,
+			envVal:  "",
+			wantGID: os.Getegid(),
+			wantErr: false,
+		},
+		{
+			name:    "valid",
+			setEnv:  true,
+			envVal:  "456",
+			wantGID: 456,
+			wantErr: false,
+		},
+		{
+			name:    "invalid",
+			setEnv:  true,
+			envVal:  "abc",
+			wantGID: 0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				os.Setenv(GIDEnv, tt.envVal)
+				defer os.Unsetenv(GIDEnv)
+			}
+			gotGID, err := Getgid()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Getgid() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotGID != tt.wantGID {
+				t.Errorf("Getgid() = %v, want %v", gotGID, tt.wantGID)
+			}
+		})
+	}
+}
+
+func TestGetUser(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootUser, err := user.LookupId("0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		setEnv  bool
+		envVal  string
+		want    *user.User
+		wantErr bool
+	}{
+		{
+			name:    "unset",
+			setEnv:  false,
+			envVal:  "",
+			want:    currentUser,
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			setEnv:  true,
+			envVal:  "",
+			want:    currentUser,
+			wantErr: false,
+		},
+		{
+			name:    "valid",
+			setEnv:  true,
+			envVal:  "0",
+			want:    rootUser,
+			wantErr: false,
+		},
+		{
+			name:    "invalid",
+			setEnv:  true,
+			envVal:  "abc",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				os.Setenv(UIDEnv, tt.envVal)
+				defer os.Unsetenv(UIDEnv)
+			}
+			got, err := GetUser()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetUser() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetUser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -10,10 +10,10 @@ package syfs
 
 import (
 	"os"
-	"os/user"
 	"path/filepath"
 	"sync"
 
+	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
@@ -49,7 +49,7 @@ func configDir() string {
 		return configDir
 	}
 
-	user, err := user.Current()
+	user, err := user.CurrentOriginal()
 	if err != nil {
 		sylog.Warningf("Could not lookup the current user's information: %s", err)
 
@@ -62,7 +62,7 @@ func configDir() string {
 		return filepath.Join(cwd, singularityDir)
 	}
 
-	return filepath.Join(user.HomeDir, singularityDir)
+	return filepath.Join(user.Dir, singularityDir)
 }
 
 func RemoteConf() string {
@@ -80,14 +80,14 @@ func DockerConf() string {
 // ConfigDirForUsername returns the directory where the singularity
 // configuration and data for the specified username is located.
 func ConfigDirForUsername(username string) (string, error) {
-	u, err := user.Lookup(username)
+	u, err := user.GetPwNam(username)
 	if err != nil {
 		return "", err
 	}
 
-	if cu, err := user.Current(); err == nil && u.Username == cu.Username {
+	if cu, err := user.CurrentOriginal(); err == nil && u.Name == cu.Name {
 		return ConfigDir(), nil
 	}
 
-	return filepath.Join(u.HomeDir, singularityDir), nil
+	return filepath.Join(u.Dir, singularityDir), nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Before this PR, if we are a non-root user we enter a root-mapped user namespace before calling `singularity oci run` at the end of the `--oci` launcher flow. If we are the root user, we do not enter any namespace. This means that bundle preparation, performed by the launcher, takes place outside of any namespaces.

As a non-root user, we want to perform bundle preparation inside a root-mapped user namespace. This is in order to benefit from fully-unprivileged FUSE operations when we start handling image mounts, plus advantages around cleanup on namespace exit. As a root user, we want to be inside a mount namespace to avoid polluting the host mount namespace with our container-specific mounts.

In this PR:

* As a non-root user, a root-mapped namespace is entered early, before   the oci launcher code executes.
* As a root user, a mount namespace is entered early, before the oci launcher code executes.

We use the `_CONTAINERS_ROOTLESS_xID` environment variables for tracking our UID/GID outside of the root-mapped namespace, since they must be set anyway for `containers/image` to operate properly inside the namespace.  We are using `containers/image` for our OCI image handling.

### This fixes or addresses the following GitHub issues:

 - Fixes #1773 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
