### PR TITLE
fakeroot: relax fakeroot seccomp rules (apptainer #1451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@
 - Fix compilation on 32-bit systems.
 - Set correct `$HOME` in `--oci` mode when `mount home = no` in
   `singularity.conf`.
+- Fix seccomp filters to allow mknod/mknodat syscalls to create pipe/socket
+  and character devices with device number 0 for fakeroot builds.
 
 ## 3.11.3 \[2023-05-04\]
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apptainer/apptainer/pull/1451

Original Commit:

Fix seccomp filters to allow mknod/mknodat syscalls to create pipe/so…

…cket

and character devices with device number 0 for fakeroot builds.