### PR TITLE
oras: fix push of oci-sif

### DIFF
--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -216,7 +216,7 @@ func ensureSIF(filepath string) error {
 	}
 	defer img.File.Close()
 
-	if img.Type != image.SIF {
+	if img.Type != image.SIF && img.Type != image.OCISIF {
 		return fmt.Errorf("%q is not a SIF", filepath)
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

After #1886 the check for a vaild SIF image must be relaxed to include `image.OCISIF`.

e2e-tests caught this bug on main after merge, but not on the PR CI run.

### This fixes or addresses the following GitHub issues:

 - Fixes #1890 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
