### PR TITLE
oci: default to /.singularity.d/runscript for SIF bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 - Lookup and store user/group information in stage one prior to entering any
   namespaces to fix issue with winbind not correctly lookup user/group
   information when using user namespace.
+- The default process for an OCI bundle created with `singualrity oci mount` is now
+  `/singularity.d/runscript` instead of `/bin/sh`.
 
 ### New Features & Functionality
 

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -23,6 +23,8 @@ import (
 	"github.com/sylabs/singularity/pkg/ocibundle/tools"
 )
 
+const singularityRunscript = "/.singularity.d/runscript"
+
 type sifBundle struct {
 	image      string
 	bundlePath string
@@ -120,6 +122,9 @@ func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate OCI bundle/config: %s", err)
 	}
+
+	// By default, we should call the container runscript
+	g.SetProcessArgs([]string{singularityRunscript})
 
 	// associate SIF image with a block
 	loop, loopCloser, err := tools.CreateLoop(img.File, offset, size)


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a bundle is created from a singularity SIF (e.g. via `singularity oci mount`), the default process is now the container runscript.

Previously the process specified in the OCI runtime config was `/bin/sh`, resulting in the default behaviour of the bundle not matching execution under singularity.

### This fixes or addresses the following GitHub issues:

 - Fixes #1898


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
