### PR TITLE
--no-setgroups option for --fakeroot (release-3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 - Added `remote get-login-password` subcommand that allows the user to
   retrieve a CLI token to interact with the OCI registry of a
   Singularity Enterprise instance.
+- Added `--no-setgroups` flag for `--fakeroot` builds and run/shell/exec. This
+  prevents the `setgroups` syscall being used on the container process in the
+  fakeroot user namespace. Maintains access from within the user namespace to
+  files on the host that have permissions based on supplementary group
+  membership. Note that supplementary groups are mapped to `nobody` in the
+  container, and `chgrp`, `newgrp`, etc. cannot be used.
 
 ### Bug Fixes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -40,6 +40,7 @@ var (
 
 	isBoot          bool
 	isFakeroot      bool
+	noSetgroups     bool
 	isCleanEnv      bool
 	isCompat        bool
 	isContained     bool
@@ -351,6 +352,16 @@ var actionFakerootFlag = cmdline.Flag{
 	ShortHand:    "f",
 	Usage:        "run container in new user namespace as uid 0",
 	EnvKeys:      []string{"FAKEROOT"},
+}
+
+// --no-setgroups
+var actionNoSetgroupsFlag = cmdline.Flag{
+	ID:           "actionNoSetgroupsFlag",
+	Value:        &noSetgroups,
+	DefaultValue: false,
+	Name:         "no-setgroups",
+	Usage:        "disable setgroups when entering --fakeroot user namespace",
+	EnvKeys:      []string{"NO_SETGROUPS"},
 }
 
 // -e|--cleanenv
@@ -844,6 +855,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionDNSFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionDropCapsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionFakerootFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoSetgroupsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionFuseMountFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionHomeFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionHostnameFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -390,6 +390,7 @@ func launchContainer(cmd *cobra.Command, image string, containerCmd string, cont
 		launcher.OptShellPath(shellPath),
 		launcher.OptPwdPath(pwdPath),
 		launcher.OptFakeroot(isFakeroot),
+		launcher.OptNoSetgroups(noSetgroups),
 		launcher.OptBoot(isBoot),
 		launcher.OptNoInit(noInit),
 		launcher.OptContain(isContained),

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -41,6 +41,7 @@ var buildArgs struct {
 	isJSON        bool
 	noCleanUp     bool
 	noTest        bool
+	noSetgroups   bool
 	remote        bool
 	sandbox       bool
 	update        bool
@@ -186,6 +187,16 @@ var buildFakerootFlag = cmdline.Flag{
 	EnvKeys:      []string{"FAKEROOT"},
 }
 
+// --no-setgroups
+var buildNoSetgroupsFlag = cmdline.Flag{
+	ID:           "buildNoSetgroupsFlag",
+	Value:        &buildArgs.noSetgroups,
+	DefaultValue: false,
+	Name:         "no-setgroups",
+	Usage:        "disable setgroups when entering --fakeroot user namespace",
+	EnvKeys:      []string{"NO_SETGROUPS"},
+}
+
 // -e|--encrypt
 var buildEncryptFlag = cmdline.Flag{
 	ID:           "buildEncryptFlag",
@@ -286,6 +297,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&buildDisableCacheFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildEncryptFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildFakerootFlag, buildCmd)
+		cmdManager.RegisterFlagForCmd(&buildNoSetgroupsFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildFixPermsFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildJSONFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildLibraryFlag, buildCmd)
@@ -331,6 +343,10 @@ var buildCmd = &cobra.Command{
 }
 
 func preRun(cmd *cobra.Command, args []string) {
+	if buildArgs.noSetgroups && !buildArgs.fakeroot {
+		sylog.Warningf("--no-setgroups only applies to --fakeroot builds")
+	}
+
 	if buildArgs.fakeroot && !buildArgs.remote {
 		fakerootExec(args)
 	}

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -80,10 +80,11 @@ func fakerootExec(cmdArgs []string) {
 	os.Setenv("_CONTAINERS_ROOTLESS_UID", strconv.Itoa(os.Getuid()))
 
 	engineConfig := &fakerootConfig.EngineConfig{
-		Args:     args,
-		Envs:     os.Environ(),
-		Home:     user.Dir,
-		BuildEnv: true,
+		Args:        args,
+		Envs:        os.Environ(),
+		Home:        user.Dir,
+		BuildEnv:    true,
+		NoSetgroups: buildArgs.noSetgroups,
 	}
 
 	cfg := &config.Common{

--- a/cmd/starter/c/include/starter.h
+++ b/cmd/starter/c/include/starter.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2018-2019, Sylabs, Inc. All rights reserved.
+  Copyright (c) 2018-2023, Sylabs, Inc. All rights reserved.
 
   This software is licensed under a 3-clause BSD license.  Please
   consult LICENSE.md file distributed with the sources of this project regarding
@@ -113,6 +113,10 @@ struct privileges {
     char uidMap[MAX_MAP_SIZE];
     char gidMap[MAX_MAP_SIZE];
     bool allowSetgroups;
+    /* skip setgroups call even if allowed. May be used with fakeroot engine to
+    access files with pre-userns supplementary group membership.
+    See https://github.com/sylabs/singularity/issues/1748 */
+    bool noSetgroups;
 
     /* path to external newuidmap/newgidmap binaries */
     char newuidmapPath[MAX_PATH_SIZE];

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2018-2021, Sylabs, Inc. All rights reserved.
+  Copyright (c) 2018-2023, Sylabs, Inc. All rights reserved.
 
   This software is licensed under a 3-clause BSD license.  Please
   consult LICENSE.md file distributed with the sources of this project regarding
@@ -311,9 +311,13 @@ static void apply_privileges(struct privileges *privileges, struct capabilities 
                 fatalf("Failed to set GID %d: %s\n", targetGID, strerror(errno));
             }
 
-            debugf("Set %d additional group IDs\n", privileges->numGID);
-            if ( setgroups(privileges->numGID, privileges->targetGID) < 0 ) {
-                fatalf("Failed to set additional groups: %s\n", strerror(errno));
+            if ( privileges->noSetgroups ) {
+                debugf("Skipping setgroups due to configuration.\n");
+            } else {
+                debugf("Set %d additional group IDs\n", privileges->numGID);
+                if ( setgroups(privileges->numGID, privileges->targetGID) < 0 ) {
+                    fatalf("Failed to set additional groups: %s\n", strerror(errno));
+                }
             }
         }
     }

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2468,6 +2468,26 @@ func countSquashfuseMounts(t *testing.T) int {
 	return count
 }
 
+// actionNoSetgoups checks that supplementary groups are visible, mapped to
+// nobody, in the container with --fakeroot --no-setgroups.
+func (c actionTests) actionNoSetgroups(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	// Inside the e2e-tests we will be a member of our user group + single supplementary group.
+	// With `--fakeroot --no-setgroups` we should see these map to:
+	//    root nobody
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.FakerootProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--no-setgroups", c.env.ImagePath, "sh", "-c", "groups"),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ExactMatch, "root nobody"),
+		),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := actionTests{
@@ -2508,6 +2528,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"fuse mount":                c.fuseMount,               // test fusemount option
 		"bind image":                c.bindImage,               // test bind image with --bind and --mount
 		"no-mount":                  c.actionNoMount,           // test --no-mount
+		"no-setgroups":              c.actionNoSetgroups,       // test --no-setgroups
 		"compat":                    np(c.actionCompat),        // test --compat
 		"umask":                     np(c.actionUmask),         // test umask propagation
 		"invalidRemote":             np(c.invalidRemote),       // GHSA-5mv9-q7fq-9394

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -197,6 +197,18 @@ func (c *Config) SetAllowSetgroups(allow bool) {
 		c.config.container.privileges.allowSetgroups = C.true
 	} else {
 		c.config.container.privileges.allowSetgroups = C.false
+	}
+}
+
+// SetNoSetgroups disables the setgroups call for the container process in the
+// starter. Preserves access to files that depends on supplementary groups
+// outside of the user namespace. The supplementary groups will map to 'nobody'
+// inside the container.
+func (c *Config) SetNoSetgroups(noSetgroups bool) {
+	if noSetgroups {
+		c.config.container.privileges.noSetgroups = C.true
+	} else {
+		c.config.container.privileges.noSetgroups = C.false
 	}
 }
 

--- a/internal/pkg/runtime/engine/fakeroot/config/config.go
+++ b/internal/pkg/runtime/engine/fakeroot/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -11,9 +11,10 @@ const Name = "fakeroot"
 // EngineConfig is the config for the fakeroot engine used to execute
 // a command in a fakeroot context
 type EngineConfig struct {
-	Args     []string `json:"args"`
-	Envs     []string `json:"envs"`
-	Home     string   `json:"home"`
-	BuildEnv bool     `json:"buildEnv"`
-	NoPIDNS  bool     `json:"NoPIDNS"`
+	Args        []string `json:"args"`
+	Envs        []string `json:"envs"`
+	Home        string   `json:"home"`
+	BuildEnv    bool     `json:"buildEnv"`
+	NoPIDNS     bool     `json:"NoPIDNS"`
+	NoSetgroups bool     `json:"NoSetgroups"`
 }

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -137,6 +137,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 
 	starterConfig.SetHybridWorkflow(true)
 	starterConfig.SetAllowSetgroups(true)
+	starterConfig.SetNoSetgroups(e.EngineConfig.NoSetgroups)
 
 	starterConfig.SetTargetUID(0)
 	starterConfig.SetTargetGID([]int{0})

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -598,6 +598,7 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 
 		starterConfig.SetHybridWorkflow(true)
 		starterConfig.SetAllowSetgroups(true)
+		starterConfig.SetNoSetgroups(e.EngineConfig.GetNoSetgroups())
 
 		starterConfig.SetTargetUID(0)
 		starterConfig.SetTargetGID([]int{0})

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -260,6 +260,14 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	if l.cfg.Fakeroot {
 		l.cfg.Namespaces.User = true
 	}
+	// Allow optional skipping of setgroups in --fakeroot mode.
+	if l.cfg.NoSetgroups {
+		if l.cfg.Fakeroot {
+			l.engineConfig.SetNoSetgroups(l.cfg.NoSetgroups)
+		} else {
+			sylog.Warningf("--no-setgroups only applies to --fakeroot mode")
+		}
+	}
 
 	l.setCgroups(instanceName)
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -183,6 +183,10 @@ func checkOpts(lo launcher.Options) error {
 		badOpt = append(badOpt, "SIFFUSE")
 	}
 
+	if lo.NoSetgroups {
+		badOpt = append(badOpt, "NoSetgroups")
+	}
+
 	if len(badOpt) > 0 {
 		return fmt.Errorf("%w: %s", ErrUnsupportedOption, strings.Join(badOpt, ","))
 	}

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -116,6 +116,8 @@ type Options struct {
 
 	// Fakeroot enables the fake root mode, using user namespaces and subuid / subgid mapping.
 	Fakeroot bool
+	// NoSetgroups disables calling setgroups for the fakeroot user namespace.
+	NoSetgroups bool
 	// Boot enables execution of /sbin/init on startup of an instance container.
 	Boot bool
 	// NoInit disables shim process when PID namespace is used.
@@ -415,6 +417,14 @@ func OptPwdPath(p string) Option {
 func OptFakeroot(b bool) Option {
 	return func(lo *Options) error {
 		lo.Fakeroot = b
+		return nil
+	}
+}
+
+// OptNoSetgroups disables calling setgroups for the fakeroot user namespace.
+func OptNoSetgroups(b bool) Option {
+	return func(lo *Options) error {
+		lo.NoSetgroups = b
 		return nil
 	}
 }

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -127,6 +127,7 @@ type JSONConfig struct {
 	XdgRuntimeDir         string            `json:"xdgRuntimeDir,omitempty"`
 	DbusSessionBusAddress string            `json:"dbusSessionBusAddress,omitempty"`
 	NoEval                bool              `json:"noEval,omitempty"`
+	NoSetgroups           bool              `json:"noSetgroups,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -833,4 +834,16 @@ func (e *EngineConfig) SetNoEval(noEval bool) {
 // runscripts generated from OCI containers CMD/ENTRYPOINT.
 func (e *EngineConfig) GetNoEval() bool {
 	return e.JSON.NoEval
+}
+
+// SetNoSetgroups sets whether to skip the setgroups call for a container in a
+// user namespace.
+func (e *EngineConfig) SetNoSetgroups(noSetgroups bool) {
+	e.JSON.NoSetgroups = noSetgroups
+}
+
+// GetNoSetgroups gets whether to skip the setgroups call for a container in a
+// user namespace.
+func (e *EngineConfig) GetNoSetgroups() bool {
+	return e.JSON.NoSetgroups
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #1757

When we run in `--fakeroot` mode, the `starter` will call `setgroups` and reduce the group membership of the container process to `gid=0` only, inside the fakeroot id-mapped user namespace.

This removes supplementary group membership, and therefore prevents access to files on the host that are restricted by group ownership where the group is a supplementary group of the current user.

If, for example, `$HOME` is accessed via a supplementary group then it cannot be mounted inside the id-mapped user namespace created at the start of a `singularity build --fakeroot`. The build will then fail.

This PR adds a new flag `--no-setgroups` to skip the `setgroups` call in `--fakeroot` mode. This results in the container process *not* having its group membership changed. Host files accessible via host supplementary groups will remain accessible.

This does not make the supplementary groups fully available in the container. Inside the id-mapped user namespace they will be mapped to `nobody`. The output of `id` may be confusing, and we still cannot e.g. `chgrp` a file to one of the user's supplementary groups.

On host...

   $ groups
   dtrudg-sylabs wheel mock docker libvirt

In container with `--fakeroot --no-setgroups`...

   Singularity> groups
   root nobody nobody nobody nobody

### This fixes or addresses the following GitHub issues:

 - Fixes #1748


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
