### PR TITLE
oci: switch direct run/shell/exec from URI to oci-sif flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - The `pull` command now accepts a new flag `--oci` for OCI image sources. This
   will create an OCI-SIF image rather than convert to Singularity's native
   container format.
+- OCI-mode now supports running OCI-SIF images directly from http/https URIs.
 
 ### Developer / API
 

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -48,19 +48,17 @@ func getCacheHandle(cfg cache.Config) *cache.Handle {
 }
 
 // actionPreRun will:
-//   - run replaceURIWithImage;
 //   - do the proper path unsetting;
 //   - and implement flag inferences for:
 //     --compat
 //     --hostname
+//   - run replaceURIWithImage;
 func actionPreRun(cmd *cobra.Command, args []string) {
 	// For compatibility - we still set USER_PATH so it will be visible in the
 	// container, and can be used there if needed. USER_PATH is not used by
 	// singularity itself in 3.9+
 	userPath := strings.Join([]string{os.Getenv("PATH"), defaultPath}, ":")
 	os.Setenv("USER_PATH", userPath)
-
-	replaceURIWithImage(cmd.Context(), cmd, args)
 
 	// --compat infers other options that give increased OCI / Docker compatibility
 	// Excludes uts/user/net namespaces as these are restrictive for many Singularity
@@ -77,6 +75,8 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 	if len(hostname) > 0 {
 		utsNamespace = true
 	}
+
+	replaceURIWithImage(cmd.Context(), cmd, args)
 }
 
 func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, pullFrom string) (string, error) {
@@ -90,6 +90,7 @@ func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, 
 		OciAuth:    ociAuth,
 		DockerHost: dockerHost,
 		NoHTTPS:    noHTTPS,
+		OciSif:     ociRuntime,
 	}
 
 	return oci.Pull(ctx, imgCache, pullFrom, pullOpts)
@@ -135,8 +136,9 @@ func handleNet(ctx context.Context, imgCache *cache.Handle, pullFrom string) (st
 }
 
 func replaceURIWithImage(ctx context.Context, cmd *cobra.Command, args []string) {
-	// If args[0] is not transport:ref (ex. instance://...) formatted return, not a URI
 	t, _ := uri.Split(args[0])
+	// If joining an instance (instance://xxx), or we have a bare filename then
+	// no retrieval / conversion is required.
 	if t == "instance" || t == "" {
 		return
 	}
@@ -148,14 +150,6 @@ func replaceURIWithImage(ctx context.Context, cmd *cobra.Command, args []string)
 	imgCache := getCacheHandle(cache.Config{Disable: disableCache})
 	if imgCache == nil {
 		sylog.Fatalf("failed to create a new image cache handle")
-	}
-
-	// The OCI runtime launcher will handle OCI image sources directly.
-	if ociRuntime {
-		if oci.IsSupported(t) != t {
-			sylog.Fatalf("OCI runtime only supports OCI image sources. %s is not supported.", t)
-		}
-		return
 	}
 
 	switch t {
@@ -177,6 +171,11 @@ func replaceURIWithImage(ctx context.Context, cmd *cobra.Command, args []string)
 
 	if err != nil {
 		sylog.Fatalf("Unable to handle %s uri: %v", args[0], err)
+	}
+
+	// TODO - drop once we have implemented prefix-less oci-sif vs native sif detection.
+	if ociRuntime {
+		image = "oci-sif:" + image
 	}
 
 	args[0] = image

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -64,6 +64,11 @@ func (c actionTests) actionOciRun(t *testing.T) {
 			exit:     0,
 		},
 		{
+			name:     "oci-sif-http",
+			imageRef: "https://s3.amazonaws.com/singularity-ci-public/alpine-oci-sif-squashfs.sif",
+			exit:     0,
+		},
+		{
 			name:     "docker-archive",
 			imageRef: "docker-archive:" + c.env.DockerArchivePath,
 			exit:     0,

--- a/internal/pkg/build/oci/fetch.go
+++ b/internal/pkg/build/oci/fetch.go
@@ -88,7 +88,7 @@ func FetchLayout(ctx context.Context, sysCtx *types.SystemContext, imgCache *cac
 		return nil, fmt.Errorf("invalid image source: %v", err)
 	}
 
-	if imgCache != nil {
+	if imgCache != nil && !imgCache.IsDisabled() {
 		// Grab the modified source ref from the cache
 		srcRef, err = ConvertReference(ctx, imgCache, srcRef, sysCtx)
 		if err != nil {

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -41,6 +41,7 @@ func sysCtx(opts PullOptions) *ocitypes.SystemContext {
 		AuthFilePath:             syfs.DockerConf(),
 		DockerRegistryUserAgent:  useragent.Value(),
 		BigFilesTemporaryDir:     opts.TmpDir,
+		DockerDaemonHost:         opts.DockerHost,
 	}
 	if opts.NoHTTPS {
 		sysCtx.DockerInsecureSkipTLSVerify = ocitypes.NewOptionalBool(true)


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a direct URI is provided for `run/shell/exec` in `--oci` mode, perform a pull through the cache to obtain an OCI-SIF image, and execute this.

`--oci` mode is no longer limited to OCI URIs or `oci-sif` as valid sources. If an `oci-sif` can be retrieved from the library/shub/oras/http/https protocols it can be run.

At this point, http/https is trivial to e2e-test so can be supported.

The barriers for the other protocols are primarily around pushing an image, rather than pulling. When push of oci-sif is supported and tested in follow-up PRs, then we can list the protocols as supported.

This PR also incorporates some small fixes for issues exposed by existing e2e-tests when the URI->oci-sif flow was enabled:

**fix: Set DockerHost in oci client sysCtx**

`DOCKER_HOST` was not being honored in this flow.

**fix: check if cache disabled in FetchLayout**

We need to avoid trying to use the cache in FetchLayout if it's disabled, as well as if none was provided.

**fix: Cleanup oci-tools Squash workdir properly**

As the function docs state, we are responsible for cleaning up the
work directory we provide to `mutate.Squash`.

### This fixes or addresses the following GitHub issues:

 - Fixes #1860


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
