### PR TITLE
library:// oci-sif push/pull

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -124,7 +124,16 @@ func handleLibrary(ctx context.Context, imgCache *cache.Handle, pullFrom string)
 	if err != nil {
 		return "", err
 	}
-	return library.Pull(ctx, imgCache, r, runtime.GOARCH, tmpDir, c)
+
+	pullOpts := library.PullOptions{
+		Architecture:  runtime.GOARCH,
+		Endpoint:      currentRemoteEndpoint,
+		LibraryConfig: c,
+		// false to allow OCI execution of native SIF from library
+		RequireOciSif: false,
+		TmpDir:        tmpDir,
+	}
+	return library.Pull(ctx, imgCache, r, pullOpts)
 }
 
 func handleShub(ctx context.Context, imgCache *cache.Handle, pullFrom string) (string, error) {

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -252,7 +252,15 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("Unable to get keyserver client configuration: %v", err)
 		}
 
-		_, err = library.PullToFile(ctx, imgCache, pullTo, ref, pullArch, tmpDir, lc, co)
+		pullOpts := library.PullOptions{
+			Architecture:  pullArch,
+			Endpoint:      currentRemoteEndpoint,
+			KeyClientOpts: co,
+			LibraryConfig: lc,
+			RequireOciSif: pullOci,
+			TmpDir:        tmpDir,
+		}
+		_, err = library.PullToFile(ctx, imgCache, pullTo, ref, pullOpts)
 		if err != nil && err != library.ErrLibraryPullUnsigned {
 			sylog.Fatalf("While pulling library image: %v", err)
 		}

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -126,7 +126,13 @@ var PushCmd = &cobra.Command{
 				}
 			}
 
-			resp, err := library.Push(cmd.Context(), file, destRef, pushDescription, lc)
+			pushCfg := library.PushOptions{
+				Description:   pushDescription,
+				Endpoint:      currentRemoteEndpoint,
+				LibraryConfig: lc,
+			}
+
+			resp, err := library.Push(cmd.Context(), file, destRef, pushCfg)
 			if err != nil {
 				sylog.Fatalf("Unable to push image to library: %v", err)
 			}

--- a/docs/content.go
+++ b/docs/content.go
@@ -616,22 +616,36 @@ Enterprise Performance Computing (EPC)`
   shub: Pull an image from Singularity Hub
       shub://user/image:tag
 
-  oras: Pull a SIF image from an OCI registry that supports ORAS.
+  oras: Pull an image from an OCI registry that supports ORAS / OCI artifacts.
       oras://registry/namespace/image:tag
 
   http, https: Pull an image using the http(s?) protocol
-      https://library.sylabs.io/v1/imagefile/library/default/alpine:latest`
+      https://example.com/containers/mycontainer.sif
+  
+  By default, images from a library URI will be pulled in the same format they
+  were uploaded. If the --oci flag is specified then the pull is required
+  to result in an OCI-SIF image.
+
+  By default, images pulled from docker and other oci URIs will be converted
+  into a singularity native SIF image. If the --oci flag is specified then they
+  will be encapsulated in an OCI-SIF image.
+
+  Images pulled from a shub/oras/http/https URI are always directly downloaded,
+  in the same format as they were uploaded.`
 	PullExample string = `
   From Sylabs cloud library
   $ singularity pull alpine.sif library://alpine:latest
 
-  From Docker
+  From Docker to a singularity native SIF image
   $ singularity pull tensorflow.sif docker://tensorflow/tensorflow:latest
+
+  From Docker to an OCI-SIF image
+  $ singularity pull --oci tensorflow.oci.sif docker://tensorflow/tensorflow:latest
 
   From Shub
   $ singularity pull singularity-images.sif shub://vsoch/singularity-images
 
-  From supporting OCI registry (e.g. Azure Container Registry)
+  From an OCI registry supporting ORAS / OCI artifacts
   $ singularity pull image.sif oras://<username>.azurecr.io/namespace/image:tag`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -51,6 +51,7 @@ type testStruct struct {
 	pullDir          string
 	imagePath        string
 	expectedImage    string
+	expectedOCI      bool
 	envVars          []string
 }
 
@@ -319,6 +320,23 @@ func (c ctx) testPullCmd(t *testing.T) {
 			force:            true,
 			expectedExitCode: 0,
 		},
+		// pulling an OCI-SIF image from library backing registry
+		{
+			desc:   "library oci-sif fallback",
+			srcURI: "library://sylabs/tests/alpine-oci-sif:latest",
+			// will try library protocol first, should then attempt oci pull
+			oci:              false,
+			expectedOCI:      true,
+			expectedExitCode: 0,
+		},
+		{
+			desc:   "library oci-sif direct",
+			srcURI: "library://sylabs/tests/alpine-oci-sif:latest",
+			// direct oci pull
+			oci:              true,
+			expectedOCI:      true,
+			expectedExitCode: 0,
+		},
 
 		//
 		// shub:// URIs
@@ -383,6 +401,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 			desc:             "docker oci to sif",
 			srcURI:           c.env.TestRegistryImage,
 			oci:              false,
+			expectedOCI:      false,
 			noHTTPS:          true,
 			force:            true,
 			expectedExitCode: 0,
@@ -392,6 +411,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 			desc:             "docker oci to oci-sif",
 			srcURI:           c.env.TestRegistryImage,
 			oci:              true,
+			expectedOCI:      true,
 			noHTTPS:          true,
 			force:            true,
 			expectedExitCode: 0,
@@ -401,6 +421,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 			desc:             "docker oci-sif to oci-sif",
 			srcURI:           c.env.TestRegistryOCISIF,
 			oci:              true,
+			expectedOCI:      true,
 			noHTTPS:          true,
 			force:            true,
 			expectedExitCode: 0,
@@ -410,6 +431,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 			desc:             "docker oci-sif to sif",
 			srcURI:           c.env.TestRegistryOCISIF,
 			oci:              false,
+			expectedOCI:      false,
 			noHTTPS:          true,
 			force:            true,
 			expectedExitCode: 255,
@@ -491,11 +513,11 @@ func checkPullResult(t *testing.T, tt testStruct) {
 		defer img.File.Close()
 		switch img.Type {
 		case image.SIF:
-			if tt.oci {
+			if tt.expectedOCI {
 				t.Errorf("Native SIF pulled, but --oci specified")
 			}
 		case image.OCISIF:
-			if !tt.oci {
+			if !tt.expectedOCI {
 				t.Errorf("OCI-SIF pulled, but --oci not specified")
 			}
 		default:
@@ -586,9 +608,15 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 		noHTTPS   bool
 	}{
 		{
-			name:      "library",
+			name:      "library native",
 			imagePath: filepath.Join(c.env.TestDir, "nocache-library.sif"),
 			imageSrc:  "library://alpine:latest",
+		},
+		{
+			name:      "library oci-sif",
+			imagePath: filepath.Join(c.env.TestDir, "nocache-library.oci.sif"),
+			imageSrc:  "library://sylabs/tests/alpine-oci-sif:latest",
+			oci:       true,
 		},
 		{
 			name:      "oras",
@@ -596,8 +624,8 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 			imageSrc:  "oras://" + c.env.TestRegistry + "/pull_test_sif:latest",
 		},
 		{
-			name:      "oci-sif",
-			imagePath: filepath.Join(c.env.TestDir, "nocache-oci-sif.sif"),
+			name:      "docker oci-sif",
+			imagePath: filepath.Join(c.env.TestDir, "nocache-docker.oci.sif"),
 			imageSrc:  c.env.TestRegistryImage,
 			oci:       true,
 			noHTTPS:   true,

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -198,6 +198,7 @@ func (c *ctx) setup(t *testing.T) {
 	}
 }
 
+//nolint:maintidx
 func (c ctx) testPullCmd(t *testing.T) {
 	tests := []testStruct{
 		//

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -72,7 +72,12 @@ func (cp *LibraryConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err 
 		Logger:    (golog.Logger)(sylog.DebugLogger{}),
 	}
 
-	imagePath, err := library.Pull(ctx, b.Opts.ImgCache, imageRef, runtime.GOARCH, cp.b.TmpDir, libraryConfig)
+	pullOpts := library.PullOptions{
+		Architecture:  runtime.GOARCH,
+		LibraryConfig: libraryConfig,
+		TmpDir:        cp.b.TmpDir,
+	}
+	imagePath, err := library.Pull(ctx, b.Opts.ImgCache, imageRef, pullOpts)
 	if err != nil {
 		return fmt.Errorf("while fetching library image: %v", err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/containers/image/v5/types"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sylabs/singularity/internal/pkg/build/oci"
 	"github.com/sylabs/singularity/internal/pkg/cache"
+	"github.com/sylabs/singularity/internal/pkg/ociimage"
 	"github.com/sylabs/singularity/internal/pkg/util/shell"
 	sytypes "github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/image"
@@ -159,7 +159,7 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 	}
 
 	// Fetch the image into a temporary containers/image oci layout dir.
-	cp.srcRef, err = oci.FetchLayout(ctx, cp.sysCtx, imgCache, ref, b.TmpDir)
+	cp.srcRef, err = ociimage.FetchLayout(ctx, cp.sysCtx, imgCache, ref, b.TmpDir)
 	if err != nil {
 		return err
 	}
@@ -246,7 +246,7 @@ func (cp *OCIConveyorPacker) unpackTmpfs(ctx context.Context) error {
 	var manifest imgspecv1.Manifest
 	json.Unmarshal(manifestData, &manifest)
 
-	if err := oci.UnpackRootfs(ctx, cp.b.TmpDir, manifest, cp.b.RootfsPath); err != nil {
+	if err := ociimage.UnpackRootfs(ctx, cp.b.TmpDir, manifest, cp.b.RootfsPath); err != nil {
 		return err
 	}
 
@@ -255,7 +255,7 @@ func (cp *OCIConveyorPacker) unpackTmpfs(ctx context.Context) error {
 	if cp.b.Opts.FixPerms {
 		sylog.Warningf("The --fix-perms option modifies the filesystem permissions on the resulting container.")
 		sylog.Debugf("Modifying permissions for file/directory owners")
-		return oci.FixPerms(cp.b.RootfsPath)
+		return ociimage.FixPerms(cp.b.RootfsPath)
 	}
 
 	// If `--fix-perms` was not used and this is a sandbox, scan for restrictive
@@ -263,7 +263,7 @@ func (cp *OCIConveyorPacker) unpackTmpfs(ctx context.Context) error {
 	// and warn if they exist
 	if cp.b.Opts.SandboxTarget {
 		sylog.Debugf("Scanning for restrictive permissions")
-		return oci.CheckPerms(cp.b.RootfsPath)
+		return ociimage.CheckPerms(cp.b.RootfsPath)
 	}
 
 	return nil

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -11,13 +11,15 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	keyclient "github.com/sylabs/scs-key-client/client"
-	libclient "github.com/sylabs/scs-library-client/client"
 	scslibrary "github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/internal/pkg/cache"
 	"github.com/sylabs/singularity/internal/pkg/client"
+	"github.com/sylabs/singularity/internal/pkg/client/ocisif"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/internal/pkg/signature"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/sylog"
@@ -27,19 +29,48 @@ import (
 // ErrLibraryPullUnsigned indicates that the interactive portion of the pull was aborted.
 var ErrLibraryPullUnsigned = errors.New("failed to verify container")
 
+// PullOptions provides options/configuration that determine the behavior of a
+// pull from a library.
+type PullOptions struct {
+	// Architecture specifies the architecture of the image to retrieve.
+	Architecture string
+	// Endpoint is the active remote endpoint, against which the OCI registry
+	// backing the library can be discovered.
+	Endpoint *endpoint.Config
+	// LibraryConfig configures operations against the library using its native
+	// API, via sylabs/scs-library-client.
+	LibraryConfig *scslibrary.Config
+	// KeyClientOpts specifies options for the keyclient that will be used to
+	// verify signatures after pulling an image.
+	KeyClientOpts []keyclient.Option
+	// TmpDir is the path to a directory used for temporary files.
+	TmpDir string
+	// RequireOciSif should be set true to require that the image pulled is an OCI-SIF.
+	// If false a native SIF pull will be attempted, followed by an OCI(-SIF) pull on failure.
+	RequireOciSif bool
+}
+
 // pull will pull a library image into the cache if directTo="", or a specific file if directTo is set.
-func pull(ctx context.Context, imgCache *cache.Handle, directTo string, imageRef *libclient.Ref, arch string, libraryConfig *libclient.Config) (string, error) {
-	c, err := libclient.NewClient(libraryConfig)
+// Attempts a native SIF pull using the library API. If this fails, and the
+// error indicates the image is an OCI image, an OCI-SIF pull will be attempted.
+func pull(ctx context.Context, imgCache *cache.Handle, directTo string, imageRef *scslibrary.Ref, opts PullOptions) (string, error) {
+	c, err := scslibrary.NewClient(opts.LibraryConfig)
 	if err != nil {
 		return "", fmt.Errorf("unable to initialize client library: %v", err)
 	}
 
 	ref := fmt.Sprintf("%s:%s", imageRef.Path, imageRef.Tags[0])
 
-	libraryImage, err := c.GetImage(ctx, arch, ref)
+	libraryImage, err := c.GetImage(ctx, opts.Architecture, ref)
 	if err != nil {
-		if errors.Is(err, libclient.ErrNotFound) {
-			return "", fmt.Errorf("image does not exist in the library: %s (%s)", ref, arch)
+		if errors.Is(err, scslibrary.ErrNotFound) {
+			return "", fmt.Errorf("image does not exist in the library: %s (%s)", ref, opts.Architecture)
+		}
+		// TODO - handle this via a friendlier error in future.
+		// Error message comes from server, so this will require changes upstream.
+		if strings.Contains(err.Error(), "application/vnd.oci.image.config.v1+json") {
+			sylog.Infof("%s is an OCI image, attempting to fetch as an OCI-SIF", ref)
+			return pullOCI(ctx, imgCache, directTo, imageRef, opts)
 		}
 		return "", err
 	}
@@ -51,7 +82,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo string, imageRef
 
 	if directTo != "" {
 		// Download direct to file
-		if err := downloadWrapper(ctx, c, directTo, arch, imageRef, progressBar); err != nil {
+		if err := downloadWrapper(ctx, c, directTo, opts.Architecture, imageRef, progressBar); err != nil {
 			return "", fmt.Errorf("unable to download image: %v", err)
 		}
 		return directTo, nil
@@ -64,11 +95,11 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo string, imageRef
 	defer cacheEntry.CleanTmp()
 
 	if !cacheEntry.Exists {
-		if err := downloadWrapper(ctx, c, cacheEntry.TmpPath, arch, imageRef, progressBar); err != nil {
+		if err := downloadWrapper(ctx, c, cacheEntry.TmpPath, opts.Architecture, imageRef, progressBar); err != nil {
 			return "", fmt.Errorf("unable to download image: %v", err)
 		}
 
-		if cacheFileHash, err := libclient.ImageHash(cacheEntry.TmpPath); err != nil {
+		if cacheFileHash, err := scslibrary.ImageHash(cacheEntry.TmpPath); err != nil {
 			return "", fmt.Errorf("error getting image hash: %v", err)
 		} else if cacheFileHash != libraryImage.Hash {
 			return "", fmt.Errorf("cached file hash(%s) and expected hash(%s) does not match", cacheFileHash, libraryImage.Hash)
@@ -103,12 +134,32 @@ func downloadWrapper(ctx context.Context, c *scslibrary.Client, imagePath, arch 
 	return nil
 }
 
+// pullOCI pulls a single layer squashfs OCI image from the library into an OCI-SIF file.
+func pullOCI(ctx context.Context, imgCache *cache.Handle, directTo string, pullFrom *scslibrary.Ref, opts PullOptions) (imagePath string, err error) {
+	lr, err := newLibraryRegistry(opts.Endpoint, opts.LibraryConfig)
+	if err != nil {
+		return "", err
+	}
+
+	pullRef, err := lr.convertRef(*pullFrom)
+	if err != nil {
+		return "", err
+	}
+
+	authConf := lr.authConfig()
+	ocisifOpts := ocisif.PullOptions{
+		TmpDir:  opts.TmpDir,
+		OciAuth: authConf,
+	}
+	return ocisif.PullOCISIF(ctx, imgCache, directTo, pullRef, ocisifOpts)
+}
+
 // Pull will pull a library image to the cache or direct to a temporary file if cache is disabled
-func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom *libclient.Ref, arch string, tmpDir string, libraryConfig *libclient.Config) (imagePath string, err error) {
+func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom *scslibrary.Ref, opts PullOptions) (imagePath string, err error) {
 	directTo := ""
 
 	if imgCache.IsDisabled() {
-		file, err := os.CreateTemp(tmpDir, "sbuild-tmp-cache-")
+		file, err := os.CreateTemp(opts.TmpDir, "sbuild-tmp-cache-")
 		if err != nil {
 			return "", fmt.Errorf("unable to create tmp file: %v", err)
 		}
@@ -116,18 +167,27 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom *libclient.Ref, 
 		sylog.Infof("Downloading library image to tmp cache: %s", directTo)
 	}
 
-	return pull(ctx, imgCache, directTo, pullFrom, arch, libraryConfig)
+	if opts.RequireOciSif {
+		return pullOCI(ctx, imgCache, directTo, pullFrom, opts)
+	}
+
+	return pull(ctx, imgCache, directTo, pullFrom, opts)
 }
 
 // PullToFile will pull a library image to the specified location, through the cache, or directly if cache is disabled
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo string, pullFrom *libclient.Ref, arch string, tmpDir string, libraryConfig *libclient.Config, co []keyclient.Option) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo string, pullFrom *scslibrary.Ref, opts PullOptions) (imagePath string, err error) {
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo
 		sylog.Debugf("Cache disabled, pulling directly to: %s", directTo)
 	}
 
-	src, err := pull(ctx, imgCache, directTo, pullFrom, arch, libraryConfig)
+	src := ""
+	if opts.RequireOciSif {
+		src, err = pullOCI(ctx, imgCache, directTo, pullFrom, opts)
+	} else {
+		src, err = pull(ctx, imgCache, directTo, pullFrom, opts)
+	}
 	if err != nil {
 		return "", fmt.Errorf("error fetching image: %v", err)
 	}
@@ -140,7 +200,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo string, pull
 		}
 	}
 
-	if err := signature.Verify(ctx, pullTo, signature.OptVerifyWithPGP(co...)); err != nil {
+	if err := signature.Verify(ctx, pullTo, signature.OptVerifyWithPGP(opts.KeyClientOpts...)); err != nil {
 		sylog.Warningf("%v", err)
 		return pullTo, ErrLibraryPullUnsigned
 	}

--- a/internal/pkg/client/library/registry.go
+++ b/internal/pkg/client/library/registry.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package library
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/containers/image/v5/types"
+	scslibrary "github.com/sylabs/scs-library-client/client"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+// libraryRegistry holds information necessary to interact with an OCI registry
+// backing a library.
+type libraryRegistry struct {
+	library  string
+	registry string
+	ud       userData
+}
+
+// newLibraryRegisty retrieves URI and authentication information for the
+// backing registry of the library associated with endpoint ep.
+func newLibraryRegistry(ep *endpoint.Config, LibraryConfig *scslibrary.Config) (*libraryRegistry, error) {
+	epLibraryURI, err := ep.GetServiceURI(endpoint.Library)
+	if err != nil {
+		return nil, err
+	}
+
+	if LibraryConfig.BaseURL != epLibraryURI {
+		return nil, fmt.Errorf("OCI-SIF push/pull to/from location other than current remote is not supported")
+	}
+
+	sylog.Debugf("Finding OCI registry URI")
+	registryURI, err := ep.RegistryURI()
+	if err != nil {
+		return nil, err
+	}
+	ru, err := url.Parse(registryURI)
+	if err != nil {
+		return nil, err
+	}
+	registry := strings.TrimSuffix(ru.Host+ru.Path, "/")
+
+	sylog.Debugf("Fetching OCI registry token")
+	ud, err := getUserData(LibraryConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	lr := libraryRegistry{
+		library:  LibraryConfig.BaseURL,
+		registry: registry,
+		ud:       *ud,
+	}
+	return &lr, nil
+}
+
+// convertRef converts the provided library ref into an OCI reference referring
+// to the library's backing OCI registry.
+func (lr *libraryRegistry) convertRef(libraryRef scslibrary.Ref) (string, error) {
+	if libraryRef.Host != "" {
+		return "", fmt.Errorf("push to location other than current remote is not supported")
+	}
+	ref := fmt.Sprintf("docker://%s/%s", lr.registry, libraryRef.Path)
+	if len(libraryRef.Tags) > 1 {
+		return "", fmt.Errorf("cannot push/pull with more than one tag")
+	}
+	if len(libraryRef.Tags) > 0 {
+		ref = ref + ":" + libraryRef.Tags[0]
+	}
+	return ref, nil
+}
+
+// authConfig returns a DockerAuthConfig with current token to authenticate
+// against the library's backing OCI registry.
+func (lr *libraryRegistry) authConfig() *types.DockerAuthConfig {
+	return &types.DockerAuthConfig{
+		Username: lr.ud.Username,
+		Password: lr.ud.OidcMeta.Secret,
+	}
+}

--- a/internal/pkg/client/library/user_test.go
+++ b/internal/pkg/client/library/user_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	scslibclient "github.com/sylabs/scs-library-client/client"
+	scslibrary "github.com/sylabs/scs-library-client/client"
 	"gotest.tools/v3/assert"
 )
 
@@ -90,7 +90,7 @@ func TestGetOCIToken(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			config := &scslibclient.Config{
+			config := &scslibrary.Config{
 				BaseURL:   srv.URL,
 				AuthToken: tt.authToken,
 			}

--- a/internal/pkg/client/oci/nativesif.go
+++ b/internal/pkg/client/oci/nativesif.go
@@ -11,18 +11,16 @@ import (
 	"fmt"
 
 	"github.com/sylabs/singularity/internal/pkg/build"
-	"github.com/sylabs/singularity/internal/pkg/build/oci"
 	"github.com/sylabs/singularity/internal/pkg/cache"
+	"github.com/sylabs/singularity/internal/pkg/ociimage"
 	buildtypes "github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
-// pullSif will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
-//
-//nolint:dupl
-func pullSif(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, opts PullOptions) (imagePath string, err error) {
+// pullNativeSIF will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
+func pullNativeSIF(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, opts PullOptions) (imagePath string, err error) {
 	sys := sysCtx(opts)
-	hash, err := oci.ImageDigest(ctx, pullFrom, sys)
+	hash, err := ociimage.ImageDigest(ctx, pullFrom, sys)
 	if err != nil {
 		return "", fmt.Errorf("failed to get checksum for %s: %s", pullFrom, err)
 	}
@@ -34,7 +32,6 @@ func pullSif(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom str
 		}
 		imagePath = directTo
 	} else {
-
 		cacheEntry, err := imgCache.GetEntry(cache.OciTempCacheType, hash)
 		if err != nil {
 			return "", fmt.Errorf("unable to check if %v exists in cache: %v", hash, err)

--- a/internal/pkg/client/oci/push.go
+++ b/internal/pkg/client/oci/push.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	ocitypes "github.com/containers/image/v5/types"
+	"github.com/sylabs/singularity/internal/pkg/client/ocisif"
 	"github.com/sylabs/singularity/pkg/image"
 )
 
@@ -24,7 +25,7 @@ func Push(ctx context.Context, sourceFile string, destRef string, ociAuth *ocity
 
 	switch img.Type {
 	case image.OCISIF:
-		return pushOCISIF(ctx, sourceFile, destRef, ociAuth)
+		return ocisif.PushOCISIF(ctx, sourceFile, destRef, ociAuth)
 	case image.SIF:
 		return fmt.Errorf("non OCI SIF images can only be pushed to OCI registries via oras://")
 	}

--- a/internal/pkg/ociimage/fetch.go
+++ b/internal/pkg/ociimage/fetch.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package oci
+package ociimage
 
 import (
 	"archive/tar"

--- a/internal/pkg/ociimage/ociimage.go
+++ b/internal/pkg/ociimage/ociimage.go
@@ -3,8 +3,9 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-// Package oci provides transparent caching of oci-like refs
-package oci
+// Package ociimage provides functions related to retrieving and manipulating
+// OCI images, used in pull/push and build operations.
+package ociimage
 
 import (
 	"context"

--- a/internal/pkg/ociimage/ociimage_test.go
+++ b/internal/pkg/ociimage/ociimage_test.go
@@ -1,9 +1,8 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
-
-package oci
+package ociimage
 
 import (
 	"context"

--- a/internal/pkg/ociimage/unpack.go
+++ b/internal/pkg/ociimage/unpack.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package oci
+package ociimage
 
 import (
 	"context"

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -17,8 +17,8 @@ import (
 	"github.com/containers/image/v5/types"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sylabs/singularity/internal/pkg/build/oci"
 	"github.com/sylabs/singularity/internal/pkg/cache"
+	"github.com/sylabs/singularity/internal/pkg/ociimage"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci/generate"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/ocibundle"
@@ -150,7 +150,7 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	}
 	defer os.RemoveAll(tmpLayout)
 
-	layoutRef, err := oci.FetchLayout(ctx, b.sysCtx, b.imgCache, b.imageRef, tmpLayout)
+	layoutRef, err := ociimage.FetchLayout(ctx, b.sysCtx, b.imgCache, b.imageRef, tmpLayout)
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	}
 	pristineRootfs := filepath.Join(b.rootfsParentDir, "rootfs")
 
-	if err := oci.UnpackRootfs(ctx, tmpLayout, manifest, pristineRootfs); err != nil {
+	if err := ociimage.UnpackRootfs(ctx, tmpLayout, manifest, pristineRootfs); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When `singularity push` is provided an OCI-SIF image file and a `library://` URI, push as a single layer squashfs OCI image to the OCI registry that backs the library service. Existing push behaviour for native SIF through the library API remains.

When `singularity pull --oci` is provided a `library://` URI with a path that points to a single layer squashfs OCI image in the backing OCI registry, pull to a local OCI-SIF image.

When `singularity pull` is provided a `library://` URI and no `--oci` flag, try a native SIF library API pull first. If that fails and the error indicates the image is an OCI image then try an OCI-SIF pull.

The push/pull process involves discovering the URI of the backing OCI registry, retrieving an authentication token, and translating `library://` URIs to OCI registry URIs.

Because a `pull` of an standard OCI image to a native SIF is implemented as a build, and the build code imports from
`pkg/client/*`, we have to do some gymnastics to avoid introducing import loops:

* Code dealing with oci image operations used by both builds and the oci client package has been moved to `internal/pkg/ociimage`.

* Low-level push/pull between OCI-SIF and OCI registries has been placed in `internal/pkg/client/ocisif` rather than `oci`.

Also tidy up the `--oci` flag CLI visibility:

* Un-hide the `--oci` flag on the `pull` command.
    
* Warn where it has no effect (oras/shub/http[s] sources are currently direct downloads without enforcing `--oci` gives an OCI-SIF.

* Explain the behaviour in the `pull --help` output.


Closes #1916