### PR TITLE
e2e: oci: oras push/pull/run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,9 @@
 - The `pull` command now accepts a new flag `--oci` for OCI image sources. This
   will create an OCI-SIF image rather than convert to Singularity's native
   container format.
-- OCI-mode now supports running OCI-SIF images directly from http/https URIs.
+- OCI-mode now supports running OCI-SIF images directly from http/https and oras
+  URIs.
+- OCI-SIF images can be pushed/pulled to/from oras URIs.
 
 ### Developer / API
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -43,6 +43,7 @@ func (c actionTests) actionOciRun(t *testing.T) {
 	e2e.EnsureOCIArchive(t, c.env)
 	e2e.EnsureOCISIF(t, c.env)
 	e2e.EnsureDockerArchive(t, c.env)
+	e2e.EnsureORASOCISIF(t, c.env)
 
 	// Prepare oci source (oci directory layout)
 	ociLayout := t.TempDir()
@@ -66,6 +67,11 @@ func (c actionTests) actionOciRun(t *testing.T) {
 		{
 			name:     "oci-sif-http",
 			imageRef: "https://s3.amazonaws.com/singularity-ci-public/alpine-oci-sif-squashfs.sif",
+			exit:     0,
+		},
+		{
+			name:     "oci-sif-oras",
+			imageRef: c.env.OrasTestOCISIF,
 			exit:     0,
 		},
 		{

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -12,6 +12,7 @@ type TestEnv struct {
 	CmdPath           string // Path to the Singularity binary to use for the execution of a Singularity command
 	ImagePath         string // Path to the image that has to be used for the execution of a Singularity command
 	OrasTestImage     string // URI to SIF image pushed into local registry with ORAS
+	OrasTestOCISIF    string // URI to OCI-SIF image pushed into local registry with ORAS
 	OCIArchivePath    string // Path to test OCI archive tar file
 	OCISIFPath        string // Path to test OCI-SIF file
 	DockerArchivePath string // Path to test Docker archive tar file

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -181,6 +181,29 @@ func EnsureORASImage(t *testing.T, env TestEnv) {
 	})
 }
 
+var orasOCISIFOnce sync.Once
+
+func EnsureORASOCISIF(t *testing.T, env TestEnv) {
+	EnsureOCISIF(t, env)
+
+	ensureMutex.Lock()
+	defer ensureMutex.Unlock()
+
+	orasOCISIFOnce.Do(func() {
+		t.Logf("Pushing %s to %s", env.OCISIFPath, env.OrasTestOCISIF)
+		env.RunSingularity(
+			t,
+			WithProfile(UserProfile),
+			WithCommand("push"),
+			WithArgs(env.OCISIFPath, env.OrasTestOCISIF),
+			ExpectExit(0),
+		)
+		if t.Failed() {
+			t.Fatalf("failed to push ORAS oci-sif image to local registry")
+		}
+	})
+}
+
 func DownloadFile(url string, path string) error {
 	dl, err := os.Create(path)
 	if err != nil {

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -139,6 +139,7 @@ func getImageNameFromURI(imgURI string) string {
 
 func (c *ctx) setup(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
+	e2e.EnsureOCISIF(t, c.env)
 
 	// setup file and dir to use as invalid images
 	orasInvalidDir, err := os.MkdirTemp(c.env.TestDir, "oras_push_dir-")
@@ -177,6 +178,11 @@ func (c *ctx) setup(t *testing.T) {
 		{
 			srcPath:        orasInvalidFile,
 			uri:            fmt.Sprintf("%s/pull_test_invalid_file:latest", c.env.TestRegistry),
+			layerMediaType: syoras.SifLayerMediaTypeV1,
+		},
+		{
+			srcPath:        c.env.OCISIFPath,
+			uri:            fmt.Sprintf("%s/pull_test_oci-sif:latest", c.env.TestRegistry),
 			layerMediaType: syoras.SifLayerMediaTypeV1,
 		},
 	}
@@ -290,7 +296,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 		// Finalized v1 layer mediaType (3.7 and onward)
 		{
 			desc:             "oras transport for SIF from registry",
-			srcURI:           "oras://" + c.env.TestRegistry + "/pull_test_sif:latest", // TODO(mem): obtain registry from context
+			srcURI:           "oras://" + c.env.TestRegistry + "/pull_test_sif:latest",
 			force:            true,
 			unauthenticated:  false,
 			expectedExitCode: 0,
@@ -298,22 +304,29 @@ func (c ctx) testPullCmd(t *testing.T) {
 		// Original/prototype layer mediaType (<3.7)
 		{
 			desc:             "oras transport for SIF from registry (SifLayerMediaTypeProto)",
-			srcURI:           "oras://" + c.env.TestRegistry + "/pull_test_sif_mediatypeproto:latest", // TODO(mem): obtain registry from context
+			srcURI:           "oras://" + c.env.TestRegistry + "/pull_test_sif_mediatypeproto:latest",
 			force:            true,
 			unauthenticated:  false,
+			expectedExitCode: 0,
+		},
+		// OCI-SIF
+		{
+			desc:             "oras pull of oci-sif",
+			srcURI:           "oras://" + c.env.TestRegistry + "/pull_test_oci-sif:latest",
+			force:            true,
 			expectedExitCode: 0,
 		},
 
 		// pulling of invalid images with oras
 		{
 			desc:             "oras pull of non SIF file",
-			srcURI:           "oras://" + c.env.TestRegistry + "/pull_test_:latest", // TODO(mem): obtain registry from context
+			srcURI:           "oras://" + c.env.TestRegistry + "/pull_test_:latest",
 			force:            true,
 			expectedExitCode: 255,
 		},
 		{
 			desc:             "oras pull of packed dir",
-			srcURI:           "oras://" + c.env.TestRegistry + "/pull_test_invalid_file:latest", // TODO(mem): obtain registry from context
+			srcURI:           "oras://" + c.env.TestRegistry + "/pull_test_invalid_file:latest",
 			force:            true,
 			expectedExitCode: 255,
 		},

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -55,6 +55,7 @@ func (c ctx) testInvalidTransport(t *testing.T) {
 
 func (c ctx) testPushCmd(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
+	e2e.EnsureOCISIF(t, c.env)
 
 	// setup file and dir to use as invalid sources
 	orasInvalidDir, err := os.MkdirTemp(c.env.TestDir, "oras_push_dir-")
@@ -97,6 +98,12 @@ func (c ctx) testPushCmd(t *testing.T) {
 			desc:             "standard SIF push",
 			imagePath:        c.env.ImagePath,
 			dstURI:           fmt.Sprintf("oras://%s/standard_sif:test", c.env.TestRegistry),
+			expectedExitCode: 0,
+		},
+		{
+			desc:             "OCI-SIF push",
+			imagePath:        c.env.OCISIFPath,
+			dstURI:           fmt.Sprintf("oras://%s/oci-sif:test", c.env.TestRegistry),
 			expectedExitCode: 0,
 		},
 	}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -230,6 +230,9 @@ func Run(t *testing.T) {
 	// Local registry ORAS SIF image, built on demand by e2e.EnsureORASImage
 	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
 
+	// Local registry ORAS OCI-SIF image, built on demand by e2e.EnsureORASOCISIF
+	testenv.OrasTestOCISIF = fmt.Sprintf("oras://%s/oras_test_oci-sif:latest", testenv.TestRegistry)
+
 	t.Cleanup(func() {
 		if !t.Failed() {
 			os.Remove(imagePath)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add e2e tests for push / pull / run against oras URIs, with OCI-SIF images.

This is a testing-only change. Because our oras code will push/pull any SIF image, it is working as of https://github.com/sylabs/singularity/pull/1882.

### This fixes or addresses the following GitHub issues:

- Closes #1863 
- Closes #1864 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
