### PR TITLE
oci: Support --no-mount, to extent possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@
   container, and `chgrp`, `newgrp`, etc. cannot be used.
 - OCI-mode now supports the `--no-home` flag, to prevent the container home
   directory from being mounted.
+- OCI-mode now supports the `--no-mount` flag to disable the `proc`, `sys`,
+  `devpts`, `tmp`, and `home` mounts in the container. `dev` cannot be disabled
+  in OCI-mode, and `bind-path` mounts are not supported.
   
 ### Bug Fixes
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2635,5 +2635,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociOverlay":           (c.actionOciOverlay),           // --overlay in OCI mode
 		"ociOverlayExtfsPerms": (c.actionOciOverlayExtfsPerms), // permissions in writable extfs overlays mounted with FUSE in OCI mode
 		"ociOverlayTeardown":   np(c.actionOciOverlayTeardown), // proper overlay unmounting in OCI mode
+		"ociNo-mount":          c.actionOciNoMount,             // --no-mount in OCI mode
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -35,11 +35,14 @@ import (
 	"github.com/sylabs/singularity/pkg/ocibundle/tools"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/singularityconf"
+	"github.com/sylabs/singularity/pkg/util/slice"
 )
 
 var (
 	ErrUnsupportedOption = errors.New("not supported by OCI launcher")
 	ErrNotImplemented    = errors.New("not implemented by OCI launcher")
+
+	unsupportedNoMount = []string{"dev", "cwd", "bind-paths"}
 )
 
 // Launcher will holds configuration for, and will launch a container using an
@@ -103,8 +106,10 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "FuseMount")
 	}
 
-	if len(lo.NoMount) > 0 {
-		badOpt = append(badOpt, "NoMount")
+	for _, nm := range lo.NoMount {
+		if strings.HasPrefix(nm, "/") || slice.ContainsString(unsupportedNoMount, nm) {
+			sylog.Warningf("--no-mount %s is not supported in OCI mode, ignoring.", nm)
+		}
 	}
 
 	if lo.NvCCLI {

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/bind"
+	"github.com/sylabs/singularity/pkg/util/slice"
 )
 
 const containerLibDir = "/.singularity.d/libs"
@@ -71,6 +72,10 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) error {
 
 	if !l.singularityConf.MountTmp {
 		sylog.Debugf("Skipping mount of /tmp due to singularity.conf")
+		return nil
+	}
+	if slice.ContainsString(l.cfg.NoMount, "tmp") {
+		sylog.Debugf("Skipping mount of /tmp due to --no-mount")
 		return nil
 	}
 
@@ -189,7 +194,6 @@ func (l *Launcher) addDevMounts(mounts *[]specs.Mount) error {
 				fmt.Sprintf("size=%dm", l.singularityConf.SessiondirMaxSize),
 			},
 		},
-		ptsMount,
 		specs.Mount{
 			Destination: "/dev/shm",
 			Type:        "tmpfs",
@@ -210,6 +214,12 @@ func (l *Launcher) addDevMounts(mounts *[]specs.Mount) error {
 		},
 	)
 
+	if slice.ContainsString(l.cfg.NoMount, "devpts") {
+		sylog.Debugf("Skipping mount of /dev/pts due to --no-mount")
+		return nil
+	}
+
+	*mounts = append(*mounts, ptsMount)
 	return nil
 }
 
@@ -217,6 +227,10 @@ func (l *Launcher) addDevMounts(mounts *[]specs.Mount) error {
 func (l *Launcher) addProcMount(mounts *[]specs.Mount) {
 	if !l.singularityConf.MountProc {
 		sylog.Debugf("Skipping mount of /proc due to singularity.conf")
+		return
+	}
+	if slice.ContainsString(l.cfg.NoMount, "proc") {
+		sylog.Debugf("Skipping mount of /proc due to --no-mount")
 		return
 	}
 
@@ -232,6 +246,10 @@ func (l *Launcher) addProcMount(mounts *[]specs.Mount) {
 func (l *Launcher) addSysMount(mounts *[]specs.Mount) error {
 	if !l.singularityConf.MountSys {
 		sylog.Debugf("Skipping mount of /sys due to singularity.conf")
+		return nil
+	}
+	if slice.ContainsString(l.cfg.NoMount, "sys") {
+		sylog.Debugf("Skipping mount of /sys due to --no-mount")
 		return nil
 	}
 
@@ -270,6 +288,10 @@ func (l *Launcher) addHomeMount(mounts *[]specs.Mount) error {
 	}
 	if l.cfg.NoHome {
 		sylog.Debugf("Skipping mount of $HOME due to --no-home")
+		return nil
+	}
+	if slice.ContainsString(l.cfg.NoMount, "home") {
+		sylog.Debugf("Skipping mount of /home due to --no-mount")
 		return nil
 	}
 


### PR DESCRIPTION
Stacked on #1784 - for rebase after it's merged.

## Description of the Pull Request (PR):

Allow the `--no-mount` flag to be specified in `--oci` mode. This allows disabling the following mounts:
  
  * proc
  * sys
  * devpts
  * tmp
  * home
  
Note that `dev` cannot be supported in `--oci` mode, as an OCI runtime *requires* that certain devices are present, and will include them in a `/dev` tmpfs.
  
We currently run similar to native mode `--compat`, so we don't mount the current working directory. Therefore, `--no-mount cwd` is not supported.
  
Similarly, `--compat` infers that `bind path` entries from `singularity.conf` are ignored. We may handle them in some way, in future.


### This fixes or addresses the following GitHub issues:

 - Fixes #1781 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
