### PR TITLE
don't bind-mount /etc passwd & group when persistent writes possible

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -2021,5 +2021,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5668":                      c.issue5668,                    // https://github.com/hpcng/singularity/issues/5435
 		"issue 5690":                      c.issue5690,                    // https://github.com/hpcng/singularity/issues/5690
 		"issue 1273":                      c.issue1273,                    // https://github.com/sylabs/singularity/issues/1273
+		"issue 1812":                      c.issue1812,                    // https://github.com/sylabs/singularity/issues/1812
 	}
 }

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,6 +6,7 @@
 package imgbuild
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -491,4 +492,146 @@ func (c *imgBuildTests) issue1273(t *testing.T) {
 			e2e.ExpectError(e2e.UnwantedContainMatch, "proot"),
 		),
 	)
+}
+
+// Check that commands that modify /etc/passwd and/or /etc/group on writable
+// filesystems are able to do so, and that the changes survive from build to
+// run, and across separate runs (i.e., that the changes don't go into a
+// later-discarded tmpfs).
+func (c *imgBuildTests) issue1812(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	defFileContents := fmt.Sprintf(`
+Bootstrap: localimage
+from: %s
+
+%%post
+	adduser -D leela
+	addgroup planetexpress
+	addgroup leela planetexpress
+`, c.env.ImagePath)
+
+	defFileName, err := e2e.WriteTempFile(c.env.TestDir, "defFile-", defFileContents)
+	if err != nil {
+		log.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(defFileName)
+		}
+	})
+
+	err = os.WriteFile(defFileName, []byte(defFileContents), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validateResult := func(t *testing.T, profile e2e.Profile, containerArg string) {
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(profile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(
+				containerArg, "/bin/sh", "-c",
+				"grep leela /etc/passwd; grep planetexpress /etc/group"),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.RegexMatch, `^leela:x`),
+				e2e.ExpectOutput(e2e.RegexMatch, `\nplanetexpress:x:1001:leela\b`),
+			),
+		)
+	}
+	var testName string
+	for _, profile := range []e2e.Profile{e2e.RootProfile, e2e.FakerootProfile} {
+		testName = profile.String() + "SifToRun"
+		t.Run(testName, func(t *testing.T) {
+			sifPath := filepath.Join(c.env.TestDir, testName+".sif")
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(profile),
+				e2e.WithCommand("build"),
+				e2e.WithArgs("-F", sifPath, defFileName),
+				e2e.ExpectExit(0),
+			)
+
+			validateResult(t, profile, sifPath)
+		})
+
+		testName = profile.String() + "SandboxToRun"
+		t.Run(testName, func(t *testing.T) {
+			sandboxDir, cleanup := e2e.MakeTempDir(
+				t, c.env.TestDir, fmt.Sprintf("issue1812-sandbox-%s-", testName), "")
+			t.Cleanup(func() {
+				if !t.Failed() {
+					e2e.Privileged(cleanup)
+				}
+			})
+
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(profile),
+				e2e.WithCommand("build"),
+				e2e.WithArgs("--sandbox", "-F", sandboxDir, defFileName),
+				e2e.ExpectExit(0),
+			)
+
+			validateResult(t, profile, sandboxDir)
+		})
+
+		testName = profile.String() + "RunToRun"
+		t.Run(testName, func(t *testing.T) {
+			sandboxDir, cleanup := e2e.MakeTempDir(
+				t, c.env.TestDir, fmt.Sprintf("issue1812-sandbox-%s-", testName), "")
+			t.Cleanup(func() {
+				if !t.Failed() {
+					e2e.Privileged(cleanup)
+				}
+			})
+
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(profile),
+				e2e.WithCommand("build"),
+				e2e.WithArgs("--sandbox", "-F", sandboxDir, c.env.ImagePath),
+				e2e.ExpectExit(0),
+			)
+
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(profile),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs(
+					"--writable", sandboxDir, "/bin/sh", "-c",
+					"adduser -D leela; addgroup planetexpress; addgroup leela planetexpress"),
+				e2e.ExpectExit(0),
+			)
+
+			validateResult(t, profile, sandboxDir)
+		})
+
+		testName = profile.String() + "SifRunToRun"
+		t.Run(testName, func(t *testing.T) {
+			sifPath := filepath.Join(c.env.TestDir, testName+".sif")
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(profile),
+				e2e.WithCommand("build"),
+				e2e.WithArgs("-F", sifPath, c.env.ImagePath),
+				e2e.ExpectExit(0),
+			)
+
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(profile),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs(
+					sifPath, "/bin/sh", "-c",
+					"adduser -D leela; addgroup planetexpress; addgroup leela planetexpress"),
+				e2e.ExpectExit(
+					1,
+					e2e.ExpectError(e2e.ContainMatch, "Read-only file system"),
+				),
+			)
+		})
+	}
 }

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1997,6 +1997,13 @@ func (c *container) addIdentityMount(system *mount.System) error {
 		uid = 0
 	}
 
+	if (uid == 0) &&
+		c.engine.EngineConfig.GetWritableImage() &&
+		(!c.engine.EngineConfig.GetWritableTmpfs()) {
+		sylog.Verbosef("skipping bind-mount of /etc/passwd and /etc/group (rootfs is writable and not a tmpfs, and container is running as root)")
+		return nil
+	}
+
 	if c.engine.EngineConfig.File.ConfigPasswd {
 		passwd := filepath.Join(rootfs, "/etc/passwd")
 		_, home, err := c.getHomePaths()


### PR DESCRIPTION
## Description of the Pull Request (PR):

If all of the following conditions hold —

- The user inside the container is root
- The root filesystem is writable
- The root filesystem is not a tmpfs

— then writes to `/etc/passwd` or `/etc/group` are possible, and would be expected to persist from build to action stage (run/exec/shell) or across distinct actions (e.g. from one run to the next).

Under this exact combination of conditions, then, we inhibit bind-mounting modified versions of `/etc/passwd` and `/etc/group` from tmpfs storage into the container.

### This fixes or addresses the following GitHub issues:

 - Fixes #1812 

