### PR TITLE
Update bash completion install dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   Unprivileged kernel overlay is supported without a plugin. In
   `singularity.conf`, the `image driver` directive has been removed, and
   `enable overlay` no longer supports the `driver` option.
+- Bash completions are now install to the modern
+  `share/bash-completion/completions` location, rather than under `etc`.
 
 ### New Features & Functionality
 

--- a/debian/singularity-ce.dirs
+++ b/debian/singularity-ce.dirs
@@ -1,7 +1,4 @@
+usr/share/bash-completion
 var/lib/singularity
 var/lib/singularity/mnt
-var/lib/singularity/mnt/container
-var/lib/singularity/mnt/final
-var/lib/singularity/mnt/overlay
 var/lib/singularity/mnt/session
-usr/share/bash-completion

--- a/debian/singularity-ce.install
+++ b/debian/singularity-ce.install
@@ -12,6 +12,6 @@ etc/singularity/global-pgp-public
 etc/singularity/cgroups/*
 etc/singularity/network/*
 etc/singularity/seccomp-profiles/*
-#etc/bash_completion.d/singularity/*
 var/lib/singularity/mnt/session
+usr/share/bash-completion/completions/singularity
 usr/share/man/man1/singularity*

--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -134,8 +134,7 @@ container platform designed to be simple, fast, and secure.
 %config(noreplace) %{_sysconfdir}/singularity/network/*
 %dir %{_sysconfdir}/singularity/seccomp-profiles
 %config(noreplace) %{_sysconfdir}/singularity/seccomp-profiles/*
-%dir %{_sysconfdir}/bash_completion.d
-%{_sysconfdir}/bash_completion.d/*
+%{_datadir}/bash-completion/completions/singularity
 %dir %{_sharedstatedir}/singularity
 %dir %{_sharedstatedir}/singularity/mnt
 %dir %{_sharedstatedir}/singularity/mnt/session

--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -37,7 +37,7 @@ ALL += $(singularity)
 
 
 # bash_completion file
-bash_completion :=  $(BUILDDIR)/etc/bash_completion.d/singularity
+bash_completion :=  $(BUILDDIR)/bash-completion/completions/singularity
 $(bash_completion): $(singularity_build_config)
 	@echo " GEN" $@
 	$(V)rm -f $@
@@ -45,7 +45,7 @@ $(bash_completion): $(singularity_build_config)
 	$(V)$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" \
 		$(SOURCEDIR)/cmd/bash_completion/bash_completion.go $@
 
-bash_completion_INSTALL := $(DESTDIR)$(SYSCONFDIR)/bash_completion.d/singularity
+bash_completion_INSTALL := $(DESTDIR)$(DATADIR)/bash-completion/completions/singularity
 $(bash_completion_INSTALL): $(bash_completion)
 	@echo " INSTALL" $@
 	$(V)umask 0022 && mkdir -p $(@D)


### PR DESCRIPTION
## Description of the Pull Request (PR):

The appropriate location for bash completion files is now `share/bash-completion/completions/` - verified against the RPM and Deb packaging guides.

Also remove unnecessary `.dirs` entries in the Debian packaging. Our `make install` creates almost everything, and there were some outdated directories in `.dirs`.


### This fixes or addresses the following GitHub issues:

 - Fixes #1137 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
