### PR TITLE
oci: support --keep-privs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
   libraries to bind into `/.singularity.d/libs/` in the container.
 - OCI-mode now supports the `--no-privs` flag to drop all capabilities from the
   container process, and enable the NoNewPrivileges flag.
+- OCI-mode now supports the `--keep-privs` flag to keep effective capabilities
+  for the container process (bounding set only for non-root container users).
 
 ### Bug Fixes
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -146,9 +146,6 @@ func checkOpts(lo launcher.Options) error {
 	if lo.AllowSUID {
 		badOpt = append(badOpt, "AllowSUID")
 	}
-	if lo.KeepPrivs {
-		badOpt = append(badOpt, "KeepPrivs")
-	}
 	if len(lo.SecurityOpts) > 0 {
 		badOpt = append(badOpt, "SecurityOpts")
 	}

--- a/pkg/util/capabilities/capabilities.go
+++ b/pkg/util/capabilities/capabilities.go
@@ -5,7 +5,10 @@
 
 package capabilities
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 const (
 	// Permitted capability string constant.
@@ -522,4 +525,17 @@ func normalize(capabilities []string) []string {
 		capabilities[i] = capb
 	}
 	return capabilities
+}
+
+// ToStrings returns a list of string CAP_ values from a uint64 capability set.
+// If a capability bit is set that is not in Map, it is ignored.
+func ToStrings(c uint64) []string {
+	s := []string{}
+	for _, cap := range Map {
+		if c&uint64(1<<cap.Value) != 0 {
+			s = append(s, cap.Name)
+		}
+	}
+	sort.Strings(s)
+	return s
 }

--- a/pkg/util/capabilities/capabilities_test.go
+++ b/pkg/util/capabilities/capabilities_test.go
@@ -6,6 +6,7 @@
 package capabilities
 
 import (
+	"reflect"
 	"sort"
 	"testing"
 )
@@ -163,6 +164,37 @@ func TestRemoveDuplicated(t *testing.T) {
 				if tc.expect[i] != actual[i] {
 					t.Fatalf("expected %s at position %d, but got %s", tc.expect[i], i, actual[i])
 				}
+			}
+		})
+	}
+}
+
+func TestToStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		c    uint64
+		want []string
+	}{
+		{
+			name: "Empty",
+			c:    0,
+			want: []string{},
+		},
+		{
+			name: "Single",
+			c:    0x8000000,
+			want: []string{"CAP_MKNOD"},
+		},
+		{
+			name: "Multi",
+			c:    0x8001001,
+			want: []string{"CAP_CHOWN", "CAP_MKNOD", "CAP_NET_ADMIN"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToStrings(tt.c); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToStrings() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/util/capabilities/process_linux.go
+++ b/pkg/util/capabilities/process_linux.go
@@ -56,6 +56,16 @@ func GetProcessInheritable() (uint64, error) {
 	return uint64(data[0].Inheritable) | uint64(data[1].Inheritable)<<32, nil
 }
 
+// GetProcessBounding returns bounding capabilities for
+// the current process.
+func GetProcessBounding() (uint64, error) {
+	data, err := getProcessCapabilities()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(data[0].Inheritable) | uint64(data[1].Inheritable)<<32, nil
+}
+
 // SetProcessEffective set effective capabilities for the
 // the current process and returns previous effective set.
 func SetProcessEffective(caps uint64) (uint64, error) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

When `--keep-privs` is specified in `--oci` mode, keep effective capabilities on the container process, rather than set the default OCI capabilities.

Non-root users in the container receive the capabilities in the bounding set only.


### This fixes or addresses the following GitHub issues:

 - Fixes #1475 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
