### PR TITLE
fix: oci: correct $HOME -> default cwd / passwd handling

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2637,5 +2637,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociOverlayExtfsPerms": (c.actionOciOverlayExtfsPerms), // permissions in writable extfs overlays mounted with FUSE in OCI mode
 		"ociOverlayTeardown":   np(c.actionOciOverlayTeardown), // proper overlay unmounting in OCI mode
 		"ociNo-mount":          c.actionOciNoMount,             // --no-mount in OCI mode
+		"ociHomeCwdPasswd":     c.actionOciHomeCwdPasswd,       // $HOME is correct in /etc/passwd, and is default cwd
 	}
 }

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1788,18 +1788,6 @@ func (c actionTests) actionOciHomeCwdPasswd(t *testing.T) {
 	e2e.EnsureOCIArchive(t, c.env)
 	imageRef := "oci-archive:" + c.env.OCIArchivePath
 	for _, p := range e2e.OCIProfiles {
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(p.String()+"/cwd"),
-			e2e.WithProfile(p),
-			e2e.WithCommand("exec"),
-			e2e.WithArgs(imageRef, "pwd"),
-			e2e.ExpectExit(
-				0,
-				e2e.ExpectOutput(e2e.ExactMatch, p.ContainerUser(t).Dir),
-			),
-		)
-
 		cu := p.ContainerUser(t)
 		// Ignore shell field as we use preserve container value. Tested previously.
 		passwdLine := fmt.Sprintf("^%s:x:%d:%d:%s:%s:",
@@ -1808,6 +1796,18 @@ func (c actionTests) actionOciHomeCwdPasswd(t *testing.T) {
 			cu.GID,
 			cu.Gecos,
 			cu.Dir,
+		)
+
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(p.String()+"/cwd"),
+			e2e.WithProfile(p),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(imageRef, "pwd"),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.ExactMatch, cu.Dir),
+			),
 		)
 
 		c.env.RunSingularity(

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -400,7 +400,7 @@ func (l *Launcher) updatePasswdGroup(rootfs string, uid, gid uint32) error {
 
 	if l.singularityConf.ConfigPasswd {
 		sylog.Debugf("Updating passwd file: %s", containerPasswd)
-		content, err := files.Passwd(containerPasswd, l.cfg.HomeDir, int(uid))
+		content, err := files.Passwd(containerPasswd, l.homeDest, int(uid))
 		if err != nil {
 			sylog.Warningf("%s", err)
 		} else if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -104,7 +104,7 @@ func (l *Launcher) getProcessCwd() (dir string, err error) {
 		return l.cfg.CwdPath, nil
 	}
 
-	return l.cfg.HomeDir, nil
+	return l.homeDest, nil
 }
 
 // getReverseUserMaps returns uid and gid mappings that re-map container uid to target


### PR DESCRIPTION
## Description of the Pull Request (PR):

In the refactoring performed in a10b379bf8859ee35abca55f31a3576f202df792, the setting of the default CWD, and creation of `/etc/passwd`, was not correctly adapted.

We need to use our parsed / processed `l.homeDest` value for the container homeDir in all cases. With a nested root-mapped user namespace re-exec, the CLI passed value is not correct unless it is a custom value.

The first commit adds e2e coverage for this issue. The second commit is the fix.

### This fixes or addresses the following GitHub issues:

 - Fixes #1791 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
