### PR TITLE
oci: wire up default capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   `enable overlay` no longer supports the `driver` option.
 - Bash completions are now install to the modern
   `share/bash-completion/completions` location, rather than under `etc`.
+- Default OCI config generated with `singularity mount` no longer sets any
+  inheritable / ambient capabilites, matching other OCI runtimes.
 
 ### New Features & Functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   `share/bash-completion/completions` location, rather than under `etc`.
 - Default OCI config generated with `singularity mount` no longer sets any
   inheritable / ambient capabilites, matching other OCI runtimes.
+- In OCI-mode, a container run as root, or with `--fakeroot` has OCI default
+  effective/permitted capabilities.
 
 ### New Features & Functionality
 

--- a/e2e/security/oci.go
+++ b/e2e/security/oci.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package security
+
+import (
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+)
+
+const (
+	// Default OCI capabilities as visible in /proc/status
+	ociDefaultCapString = "00000020a80425fb"
+	// No capabilities, as visible in /proc/status
+	nullCapString = "0000000000000000"
+)
+
+func (c ctx) ociCapabilities(t *testing.T) {
+	e2e.EnsureOCIArchive(t, c.env)
+	imageRef := "oci-archive:" + c.env.OCIArchivePath
+
+	tests := []struct {
+		name       string
+		profile    e2e.Profile
+		expectInh  string
+		expectPrm  string
+		expectEff  string
+		expectBnd  string
+		expectAmb  string
+		expectExit int
+	}{
+		{
+			name:      "DefaultUser",
+			profile:   e2e.OCIUserProfile,
+			expectInh: nullCapString,
+			expectPrm: nullCapString,
+			expectEff: nullCapString,
+			expectBnd: ociDefaultCapString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "DefaultRoot",
+			profile:   e2e.OCIRootProfile,
+			expectInh: nullCapString,
+			expectPrm: ociDefaultCapString,
+			expectEff: ociDefaultCapString,
+			expectBnd: ociDefaultCapString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "DefaultFakeroot",
+			profile:   e2e.OCIRootProfile,
+			expectInh: nullCapString,
+			expectPrm: ociDefaultCapString,
+			expectEff: ociDefaultCapString,
+			expectBnd: ociDefaultCapString,
+			expectAmb: nullCapString,
+		},
+	}
+
+	e2e.EnsureImage(t, c.env)
+
+	for _, tt := range tests {
+		args := []string{imageRef, "grep", "^Cap...:", "/proc/self/status"}
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(tt.profile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(args...),
+			e2e.ExpectExit(tt.expectExit,
+				e2e.ExpectOutput(e2e.ContainMatch, "CapInh:\t"+tt.expectInh),
+				e2e.ExpectOutput(e2e.ContainMatch, "CapPrm:\t"+tt.expectPrm),
+				e2e.ExpectOutput(e2e.ContainMatch, "CapEff:\t"+tt.expectEff),
+				e2e.ExpectOutput(e2e.ContainMatch, "CapBnd:\t"+tt.expectBnd),
+				e2e.ExpectOutput(e2e.ContainMatch, "CapAmb:\t"+tt.expectAmb),
+			),
+		)
+	}
+}

--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -245,5 +245,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"singularitySecurityUnpriv": c.testSecurityUnpriv,
 		"singularitySecurityPriv":   c.testSecurityPriv,
 		"testSecurityConfOwnership": np(c.testSecurityConfOwnership),
+		// OCI-Mode
+		"ociCapabilities": c.ociCapabilities,
 	}
 }

--- a/etc/conf/testdata/test_1.out.correct
+++ b/etc/conf/testdata/test_1.out.correct
@@ -200,7 +200,8 @@ always use nv = no
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the singularity runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/singularity/capability.json

--- a/etc/conf/testdata/test_2.in
+++ b/etc/conf/testdata/test_2.in
@@ -200,7 +200,8 @@ always use nv = no
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the singularity runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/singularity/capability.json

--- a/etc/conf/testdata/test_2.out.correct
+++ b/etc/conf/testdata/test_2.out.correct
@@ -200,7 +200,8 @@ always use nv = no
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the singularity runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/singularity/capability.json

--- a/etc/conf/testdata/test_3.in
+++ b/etc/conf/testdata/test_3.in
@@ -191,7 +191,8 @@ always use nv = no
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the singularity runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/singularity/capability.json

--- a/etc/conf/testdata/test_3.out.correct
+++ b/etc/conf/testdata/test_3.out.correct
@@ -200,7 +200,8 @@ always use nv = no
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the singularity runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/singularity/capability.json

--- a/etc/conf/testdata/test_default.tmpl
+++ b/etc/conf/testdata/test_default.tmpl
@@ -211,7 +211,8 @@ always use nv = {{ if eq .AlwaysUseNv true }}yes{{ else }}no{{ end }}
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the singularity runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/singularity/capability.json

--- a/internal/pkg/runtime/engine/config/oci/config.go
+++ b/internal/pkg/runtime/engine/config/oci/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,6 +15,26 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/sylabs/singularity/internal/pkg/security/seccomp"
 )
+
+// DefaultCaps is the default set of capabilities granted to an OCI container.
+// Ref: https://github.com/opencontainers/runc/blob/main/libcontainer/SPEC.md#security
+var DefaultCaps = []string{
+	"CAP_NET_RAW",
+	"CAP_NET_BIND_SERVICE",
+	"CAP_AUDIT_READ",
+	"CAP_AUDIT_WRITE",
+	"CAP_DAC_OVERRIDE",
+	"CAP_SETFCAP",
+	"CAP_SETPCAP",
+	"CAP_SETGID",
+	"CAP_SETUID",
+	"CAP_MKNOD",
+	"CAP_CHOWN",
+	"CAP_FOWNER",
+	"CAP_FSETID",
+	"CAP_KILL",
+	"CAP_SYS_CHROOT",
+}
 
 // Config is the OCI runtime configuration.
 type Config struct {
@@ -81,86 +101,9 @@ func DefaultConfigV1() (*generate.Generator, error) {
 	}
 
 	config.Process.Capabilities = &specs.LinuxCapabilities{
-		Bounding: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FSETID",
-			"CAP_FOWNER",
-			"CAP_MKNOD",
-			"CAP_NET_RAW",
-			"CAP_SETGID",
-			"CAP_SETUID",
-			"CAP_SETFCAP",
-			"CAP_SETPCAP",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SYS_CHROOT",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Permitted: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FSETID",
-			"CAP_FOWNER",
-			"CAP_MKNOD",
-			"CAP_NET_RAW",
-			"CAP_SETGID",
-			"CAP_SETUID",
-			"CAP_SETFCAP",
-			"CAP_SETPCAP",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SYS_CHROOT",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Inheritable: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FSETID",
-			"CAP_FOWNER",
-			"CAP_MKNOD",
-			"CAP_NET_RAW",
-			"CAP_SETGID",
-			"CAP_SETUID",
-			"CAP_SETFCAP",
-			"CAP_SETPCAP",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SYS_CHROOT",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Effective: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FSETID",
-			"CAP_FOWNER",
-			"CAP_MKNOD",
-			"CAP_NET_RAW",
-			"CAP_SETGID",
-			"CAP_SETUID",
-			"CAP_SETFCAP",
-			"CAP_SETPCAP",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SYS_CHROOT",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
-		Ambient: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FSETID",
-			"CAP_FOWNER",
-			"CAP_MKNOD",
-			"CAP_NET_RAW",
-			"CAP_SETGID",
-			"CAP_SETUID",
-			"CAP_SETFCAP",
-			"CAP_SETPCAP",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SYS_CHROOT",
-			"CAP_KILL",
-			"CAP_AUDIT_WRITE",
-		},
+		Bounding:  DefaultCaps,
+		Permitted: DefaultCaps,
+		Effective: DefaultCaps,
 	}
 	config.Mounts = []specs.Mount{
 		{

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -53,24 +53,6 @@ func minimalSpec() specs.Spec {
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	}
 
-	// TODO - these are appropriate minimum for rootless. We need to tie into
-	// Singularity's cap-add / cap-drop mechanism.
-	config.Process.Capabilities = &specs.LinuxCapabilities{
-		Bounding: []string{
-			"CAP_CHOWN",
-			"CAP_DAC_OVERRIDE",
-			"CAP_FOWNER",
-			"CAP_FSETID",
-			"CAP_KILL",
-			"CAP_NET_BIND_SERVICE",
-			"CAP_SETFCAP",
-			"CAP_SETGID",
-			"CAP_SETPCAP",
-			"CAP_SETUID",
-			"CAP_SYS_CHROOT",
-		},
-	}
-
 	// All mounts are added by the launcher, as it must handle flags.
 	config.Mounts = []specs.Mount{}
 

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -356,7 +356,8 @@ always use rocm = {{ if eq .AlwaysUseRocm true }}yes{{ else }}no{{ end }}
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full
-# Define default root capability set kept during runtime
+# Define default root capability set kept during runtime.
+# Applies to the singularity runtime only, not --oci mode.
 # - full: keep all capabilities (same as --keep-privs)
 # - file: keep capabilities configured for root in
 #         ${prefix}/etc/singularity/capability.json


### PR DESCRIPTION
## Description of the Pull Request (PR):

### Preparatory commit, for consistency:

**oci: Don't set inheritable/ambient caps in DefaultConfig**

The OCI DefaultConfig, used when creating a bundle from a SIF via `singularity oci mount`, no longer sets any inheritable or ambient capabilities. This matches other OCI container runtimes.

The capability set matches:
  https://github.com/opencontainers/runc/blob/main/libcontainer/SPEC.md#security

### Implementation commit in --oci mode:

**oci: set default capabilities in --oci mode**

When running in `--oci` mode, set default capabilities for the container.

When root inside the container, this means that effective / permitted / bounding match the oci.DefaultCaps set, per the oci runtime spec docs.

When non-root inside the container, this means that only bounding matches the oci.DefaultCaps set.

No other capabilities are set. `--oci` mode does not set any inheritable or ambient capabilities, unlike native mode.


### This fixes or addresses the following GitHub issues:

 - Fixes #1587 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
