### PR TITLE
remote: Make registryUri available for library

### DIFF
--- a/internal/pkg/remote/endpoint/client.go
+++ b/internal/pkg/remote/endpoint/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -157,4 +157,16 @@ func (ep *Config) BuilderClientConfig(uri string) (baseURI, authToken string, er
 	}
 
 	return baseURI, authToken, nil
+}
+
+// RegistryURI returns the URI of the backing OCI registry for the library service, associated with ep.
+func (ep *Config) RegistryURI() (string, error) {
+	registryURI, err := ep.getServiceConfigVal(Library, RegistryURIConfigKey)
+	if err != nil {
+		return "", err
+	}
+	if registryURI == "" {
+		return "", fmt.Errorf("library does not provide an OCI registry")
+	}
+	return registryURI, nil
 }

--- a/internal/pkg/remote/endpoint/client_test.go
+++ b/internal/pkg/remote/endpoint/client_test.go
@@ -7,6 +7,8 @@
 package endpoint
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
@@ -268,5 +270,27 @@ func TestBuilderClientConfig(t *testing.T) {
 				t.Errorf("unexpected token returned: %s", authToken)
 			}
 		})
+	}
+}
+
+func TestConfig_RegistryURI(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "../../../../test/remote/config.example.json")
+	}))
+	t.Cleanup(srv.Close)
+
+	ep := Config{
+		URI:      srv.URL,
+		Insecure: true,
+	}
+
+	expectRegistry := "https://registry.example.com"
+	rURI, err := ep.RegistryURI()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if rURI != expectRegistry {
+		t.Errorf("expected %q, got %q", expectRegistry, rURI)
 	}
 }

--- a/test/remote/config.example.json
+++ b/test/remote/config.example.json
@@ -1,0 +1,20 @@
+{
+    "libraryAPI": {
+      "uri": "https://library.example.com",
+      "registryUri": "https://registry.example.com"
+    },
+    "keystoreAPI": {
+      "uri": "https://keys.example.com"
+    },
+    "builderAPI": {
+      "uri": "https://build.example.com",
+      "managerUri": "https://build.example.com"
+    },
+    "consentAPI": {
+      "uri": "https://auth.example.com/consent"
+    },
+    "tokenAPI": {
+      "uri": "https://auth.example.com/token"
+    }
+  }
+  


### PR DESCRIPTION
## Description of the Pull Request (PR):

Retrieve the `registryUri` value from the library service config for SCS/Enterprise remotes.

The concept of a service in the remote code is rather overloaded and inflexible. Add an internal use map that we can pull the `registryUri` into and out of. Hide it behind a single `RegistryURI` public fn.

Not the tidiest, but it works pending major overhaul of the remote / endpoint code.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
