### PR TITLE
oci: Execute non-oci SIF in --oci mode

### DIFF
--- a/cmd/internal/cli/instance_start_linux.go
+++ b/cmd/internal/cli/instance_start_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/app/singularity"
+	"github.com/sylabs/singularity/internal/pkg/runtime/launcher"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
@@ -37,16 +38,18 @@ var instanceStartCmd = &cobra.Command{
 	PreRun:                actionPreRun,
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		image := args[0]
-		name := args[1]
-		containerCmd := "/.singularity.d/actions/start"
-		containerArgs := args[2:]
-		if err := launchContainer(cmd, image, containerCmd, containerArgs, name); err != nil {
+		ep := launcher.ExecParams{
+			Image:    args[0],
+			Action:   "start",
+			Instance: args[1],
+			Args:     args[2:],
+		}
+		if err := launchContainer(cmd, ep); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 
 		if instanceStartPidFile != "" {
-			err := singularity.WriteInstancePidFile(name, instanceStartPidFile)
+			err := singularity.WriteInstancePidFile(ep.Instance, instanceStartPidFile)
 			if err != nil {
 				sylog.Warningf("Failed to write pid file: %v", err)
 			}

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -107,9 +107,19 @@ func (c actionTests) actionOciRun(t *testing.T) {
 			exit:     1,
 		},
 		{
-			name:     "non-oci-sif",
+			name:     "native-sif",
 			imageRef: c.env.ImagePath,
-			exit:     255,
+			exit:     0,
+		},
+		{
+			name:     "native-sif-oras",
+			imageRef: c.env.OrasTestImage,
+			exit:     0,
+		},
+		{
+			name:     "native-sif-library",
+			imageRef: "library://busybox:1.31.1",
+			exit:     0,
 		},
 	}
 

--- a/internal/pkg/runtime/launcher/launcher.go
+++ b/internal/pkg/runtime/launcher/launcher.go
@@ -1,21 +1,17 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 // Package launcher is responsible for implementing launchers, which can start a
 // container, with configuration passed from the CLI layer.
-//
-// The package currently implements a single native.Launcher, with an Exec
-// method that constructs a runtime configuration and calls the Singularity
-// runtime starter binary to start the container.
-//
-// TODO - the launcher package will be extended to support launching containers
-// via the OCI runc/crun runtime, in addition to the current Singularity runtime
-// starter, by adding an oci.Launcher.
 package launcher
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+)
 
 // Launcher is responsible for configuring and launching a container image.
 // It will execute a runtime, such as Singularity's native runtime (via the starter
@@ -25,5 +21,62 @@ type Launcher interface {
 	// passing arguments 'args'. If instanceName is specified, the container
 	// must be launched as a background instance, otherwise it must run
 	// interactively, attached to the console.
-	Exec(ctx context.Context, image string, process string, args []string, instanceName string) error
+	Exec(ctx context.Context, ep ExecParams) error
+}
+
+// ExecParams specifies the image and process for a launcher to Exec.
+type ExecParams struct {
+	// Image is the container image to execute, as a bare path, or <transport>:<path>.
+	Image string
+	// Action is one of exec/run/shell/start/test as specified on the CLI.
+	Action string
+	// Process is the command to execute as the container process, where applicable.
+	Process string
+	// Args are the arguments passed to the container process.
+	Args []string
+	// Instance is the name of an instance (optional).
+	Instance string
+}
+
+const singularityActions = "/.singularity.d/actions"
+
+// ActionScriptArgs returns the args that will appropriately exec the action
+// script in a singularity (non-oci) container, for a given ExecParams.
+func (ep ExecParams) ActionScriptArgs() (args []string, err error) {
+	if ep.Image == "" {
+		return []string{}, fmt.Errorf("%s action requires an image", ep.Action)
+	}
+
+	args = []string{filepath.Join(singularityActions, ep.Action)}
+
+	switch ep.Action {
+	case "exec":
+		if ep.Process == "" {
+			return []string{}, fmt.Errorf("%s action requires a process", ep.Action)
+		}
+		if ep.Instance != "" {
+			return []string{}, fmt.Errorf("%s action doesn't support specifying an instance", ep.Action)
+		}
+		args = append(args, ep.Process)
+		args = append(args, ep.Args...)
+	case "run", "shell", "test":
+		if ep.Process != "" {
+			return []string{}, fmt.Errorf("%s action doesn't support specifying a process", ep.Action)
+		}
+		if ep.Instance != "" {
+			return []string{}, fmt.Errorf("%s action doesn't support specifying an instance", ep.Action)
+		}
+		args = append(args, ep.Args...)
+	case "start":
+		if ep.Process != "" {
+			return []string{}, fmt.Errorf("%s action doesn't support specifying a process", ep.Action)
+		}
+		if ep.Instance == "" {
+			return []string{}, fmt.Errorf("%s action requires an instance", ep.Action)
+		}
+		args = append(args, ep.Args...)
+	default:
+		return []string{}, fmt.Errorf("unknown action %q", ep.Action)
+	}
+	return args, nil
 }

--- a/internal/pkg/runtime/launcher/launcher_test.go
+++ b/internal/pkg/runtime/launcher/launcher_test.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package launcher
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExecParams_ActionArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		Image    string
+		Action   string
+		Process  string
+		Args     []string
+		Instance string
+		wantArgs []string
+		wantErr  bool
+	}{
+		// exec
+		{
+			name:     "exec",
+			Image:    "image.sif",
+			Action:   "exec",
+			Process:  "process",
+			wantArgs: []string{"/.singularity.d/actions/exec", "process"},
+			wantErr:  false,
+		},
+		{
+			name:     "execArgs",
+			Image:    "image.sif",
+			Action:   "exec",
+			Process:  "process",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{"/.singularity.d/actions/exec", "process", "a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "execNoProcess",
+			Image:    "image.sif",
+			Action:   "exec",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "execWithInstance",
+			Image:    "image.sif",
+			Action:   "exec",
+			Process:  "process",
+			Instance: "myinstance",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		// run
+		{
+			name:     "run",
+			Image:    "image.sif",
+			Action:   "run",
+			wantArgs: []string{"/.singularity.d/actions/run"},
+			wantErr:  false,
+		},
+		{
+			name:     "runArgs",
+			Image:    "image.sif",
+			Action:   "run",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{"/.singularity.d/actions/run", "a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "runNoImage",
+			Action:   "run",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "runWithProcess",
+			Image:    "image.sif",
+			Action:   "run",
+			Process:  "process",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "runWithInstance",
+			Image:    "image.sif",
+			Action:   "run",
+			Instance: "myinstance",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		// shell
+		{
+			name:     "shell",
+			Image:    "image.sif",
+			Action:   "shell",
+			wantArgs: []string{"/.singularity.d/actions/shell"},
+			wantErr:  false,
+		},
+		{
+			name:     "shellArgs",
+			Image:    "image.sif",
+			Action:   "shell",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{"/.singularity.d/actions/shell", "a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "shellWithProcess",
+			Image:    "image.sif",
+			Action:   "shell",
+			Process:  "process",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "shellWithInstance",
+			Image:    "image.sif",
+			Action:   "shell",
+			Instance: "myinstance",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		// start
+		{
+			name:     "start",
+			Image:    "image.sif",
+			Action:   "start",
+			Instance: "myinstance",
+			wantArgs: []string{"/.singularity.d/actions/start"},
+			wantErr:  false,
+		},
+		{
+			name:     "startArgs",
+			Image:    "image.sif",
+			Action:   "start",
+			Instance: "myinstance",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{"/.singularity.d/actions/start", "a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "startWithProcess",
+			Image:    "image.sif",
+			Action:   "start",
+			Instance: "myinstance",
+			Process:  "process",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "startNoInstance",
+			Image:    "image.sif",
+			Action:   "start",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		// test
+		{
+			name:     "test",
+			Image:    "image.sif",
+			Action:   "test",
+			wantArgs: []string{"/.singularity.d/actions/test"},
+			wantErr:  false,
+		},
+		{
+			name:     "testArgs",
+			Image:    "image.sif",
+			Action:   "test",
+			Args:     []string{"a", "b", "c"},
+			wantArgs: []string{"/.singularity.d/actions/test", "a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "testWithProcess",
+			Image:    "image.sif",
+			Action:   "test",
+			Process:  "process",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		{
+			name:     "testWithInstance",
+			Image:    "image.sif",
+			Action:   "test",
+			Instance: "myinstance",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+		// Invalid
+		{
+			name:     "InvalidAction",
+			Image:    "image.sif",
+			Action:   "delete",
+			wantArgs: []string{},
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := ExecParams{
+				Image:    tt.Image,
+				Action:   tt.Action,
+				Process:  tt.Process,
+				Args:     tt.Args,
+				Instance: tt.Instance,
+			}
+			gotArgs, err := ep.ActionScriptArgs()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExecParams.ActionArgs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Errorf("ExecParams.ActionArgs() = %v, want %v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -115,8 +115,8 @@ func Test_normalizeImageRef(t *testing.T) {
 		{
 			name:     "sif image",
 			imageRef: "../../../../../test/images/empty.sif",
-			want:     "",
-			wantErr:  true,
+			want:     "sif:../../../../../test/images/empty.sif",
+			wantErr:  false,
 		},
 		{
 			name:     "oci ref",

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -147,6 +147,7 @@ func TestEnvFileMap(t *testing.T) {
 func TestGetProcessArgs(t *testing.T) {
 	tests := []struct {
 		name              string
+		nativeSIF         bool
 		imgEntrypoint     []string
 		imgCmd            []string
 		bundleProcess     string
@@ -251,7 +252,11 @@ func TestGetProcessArgs(t *testing.T) {
 					Cmd:        tt.imgCmd,
 				},
 			}
-			args := getProcessArgs(i, tt.bundleProcess, tt.bundleArgs)
+			ep := launcher.ExecParams{
+				Process: tt.bundleProcess,
+				Args:    tt.bundleArgs,
+			}
+			args := getProcessArgs(i, ep)
 			if !reflect.DeepEqual(args, tt.expectProcessArgs) {
 				t.Errorf("Expected: %v, Got: %v", tt.expectProcessArgs, args)
 			}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -121,6 +121,8 @@ type Section struct {
 	ID           uint32 `json:"id"`
 	Type         uint32 `json:"type"`
 	AllowedUsage Usage  `json:"allowed_usage"`
+	// Architecture is only known for system partitions in SIF files.
+	Architecture string `json:"architecture,omitempty"`
 }
 
 // Image describes an image object, an image is composed of one

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -116,6 +116,7 @@ func (f *sifFormat) initializer(img *Image, fi os.FileInfo) error {
 				Name:         RootFs,
 				Type:         htype,
 				AllowedUsage: RootFsUsage,
+				Architecture: goArch,
 			},
 		}
 	}

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -12,16 +12,19 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
-	imageSpecs "github.com/opencontainers/image-spec/specs-go/v1"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci/generate"
+	"github.com/sylabs/singularity/internal/pkg/util/env"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/internal/pkg/util/fs/squashfs"
 
 	"github.com/sylabs/singularity/pkg/image"
 	"github.com/sylabs/singularity/pkg/ocibundle"
 	"github.com/sylabs/singularity/pkg/ocibundle/tools"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 type sifBundle struct {
@@ -29,22 +32,16 @@ type sifBundle struct {
 	bundlePath string
 	writable   bool
 	ocibundle.Bundle
+	arch string
+	// imageSpec is the OCI image information, CMD, ENTRYPOINT, etc.
+	imageSpec *imgspecv1.Image
 }
 
-func (s *sifBundle) writeConfig(img *image.Image, g *generate.Generator) error {
-	// check if SIF file contain an OCI image configuration
-	reader, err := image.NewSectionReader(img, image.SIFDescOCIConfigJSON, -1)
-	if err != nil && err != image.ErrNoSection {
-		return fmt.Errorf("failed to read %s section: %s", image.SIFDescOCIConfigJSON, err)
-	} else if err == image.ErrNoSection {
-		return tools.SaveBundleConfig(s.bundlePath, g)
+func (s *sifBundle) writeConfig(g *generate.Generator) error {
+	if s.imageSpec == nil {
+		return fmt.Errorf("cannot write bundle config with nil image spec")
 	}
-
-	var imgConfig imageSpecs.ImageConfig
-
-	if err := json.NewDecoder(reader).Decode(&imgConfig); err != nil {
-		return fmt.Errorf("failed to decode %s: %s", image.SIFDescOCIConfigJSON, err)
-	}
+	imgConfig := s.imageSpec.Config
 
 	if len(g.Config.Process.Args) == 1 && g.Config.Process.Args[0] == tools.RunScript {
 		args := imgConfig.Entrypoint
@@ -114,6 +111,11 @@ func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 		return fmt.Errorf("unsupported image fs type: %v", part.Type)
 	}
 	offset := part.Offset
+	s.arch = part.Architecture
+
+	if err := s.setImageSpec(img); err != nil {
+		return fmt.Errorf("failed to set image spec: %w", err)
+	}
 
 	// generate OCI bundle directory and config
 	g, err := tools.GenerateBundleConfig(s.bundlePath, ociConfig)
@@ -127,7 +129,7 @@ func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 		return fmt.Errorf("failed to mount SIF partition: %s", err)
 	}
 
-	if err := s.writeConfig(img, g); err != nil {
+	if err := s.writeConfig(g); err != nil {
 		// best effort to release FUSE mount
 		squashfs.FUSEUnmount(ctx, rootFs)
 		tools.DeleteBundle(s.bundlePath)
@@ -147,7 +149,12 @@ func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 
 // Update will update the OCI config for the OCI bundle, so that it is ready for execution.
 func (s *sifBundle) Update(ctx context.Context, ociConfig *specs.Spec) error {
-	return fmt.Errorf("cannot update config of a SIF OCI bundle: not implemented")
+	// generate OCI bundle directory and config
+	g, err := tools.GenerateBundleConfig(s.bundlePath, ociConfig)
+	if err != nil {
+		return fmt.Errorf("failed to generate OCI bundle/config: %s", err)
+	}
+	return s.writeConfig(g)
 }
 
 // Delete erases OCI bundle create from SIF image
@@ -167,8 +174,47 @@ func (s *sifBundle) Delete(ctx context.Context) error {
 	return tools.DeleteBundle(s.bundlePath)
 }
 
-// ImageSpec returns nil for SIF bundles, as they currently do not carry an OCI image spec.
-func (s *sifBundle) ImageSpec() (imgSpec *imageSpecs.Image) {
+// ImageSpec returns an OCI Image Spec for the container.
+func (s *sifBundle) ImageSpec() *imgspecv1.Image {
+	return s.imageSpec
+}
+
+// setImageSpec will generate an imageSpec, using the OCI image config embedded
+// in the SIF file if present.
+func (s *sifBundle) setImageSpec(img *image.Image) error {
+	now := time.Now()
+	p := imgspecv1.Platform{
+		Architecture: s.arch,
+		OS:           "linux",
+	}
+
+	// Singularity images have a runscript and/or startscript. These do not
+	// translate well to the OCI Entrypoint/Cmd specification. The OCI config
+	// embedded into a SIF at build time doesn't try to resolve the issue, and
+	// just sets Cmd to /bin/sh. Use the same default here, so it's up to the
+	// launcher to resolve runscript/startscript handling.
+	c := imgspecv1.ImageConfig{
+		Cmd: []string{"/bin/sh"},
+		Env: []string{"PATH=" + env.DefaultPath},
+	}
+
+	reader, err := image.NewSectionReader(img, image.SIFDescOCIConfigJSON, -1)
+	if err != nil && err != image.ErrNoSection {
+		return fmt.Errorf("failed to read %s section: %s", image.SIFDescOCIConfigJSON, err)
+	}
+	// We have an image config from the SIF, so overwrite default
+	if err == nil {
+		if err := json.NewDecoder(reader).Decode(&c); err != nil {
+			return fmt.Errorf("failed to decode %s: %s", image.SIFDescOCIConfigJSON, err)
+		}
+	}
+
+	s.imageSpec = &imgspecv1.Image{
+		Created:  &now,
+		Author:   useragent.Value(),
+		Platform: p,
+		Config:   c,
+	}
 	return nil
 }
 

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -154,7 +154,7 @@ func (s *sifBundle) Update(ctx context.Context, ociConfig *specs.Spec) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate OCI bundle/config: %s", err)
 	}
-	return s.writeConfig(g)
+	return tools.SaveBundleConfig(s.bundlePath, g)
 }
 
 // Delete erases OCI bundle create from SIF image

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,6 +17,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/ocibundle/tools"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 // We need a busybox SIF for these tests. We used to download it each time, but we have one
@@ -24,6 +25,7 @@ import (
 const busyboxSIF = "../../../e2e/testdata/busybox_" + runtime.GOARCH + ".sif"
 
 func TestFromSif(t *testing.T) {
+	useragent.InitValue("TestFromSif", "0.0.0")
 	test.EnsurePrivilege(t)
 
 	bundlePath := t.TempDir()


### PR DESCRIPTION
## Description of the Pull Request (PR):

Implement `ImageSpec()` for `ocibundle/sif`, so that it returns a usable OCI image spec. Use the OCI image config embedded in the SIF file, if it is present.
       
Implement basic execution of non-oci SIF images in `--oci` mode. This is acheived by calling the `/singularity.d/action/*` scripts inside the non-oci SIF container. Generation of container process args including the action script has been moved to a struct `ExecParams` in the `launcher` package, so that it can be called from the OCI launcher when needed.

e2e testing is currently minimal. As work proceeds to wire-up native runtime compatible env handling, and have the option to run in non- `--compat`, we will be adding proper tests of the behaviour of the non-oci containers.

Note that due to prior work, we already have handling of non-oci SIF from `library://`, `oras://` via pull through the cache, so an e2e test for these sources is also added.

### This fixes or addresses the following GitHub issues:

 - Fixes #1899 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
