### PR TITLE
oci: Support --add-caps and --drop-caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@
   container process, and enable the NoNewPrivileges flag.
 - OCI-mode now supports the `--keep-privs` flag to keep effective capabilities
   for the container process (bounding set only for non-root container users).
+- OCI-mode now supports the `--add-caps` and `--drop-caps` flags to modify
+  capabilities of the container process.
 
 ### Bug Fixes
 

--- a/e2e/security/oci.go
+++ b/e2e/security/oci.go
@@ -16,6 +16,11 @@ import (
 const (
 	// Default OCI capabilities as visible in /proc/status
 	ociDefaultCapString = "00000020a80425fb"
+	// DefaultOCI capabilities with CAP_CHOWN dropped
+	ociDropChownString = "00000020a80425fa"
+	// DefaultOCI capabilities with CAP_SYS_ADMIN added
+	ociAddSysAdminString = "00000020a82425fb"
+	capSysAdminString    = "0000000000200000"
 	// No capabilities, as visible in /proc/status
 	nullCapString = "0000000000000000"
 )
@@ -91,6 +96,46 @@ func (c ctx) ociCapabilities(t *testing.T) {
 			expectPrm: fullCapString,
 			expectEff: fullCapString,
 			expectBnd: fullCapString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "DropChownUser",
+			options:   []string{"--drop-caps", "CAP_CHOWN"},
+			profiles:  []e2e.Profile{e2e.OCIUserProfile},
+			expectInh: nullCapString,
+			expectPrm: nullCapString,
+			expectEff: nullCapString,
+			expectBnd: ociDropChownString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "DropChownRoot",
+			options:   []string{"--drop-caps", "CAP_CHOWN"},
+			profiles:  []e2e.Profile{e2e.OCIRootProfile, e2e.OCIFakerootProfile},
+			expectInh: nullCapString,
+			expectPrm: ociDropChownString,
+			expectEff: ociDropChownString,
+			expectBnd: ociDropChownString,
+			expectAmb: nullCapString,
+		},
+		{
+			name:      "AddSysAdminUser",
+			options:   []string{"--add-caps", "CAP_SYS_ADMIN"},
+			profiles:  []e2e.Profile{e2e.OCIUserProfile},
+			expectInh: capSysAdminString,
+			expectPrm: capSysAdminString,
+			expectEff: capSysAdminString,
+			expectBnd: ociAddSysAdminString,
+			expectAmb: capSysAdminString,
+		},
+		{
+			name:      "AddSysAdminRoot",
+			options:   []string{"--add-caps", "CAP_SYS_ADMIN"},
+			profiles:  []e2e.Profile{e2e.OCIRootProfile, e2e.OCIFakerootProfile},
+			expectInh: nullCapString,
+			expectPrm: ociAddSysAdminString,
+			expectEff: ociAddSysAdminString,
+			expectBnd: ociAddSysAdminString,
 			expectAmb: nullCapString,
 		},
 	}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -137,12 +137,6 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "NetworkArgs")
 	}
 
-	if lo.AddCaps != "" {
-		badOpt = append(badOpt, "AddCaps")
-	}
-	if lo.DropCaps != "" {
-		badOpt = append(badOpt, "DropCaps")
-	}
 	if lo.AllowSUID {
 		badOpt = append(badOpt, "AllowSUID")
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add support for --add-caps and --drop-caps to modify the capabilities of the container process.

When the container user is root, these modify the permitted/effective/bounding sets.

When the container user is non-root, the bounding set is modified, and any explicit add-caps are added to the permitted/effective/inheritable/ambient sets.


### This fixes or addresses the following GitHub issues:

 - Fixes #1468 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
