### PR TITLE
deps: Bundle squashfuse 0.2.0, prefer squashfuse_ll

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ commands:
             <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q update
       - run:
           name: Install dependencies
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>DEBIAN_FRONTEND=noninteractive apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin libglib2.0-dev squashfuse dbus-user-session uidmap
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>DEBIAN_FRONTEND=noninteractive apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin libfuse-dev libglib2.0-dev dbus-user-session uidmap
       - run:
           name: Install proot
           command: |-
@@ -180,7 +180,7 @@ jobs:
       - checkout
       - run:
           name: Fetch deps
-          command: apk add -q --no-cache git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup libseccomp-dev glib-dev
+          command: apk add -q --no-cache git alpine-sdk autoconf automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup libseccomp-dev glib-dev fuse-dev
       - update-submodules
       - build-singularity
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/conmon"]
 	path = third_party/conmon
 	url = https://github.com/containers/conmon
+[submodule "third_party/squashfuse"]
+	path = third_party/squashfuse
+	url = https://github.com/vasi/squashfuse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
 - Adding a new remote endpoint using the `singularity remote add` command will
   now set the new endpoint as default. This behavior can be suppressed by
   supplying the `--no-default` (or `-n`) flag to `remote add`.
+- Singularity uses squashfuse_ll/squashfuse, which is now built from a git
+  submodule unless `--without-squashfuse` is specified as an argument to
+  `mconfig`. When built with `--without-squashfuse`, `squashfuse_ll` or
+  `squashfuse` will be located on `PATH`. Version 0.2.0 or later is required.
 
 ### New Features & Functionality
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,6 +20,7 @@ sudo apt-get install -y \
     build-essential \
     libseccomp-dev \
     libglib2.0-dev \
+    libfuse-dev \
     pkg-config \
     squashfs-tools \
     cryptsetup \
@@ -37,6 +38,7 @@ sudo yum groupinstall -y 'Development Tools'
 # Install RPM packages for dependencies
 sudo yum install -y \
     libseccomp-devel \
+    fuse-devel \
     glib2-devel \
     squashfs-tools \
     cryptsetup \
@@ -53,6 +55,7 @@ sudo yum groupinstall -y 'Development Tools'
 # Install RPM packages for dependencies
 sudo yum install -y \
     libseccomp-devel \
+    fuse-devel \
     glib2-devel \
     squashfs-tools \
     cryptsetup \

--- a/LICENSE_THIRD_PARTY.md
+++ b/LICENSE_THIRD_PARTY.md
@@ -536,3 +536,45 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+## github.com/vasi/squashfuse
+
+The source files:
+
+* `third_party/squashfuse/*`
+
+Are code from the squashfuse project, under the following license:
+
+```text
+The squashfuse distribution as a whole is copyright Dave
+Vasilevsky and is subject to the copyright notice reproduced at
+the bottom of this file.
+
+The file squashfs_fs.h is copyright Phillip Lougher and, with his permission,
+subject to the same license.
+
+
+Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+                   Phillip Lougher <phillip@squashfs.org.uk>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -41,8 +41,11 @@ func FindBin(name string) (path string, err error) {
 		return findFromConfigOnly(name)
 	// distro provided squashfuse and fusermount for unpriv SIF mount and
 	// OCI-mode bare-image overlay
-	case "squashfuse", "fusermount":
+	case "fusermount":
 		return findOnPath(name)
+	case "squashfuse":
+		// Behavior depends on buildcfg - whether to use bundled squashfuse_ll or external squashfuse_ll/squashfuse
+		return findSquashfuse(name)
 	// fuse2fs for OCI-mode bare-image overlay
 	case "fuse2fs":
 		return findOnPath(name)

--- a/internal/pkg/util/bin/bin_no_singularity.go
+++ b/internal/pkg/util/bin/bin_no_singularity.go
@@ -31,3 +31,14 @@ func findFromConfigOnly(name string) (path string, err error) {
 func findConmon(name string) (path string, err error) {
 	return findOnPath(name)
 }
+
+// findSquashfuse looks for squashfuse_ll / squashfuse on PATH.
+func findSquashfuse(name string) (path string, err error) {
+	// squashfuse_ll if found on PATH
+	llPath, err := findOnPath("squashfuse_ll")
+	if err == nil {
+		return llPath, nil
+	}
+	// squashfuse if found on PATH
+	return findOnPath(name)
+}

--- a/internal/pkg/util/bin/bin_singularity.go
+++ b/internal/pkg/util/bin/bin_singularity.go
@@ -105,3 +105,19 @@ func findConmon(name string) (path string, err error) {
 	}
 	return findOnPath(name)
 }
+
+// findSquashfuse returns either the bundled squashfuse_ll (if built), or looks
+// for squashfuse_ll / squashfuse on PATH.
+func findSquashfuse(name string) (path string, err error) {
+	// Bundled squashfuse_ll if it was built
+	if buildcfg.SQUASHFUSE_LIBEXEC == 1 {
+		return filepath.Join(buildcfg.LIBEXECDIR, "singularity", "bin", "squashfuse_ll"), nil
+	}
+	// squashfuse_ll if found on PATH
+	llPath, err := findOnPath("squashfuse_ll")
+	if err == nil {
+		return llPath, nil
+	}
+	// squashfuse if found on PATH
+	return findOnPath(name)
+}

--- a/mconfig
+++ b/mconfig
@@ -57,6 +57,7 @@ fi
 
 with_network=1
 with_conmon=1
+with_squashfuse=1
 with_suid=1
 with_seccomp_check=1
 
@@ -117,7 +118,8 @@ usage_args () {
 	echo "     --without-seccomp do not compile/install seccomp support (linux only)"
   echo
   echo "  Third-party dependencies:"
-  echo "     --without-conmon  do not build conmon, use distro provided version"
+  echo "     --without-conmon      do not build conmon, use distro provided version"
+  echo "     --without-squashfuse  do not build squashfuse, use distro provided version"
 	echo
 	echo "  Path modification options:"
 	echo "     --prefix         install project in \`prefix'"
@@ -377,6 +379,8 @@ while [ $# -ne 0 ]; do
    with_seccomp_check=0; shift;;
   --without-conmon)
    with_conmon=0; shift;;
+  --without-squashfuse)
+   with_squashfuse=0; shift;;
   --reproducible)
    reproducible=1; shift;;
   -V)
@@ -839,6 +843,11 @@ if [ "$with_conmon" = 1 ]; then
     cat $makeit_fragsdir/build_conmon.mk >> $makeit_makefile
 fi
 
+if [ "$with_squashfuse" = 1 ]; then
+    drawline $makeit_fragsdir/build_squashfuse.mk
+    cat $makeit_fragsdir/build_squashfuse.mk >> $makeit_makefile
+fi
+
 if [ "$build_runtime" = 1 ]; then
 	drawline $makeit_fragsdir/build_runtime.mk
 	cat $makeit_fragsdir/build_runtime.mk >> $makeit_makefile
@@ -921,6 +930,11 @@ if [ "$with_conmon" = 0 ]; then
 	echo "    - Build conmon: no"
 else
 	echo "    - Build conmon: yes"
+fi
+if [ "$with_squashfuse" = 0 ]; then
+	echo "    - Build squashfuse: no"
+else
+	echo "    - Build squashfuse: yes"
 fi
 echo "      ---"
 if [ "$verbose" = 1 ]; then

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -52,6 +52,7 @@ config_add_def SESSIONDIR LOCALSTATEDIR \"/singularity/mnt/session\"
 config_add_def SINGULARITY_SUID_INSTALL $with_suid
 config_add_def PLUGIN_ROOTDIR LIBEXECDIR \"/singularity/plugin\"
 config_add_def CONMON_LIBEXEC $with_conmon 
+config_add_def SQUASHFUSE_LIBEXEC $with_squashfuse 
 
 # engine configuration constants
 engine_config_env="ENGINE_CONFIG"
@@ -375,6 +376,38 @@ if [ "$with_conmon" = "1" ]; then
    fi
 fi
 
+########################
+# squashfuse deps
+########################
+if [ "$with_squashfuse" = "1" ]; then
+
+   printf " checking: squashfuse source... "
+   if [ ! -f "$sourcedir/third_party/squashfuse/autogen.sh" ]; then
+      echo "no"
+      echo
+      echo "squashfuse source not found"
+      echo
+      echo "Unless you are building --without-squashfuse you must 'git clone --recurse-submodules'"
+      echo "or 'git submodule update --init'."
+      echo
+      exit 2
+   fi
+   echo "yes"
+
+   printf " checking: squashfuse libfuse headers... "
+   fuse_iflags=`pkg-config --cflags fuse 2>/dev/null || true`
+   fuse_lflags=`pkg-config --libs fuse 2>/dev/null || true`
+   if ! printf "#include <fuse.h>\nint main() { }" | \
+      $tgtcc $user_cflags $ldflags $fuse_iflags -x c -o /dev/null - $fuse_lflags >/dev/null 2>&1; then  
+      echo "no"
+      echo
+      echo "libfuse headers are required to build squashfuse."
+      echo
+      exit 2
+   else
+   echo "yes"
+   fi
+fi
 
 ################################
 # Configurable external programs

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -24,7 +24,7 @@ check: codegen
 	@echo "       PASS"
 
 .PHONY: dist
-dist: conmon_CLEAN
+dist: conmon_CLEAN squashfuse_CLEAN
 	$(V) if test -e '$(SOURCEDIR)/vendor' ; then \
 		echo 'E: There is a vendor directory in $(SOURCEDIR).' ; \
 		echo 'E: This is unexpected. Abort.' ; \

--- a/mlocal/frags/build_squashfuse.mk
+++ b/mlocal/frags/build_squashfuse.mk
@@ -1,0 +1,26 @@
+# This file contains all of the rules for building squashfuse_ll
+
+squashfuse_ll := $(SOURCEDIR)/third_party/squashfuse/squashfuse_ll
+squashfuse_dir := $(SOURCEDIR)/third_party/squashfuse
+squashfuse_src := $(SOURCEDIR)/third_party/squashfuse/autogen.sh
+squashfuse_INSTALL := $(DESTDIR)$(LIBEXECDIR)/singularity/bin/squashfuse_ll
+
+$(squashfuse_ll): $(squashfuse_src)
+	@echo " SQUASHFUSE"
+	cd $(squashfuse_dir) && ./autogen.sh
+	cd $(squashfuse_dir) && ./configure
+	$(MAKE) -C $(squashfuse_dir) squashfuse_ll
+	
+$(squashfuse_INSTALL): $(squashfuse_ll)
+	@echo " INSTALL SQUASHFUSE" $@
+	$(V)umask 0022 && mkdir -p $(@D)
+	$(V)install -m 0755 $< $@
+
+.PHONY:
+squashfuse_CLEAN:
+	@echo " CLEAN SQUASHFUSE"
+	$(MAKE) -C $(squashfuse_dir) clean
+
+INSTALLFILES += $(squashfuse_INSTALL)
+ALL += $(squashfuse_ll)
+CLEANTARGETS += squashfuse_CLEAN


### PR DESCRIPTION
## Description of the Pull Request (PR):

The squashfuse project now includes a `squashfuse_ll` binary, which takes advantage of multi-threading for increased performance.

In addition, there is a bug in some older versions of squashfuse, packaged by Linux distributions, that affects execution of containers built on selinux systems.

Bundle the latest squashfuse 0.2.0 and build `squashfuse_ll` unless `--without-squashfuse` is specified.

In the case that `--without-squashfuse` is specified, prefer `squashfuse_ll` from `PATH`, falling back to `squashfuse`.


### This fixes or addresses the following GitHub issues:

 - Fixes #1910


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
