### PR TITLE
ci: fix buildcfg check, and usage in bin.FindBin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,11 @@ commands:
       - run:
           name: Check pkg/... doesn't depend on buildcfg
           command: |-
-            if go list -f '{{.Deps}}' ./pkg/... | grep -q buildcfg
+            if $(/usr/local/go/bin/go list -f '{{.Deps}}' ./pkg/... | grep -q buildcfg)
             then
               echo "Prohibited buildcfg dependency found in pkg/:"
               echo
-              go list -f '{{.ImportPath}} - {{.Deps}}' ./pkg/... | grep buildcfg
+              /usr/local/go/bin/go list -f '{{.ImportPath}} - {{.Deps}}' ./pkg/... | grep buildcfg
               exit 1
             fi
   stop-background-apt:

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -8,15 +8,6 @@ package bin
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-
-	"github.com/pkg/errors"
-	"github.com/sylabs/singularity/internal/pkg/buildcfg"
-	"github.com/sylabs/singularity/internal/pkg/util/env"
-	"github.com/sylabs/singularity/pkg/sylog"
-	"github.com/sylabs/singularity/pkg/util/singularityconf"
 )
 
 // FindBin returns the path to the named binary, or an error if it is not found.
@@ -40,10 +31,8 @@ func FindBin(name string) (path string, err error) {
 		return findOnPath(name)
 	// our, or distro provided conmon
 	case "conmon":
-		if buildcfg.CONMON_LIBEXEC == 1 {
-			return filepath.Join(buildcfg.LIBEXECDIR, "singularity", "bin", name), nil
-		}
-		return findOnPath(name)
+		// Behavior depends on a buildcfg - whether to use bundled or external conmon
+		return findConmon(name)
 	// cryptsetup & nvidia-container-cli paths must be explicitly specified
 	// They are called as root from the RPC server in a setuid install, so this
 	// limits to sysadmin controlled paths.
@@ -64,83 +53,4 @@ func FindBin(name string) (path string, err error) {
 	default:
 		return "", fmt.Errorf("executable name %q is not known to FindBin", name)
 	}
-}
-
-// findOnPath performs a simple search on PATH for the named executable, returning its full path.
-// env.DefaultPath` is appended to PATH to ensure standard locations are searched. This
-// is necessary as some distributions don't include sbin on user PATH etc.
-func findOnPath(name string) (path string, err error) {
-	oldPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", oldPath)
-	os.Setenv("PATH", oldPath+":"+env.DefaultPath)
-
-	path, err = exec.LookPath(name)
-	if err == nil {
-		sylog.Debugf("Found %q at %q", name, path)
-	}
-	return path, err
-}
-
-// findFromConfigOrPath retrieves the path to an executable from singularity.conf,
-// or searches PATH if not set there.
-func findFromConfigOrPath(name string) (path string, err error) {
-	cfg := singularityconf.GetCurrentConfig()
-	if cfg == nil {
-		cfg, err = singularityconf.Parse(buildcfg.SINGULARITY_CONF_FILE)
-		if err != nil {
-			return "", errors.Wrap(err, "unable to parse singularity configuration file")
-		}
-	}
-
-	switch name {
-	case "go":
-		path = cfg.GoPath
-	case "mksquashfs":
-		path = cfg.MksquashfsPath
-	case "unsquashfs":
-		path = cfg.UnsquashfsPath
-	default:
-		return "", fmt.Errorf("unknown executable name %q", name)
-	}
-
-	if path == "" {
-		return findOnPath(name)
-	}
-
-	sylog.Debugf("Using %q at %q (from singularity.conf)", name, path)
-
-	// Use lookPath with the absolute path to confirm it is accessible & executable
-	return exec.LookPath(path)
-}
-
-// findFromConfigOnly retrieves the path to an executable from singularity.conf.
-// If it's not set there we error.
-func findFromConfigOnly(name string) (path string, err error) {
-	cfg := singularityconf.GetCurrentConfig()
-	if cfg == nil {
-		cfg, err = singularityconf.Parse(buildcfg.SINGULARITY_CONF_FILE)
-		if err != nil {
-			return "", errors.Wrap(err, "unable to parse singularity configuration file")
-		}
-	}
-
-	switch name {
-	case "cryptsetup":
-		path = cfg.CryptsetupPath
-	case "ldconfig":
-		path = cfg.LdconfigPath
-	case "nvidia-container-cli":
-		path = cfg.NvidiaContainerCliPath
-	default:
-		return "", fmt.Errorf("unknown executable name %q", name)
-	}
-
-	if path == "" {
-		return "", fmt.Errorf("path to %q not set in singularity.conf", name)
-	}
-
-	sylog.Debugf("Using %q at %q (from singularity.conf)", name, path)
-
-	// Use lookPath with the absolute path to confirm it is accessible & executable
-	return exec.LookPath(path)
 }

--- a/internal/pkg/util/bin/bin_no_singularity.go
+++ b/internal/pkg/util/bin/bin_no_singularity.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build !singularity_engine
+
+package bin
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// findOnPath falls back to exec.LookPath when not built as part of Singularity.
+func findOnPath(name string) (path string, err error) {
+	return exec.LookPath(name)
+}
+
+// findFromConfigOrPath falls back to exec.LookPath when not built as part of Singularity.
+func findFromConfigOrPath(name string) (path string, err error) {
+	return exec.LookPath(path)
+}
+
+// findFromConfigOnly returns an error when not built as part of Singularity.
+func findFromConfigOnly(name string) (path string, err error) {
+	return "", fmt.Errorf("findFromConfigOnly is not implemented")
+}
+
+// findConmon falls back to exec.LookPath when not built as part of Singularity.
+func findConmon(name string) (path string, err error) {
+	return findOnPath(name)
+}

--- a/internal/pkg/util/bin/bin_singularity.go
+++ b/internal/pkg/util/bin/bin_singularity.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build singularity_engine
+
+package bin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/internal/pkg/util/env"
+	"github.com/sylabs/singularity/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/util/singularityconf"
+)
+
+// findOnPath performs a simple search on PATH for the named executable, returning its full path.
+// env.DefaultPath` is appended to PATH to ensure standard locations are searched. This
+// is necessary as some distributions don't include sbin on user PATH etc.
+func findOnPath(name string) (path string, err error) {
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+	os.Setenv("PATH", oldPath+":"+env.DefaultPath)
+
+	path, err = exec.LookPath(name)
+	if err == nil {
+		sylog.Debugf("Found %q at %q", name, path)
+	}
+	return path, err
+}
+
+// findFromConfigOrPath retrieves the path to an executable from singularity.conf,
+// or searches PATH if not set there.
+func findFromConfigOrPath(name string) (path string, err error) {
+	cfg := singularityconf.GetCurrentConfig()
+	if cfg == nil {
+		cfg, err = singularityconf.Parse(buildcfg.SINGULARITY_CONF_FILE)
+		if err != nil {
+			return "", fmt.Errorf("unable to parse singularity configuration file: %w", err)
+		}
+	}
+
+	switch name {
+	case "go":
+		path = cfg.GoPath
+	case "mksquashfs":
+		path = cfg.MksquashfsPath
+	case "unsquashfs":
+		path = cfg.UnsquashfsPath
+	default:
+		return "", fmt.Errorf("unknown executable name %q", name)
+	}
+
+	if path == "" {
+		return findOnPath(name)
+	}
+
+	sylog.Debugf("Using %q at %q (from singularity.conf)", name, path)
+
+	// Use lookPath with the absolute path to confirm it is accessible & executable
+	return exec.LookPath(path)
+}
+
+// findFromConfigOnly retrieves the path to an executable from singularity.conf.
+// If it's not set there we error.
+func findFromConfigOnly(name string) (path string, err error) {
+	cfg := singularityconf.GetCurrentConfig()
+	if cfg == nil {
+		cfg, err = singularityconf.Parse(buildcfg.SINGULARITY_CONF_FILE)
+		if err != nil {
+			return "", fmt.Errorf("unable to parse singularity configuration file: %w", err)
+		}
+	}
+
+	switch name {
+	case "cryptsetup":
+		path = cfg.CryptsetupPath
+	case "ldconfig":
+		path = cfg.LdconfigPath
+	case "nvidia-container-cli":
+		path = cfg.NvidiaContainerCliPath
+	default:
+		return "", fmt.Errorf("unknown executable name %q", name)
+	}
+
+	if path == "" {
+		return "", fmt.Errorf("path to %q not set in singularity.conf", name)
+	}
+
+	sylog.Debugf("Using %q at %q (from singularity.conf)", name, path)
+
+	// Use lookPath with the absolute path to confirm it is accessible & executable
+	return exec.LookPath(path)
+}
+
+// findConmon returns either the bundled conmon (if built), or looks for conmon on PATH.
+func findConmon(name string) (path string, err error) {
+	if buildcfg.CONMON_LIBEXEC == 1 {
+		return filepath.Join(buildcfg.LIBEXECDIR, "singularity", "bin", name), nil
+	}
+	return findOnPath(name)
+}

--- a/internal/pkg/util/bin/bin_test.go
+++ b/internal/pkg/util/bin/bin_test.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build singularity_engine
+
 package bin
 
 import (


### PR DESCRIPTION
If code in `pkg/` uses `bin.FindBin` then prior to this PR it would attempt to import `buildcfg`.

`buildcfg` is only available as part of a full build of SingularityCE, not when other code imports `pkg/`.

Add build tag gated variants of the private functions called by `bin.FindBin` that do not require `buildcfg`, to avoid this issue.

### This fixes or addresses the following GitHub issues:

 - Fixes #1823


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
