### PR TITLE
clean up format of `remote list` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
 - The commands related to OCI/Docker registries that were under `remote` have
   been moved to their own, dedicated `registry` command. Run
   `singularity help registry` for more information.
+- The the `remote list` subcommand now outputs only remote endpoints (with
+  keyservers and OCI/Docker registries having been moved to separate commands),
+  and the output has been streamlined.
 
 ### New Features & Functionality
 

--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -59,31 +59,28 @@ func RemoteList(usrConfigFile string) (err error) {
 	})
 	sort.Strings(names)
 
-	fmt.Println("Cloud Services Endpoints")
-	fmt.Println("========================")
 	fmt.Println()
-
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, listLine, "NAME", "URI", "ACTIVE", "GLOBAL", "EXCLUSIVE", "INSECURE")
+	fmt.Fprintf(tw, listLine, "NAME", "URI", "DEFAULT?", "GLOBAL?", "EXCLUSIVE?", "SECURE?")
 	for _, n := range names {
-		sys := "NO"
+		sys := ""
 		if c.Remotes[n].System {
-			sys = "YES"
+			sys = "✓"
 		}
-		excl := "NO"
+		excl := ""
 		if c.Remotes[n].Exclusive {
-			excl = "YES"
+			excl = "✓"
 		}
-		insec := "NO"
+		secure := "✓"
 		if c.Remotes[n].Insecure {
-			insec = "YES"
+			secure = "✗!"
 		}
-		active := "NO"
+		isDefault := ""
 		if c.DefaultRemote != "" && c.DefaultRemote == n {
-			active = "YES"
+			isDefault = "✓"
 		}
 
-		fmt.Fprintf(tw, listLine, n, c.Remotes[n].URI, active, sys, excl, insec)
+		fmt.Fprintf(tw, listLine, n, c.Remotes[n].URI, isDefault, sys, excl, secure)
 	}
 	tw.Flush()
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Changes the format of the output of `singularity remote list` in accordance with option (a) outlined in https://github.com/sylabs/singularity/discussions/1639

Note that the output now includes _only_ the configured remote endpoints, to the exclusion of keyservers (see #1905) and OCI/Docker registries (see #1908).

### This fixes or addresses the following GitHub issues:

 - Fixes #1896 

