### PR TITLE
oci: re-exec as early as possible

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/runtime/launcher"
 	"github.com/sylabs/singularity/internal/pkg/runtime/launcher/native"
 	ocilauncher "github.com/sylabs/singularity/internal/pkg/runtime/launcher/oci"
-	"github.com/sylabs/singularity/internal/pkg/util/rootless"
 	"github.com/sylabs/singularity/internal/pkg/util/uri"
 	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
@@ -333,20 +332,6 @@ var TestCmd = &cobra.Command{
 }
 
 func launchContainer(cmd *cobra.Command, image string, containerCmd string, containerArgs []string, instanceName string) error {
-	// The OCI runtime must always be launched where the effective uid/gid is 0 (root or fake-root).
-	if ociRuntime && !rootless.InNS() {
-		// If we need to, enter a new cgroup now, to workaround an issue with crun container cgroup creation (#1538).
-		if err := ocilauncher.CrunNestCgroup(); err != nil {
-			return fmt.Errorf("while applying crun cgroup workaround: %w", err)
-		}
-		// If we are root already, run the launcher in a new mount namespace only.
-		if os.Geteuid() == 0 {
-			return rootless.RunInMountNS(os.Args[1:])
-		}
-		// If we are not root, re-exec in a root-mapped user namespace and mount namespace.
-		return rootless.ExecWithFakeroot(os.Args[1:])
-	}
-
 	ns := launcher.Namespaces{
 		User: userNamespace,
 		UTS:  utsNamespace,

--- a/internal/pkg/util/rootless/rootless.go
+++ b/internal/pkg/util/rootless/rootless.go
@@ -120,5 +120,10 @@ func RunInMountNS(args []string) error {
 	if errors.As(err, &exitErr) {
 		os.Exit(exitErr.ExitCode())
 	}
+
+	if err == nil {
+		os.Exit(0)
+	}
+
 	return err
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

When we need to enter a mount or user namespace to begin oci-mode operation, do so as early as possible.

The CLI code has a lot of logic in it, much of which may run twice if we re-exec in `launchContainer`. This code may also cause side effects.

Re-execing much earlier, at the root command's `PersistentPreRun`, avoids these issues.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
