### PR TITLE
cache: Add oci-sif cache type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
   for the container process (bounding set only for non-root container users).
 - OCI-mode now supports the `--add-caps` and `--drop-caps` flags to modify
   capabilities of the container process.
+- The `cache` commands now accept `--type oci-sif` to list and clean cached
+  OCI-SIF image conversions of OCI sources.
 
 ### Developer / API
 

--- a/cmd/internal/cli/cache_clean_linux.go
+++ b/cmd/internal/cli/cache_clean_linux.go
@@ -41,7 +41,7 @@ var (
 		DefaultValue: []string{"all"},
 		Name:         "type",
 		ShortHand:    "T",
-		Usage:        "a list of cache types to clean (possible values: library, oci, shub, blob, net, oras, all)",
+		Usage:        "a list of cache types to clean, possible entries: all, " + strings.Join(cache.AllCacheTypes, ", "),
 	}
 
 	// -D|--days

--- a/cmd/internal/cli/cache_list_linux.go
+++ b/cmd/internal/cli/cache_list_linux.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
@@ -28,7 +29,7 @@ var cacheListTypesFlag = cmdline.Flag{
 	DefaultValue: []string{"all"},
 	Name:         "type",
 	ShortHand:    "T",
-	Usage:        "a list of cache types to display, possible entries: library, oci, shub, blob(s), all",
+	Usage:        "a list of cache types to display, possible entries: all, " + strings.Join(cache.AllCacheTypes, ", "),
 }
 
 // -s|--summary

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -38,29 +38,35 @@ const (
 	LibraryCacheType = "library"
 	// OciTempCacheType specifies the cache holds SIF images created from OCI sources
 	OciTempCacheType = "oci-tmp"
-	// OciBlobCacheType specifies the cache holds OCI blobs (layers) pulled from OCI sources
-	OciBlobCacheType = "blob"
 	// ShubCacheType specifies the cache holds images pulled from Singularity Hub
 	ShubCacheType = "shub"
 	// OrasCacheType specifies the cache holds SIF images pulled from Oras sources
 	OrasCacheType = "oras"
 	// NetCacheType specifies the cache holds images pulled from http(s) internet sources
 	NetCacheType = "net"
+	// OciSifCachetType specifies cache holds OCI-SIF conversions of OCI sources.
+	OciSifCacheType = "oci-sif"
+
+	// OciBlobCacheType specifies the cache holds OCI blobs (layers) pulled from OCI sources
+	OciBlobCacheType = "blob"
 )
 
 var (
-	// FileCacheTypes specifies the file cache types.
+	// FileCacheTypes lists the file cache types, that store SIF or other single file images named by their hash.
 	FileCacheTypes = []string{
 		LibraryCacheType,
 		OciTempCacheType,
 		ShubCacheType,
 		OrasCacheType,
 		NetCacheType,
+		OciSifCacheType,
 	}
-	// OciCacheTypes specifies the OCI cache types.
+	// OciCacheTypes lists the OCI layout cache types, that store OCI blob content in a single OCI layout directory.
 	OciCacheTypes = []string{
 		OciBlobCacheType,
 	}
+	// AllCacheTypes lists both file and OCI layout cache types.
+	AllCacheTypes = append(FileCacheTypes, OciCacheTypes...)
 )
 
 // Config describes the requested configuration requested when a new handle is created,


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add an oci-sif cache type, that will be used to store 1:1 conversions of OCI source images (e.g. docker://) into oci-sif format.

Refactor the help display for cache types, to list types programatically. This corrects and avoids incorrect/incomplete help information.

### This fixes or addresses the following GitHub issues:

 - Fixes #1857

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
