### PR TITLE
fix `mount home=no`, support `--no-home` in `--oci` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@
   of SIF metadata.
 - Pass STDIN to `--oci` containers correctly, to fix piping input to a container.
 - Fix compilation on 32-bit systems.
+- Set correct `$HOME` in `--oci` mode when `mount home = no` in
+  `singularity.conf`.
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,9 @@
   files on the host that have permissions based on supplementary group
   membership. Note that supplementary groups are mapped to `nobody` in the
   container, and `chgrp`, `newgrp`, etc. cannot be used.
-
+- OCI-mode now supports the `--no-home` flag, to prevent the container home
+  directory from being mounted.
+  
 ### Bug Fixes
 
 - Fix interaction between `--workdir` when given relative path and `--scratch`.

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -210,6 +210,11 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "NoHome",
+			argv: []string{"--no-home", imageRef, "grep", e2e.OCIUserProfile.ContainerUser(t).Dir, "/proc/self/mountinfo"},
+			exit: 1,
+		},
+		{
 			name: "UTSNamespace",
 			argv: []string{"--uts", imageRef, "true"},
 			exit: 0,

--- a/e2e/config/oci.go
+++ b/e2e/config/oci.go
@@ -211,6 +211,17 @@ func (c configTests) ociConfigGlobal(t *testing.T) {
 			directiveValue: "no",
 			exit:           1,
 		},
+		// Verify that though mount is skipped, $HOME is still set correctly
+		// https://github.com/sylabs/singularity/issues/1783
+		{
+			name:           "MountHomeNoCorrectDir",
+			argv:           []string{archiveRef, "sh", "-c", "test $HOME == " + e2e.OCIUserProfile.ContainerUser(t).Dir},
+			profile:        e2e.OCIUserProfile,
+			cwd:            "/",
+			directive:      "mount home",
+			directiveValue: "no",
+			exit:           0,
+		},
 		{
 			name:           "MountHomeYes",
 			argv:           []string{archiveRef, "grep", e2e.OCIUserProfile.ContainerUser(t).Dir, "/proc/self/mountinfo"},

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -82,9 +82,6 @@ func checkOpts(lo launcher.Options) error {
 	if lo.WritableTmpfs {
 		sylog.Infof("--oci mode uses --writable-tmpfs by default")
 	}
-	if lo.NoHome {
-		badOpt = append(badOpt, "NoHome")
-	}
 
 	if len(lo.FuseMount) > 0 {
 		badOpt = append(badOpt, "FuseMount")

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -47,6 +47,12 @@ var (
 type Launcher struct {
 	cfg             launcher.Options
 	singularityConf *singularityconf.File
+	// homeSrc is the computed source (on the host) for the user's home directory.
+	// An empty value indicates there is no source on the host, and a tmpfs will be used.
+	homeSrc string
+	// homeDest is the computed destination (in the container) for the user's home directory.
+	// An empty value is not valid at mount time.
+	homeDest string
 }
 
 // NewLauncher returns a oci.Launcher with an initial configuration set by opts.
@@ -67,7 +73,17 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 		return nil, fmt.Errorf("singularity configuration is not initialized")
 	}
 
-	return &Launcher{cfg: lo, singularityConf: c}, nil
+	homeSrc, homeDest, err := parseHomeDir(lo.HomeDir, lo.CustomHome, lo.Fakeroot)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Launcher{
+		cfg:             lo,
+		singularityConf: c,
+		homeSrc:         homeSrc,
+		homeDest:        homeDest,
+	}, nil
 }
 
 // checkOpts ensures that options set are supported by the oci.Launcher.
@@ -184,6 +200,43 @@ func checkOpts(lo launcher.Options) error {
 	}
 
 	return nil
+}
+
+// parseHomeDir parses the homedir value passed from the CLI layer into a host source, and container dest.
+// This includes handling fakeroot and custom --home dst, or --home src:dst specifications.
+func parseHomeDir(homedir string, custom, fakeroot bool) (src, dest string, err error) {
+	// Get the host user's information, looking outside of a user namespace if necessary.
+	pw, err := rootless.GetUser()
+	if err != nil {
+		return "", "", err
+	}
+
+	// By default in --oci mode there is no external source for $HOME, i.e. a `tmpfs` will be used.
+	src = ""
+	// By default the destination in the container matches the users's $HOME on the host.
+	dest = pw.HomeDir
+
+	// --fakeroot means we are root in the container so $HOME=/root
+	if fakeroot {
+		dest = "/root"
+	}
+
+	// If the user set a custom --home via the CLI, then override the defaults.
+	if custom {
+		homeSlice := strings.Split(homedir, ":")
+		if len(homeSlice) < 1 || len(homeSlice) > 2 {
+			return "", "", fmt.Errorf("home argument has incorrect number of elements: %v", homeSlice)
+		}
+		// A single path was provided, so we will be mounting a tmpfs on this custom destination.
+		dest = homeSlice[0]
+
+		// Two paths provided (<src>:<dest>), so we will be bind mounting from host to container.
+		if len(homeSlice) > 1 {
+			src = homeSlice[0]
+			dest = homeSlice[1]
+		}
+	}
+	return src, dest, nil
 }
 
 // createSpec creates an initial OCI runtime specification, suitable to launch a

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -6,6 +6,7 @@
 package oci
 
 import (
+	"os/user"
 	"reflect"
 	"testing"
 
@@ -24,6 +25,11 @@ func TestNewLauncher(t *testing.T) {
 	}
 	singularityconf.SetCurrentConfig(sc)
 
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("while getting current user: %s", err)
+	}
+
 	tests := []struct {
 		name    string
 		opts    []launcher.Option
@@ -31,16 +37,38 @@ func TestNewLauncher(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "default",
-			want:    &Launcher{singularityConf: sc},
+			name: "default",
+			want: &Launcher{
+				singularityConf: sc,
+				homeSrc:         "",
+				homeDest:        u.HomeDir,
+			},
+		},
+		{
+			name: "homeDest",
+			opts: []launcher.Option{
+				launcher.OptHome("/home/dest", true, false),
+			},
+			want: &Launcher{
+				cfg:             launcher.Options{HomeDir: "/home/dest", CustomHome: true},
+				singularityConf: sc,
+				homeSrc:         "",
+				homeDest:        "/home/dest",
+			},
 			wantErr: false,
 		},
 		{
-			name: "validOption",
+			name: "homeSrcDest",
 			opts: []launcher.Option{
-				launcher.OptHome("/home/test", false, false),
+				launcher.OptHome("/home/src:/home/dest", true, false),
 			},
-			want: &Launcher{cfg: launcher.Options{HomeDir: "/home/test"}, singularityConf: sc},
+			want: &Launcher{
+				cfg:             launcher.Options{HomeDir: "/home/src:/home/dest", CustomHome: true},
+				singularityConf: sc,
+				homeSrc:         "/home/src",
+				homeDest:        "/home/dest",
+			},
+			wantErr: false,
 		},
 		{
 			name: "unsupportedOption",

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -266,11 +266,15 @@ func (l *Launcher) addSysMount(mounts *[]specs.Mount) error {
 // `--containall`, so the user must specifically bind in their home directory
 // from the host for it to be available.
 func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
-	// If the $HOME mount is skipped by config need to still handle setting the
-	// correct $HOME dir, but just skip adding the mount.
+	// If the $HOME mount is skipped by config or --no-home, we still need to
+	// handle setting the correct $HOME dir, but just skip adding the mount.
 	skipMount := false
 	if !l.singularityConf.MountHome {
 		sylog.Debugf("Skipping mount of $HOME due to singularity.conf")
+		skipMount = true
+	}
+	if l.cfg.NoHome {
+		sylog.Debugf("Skipping mount of $HOME due to --no-home")
 		skipMount = true
 	}
 

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -49,7 +49,7 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, imag
 
 	// Ensure HOME points to the required home directory, even if it is a custom one, unless the container explicitly specifies its USER, in which case we don't want to touch HOME.
 	if imgSpec.Config.User == "" {
-		rtEnv["HOME"] = l.cfg.HomeDir
+		rtEnv["HOME"] = l.homeDest
 	}
 
 	cwd, err := l.getProcessCwd()


### PR DESCRIPTION
## Description of the Pull Request (PR):

**fix: set correct $HOME in --oci mode when mount home = no**

When `mount home = no` is set in `singularity.conf`, we still need to
set the correct value for `$HOME` in the container... we just don't
want to mount it.

Fixes #1783

**support `--no-home` in `--oci` mode**

When `--no-home` is set on the CLI in `--oci` mode, do not mount
onto the container home directory.

Fixes #1780

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
