### PR TITLE
push: OCI-SIF to docker:// OCI registries

### DIFF
--- a/LICENSE_THIRD_PARTY.md
+++ b/LICENSE_THIRD_PARTY.md
@@ -511,3 +511,28 @@ The source files:
 * `internal/app/singularity/instance_linux.go`
 
 Contain code from the docker cli project, under the Apache License, Version 2.0.
+
+## github.com/google/go-containerregistry
+
+The source files:
+
+* `internal/pkg/client/oci/auth.go`
+
+Contain code from the go-containerregistry project, under the Apache License,
+Version 2.0.
+
+```text
+Copyright 2018 Google LLC All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -38,6 +38,8 @@ const (
 	HTTPSProtocol = "https"
 	// OrasProtocol holds the oras URI.
 	OrasProtocol = "oras"
+	// Docker Registry protocol
+	DockerProtocol = "docker"
 )
 
 var (

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/pkg/client/library"
+	"github.com/sylabs/singularity/internal/pkg/client/oci"
 	"github.com/sylabs/singularity/internal/pkg/client/oras"
 	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/internal/pkg/signature"
@@ -166,6 +167,20 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
 			sylog.Infof("Upload complete")
+
+		case DockerProtocol:
+			if cmd.Flag(pushDescriptionFlag.Name).Changed {
+				sylog.Warningf("Description is not supported for push to docker / OCI registries. Ignoring it.")
+			}
+			ociAuth, err := makeDockerCredentials(cmd)
+			if err != nil {
+				sylog.Fatalf("Unable to make docker oci credentials: %s", err)
+			}
+			if err := oci.Push(cmd.Context(), file, ref, ociAuth); err != nil {
+				sylog.Fatalf("Unable to push image to oci registry: %v", err)
+			}
+			sylog.Infof("Upload complete")
+
 		default:
 			sylog.Fatalf("Unsupported transport type: %s", transport)
 		}

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -58,15 +58,15 @@ func (c ctx) testPushCmd(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.env)
 
 	// setup file and dir to use as invalid sources
-	orasInvalidDir, err := os.MkdirTemp(c.env.TestDir, "oras_push_dir-")
+	invalidDir, err := os.MkdirTemp(c.env.TestDir, "push_dir-")
 	if err != nil {
-		err = errors.Wrap(err, "creating oras temporary directory")
+		err = errors.Wrap(err, "creating temporary directory")
 		t.Fatalf("unable to create src dir for push tests: %+v", err)
 	}
 
-	orasInvalidFile, err := e2e.WriteTempFile(orasInvalidDir, "oras_invalid_image-", "Invalid Image Contents")
+	invalidFile, err := e2e.WriteTempFile(invalidDir, "invalid_image-", "Invalid Image Contents")
 	if err != nil {
-		err = errors.Wrap(err, "creating oras temporary file")
+		err = errors.Wrap(err, "creating temporary file")
 		t.Fatalf("unable to create src file for push tests: %+v", err)
 	}
 
@@ -77,33 +77,63 @@ func (c ctx) testPushCmd(t *testing.T) {
 		expectedExitCode int    // expected exit code for the test
 	}{
 		{
-			desc:             "non existent image",
-			imagePath:        filepath.Join(orasInvalidDir, "not_an_existing_file.sif"),
-			dstURI:           fmt.Sprintf("oras://%s/non_existent:test", c.env.TestRegistry),
+			desc:             "oras non existent image",
+			imagePath:        filepath.Join(invalidDir, "not_an_existing_file.sif"),
+			dstURI:           fmt.Sprintf("oras://%s/oras_non_existent:test", c.env.TestRegistry),
 			expectedExitCode: 255,
 		},
 		{
-			desc:             "non SIF file",
-			imagePath:        orasInvalidFile,
-			dstURI:           fmt.Sprintf("oras://%s/non_sif:test", c.env.TestRegistry),
+			desc:             "oras non SIF file",
+			imagePath:        invalidFile,
+			dstURI:           fmt.Sprintf("oras://%s/oras_non_sif:test", c.env.TestRegistry),
 			expectedExitCode: 255,
 		},
 		{
-			desc:             "directory",
-			imagePath:        orasInvalidDir,
-			dstURI:           fmt.Sprintf("oras://%s/directory:test", c.env.TestRegistry),
+			desc:             "oras directory",
+			imagePath:        invalidDir,
+			dstURI:           fmt.Sprintf("oras://%s/oras_directory:test", c.env.TestRegistry),
 			expectedExitCode: 255,
 		},
 		{
-			desc:             "standard SIF push",
+			desc:             "oras standard SIF push",
 			imagePath:        c.env.ImagePath,
-			dstURI:           fmt.Sprintf("oras://%s/standard_sif:test", c.env.TestRegistry),
+			dstURI:           fmt.Sprintf("oras://%s/oras_standard_sif:test", c.env.TestRegistry),
 			expectedExitCode: 0,
 		},
 		{
-			desc:             "OCI-SIF push",
+			desc:             "oras OCI-SIF push",
 			imagePath:        c.env.OCISIFPath,
-			dstURI:           fmt.Sprintf("oras://%s/oci-sif:test", c.env.TestRegistry),
+			dstURI:           fmt.Sprintf("oras://%s/oras_oci-sif:test", c.env.TestRegistry),
+			expectedExitCode: 0,
+		},
+		{
+			desc:             "docker non existent image",
+			imagePath:        filepath.Join(invalidDir, "not_an_existing_file.sif"),
+			dstURI:           fmt.Sprintf("docker://%s/docker_non_existent:test", c.env.TestRegistry),
+			expectedExitCode: 255,
+		},
+		{
+			desc:             "docker non SIF file",
+			imagePath:        invalidFile,
+			dstURI:           fmt.Sprintf("docker://%s/docker_non_sif:test", c.env.TestRegistry),
+			expectedExitCode: 255,
+		},
+		{
+			desc:             "docker directory",
+			imagePath:        invalidDir,
+			dstURI:           fmt.Sprintf("docker://%s/docker_directory:test", c.env.TestRegistry),
+			expectedExitCode: 255,
+		},
+		{
+			desc:             "docker standard SIF push",
+			imagePath:        c.env.ImagePath,
+			dstURI:           fmt.Sprintf("docker://%s/docker_standard_sif:test", c.env.TestRegistry),
+			expectedExitCode: 255,
+		},
+		{
+			desc:             "docker OCI-SIF push",
+			imagePath:        c.env.OCISIFPath,
+			dstURI:           fmt.Sprintf("docker://%s/docker_oci-sif:test", c.env.TestRegistry),
 			expectedExitCode: 0,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/containers/common v0.55.2
 	github.com/containers/image/v5 v5.26.1
 	github.com/cyphar/filepath-securejoin v0.2.3
+	github.com/docker/cli v24.0.2+incompatible
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/docker v24.0.4+incompatible
 	github.com/docker/go-units v0.5.0
@@ -91,7 +92,6 @@ require (
 	github.com/cyberphone/json-canonicalization v0.0.0-20230514072755-504adb8a8af1 // indirect
 	github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c // indirect
 	github.com/d2g/dhcp4client v1.0.0 // indirect
-	github.com/docker/cli v24.0.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/internal/pkg/client/oci/auth.go
+++ b/internal/pkg/client/oci/auth.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2023 Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+//
+// The following code is adapted from:
+//
+//	https://github.com/google/go-containerregistry/blob/v0.15.2/pkg/authn/keychain.go
+//
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"os"
+	"sync"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sylabs/singularity/pkg/syfs"
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+type singularityKeychain struct {
+	mu sync.Mutex
+}
+
+// Resolve implements Keychain.
+func (sk *singularityKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	sk.mu.Lock()
+	defer sk.mu.Unlock()
+
+	authFile := syfs.DockerConf()
+	f, err := os.Open(authFile)
+	if os.IsNotExist(err) {
+		sylog.Debugf("Auth file %q does not exist, using anonymous auth.", authFile)
+		return authn.Anonymous, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	cf, err := config.LoadFromReader(f)
+	if err != nil {
+		return nil, err
+	}
+
+	// See:
+	// https://github.com/google/ko/issues/90
+	// https://github.com/moby/moby/blob/fc01c2b481097a6057bec3cd1ab2d7b4488c50c4/registry/config.go#L397-L404
+	var cfg, empty types.AuthConfig
+	for _, key := range []string{
+		target.String(),
+		target.RegistryStr(),
+	} {
+		if key == name.DefaultRegistry {
+			key = authn.DefaultAuthKey
+		}
+
+		cfg, err = cf.GetAuthConfig(key)
+		if err != nil {
+			return nil, err
+		}
+		// cf.GetAuthConfig automatically sets the ServerAddress attribute. Since
+		// we don't make use of it, clear the value for a proper "is-empty" test.
+		// See: https://github.com/google/go-containerregistry/issues/1510
+		cfg.ServerAddress = ""
+		if cfg != empty {
+			break
+		}
+	}
+
+	sylog.Warningf("%v", cfg)
+
+	if cfg == empty {
+		return authn.Anonymous, nil
+	}
+
+	return authn.FromConfig(authn.AuthConfig{
+		Username:      cfg.Username,
+		Password:      cfg.Password,
+		Auth:          cfg.Auth,
+		IdentityToken: cfg.IdentityToken,
+		RegistryToken: cfg.RegistryToken,
+	}), nil
+}

--- a/internal/pkg/client/oci/push.go
+++ b/internal/pkg/client/oci/push.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oci
+
+import (
+	"context"
+	"fmt"
+
+	ocitypes "github.com/containers/image/v5/types"
+	"github.com/sylabs/singularity/pkg/image"
+)
+
+// Push pushes an image into an OCI registry, as an OCI image (not an ORAS artifact).
+// At present, only OCI-SIF images can be pushed in this manner.
+func Push(ctx context.Context, sourceFile string, destRef string, ociAuth *ocitypes.DockerAuthConfig) error {
+	img, err := image.Init(sourceFile, false)
+	if err != nil {
+		return err
+	}
+	defer img.File.Close()
+
+	switch img.Type {
+	case image.OCISIF:
+		return pushOCISIF(ctx, sourceFile, destRef, ociAuth)
+	case image.SIF:
+		return fmt.Errorf("non OCI SIF images can only be pushed to OCI registries via oras://")
+	}
+
+	return fmt.Errorf("push only supports SIF images")
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow `singularity push` to push OCI-SIF images (only) to OCI registries specified by a `docker://` URI.

This code uses go-containerregistry rather than containers/image so that the implementation is simple to couple to the sylabs/oci-tools package.

### This fixes or addresses the following GitHub issues:

 - Fixes #1914 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
