### PR TITLE
chore: Move i/p/a/singularity Sign/Verify functions to separate pkg

### DIFF
--- a/cmd/internal/cli/pgp.go
+++ b/cmd/internal/cli/pgp.go
@@ -21,7 +21,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/sylabs/sif/v2/pkg/integrity"
 	"github.com/sylabs/sif/v2/pkg/sif"
-	"github.com/sylabs/singularity/internal/app/singularity"
+	sifsignature "github.com/sylabs/singularity/internal/pkg/signature"
 	"github.com/sylabs/singularity/internal/pkg/util/interactive"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/sypgp"
@@ -220,8 +220,8 @@ type keyList struct {
 	SignerKeys []*key
 }
 
-// getJSONCallback returns a singularity.VerifyCallback that appends to kl.
-func getJSONCallback(kl *keyList) singularity.VerifyCallback {
+// getJSONCallback returns a signature.VerifyCallback that appends to kl.
+func getJSONCallback(kl *keyList) sifsignature.VerifyCallback {
 	return func(f *sif.FileImage, r integrity.VerifyResult) bool {
 		name, fp := "unknown", ""
 		var keyLocal, keyCheck bool

--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
-	"github.com/sylabs/singularity/internal/app/singularity"
+	sifsignature "github.com/sylabs/singularity/internal/pkg/signature"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/sypgp"
@@ -126,7 +126,7 @@ var SignCmd = &cobra.Command{
 }
 
 func doSignCmd(cmd *cobra.Command, cpath string) {
-	var opts []singularity.SignOpt
+	var opts []sifsignature.SignOpt
 
 	// Set key material.
 	switch {
@@ -137,7 +137,7 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 		if err != nil {
 			sylog.Fatalf("Failed to load key material: %v", err)
 		}
-		opts = append(opts, singularity.OptSignWithSigner(s))
+		opts = append(opts, sifsignature.OptSignWithSigner(s))
 
 	default:
 		sylog.Infof("Signing image with PGP key material")
@@ -150,21 +150,21 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 			f = selectEntityInteractive()
 		}
 		f = decryptSelectedEntityInteractive(f)
-		opts = append(opts, singularity.OptSignEntitySelector(f))
+		opts = append(opts, sifsignature.OptSignEntitySelector(f))
 	}
 
 	// Set group option, if applicable.
 	if cmd.Flag(signSifGroupIDFlag.Name).Changed || cmd.Flag(signOldSifGroupIDFlag.Name).Changed {
-		opts = append(opts, singularity.OptSignGroup(sifGroupID))
+		opts = append(opts, sifsignature.OptSignGroup(sifGroupID))
 	}
 
 	// Set object option, if applicable.
 	if cmd.Flag(signSifDescSifIDFlag.Name).Changed || cmd.Flag(signSifDescIDFlag.Name).Changed {
-		opts = append(opts, singularity.OptSignObjects(sifDescID))
+		opts = append(opts, sifsignature.OptSignObjects(sifDescID))
 	}
 
 	// Sign the image.
-	if err := singularity.Sign(cmd.Context(), cpath, opts...); err != nil {
+	if err := sifsignature.Sign(cmd.Context(), cpath, opts...); err != nil {
 		sylog.Fatalf("Failed to sign container: %v", err)
 	}
 	sylog.Infof("Signature created and applied to image '%v'", cpath)

--- a/internal/app/singularity/push.go
+++ b/internal/app/singularity/push.go
@@ -18,6 +18,7 @@ import (
 	keyclient "github.com/sylabs/scs-key-client/client"
 	"github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/sif/v2/pkg/sif"
+	"github.com/sylabs/singularity/internal/pkg/signature"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/vbauerster/mpb/v8"
@@ -96,7 +97,7 @@ func LibraryPush(ctx context.Context, pushSpec LibraryPushSpec, libraryConfig *c
 
 	if !pushSpec.AllowUnsigned {
 		// Check if the container has a valid signature.
-		if err := Verify(ctx, pushSpec.SourceFile, OptVerifyWithPGP(co...)); err != nil {
+		if err := signature.Verify(ctx, pushSpec.SourceFile, signature.OptVerifyWithPGP(co...)); err != nil {
 			sylog.Warningf("%v", err)
 			return ErrLibraryUnsigned
 		}

--- a/internal/pkg/build/sources/verify_sif.go
+++ b/internal/pkg/build/sources/verify_sif.go
@@ -9,18 +9,18 @@ import (
 	"context"
 
 	scskeyclient "github.com/sylabs/scs-key-client/client"
-	"github.com/sylabs/singularity/internal/app/singularity"
+	"github.com/sylabs/singularity/internal/pkg/signature"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
 // checkSIFFingerprint checks whether a bootstrap SIF image verifies, and was signed with a specified fingerprint
 func checkSIFFingerprint(ctx context.Context, imagePath string, fingerprints []string, co ...scskeyclient.Option) error {
 	sylog.Infof("Checking bootstrap image verifies with fingerprint(s): %v", fingerprints)
-	return singularity.VerifyFingerprints(ctx, imagePath, fingerprints, singularity.OptVerifyWithPGP(co...))
+	return signature.VerifyFingerprints(ctx, imagePath, fingerprints, signature.OptVerifyWithPGP(co...))
 }
 
 // verifySIF checks whether a bootstrap SIF image verifies
 func verifySIF(ctx context.Context, imagePath string, co ...scskeyclient.Option) error {
 	sylog.Infof("Verifying bootstrap image %s", imagePath)
-	return singularity.Verify(ctx, imagePath, singularity.OptVerifyWithPGP(co...))
+	return signature.Verify(ctx, imagePath, signature.OptVerifyWithPGP(co...))
 }

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -16,9 +16,9 @@ import (
 	keyclient "github.com/sylabs/scs-key-client/client"
 	libclient "github.com/sylabs/scs-library-client/client"
 	scslibrary "github.com/sylabs/scs-library-client/client"
-	"github.com/sylabs/singularity/internal/app/singularity"
 	"github.com/sylabs/singularity/internal/pkg/cache"
 	"github.com/sylabs/singularity/internal/pkg/client"
+	"github.com/sylabs/singularity/internal/pkg/signature"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"golang.org/x/term"
@@ -140,7 +140,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo string, pull
 		}
 	}
 
-	if err := singularity.Verify(ctx, pullTo, singularity.OptVerifyWithPGP(co...)); err != nil {
+	if err := signature.Verify(ctx, pullTo, signature.OptVerifyWithPGP(co...)); err != nil {
 		sylog.Warningf("%v", err)
 		return pullTo, ErrLibraryPullUnsigned
 	}

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -216,7 +216,7 @@ func ensureSIF(filepath string) error {
 	}
 	defer img.File.Close()
 
-	if img.Type != image.SIF {
+	if img.Type != image.SIF && img.Type != image.OCISIF {
 		return fmt.Errorf("%q is not a SIF", filepath)
 	}
 

--- a/internal/pkg/signature/sign.go
+++ b/internal/pkg/signature/sign.go
@@ -3,7 +3,7 @@
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
 
-package singularity
+package signature
 
 import (
 	"context"

--- a/internal/pkg/signature/sign_test.go
+++ b/internal/pkg/signature/sign_test.go
@@ -3,7 +3,7 @@
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
 
-package singularity
+package signature
 
 import (
 	"context"

--- a/internal/pkg/signature/verify.go
+++ b/internal/pkg/signature/verify.go
@@ -4,7 +4,7 @@
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
 
-package singularity
+package signature
 
 import (
 	"context"

--- a/internal/pkg/signature/verify_ocsp.go
+++ b/internal/pkg/signature/verify_ocsp.go
@@ -4,7 +4,7 @@
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
 
-package singularity
+package signature
 
 import (
 	"bytes"

--- a/internal/pkg/signature/verify_test.go
+++ b/internal/pkg/signature/verify_test.go
@@ -3,7 +3,7 @@
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
 
-package singularity
+package signature
 
 import (
 	"bytes"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Implementation of SIF signing and verification was previously part of the large internal/pkg/app/singularity package.

This situation is problematic, as verification may need to be performed in builds, client pulls etc. Consequently internal/pkg/app/singularity had to be imported in lower level code.

Work on the OCI mode has exposed situations where this can result in import loops.

After recent re-writes, the Sign / Verify functions are not tied to other portions of internal/pkg/app/singularity. Therefore this PR moves them to a separate package to avoid import loops etc.

As a result, internal/pkg/app/singularity is now only imported by cmd/.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
