### PR TITLE
move OCI/Docker-registry-related cmds from `remote` to their own cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
 - The keyserver-related commands that were under `remote` have been moved to
   their own, dedicated `keyserver` command. Run `singularity help keyserver` for
   more information.
+- The commands related to OCI/Docker registries that were under `remote` have
+  been moved to their own, dedicated `registry` command. Run
+  `singularity help registry` for more information.
 
 ### New Features & Functionality
 

--- a/cmd/internal/cli/keyserver.go
+++ b/cmd/internal/cli/keyserver.go
@@ -7,9 +7,7 @@
 package cli
 
 import (
-	"io"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
@@ -168,25 +166,7 @@ func setKeyserver(_ *cobra.Command, _ []string) {
 var KeyserverLoginCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		loginArgs := new(singularity.LoginArgs)
-
-		loginArgs.Name = args[0]
-
-		loginArgs.Username = loginUsername
-		loginArgs.Password = loginPassword
-		loginArgs.Tokenfile = loginTokenFile
-		loginArgs.Insecure = loginInsecure
-
-		if loginPasswordStdin {
-			p, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				sylog.Fatalf("Failed to read password from stdin: %s", err)
-			}
-			loginArgs.Password = strings.TrimSuffix(string(p), "\n")
-			loginArgs.Password = strings.TrimSuffix(loginArgs.Password, "\r")
-		}
-
-		if err := singularity.KeyserverLogin(remoteConfig, loginArgs); err != nil {
+		if err := singularity.KeyserverLogin(remoteConfig, ObtainLoginArgs(args[0])); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/cmd/internal/cli/loginargs.go
+++ b/cmd/internal/cli/loginargs.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/sylabs/singularity/internal/app/singularity"
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+func ObtainLoginArgs(name string) *singularity.LoginArgs {
+	var loginArgs singularity.LoginArgs
+
+	loginArgs.Name = name
+
+	loginArgs.Username = loginUsername
+	loginArgs.Password = loginPassword
+	loginArgs.Tokenfile = loginTokenFile
+	loginArgs.Insecure = loginInsecure
+
+	if loginPasswordStdin {
+		p, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			sylog.Fatalf("Failed to read password from stdin: %s", err)
+		}
+		loginArgs.Password = strings.TrimSuffix(string(p), "\n")
+		loginArgs.Password = strings.TrimSuffix(loginArgs.Password, "\r")
+	}
+
+	return &loginArgs
+}

--- a/cmd/internal/cli/registry.go
+++ b/cmd/internal/cli/registry.go
@@ -7,10 +7,6 @@
 package cli
 
 import (
-	"io"
-	"os"
-	"strings"
-
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/app/singularity"
@@ -91,25 +87,7 @@ var RegistryCmd = &cobra.Command{
 var RegistryLoginCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		loginArgs := new(singularity.LoginArgs)
-
-		loginArgs.Name = args[0]
-
-		loginArgs.Username = loginUsername
-		loginArgs.Password = loginPassword
-		loginArgs.Tokenfile = loginTokenFile
-		loginArgs.Insecure = loginInsecure
-
-		if loginPasswordStdin {
-			p, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				sylog.Fatalf("Failed to read password from stdin: %s", err)
-			}
-			loginArgs.Password = strings.TrimSuffix(string(p), "\n")
-			loginArgs.Password = strings.TrimSuffix(loginArgs.Password, "\r")
-		}
-
-		if err := singularity.RegistryLogin(remoteConfig, loginArgs); err != nil {
+		if err := singularity.RegistryLogin(remoteConfig, ObtainLoginArgs(args[0])); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/cmd/internal/cli/registry.go
+++ b/cmd/internal/cli/registry.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/docs"
+	"github.com/sylabs/singularity/internal/app/singularity"
+	"github.com/sylabs/singularity/pkg/cmdline"
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+// -c|--config
+var registryConfigFlag = cmdline.Flag{
+	ID:           "registryConfigFlag",
+	Value:        &remoteConfig,
+	DefaultValue: remoteConfigUser,
+	Name:         "config",
+	ShortHand:    "c",
+	Usage:        "path to the file holding remote endpoint configurations",
+}
+
+// -u|--username
+var registryLoginUsernameFlag = cmdline.Flag{
+	ID:           "registryLoginUsernameFlag",
+	Value:        &loginUsername,
+	DefaultValue: "",
+	Name:         "username",
+	ShortHand:    "u",
+	Usage:        "username to authenticate with (required for Docker/OCI registry login)",
+	EnvKeys:      []string{"LOGIN_USERNAME"},
+}
+
+// -p|--password
+var registryLoginPasswordFlag = cmdline.Flag{
+	ID:           "registryLoginPasswordFlag",
+	Value:        &loginPassword,
+	DefaultValue: "",
+	Name:         "password",
+	ShortHand:    "p",
+	Usage:        "password / token to authenticate with",
+	EnvKeys:      []string{"LOGIN_PASSWORD"},
+}
+
+// --password-stdin
+var registryLoginPasswordStdinFlag = cmdline.Flag{
+	ID:           "registryLoginPasswordStdinFlag",
+	Value:        &loginPasswordStdin,
+	DefaultValue: false,
+	Name:         "password-stdin",
+	Usage:        "take password from standard input",
+}
+
+func init() {
+	addCmdInit(func(cmdManager *cmdline.CommandManager) {
+		cmdManager.RegisterCmd(RegistryCmd)
+		cmdManager.RegisterSubCmd(RegistryCmd, RegistryLoginCmd)
+		cmdManager.RegisterSubCmd(RegistryCmd, RegistryLogoutCmd)
+		cmdManager.RegisterSubCmd(RegistryCmd, RegistryListCmd)
+
+		// default location of the remote.yaml file is the user directory
+		cmdManager.RegisterFlagForCmd(&registryConfigFlag, RegistryCmd)
+
+		cmdManager.RegisterFlagForCmd(&registryLoginUsernameFlag, RegistryLoginCmd)
+		cmdManager.RegisterFlagForCmd(&registryLoginPasswordFlag, RegistryLoginCmd)
+		cmdManager.RegisterFlagForCmd(&registryLoginPasswordStdinFlag, RegistryLoginCmd)
+	})
+}
+
+// RegistryCmd singularity registry [...]
+var RegistryCmd = &cobra.Command{
+	Run: nil,
+
+	Use:     docs.RegistryUse,
+	Short:   docs.RegistryShort,
+	Long:    docs.RegistryLong,
+	Example: docs.RegistryExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+// RegistryLoginCmd singularity registry login [option] <registry_url>
+var RegistryLoginCmd = &cobra.Command{
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		loginArgs := new(singularity.LoginArgs)
+
+		loginArgs.Name = args[0]
+
+		loginArgs.Username = loginUsername
+		loginArgs.Password = loginPassword
+		loginArgs.Tokenfile = loginTokenFile
+		loginArgs.Insecure = loginInsecure
+
+		if loginPasswordStdin {
+			p, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				sylog.Fatalf("Failed to read password from stdin: %s", err)
+			}
+			loginArgs.Password = strings.TrimSuffix(string(p), "\n")
+			loginArgs.Password = strings.TrimSuffix(loginArgs.Password, "\r")
+		}
+
+		if err := singularity.RegistryLogin(remoteConfig, loginArgs); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use:     docs.RegistryLoginUse,
+	Short:   docs.RegistryLoginShort,
+	Long:    docs.RegistryLoginLong,
+	Example: docs.RegistryLoginExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+// RegistryLogoutCmd singularity remote logout [remoteName|serviceURI]
+var RegistryLogoutCmd = &cobra.Command{
+	Args: cobra.RangeArgs(0, 1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// default to empty string to signal to registryLogin to use default remote
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		}
+
+		if err := singularity.RegistryLogout(remoteConfig, name); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+		sylog.Infof("Logout succeeded")
+	},
+
+	Use:     docs.RegistryLogoutUse,
+	Short:   docs.RegistryLogoutShort,
+	Long:    docs.RegistryLogoutLong,
+	Example: docs.RegistryLogoutExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+// RegistryListCmd singularity remote list
+var RegistryListCmd = &cobra.Command{
+	Args: cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := singularity.RegistryList(remoteConfig); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use:     docs.RegistryListUse,
+	Short:   docs.RegistryListShort,
+	Long:    docs.RegistryListLong,
+	Example: docs.RegistryListExample,
+
+	DisableFlagsInUseLine: true,
+}

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -86,7 +86,7 @@ var remoteLoginUsernameFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "username",
 	ShortHand:    "u",
-	Usage:        "username to authenticate with (required for Docker/OCI registry login)",
+	Usage:        "username to authenticate with",
 	EnvKeys:      []string{"LOGIN_USERNAME"},
 }
 

--- a/docs/registry.go
+++ b/docs/registry.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package docs
+
+// Global content for help and man pages
+const (
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// registry command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RegistryUse   string = `registry [subcommand options...]`
+	RegistryShort string = `Manage authentication to OCI/Docker registries`
+	RegistryLong  string = `
+  The 'registry' command allows you to manage authentication to standalone OCI/Docker
+  registries, such as 'docker://'' or 'oras://'.`
+	RegistryExample string = `
+  All group commands have their own help output:
+
+    $ singularity help registry login
+    $ singularity registry login`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// registry login command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RegistryLoginUse   string = `login [login options...] <registry_uri>`
+	RegistryLoginShort string = `Login to an OCI/Docker registry`
+	RegistryLoginLong  string = `
+  The 'registry login' command allows you to login to a specific OCI/Docker
+  registry.`
+	RegistryLoginExample string = `
+  To login in to a docker/OCI registry:
+  $ singularity registry login --username foo docker://docker.io
+  $ singularity registry login --username foo oras://myregistry.example.com
+
+  Note that many cloud OCI registries use token-based authentication. The token
+  should be specified as the password for login. A username is still required.
+  E.g. when using a standard Azure identity and token to login to an ACR 
+  registry, the username '00000000-0000-0000-0000-000000000000' is required.
+  Consult your provider's documentation for details concerning their specific
+  login requirements.`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// registry logout command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RegistryLogoutUse   string = `logout <registry_uri>`
+	RegistryLogoutShort string = `Logout from an OCI/Docker registry`
+	RegistryLogoutLong  string = `
+  The 'registry logout' command allows you to log out from an OCI/Docker
+  registry.`
+	RegistryLogoutExample string = `
+  To log out from an OCI/Docker registry
+  $ singularity registry logout docker://docker.io`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// registry list command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RegistryListUse   string = `list`
+	RegistryListShort string = `List all OCI credentials that are configured`
+	RegistryListLong  string = `
+  The 'registry list' command lists all credentials for OCI/Docker registries
+  that are configured for use.`
+	RegistryListExample string = `
+  $ singularity registry list`
+)

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -13,10 +13,10 @@ const (
 	// remote command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteUse   string = `remote [remote options...]`
-	RemoteShort string = `Manage singularity remote endpoints and OCI/Docker registry credentials`
+	RemoteShort string = `Manage singularity remote endpoints`
 	RemoteLong  string = `
-  The 'remote' command allows you to manage Singularity remote endpoints and 
-  OCI/Docker registry credentials through its subcommands.
+  The 'remote' command allows you to manage Singularity remote endpoints through
+  its subcommands.
 
   A 'remote endpoint' is the Sylabs Cloud, a Singularity Enterprise installation,
   or a compatible group of services. The remote endpoint is a single address,
@@ -29,12 +29,6 @@ const (
   endpoint will be used for remote builds, key operations, and 'library://' pull
   and push. You can also 'remote logout' from and 'remote remove' an endpoint that
   is no longer required.
-
-  To configure credentials for OCI registries that should be used when pulling or
-  pushing from/to 'docker://'' or 'oras://' URIs, use the 'remote login' command
-  only. You do not have to 'remote add' OCI registries. To remove credentials
-  'remote logout' with the same URI. You do not need to 'remote remove' OCI
-  credentials.
 
   The remote configuration is stored in $HOME/.singularity/remotes.yaml by default.`
 	RemoteExample string = `
@@ -84,10 +78,9 @@ const (
 	// remote list command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteListUse   string = `list`
-	RemoteListShort string = `List all singularity remote endpoints and OCI credentials that are configured`
+	RemoteListShort string = `List all singularity remote endpoints that are configured`
 	RemoteListLong  string = `
-  The 'remote list' command lists all remote endpoints and OCI registry
-  credentials configured for use.
+  The 'remote list' command lists all remote endpoints configured for use.
 
   The current remote is indicated by 'YES' in the 'ACTIVE' column and can be changed
   with the 'remote use' command.`
@@ -96,43 +89,30 @@ const (
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote login command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	RemoteLoginUse   string = `login [login options...] <remote_name|registry_uri>`
-	RemoteLoginShort string = `Login to a singularity remote endpoint or an OCI/Docker registry using credentials`
+	RemoteLoginUse   string = `login [login options...] <remote_name>`
+	RemoteLoginShort string = `Login to a singularity remote endpoint`
 	RemoteLoginLong  string = `
-  The 'remote login' command allows you to set credentials for a specific endpoint or
-  an OCI/Docker registry.
+  The 'remote login' command allows you to set credentials for a specific
+  endpoint.
 
-  If no endpoint or registry is specified, the command will login to the currently
-  active remote endpoint. This is cloud.sylabs.io by default.`
+  If no endpoint is specified, the command will login to the currently active
+  remote endpoint. This is cloud.sylabs.io by default.`
 	RemoteLoginExample string = `
   To log in to an endpoint:
-  $ singularity remote login SylabsCloud
-
-  To login in to a docker/OCI registry:
-  $ singularity remote login --username foo docker://docker.io
-  $ singularity remote login --username foo oras://myregistry.example.com
-
-  Note that many cloud OCI registries use token based authentication. The token
-  should be specified as the password for login. A username is still required. E.g.
-  when using a standard Azure identity and token to login to an ACR registry the
-  username '00000000-0000-0000-0000-000000000000' is required. Consult your provider
-  documentation for detail of their login requirements.`
+  $ singularity remote login SylabsCloud`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote logout command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	RemoteLogoutUse   string = `logout <remote_name|registry_uri>`
-	RemoteLogoutShort string = `Log out from a singularity remote endpoint or an OCI/Docker registry`
+	RemoteLogoutUse   string = `logout <remote_name>`
+	RemoteLogoutShort string = `Log out from a singularity remote endpoint`
 	RemoteLogoutLong  string = `
   The 'remote logout' command allows you to log out from a singularity specific
-  endpoint or an OCI/Docker registry. If no endpoint or service is specified, it
-  will logout from the current active remote endpoint.
+  endpoint. If no endpoint or service is specified, it will logout from the
+  currently active remote endpoint.
   `
 	RemoteLogoutExample string = `
   To log out from an endpoint
-  $ singularity remote logout SylabsCloud
-
-  To log out from a docker/OCI registry
-  $ singularity remote logout docker://docker.io`
+  $ singularity remote logout SylabsCloud`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote status command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/e2e/registry/registry.go
+++ b/e2e/registry/registry.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package registry
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/e2e/internal/testhelper"
+)
+
+type ctx struct {
+	env e2e.TestEnv
+}
+
+// registryList tests the functionality of "singularity registry list" command
+func (c ctx) registryList(t *testing.T) {
+	registry := fmt.Sprintf("oras://%s", c.env.TestRegistry)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("registry login"),
+		e2e.WithArgs("-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("registry list"),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(
+				e2e.ContainMatch,
+				strings.Join([]string{
+					"URI                     SECURE?",
+					registry + "  ✓",
+				}, "\n"))),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("registry logout"),
+		e2e.WithArgs(registry),
+		e2e.ExpectExit(0),
+	)
+}
+
+func (c ctx) registryTestHelp(t *testing.T) {
+	tests := []struct {
+		name           string
+		cmdArgs        []string
+		expectedOutput string
+	}{
+		{
+			name:           "list help",
+			cmdArgs:        []string{"list", "--help"},
+			expectedOutput: "List all OCI credentials that are configured",
+		},
+		{
+			name:           "login help",
+			cmdArgs:        []string{"login", "--help"},
+			expectedOutput: "Login to an OCI/Docker registry",
+		},
+		{
+			name:           "logout help",
+			cmdArgs:        []string{"logout", "--help"},
+			expectedOutput: "Logout from an OCI/Docker registry",
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("registry"),
+			e2e.WithArgs(tt.cmdArgs...),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.RegexMatch, `^`+tt.expectedOutput),
+			),
+		)
+	}
+}
+
+func (c ctx) registryLogin(t *testing.T) {
+	var (
+		registry    = fmt.Sprintf("oras://%s", c.env.TestRegistry)
+		badRegistry = "oras://bad_registry:5000"
+	)
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		stdin      io.Reader
+		expectExit int
+	}{
+		{
+			name:       "login username and empty password",
+			command:    "registry login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", "", registry},
+			expectExit: 255,
+		},
+		{
+			name:       "login empty username and empty password",
+			command:    "registry login",
+			args:       []string{"-p", "", registry},
+			expectExit: 255,
+		},
+		{
+			name:       "login empty username and bad password",
+			command:    "registry login",
+			args:       []string{"-p", "bad", registry},
+			expectExit: 255,
+		},
+		{
+			name:       "login KO",
+			command:    "registry login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", "bad", registry},
+			expectExit: 255,
+		},
+		{
+			name:       "login without scheme KO",
+			command:    "registry login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, c.env.TestRegistry},
+			expectExit: 255,
+		},
+		{
+			name:       "login OK",
+			command:    "registry login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry},
+			expectExit: 0,
+		},
+		{
+			name:       "login password-stdin",
+			command:    "registry login",
+			args:       []string{"-u", e2e.DefaultUsername, "--password-stdin", registry},
+			stdin:      strings.NewReader(e2e.DefaultPassword),
+			expectExit: 0,
+		},
+		{
+			name:       "logout KO",
+			command:    "registry logout",
+			args:       []string{badRegistry},
+			expectExit: 255,
+		},
+		{
+			name:       "logout OK",
+			command:    "registry logout",
+			args:       []string{registry},
+			expectExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithStdin(tt.stdin),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.expectExit),
+		)
+	}
+}
+
+func (c ctx) registryLoginPushPrivate(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	var (
+		registry = fmt.Sprintf("oras://%s", c.env.TestRegistry)
+		repo     = fmt.Sprintf("oras://%s/private/e2e:1.0.0", c.env.TestRegistry)
+	)
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		expectExit int
+	}{
+		{
+			name:       "push before login",
+			command:    "push",
+			args:       []string{c.env.ImagePath, repo},
+			expectExit: 255,
+		},
+		{
+			name:       "login",
+			command:    "registry login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry},
+			expectExit: 0,
+		},
+		{
+			name:       "push after login",
+			command:    "push",
+			args:       []string{c.env.ImagePath, repo},
+			expectExit: 0,
+		},
+		{
+			name:       "logout",
+			command:    "registry logout",
+			args:       []string{registry},
+			expectExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.expectExit),
+		)
+	}
+}
+
+// Repeated logins with same URI should not create duplicate remote.yaml entries.
+// If we login twice, and logout once we should not see the URI in list.
+// See https://github.com/sylabs/singularity/issues/214
+func (c ctx) registryLoginRepeated(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	registry := fmt.Sprintf("oras://%s", c.env.TestRegistry)
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		expectExit int
+		resultOp   e2e.SingularityCmdResultOp
+	}{
+		{
+			name:       "FirstLogin",
+			command:    "registry login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry},
+			expectExit: 0,
+		},
+		{
+			name:       "SecondLogin",
+			command:    "registry login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry},
+			expectExit: 0,
+		},
+		{
+			name:       "logout",
+			command:    "registry logout",
+			args:       []string{registry},
+			expectExit: 0,
+		},
+		{
+			name:       "list",
+			command:    "registry list",
+			expectExit: 0,
+			resultOp:   e2e.ExpectOutput(e2e.UnwantedContainMatch, registry),
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.expectExit, tt.resultOp),
+		)
+	}
+}
+
+// E2ETests is the main func to trigger the test suite
+func E2ETests(env e2e.TestEnv) testhelper.Tests {
+	c := ctx{
+		env: env,
+	}
+
+	np := testhelper.NoParallel
+
+	return testhelper.Tests{
+		"test registry help":          c.registryTestHelp,
+		"registry login basic":        np(c.registryLogin),
+		"registry login push private": np(c.registryLoginPushPrivate),
+		"registry login repeated":     np(c.registryLoginRepeated),
+		"registry list":               np(c.registryList),
+	}
+}

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -7,11 +7,8 @@
 package remote
 
 import (
-	"fmt"
-	"io"
 	"log"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -402,7 +399,7 @@ func (c ctx) remoteList(t *testing.T) {
 	}
 }
 
-func (c ctx) remoteTestFlag(t *testing.T) {
+func (c ctx) remoteTestHelp(t *testing.T) {
 	tests := []struct {
 		name           string
 		cmdArgs        []string
@@ -416,12 +413,12 @@ func (c ctx) remoteTestFlag(t *testing.T) {
 		{
 			name:           "list help",
 			cmdArgs:        []string{"list", "--help"},
-			expectedOutput: "List all singularity remote endpoints and OCI credentials that are configured",
+			expectedOutput: "List all singularity remote endpoints that are configured",
 		},
 		{
 			name:           "login help",
 			cmdArgs:        []string{"login", "--help"},
-			expectedOutput: "Login to a singularity remote endpoint or an OCI/Docker registry using credentials",
+			expectedOutput: "Login to a singularity remote endpoint",
 		},
 		{
 			name:           "remove help",
@@ -451,200 +448,6 @@ func (c ctx) remoteTestFlag(t *testing.T) {
 				0,
 				e2e.ExpectOutput(e2e.RegexMatch, `^`+tt.expectedOutput),
 			),
-		)
-	}
-}
-
-func (c ctx) remoteBasicLogin(t *testing.T) {
-	var (
-		registry    = fmt.Sprintf("oras://%s", c.env.TestRegistry)
-		badRegistry = "oras://bad_registry:5000"
-	)
-
-	tests := []struct {
-		name       string
-		command    string
-		args       []string
-		stdin      io.Reader
-		expectExit int
-	}{
-		{
-			name:       "login username and empty password",
-			command:    "remote login",
-			args:       []string{"-u", e2e.DefaultUsername, "-p", "", registry},
-			expectExit: 255,
-		},
-		{
-			name:       "login empty username and empty password",
-			command:    "remote login",
-			args:       []string{"-p", "", registry},
-			expectExit: 255,
-		},
-		{
-			name:       "login empty username and bad password",
-			command:    "remote login",
-			args:       []string{"-p", "bad", registry},
-			expectExit: 255,
-		},
-		{
-			name:       "login KO",
-			command:    "remote login",
-			args:       []string{"-u", e2e.DefaultUsername, "-p", "bad", registry},
-			expectExit: 255,
-		},
-		{
-			name:       "login without scheme KO",
-			command:    "remote login",
-			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, c.env.TestRegistry},
-			expectExit: 255,
-		},
-		{
-			name:       "login into non-existing remote",
-			command:    "remote login",
-			args:       []string{"http://localhost:11371"},
-			expectExit: 255,
-		},
-		{
-			name:       "login OK",
-			command:    "remote login",
-			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry},
-			expectExit: 0,
-		},
-		{
-			name:       "login password-stdin",
-			command:    "remote login",
-			args:       []string{"-u", e2e.DefaultUsername, "--password-stdin", registry},
-			stdin:      strings.NewReader(e2e.DefaultPassword),
-			expectExit: 0,
-		},
-		{
-			name:       "logout KO",
-			command:    "remote logout",
-			args:       []string{badRegistry},
-			expectExit: 255,
-		},
-		{
-			name:       "logout OK",
-			command:    "remote logout",
-			args:       []string{registry},
-			expectExit: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
-			e2e.WithStdin(tt.stdin),
-			e2e.WithCommand(tt.command),
-			e2e.WithArgs(tt.args...),
-			e2e.ExpectExit(tt.expectExit),
-		)
-	}
-}
-
-func (c ctx) remoteLoginPushPrivate(t *testing.T) {
-	e2e.EnsureImage(t, c.env)
-
-	var (
-		registry = fmt.Sprintf("oras://%s", c.env.TestRegistry)
-		repo     = fmt.Sprintf("oras://%s/private/e2e:1.0.0", c.env.TestRegistry)
-	)
-
-	tests := []struct {
-		name       string
-		command    string
-		args       []string
-		expectExit int
-	}{
-		{
-			name:       "push before login",
-			command:    "push",
-			args:       []string{c.env.ImagePath, repo},
-			expectExit: 255,
-		},
-		{
-			name:       "login",
-			command:    "remote login",
-			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry},
-			expectExit: 0,
-		},
-		{
-			name:       "push after login",
-			command:    "push",
-			args:       []string{c.env.ImagePath, repo},
-			expectExit: 0,
-		},
-		{
-			name:       "logout",
-			command:    "remote logout",
-			args:       []string{registry},
-			expectExit: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
-			e2e.WithCommand(tt.command),
-			e2e.WithArgs(tt.args...),
-			e2e.ExpectExit(tt.expectExit),
-		)
-	}
-}
-
-// Repeated logins with same URI should not create duplicate remote.yaml entries.
-// If we login twice, and logout once we should not see the URI in list.
-// See https://github.com/sylabs/singularity/issues/214
-func (c ctx) remoteLoginRepeated(t *testing.T) {
-	e2e.EnsureImage(t, c.env)
-
-	registry := fmt.Sprintf("oras://%s", c.env.TestRegistry)
-
-	tests := []struct {
-		name       string
-		command    string
-		args       []string
-		expectExit int
-		resultOp   e2e.SingularityCmdResultOp
-	}{
-		{
-			name:       "FirstLogin",
-			command:    "remote login",
-			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry},
-			expectExit: 0,
-		},
-		{
-			name:       "SecondLogin",
-			command:    "remote login",
-			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry},
-			expectExit: 0,
-		},
-		{
-			name:       "logout",
-			command:    "remote logout",
-			args:       []string{registry},
-			expectExit: 0,
-		},
-		{
-			name:       "list",
-			command:    "remote list",
-			expectExit: 0,
-			resultOp:   e2e.ExpectOutput(e2e.UnwantedContainMatch, registry),
-		},
-	}
-
-	for _, tt := range tests {
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
-			e2e.WithCommand(tt.command),
-			e2e.WithArgs(tt.args...),
-			e2e.ExpectExit(tt.expectExit, tt.resultOp),
 		)
 	}
 }
@@ -783,15 +586,12 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	np := testhelper.NoParallel
 
 	return testhelper.Tests{
-		"add":                    c.remoteAdd,
-		"list":                   c.remoteList,
-		"remove":                 c.remoteRemove,
-		"status":                 c.remoteStatus,
-		"test flag":              c.remoteTestFlag,
-		"use":                    c.remoteUse,
-		"oci login basic":        np(c.remoteBasicLogin),
-		"oci login push private": np(c.remoteLoginPushPrivate),
-		"oci login repeated":     np(c.remoteLoginRepeated),
-		"use exclusive":          np(c.remoteUseExclusive),
+		"add":           c.remoteAdd,
+		"list":          c.remoteList,
+		"remove":        c.remoteRemove,
+		"status":        c.remoteStatus,
+		"test help":     c.remoteTestHelp,
+		"use":           c.remoteUse,
+		"use exclusive": np(c.remoteUseExclusive),
 	}
 }

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -44,6 +44,7 @@ import (
 	"github.com/sylabs/singularity/e2e/plugin"
 	"github.com/sylabs/singularity/e2e/pull"
 	"github.com/sylabs/singularity/e2e/push"
+	"github.com/sylabs/singularity/e2e/registry"
 	"github.com/sylabs/singularity/e2e/remote"
 	"github.com/sylabs/singularity/e2e/run"
 	"github.com/sylabs/singularity/e2e/runhelp"
@@ -88,6 +89,7 @@ var e2eGroups = map[string]testhelper.Group{
 	"PLUGIN":     plugin.E2ETests,
 	"PULL":       pull.E2ETests,
 	"PUSH":       push.E2ETests,
+	"REGISTRY":   registry.E2ETests,
 	"REMOTE":     remote.E2ETests,
 	"RUN":        run.E2ETests,
 	"RUNHELP":    runhelp.E2ETests,

--- a/internal/app/singularity/registry_list.go
+++ b/internal/app/singularity/registry_list.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/sylabs/singularity/internal/pkg/remote"
+)
+
+// RegistryList prints information about remote configurations
+func RegistryList(usrConfigFile string) (err error) {
+	c := &remote.Config{}
+
+	// opening config file
+	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0o600)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no remote configurations")
+		}
+		return fmt.Errorf("while opening remote config file: %s", err)
+	}
+	defer file.Close()
+
+	// read file contents to config struct
+	c, err = remote.ReadFrom(file)
+	if err != nil {
+		return fmt.Errorf("while parsing remote config data: %s", err)
+	}
+
+	if err := syncSysConfig(c); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "%s\t%s\n", "URI", "SECURE?")
+	for _, r := range c.Credentials {
+		secure := "✓"
+		if r.Insecure {
+			secure = ""
+		}
+		fmt.Fprintf(tw, "%s\t%s\n", r.URI, secure)
+	}
+	tw.Flush()
+
+	return nil
+}

--- a/internal/app/singularity/registry_list.go
+++ b/internal/app/singularity/registry_list.go
@@ -44,7 +44,7 @@ func RegistryList(usrConfigFile string) (err error) {
 	for _, r := range c.Credentials {
 		secure := "✓"
 		if r.Insecure {
-			secure = ""
+			secure = "✗!"
 		}
 		fmt.Fprintf(tw, "%s\t%s\n", r.URI, secure)
 	}

--- a/internal/app/singularity/registry_login.go
+++ b/internal/app/singularity/registry_login.go
@@ -20,14 +20,14 @@ func RegistryLogin(usrConfigFile string, args *LoginArgs) (err error) {
 	// opening config file
 	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
-		return fmt.Errorf("while opening remote config file: %s", err)
+		return fmt.Errorf("while opening configuration file: %s", err)
 	}
 	defer file.Close()
 
 	// read file contents to config struct
 	c, err := remote.ReadFrom(file)
 	if err != nil {
-		return fmt.Errorf("while parsing remote config data: %s", err)
+		return fmt.Errorf("while parsing configuration data: %s", err)
 	}
 
 	if err := syncSysConfig(c); err != nil {
@@ -40,7 +40,7 @@ func RegistryLogin(usrConfigFile string, args *LoginArgs) (err error) {
 
 	// truncating file before writing new contents and syncing to commit file
 	if err := file.Truncate(0); err != nil {
-		return fmt.Errorf("while truncating remote config file: %s", err)
+		return fmt.Errorf("while truncating configuration file: %s", err)
 	}
 
 	if n, err := file.Seek(0, io.SeekStart); err != nil || n != 0 {
@@ -48,11 +48,11 @@ func RegistryLogin(usrConfigFile string, args *LoginArgs) (err error) {
 	}
 
 	if _, err := c.WriteTo(file); err != nil {
-		return fmt.Errorf("while writing remote config to file: %s", err)
+		return fmt.Errorf("while writing configuration to file: %s", err)
 	}
 
 	if err := file.Sync(); err != nil {
-		return fmt.Errorf("failed to flush remote config file %s: %s", file.Name(), err)
+		return fmt.Errorf("failed to flush configuration file %s: %s", file.Name(), err)
 	}
 
 	sylog.Infof("Token stored in %s", file.Name())

--- a/internal/app/singularity/registry_logout.go
+++ b/internal/app/singularity/registry_logout.go
@@ -19,14 +19,14 @@ func RegistryLogout(usrConfigFile, name string) (err error) {
 	// opening config file
 	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
-		return fmt.Errorf("while opening remote config file: %s", err)
+		return fmt.Errorf("while opening configuration file: %s", err)
 	}
 	defer file.Close()
 
 	// read file contents to config struct
 	c, err := remote.ReadFrom(file)
 	if err != nil {
-		return fmt.Errorf("while parsing remote config data: %s", err)
+		return fmt.Errorf("while parsing configuration data: %s", err)
 	}
 
 	if err := syncSysConfig(c); err != nil {
@@ -40,7 +40,7 @@ func RegistryLogout(usrConfigFile, name string) (err error) {
 
 	// truncating file before writing new contents and syncing to commit file
 	if err := file.Truncate(0); err != nil {
-		return fmt.Errorf("while truncating remote config file: %s", err)
+		return fmt.Errorf("while truncating configuration file: %s", err)
 	}
 
 	if n, err := file.Seek(0, io.SeekStart); err != nil || n != 0 {
@@ -48,11 +48,11 @@ func RegistryLogout(usrConfigFile, name string) (err error) {
 	}
 
 	if _, err := c.WriteTo(file); err != nil {
-		return fmt.Errorf("while writing remote config to file: %s", err)
+		return fmt.Errorf("while writing configuration to file: %s", err)
 	}
 
 	if err := file.Sync(); err != nil {
-		return fmt.Errorf("failed to flush remote config file %s: %s", file.Name(), err)
+		return fmt.Errorf("failed to flush configuration file %s: %s", file.Name(), err)
 	}
 
 	return nil

--- a/internal/app/singularity/registry_logout.go
+++ b/internal/app/singularity/registry_logout.go
@@ -12,11 +12,10 @@ import (
 	"os"
 
 	"github.com/sylabs/singularity/internal/pkg/remote"
-	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 )
 
-// RemoteLogout logs out from an endpoint.
-func RemoteLogout(usrConfigFile, name string) (err error) {
+// RegistryLogout logs out from an OCI/Docker registry.
+func RegistryLogout(usrConfigFile, name string) (err error) {
 	// opening config file
 	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
@@ -34,18 +33,10 @@ func RemoteLogout(usrConfigFile, name string) (err error) {
 		return err
 	}
 
-	var r *endpoint.Config
-	if name == "" {
-		r, err = c.GetDefault()
-	} else {
-		r, err = c.GetRemote(name)
-		if err != nil {
-			return err
-		}
+	// services
+	if err := c.Logout(name); err != nil {
+		return fmt.Errorf("while verifying token: %v", err)
 	}
-
-	// Remove the token in question
-	r.Token = ""
 
 	// truncating file before writing new contents and syncing to commit file
 	if err := file.Truncate(0); err != nil {

--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -87,23 +87,5 @@ func RemoteList(usrConfigFile string) (err error) {
 	}
 	tw.Flush()
 
-	if len(c.Credentials) > 0 {
-		fmt.Println()
-		fmt.Println("Authenticated Logins")
-		fmt.Println("=================================")
-		fmt.Println()
-
-		tw = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintf(tw, "%s\t%s\n", "URI", "INSECURE")
-		for _, r := range c.Credentials {
-			insecure := "NO"
-			if r.Insecure {
-				insecure = "YES"
-			}
-			fmt.Fprintf(tw, "%s\t%s\n", r.URI, insecure)
-		}
-		tw.Flush()
-	}
-
 	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Moves the operations associated with OCI/Docker registries - `login`, `logout`, and `list` - from subcommands of the `remote` command (`singularity remote login [options] <registryURI>`, etc.) to their own dedicated command, `registry` (`singularity registry login [options] <registryURI>`, etc.). See the output of `singularity help registry` for more information.

Note that this does not **remove** the subcommands `login`, `logout`, and `list` from `singularity remote`, as they have separate functionality when given a remote endpoint (Singularity Cloud Services, Singularity Enterprise installs) as an argument. This former "duality" of functions of `singularity remote {login, logout, list}` is in fact a central part of the motivation for this PR. (See https://github.com/sylabs/singularity/discussions/1639 for discussion.) See the output of `singularity help remote` for more information.

### This fixes or addresses the following GitHub issues:

 - Fixes https://github.com/sylabs/singularity/issues/1894

