### PR TITLE
fix: disable IDMapping in inter-stage copy for proot builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
   `singularity.conf`.
 - Fix seccomp filters to allow mknod/mknodat syscalls to create pipe/socket
   and character devices with device number 0 for fakeroot builds.
+- Fix freeze when copying files between stages in an unprivileged proot build.
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1631,6 +1631,11 @@ func (c imgBuildTests) buildProot(t *testing.T) {
 			name:      "Ubuntu",
 			buildSpec: "testdata/proot_ubuntu.def",
 		},
+		// See: https://github.com/sylabs/singularity/issues/1643
+		{
+			name:      "MultiStage",
+			buildSpec: "testdata/proot_multistage.def",
+		},
 	}
 
 	profiles := []e2e.Profile{e2e.UserProfile}

--- a/e2e/testdata/proot_multistage.def
+++ b/e2e/testdata/proot_multistage.def
@@ -1,0 +1,19 @@
+bootstrap: library
+from: alpine:3.11.5
+Stage: build
+
+%post
+    echo 'test' > /test.txt
+
+bootstrap: library
+from: alpine:3.11.5
+Stage: final
+
+%files from build
+    /test.txt /test.txt
+
+%post
+    echo 'done'
+
+%test
+    test -f /test.txt

--- a/internal/pkg/build/assemblers/sandbox.go
+++ b/internal/pkg/build/assemblers/sandbox.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -30,7 +30,7 @@ func (a *SandboxAssembler) Assemble(b *types.Bundle, path string) (err error) {
 	if a.Copy {
 		sylog.Debugf("Copying sandbox from %v to %v", b.RootfsPath, path)
 
-		err := archive.CopyWithTar(b.RootfsPath+`/.`, path)
+		err := archive.CopyWithTar(b.RootfsPath+`/.`, path, false)
 		if err != nil {
 			return fmt.Errorf("copy Failed: %v", err)
 		}

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -101,7 +101,9 @@ func CopyFromHost(src, dstRel, dstRootfs string) error {
 // Symlinks are only dereferenced for the specified source or files that resolve
 // directly from a specified glob pattern. Any additional links inside a directory
 // being copied are not dereferenced.
-func CopyFromStage(src, dst, srcRootfs, dstRootfs string) error {
+// The disableIDMapping boolean should be set if this is a proot build, as the moby CopyWithTar
+// will freeze with ID mapping enabled in this case.
+func CopyFromStage(src, dst, srcRootfs, dstRootfs string, disableIDMapping bool) error {
 	// An absolute path on the host is required for globbing.
 	// Make sure the glob pattern doesn't climb out of the srcRootfs, by making it absolute w.r.t.
 	// the srcRootfs, and cleaning any '../' components that lead above the srcRootfs '/' before we
@@ -159,7 +161,7 @@ func CopyFromStage(src, dst, srcRootfs, dstRootfs string) error {
 			dstResolved = path.Join(dstResolved, srcName)
 		}
 
-		err = archive.CopyWithTar(srcResolved, dstResolved)
+		err = archive.CopyWithTar(srcResolved, dstResolved, disableIDMapping)
 		if err != nil {
 			return fmt.Errorf("while copying %s to %s: %s", paths, dstResolved, err)
 		}

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -730,7 +730,7 @@ func TestCopyFromStage(t *testing.T) {
 
 			// Manually concatenating because we need to preserve any trailing slash that is
 			// stripped by Join.
-			if err := CopyFromStage(tt.srcRel, tt.dstRel, srcRoot, dstRoot); err != nil {
+			if err := CopyFromStage(tt.srcRel, tt.dstRel, srcRoot, dstRoot, false); err != nil {
 				t.Errorf("unexpected failure running %s test: %s", t.Name(), err)
 			}
 
@@ -805,7 +805,7 @@ func TestCopyFromStageNested(t *testing.T) {
 	t.Logf("dstRoot location: %s\n", dstRoot)
 
 	// Copy our source innerDir over into the destination dir
-	if err := CopyFromStage("innerDir", "", srcRoot, dstRoot); err != nil {
+	if err := CopyFromStage("innerDir", "", srcRoot, dstRoot, false); err != nil {
 		t.Errorf("unexpected failure copying directory: %s", err)
 	}
 

--- a/internal/pkg/build/sources/packer_ext3.go
+++ b/internal/pkg/build/sources/packer_ext3.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -71,7 +71,7 @@ func unpackExt3(b *types.Bundle, img *image.Image) error {
 	// copy filesystem into bundle rootfs
 	sylog.Debugf("Copying filesystem from %s to %s in Bundle\n", tmpmnt, b.RootfsPath)
 
-	err = archive.CopyWithTar(tmpmnt+`/.`, b.RootfsPath)
+	err = archive.CopyWithTar(tmpmnt+`/.`, b.RootfsPath, false)
 	if err != nil {
 		return fmt.Errorf("copy Failed: %v", err)
 	}

--- a/internal/pkg/build/sources/packer_sandbox.go
+++ b/internal/pkg/build/sources/packer_sandbox.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -28,7 +28,7 @@ func (p *SandboxPacker) Pack(context.Context) (*types.Bundle, error) {
 	// copy filesystem into bundle rootfs
 	sylog.Debugf("Copying file system from %s to %s in Bundle\n", rootfs, p.b.RootfsPath)
 
-	err := archive.CopyWithTar(rootfs+`/.`, p.b.RootfsPath)
+	err := archive.CopyWithTar(rootfs+`/.`, p.b.RootfsPath, false)
 	if err != nil {
 		return nil, fmt.Errorf("copy Failed: %v", err)
 	}

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -199,8 +199,10 @@ func (s *stage) copyFilesFrom(b *Build) error {
 				continue
 			}
 			// copy each file into bundle rootfs
+			// Disable IDMapping entirely if it's a proot build
+			proot := os.Getenv("SINGULARITY_PROOT") != ""
 			sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)
-			if err := files.CopyFromStage(transfer.Src, transfer.Dst, srcRootfsPath, dstRootfsPath); err != nil {
+			if err := files.CopyFromStage(transfer.Src, transfer.Dst, srcRootfsPath, dstRootfsPath, proot); err != nil {
 				return err
 			}
 		}

--- a/pkg/util/archive/copy.go
+++ b/pkg/util/archive/copy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -21,7 +21,7 @@ import (
 // cannot modify to pass a context.
 //
 // nolint:contextcheck
-func CopyWithTar(src, dst string) error {
+func CopyWithTar(src, dst string, disableIDMapping bool) error {
 	ar := da.NewDefaultArchiver()
 
 	// If we are running unprivileged, then squash uid / gid as necessary.
@@ -30,7 +30,7 @@ func CopyWithTar(src, dst string) error {
 	// ownership to be preserved.
 	euid := os.Geteuid()
 	egid := os.Getgid()
-	if euid != 0 || egid != 0 {
+	if (euid != 0 || egid != 0) && !disableIDMapping {
 		sylog.Debugf("Using unprivileged CopyWithTar (uid=%d, gid=%d)", euid, egid)
 		// The docker CopytWithTar function assumes it should create the top-level of dst as the
 		// container root user. If we are unprivileged this means setting up an ID mapping

--- a/pkg/util/archive/copy_test.go
+++ b/pkg/util/archive/copy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -54,7 +54,7 @@ func testCopyWithTar(t *testing.T) {
 	// Perform the actual copy to a subdir of our dst tempdir.
 	// This ensures CopyWithTar has to create the dest directory, which is
 	// where the non-wrapped call would fail for unprivileged users.
-	err := CopyWithTar(srcRoot, path.Join(dstRoot, "dst"))
+	err := CopyWithTar(srcRoot, path.Join(dstRoot, "dst"), false)
 	if err != nil {
 		t.Fatalf("Error during CopyWithTar: %v", err)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In builds, we use a wrapped `CopyWithTar` to handle `%file` copies between stages. The wrapper includes logic to perform ID mappings to ensure correct, squashed, ownership of files.

Within a `proot` build, a copy between stages has been found to hang. The ID mapping is the cause of the hang. Disable it for the particular circumstance of proot build between-stage copy.

### This fixes or addresses the following GitHub issues:

 - Fixes #1643 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
