### PR TITLE
fix: correct capability.Name for CAP_BLOCK_SUSPEND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - Fix seccomp filters to allow mknod/mknodat syscalls to create pipe/socket
   and character devices with device number 0 for fakeroot builds.
 - Fix freeze when copying files between stages in an unprivileged proot build.
+- Correct internal name for CAP_BLOCK_SUSPEND.
 
 ## 3.11.3 \[2023-05-04\]
 

--- a/pkg/util/capabilities/capabilities.go
+++ b/pkg/util/capabilities/capabilities.go
@@ -370,7 +370,7 @@ var (
 	}
 
 	capBlockSuspend = &capability{
-		Name:  "CAP_WAKE_ALARM",
+		Name:  "CAP_BLOCK_SUSPEND",
 		Value: 36,
 		Description: `CAP_BLOCK_SUSPEND (since Linux 3.5)
 	Employ features that can block system suspend (epoll(7) EPOLLWAKEUP, /proc/sys/wake_lock).`,


### PR DESCRIPTION
## Description of the Pull Request (PR):

fix: correct capability.Name for CAP_BLOCK_SUSPEND


### This fixes or addresses the following GitHub issues:

 - Fixes #1801 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
