### PR TITLE
oci: support --no-setgroups with crun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,12 +65,13 @@
   `SINGULARITY_CONFIGDIR` environment variable.
 - If kernel does not support unprivileged overlays, OCI-mode will attempt to use
   `fuse-overlayfs` and `fusermount` for overlay mounting and unmounting.
-- Added `--no-setgroups` flag for `--fakeroot` builds and run/shell/exec. This
-  prevents the `setgroups` syscall being used on the container process in the
-  fakeroot user namespace. Maintains access from within the user namespace to
-  files on the host that have permissions based on supplementary group
-  membership. Note that supplementary groups are mapped to `nobody` in the
-  container, and `chgrp`, `newgrp`, etc. cannot be used.
+- Added `--no-setgroups` flag, to prevent the `setgroups` syscall being called
+  when starting a container.  Applies to `--fakeroot` builds and actions in
+  native mode. Applies to all non-root actions in OCI-mode. Maintains access
+  from within the user namespace to files on the host that have permissions
+  based on supplementary group membership. Note that supplementary groups are
+  mapped to `nobody` in the container, and `chgrp`, `newgrp`, etc. cannot be
+  used.
 - OCI-mode now supports the `--no-home` flag, to prevent the container home
   directory from being mounted.
 - OCI-mode now supports the `--no-mount` flag to disable the `proc`, `sys`,

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2629,6 +2629,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociSTDPIPE":           c.ociSTDPipe,                   // stdin/stdout pipe --oci
 		"ociNetwork":           c.actionOciNetwork,             // singularity exec --oci --net
 		"ociBinds":             c.actionOciBinds,               // singularity exec --oci --bind / --mount
+		"ociNo-setgroups":      c.actionOciNoSetgroups,         // --no-setgroups in OCI mode
 		"ociCdi":               c.actionOciCdi,                 // singularity exec --oci --cdi
 		"ociIDMaps":            c.actionOciIDMaps,              // check uid/gid mapping on host for --oci as user / --fakeroot
 		"ociCompat":            np(c.actionOciCompat),          // --oci equivalence to native mode --compat

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -193,10 +193,6 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "SIFFUSE")
 	}
 
-	if lo.NoSetgroups {
-		badOpt = append(badOpt, "NoSetgroups")
-	}
-
 	if len(badOpt) > 0 {
 		return fmt.Errorf("%w: %s", ErrUnsupportedOption, strings.Join(badOpt, ","))
 	}
@@ -276,6 +272,12 @@ func (l *Launcher) createSpec() (spec *specs.Spec, err error) {
 	if cgPath != "" {
 		spec.Linux.CgroupsPath = cgPath
 		spec.Linux.Resources = resources
+	}
+
+	if l.cfg.NoSetgroups {
+		if err := noSetgroupsAnnotation(spec); err != nil {
+			return nil, err
+		}
 	}
 
 	return spec, nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

The crun runtime supports skipping a setgroups call when entering a container. This is via an annotation on the runtime config.

Wire up the annotation to the `--no-setgroups` flag that we previously added in #1757 for native mode.

### This fixes or addresses the following GitHub issues:

 - Fixes #1550

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
