### PR TITLE
oci: switch `oci mount` to squashfuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 - Lookup and store user/group information in stage one prior to entering any
   namespaces to fix issue with winbind not correctly lookup user/group
   information when using user namespace.
+- `singularity oci mount` now uses, and requires, `squashfuse` to mount a SIF
+  image to an OCI bundle.
 
 ### New Features & Functionality
 

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -80,6 +80,8 @@ func (c *ctx) checkOciState(t *testing.T, containerID, state string) {
 
 func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 	require.Seccomp(t)
+	require.Command(t, "squashfuse")
+	require.Command(t, "fusermount")
 	require.Filesystem(t, "overlay")
 
 	bundleDir, err := os.MkdirTemp(c.env.TestDir, "bundle-")


### PR DESCRIPTION
## Description of the Pull Request (PR):

The singularity SIF -> OCI bundle mount was previously performed with a kernel squashfs mount.

We will be using `pkg/ocibundle/sif` as the basis of `--oci` mode execution of singularity SIF (non oci-sif) images.

Switch the mount to use squashfuse for consistency. `--oci` mode does not perform kernel mounts from SIF.


### This fixes or addresses the following GitHub issues:

 - Fixes #1897


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
