### PR TITLE
fix: correct rpm/deb builds for squashfuse bundling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,20 @@ commands:
             <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q update
       - run:
           name: Install dependencies
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>DEBIAN_FRONTEND=noninteractive apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin libfuse-dev libglib2.0-dev dbus-user-session uidmap
+          command: |-
+            <<# parameters.sudo >>sudo <</ parameters.sudo >>DEBIAN_FRONTEND=noninteractive apt-get -q install -y autoconf \
+              automake \
+              build-essential \
+              cryptsetup \
+              git \
+              libfuse-dev \
+              libglib2.0-dev \
+              libseccomp-dev \
+              libtool \
+              pkg-config \
+              squashfs-tools \
+              uidmap \
+              zlib1g-dev
       - run:
           name: Install proot
           command: |-
@@ -180,7 +193,19 @@ jobs:
       - checkout
       - run:
           name: Fetch deps
-          command: apk add -q --no-cache git alpine-sdk autoconf automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup libseccomp-dev glib-dev fuse-dev
+          command: |-
+            apk add -q --no-cache alpine-sdk \
+              autoconf \
+              automake \
+              cryptsetup \
+              fuse3-dev \
+              gawk \
+              git \
+              glib-dev \
+              libseccomp-dev \
+              libtool \
+              sed \
+              squashfs-tools
       - update-submodules
       - build-singularity
 
@@ -270,7 +295,15 @@ jobs:
           name: Install dependencies
           command: |-
             yum groupinstall -q -y 'Development Tools'
-            yum install -q -y cryptsetup libseccomp-devel squashfs-tools glib2-devel
+            yum install -q -y autoconf \
+             automake \
+             cryptsetup \
+             fuse3-devel \
+             glib2-devel \
+             libseccomp-devel \
+             libtool \
+             squashfs-tools \
+             zlib-devel
       - run:
           name: Install Go
           command: |-
@@ -301,7 +334,22 @@ jobs:
           name: Install dependencies
           command: |-
             apt-get update
-            DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git libseccomp-dev pkg-config squashfs-tools cryptsetup dh-golang devscripts fakeroot libglib2.0-dev
+            DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf \
+              automake \
+              build-essential \
+              cryptsetup \
+              devscripts \
+              dh-golang \
+              fakeroot \
+              git \
+              libfuse-dev \
+              libglib2.0-dev \
+              libseccomp-dev \
+              libtool \
+              pkg-config \
+              squashfs-tools \
+              uidmap \
+              zlib1g-dev
       - run:
           name: Install Go
           command: |-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,58 +10,68 @@ For full instructions on installation, including building RPMs, please check the
 
 You must first install development tools and libraries to your host.
 
-On Debian-based systems, including Ubuntu 20.04 and above:
+**On Debian-based systems, including Ubuntu 20.04 and above:**
 
 ```sh
 # Ensure repositories are up-to-date
 sudo apt-get update
 # Install debian packages for dependencies
 sudo apt-get install -y \
-    build-essential \
-    libseccomp-dev \
-    libglib2.0-dev \
+    autoconf \
+    automake \
+    cryptsetup \
+    git \
     libfuse-dev \
+    libglib2.0-dev \
+    libseccomp-dev \
+    libtool \
     pkg-config \
-    squashfs-tools \
-    cryptsetup \
-    crun \
-    uidmap \
-    git \
-    wget
-```
-
-On CentOS/RHEL 8 and above:
-
-```sh
-# Install basic tools for compiling
-sudo yum groupinstall -y 'Development Tools'
-# Install RPM packages for dependencies
-sudo yum install -y \
-    libseccomp-devel \
-    fuse-devel \
-    glib2-devel \
-    squashfs-tools \
-    cryptsetup \
-    crun \
-    git \
-    wget
-```
-
-On CentOS/RHEL 7:
-
-```sh
-# Install basic tools for compiling
-sudo yum groupinstall -y 'Development Tools'
-# Install RPM packages for dependencies
-sudo yum install -y \
-    libseccomp-devel \
-    fuse-devel \
-    glib2-devel \
-    squashfs-tools \
-    cryptsetup \
     runc \
+    squashfs-tools \
+    wget \
+    zlib1g-dev \
+```
+
+**On RHEL / AlmaLinux / RockyLinux / CentOS Stream 8 and above:**
+
+```sh
+# Install basic tools for compiling
+sudo yum groupinstall -y 'Development Tools'
+# Install RPM packages for dependencies
+sudo yum install -y \
+    autoconf \
+    automake \
+    crun \
+    cryptsetup \
+    fuse3-devel \
     git \
-    wget
+    glib2-devel \
+    libseccomp-devel \
+    libtool \
+    squashfs-tools \
+    wget \
+    zlib-devel
+```
+
+**On CentOS/RHEL 7:**
+
+```sh
+# Install basic tools for compiling
+sudo yum groupinstall -y 'Development Tools'
+# Install RPM packages for dependencies
+sudo yum install -y \
+    autoconf \
+    automake \
+    cryptsetup \
+    fuse3-devel \
+    git \
+    glib2-devel \
+    libseccomp-devel \
+    libtool \
+    runc \
+    squashfs-tools \
+    wget \
+    zlib-devel
 ```
 
 _Note - `crun` / `runc` can be omitted if you will not use the `singularity oci`

--- a/debian/control
+++ b/debian/control
@@ -5,12 +5,16 @@ Maintainer: Sylabs Community Packaging <community@sylabs.io>
 Uploaders:
   Sylabs Community Packaging <community@sylabs.io>
 Build-Depends:
+ autoconf,
  cryptsetup,
  git,
- libseccomp-dev,
+ libfuse-dev,
  libglib2.0-dev,
+ libseccomp-dev,
+ libtool,
  pkg-config,
- squashfs-tools
+ squashfs-tools,
+ zlib1g-dev
 Standards-Version: 3.9.8
 Homepage: https://sylabs.io/singularity
 Vcs-Git: https://github.com/sylabs/singularity.git
@@ -21,8 +25,9 @@ Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends},
   crun | runc,
   cryptsetup-bin,
-  libseccomp2,
+  fuse,
   libglib2.0-0,
+  libseccomp2,
   squashfs-tools,
   uidmap
 Conflicts:

--- a/debian/singularity-ce.install
+++ b/debian/singularity-ce.install
@@ -1,6 +1,7 @@
 usr/bin/singularity
 usr/bin/run-singularity
 usr/lib/*/singularity/bin/conmon
+usr/lib/*/singularity/bin/squashfuse_ll
 usr/lib/*/singularity/bin/starter
 usr/lib/*/singularity/bin/starter-suid
 usr/lib/*/singularity/cni/*

--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -44,6 +44,7 @@ Source: %{name}-@PACKAGE_VERSION@.tar.gz
 # mock. Distro packages derived from this spec need to require it.
 BuildRequires: gcc
 BuildRequires: make
+BuildRequires: /usr/bin/pkg-config
 # Paths to runtime dependencies detected by mconfig, so must be present at build time.
 BuildRequires: cryptsetup
 %if "%{_target_vendor}" == "suse"
@@ -54,6 +55,12 @@ BuildRequires: squashfs-tools
 # Required for building bundled conmon
 BuildRequires: libseccomp-devel
 BuildRequires: glib2-devel
+# Required for building bundled squashfuse
+BuildRequires: autoconf
+BuildRequires: automake
+BuildRequires: fuse3-devel
+BuildRequires: libtool
+BuildRequires: zlib-devel
 
 # crun requirement not satisfied on EL7 or SLES default repos - use runc there.
 %if "%{_target_vendor}" == "suse" || 0%{?rhel} < 8
@@ -68,6 +75,7 @@ Requires: shadow-utils
 Requires: squashfs-tools
 %endif
 Requires: cryptsetup
+Requires: fuse3
 
 Provides: %{name}-runtime
 
@@ -119,6 +127,7 @@ container platform designed to be simple, fast, and secure.
 %dir %{_libexecdir}/singularity
 %dir %{_libexecdir}/singularity/bin
 %{_libexecdir}/singularity/bin/conmon
+%{_libexecdir}/singularity/bin/squashfuse_ll
 %{_libexecdir}/singularity/bin/starter
 %dir %{_libexecdir}/singularity/cni
 %{_libexecdir}/singularity/cni/*

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -394,19 +394,38 @@ if [ "$with_squashfuse" = "1" ]; then
    fi
    echo "yes"
 
-   printf " checking: squashfuse libfuse headers... "
+   has_fuse3=0
+   has_fuse=0
+
+   printf " checking: squashfuse fuse3 headers... "
+   fuse_iflags=`pkg-config --cflags fuse3 2>/dev/null || true`
+   fuse_lflags=`pkg-config --libs fuse3 2>/dev/null || true`
+   if printf "#include <fuse.h>\nint main() { }" | \
+      $tgtcc -DFUSE_USE_VERSION=32 $user_cflags $ldflags $fuse_iflags -x c -o /dev/null - $fuse_lflags >/dev/null  2>&1; then
+      echo "yes"
+      has_fuse3=1
+   else
+      echo "no"
+   fi
+
+   printf " checking: squashfuse fuse headers... "
    fuse_iflags=`pkg-config --cflags fuse 2>/dev/null || true`
    fuse_lflags=`pkg-config --libs fuse 2>/dev/null || true`
-   if ! printf "#include <fuse.h>\nint main() { }" | \
-      $tgtcc $user_cflags $ldflags $fuse_iflags -x c -o /dev/null - $fuse_lflags >/dev/null 2>&1; then  
+   if printf "#include <fuse.h>\nint main() { }" | \
+      $tgtcc $user_cflags $ldflags $fuse_iflags -x c -o /dev/null - $fuse_lflags  >/dev/null 2>&1; then
+      echo "yes"
+      has_fuse=1
+   else
       echo "no"
+   fi
+
+   if [ $has_fuse3 -eq 0 -a $has_fuse -eq 0 ]; then
       echo
-      echo "libfuse headers are required to build squashfuse."
+      echo "fuse / fuse3 (libfuse / libfuse3) headers are required to build squashfuse."
       echo
       exit 2
-   else
-   echo "yes"
    fi
+
 fi
 
 ################################

--- a/mlocal/frags/build_conmon.mk
+++ b/mlocal/frags/build_conmon.mk
@@ -5,8 +5,8 @@ conmon_dir := $(SOURCEDIR)/third_party/conmon/
 conmon_src := $(SOURCEDIR)/third_party/conmon/Makefile
 conmon_INSTALL := $(DESTDIR)$(LIBEXECDIR)/singularity/bin/conmon
 
-# conmon currently fails to build with theses warnings as errors,
-# which are enforced for our own CGO compilations.
+# conmon currently fails to build with these warnings as errors,
+# which are enforced by our own flags for CGO, or by distributions.
 conmon_CFLAGS := $(filter-out -Wstrict-prototypes,$(CFLAGS))
 conmon_CFLAGS := $(filter-out -Wframe-larger-than=2047,$(conmon_CFLAGS))
 conmon_CFLAGS := $(filter-out -Wpointer-arith,$(conmon_CFLAGS))

--- a/mlocal/frags/build_squashfuse.mk
+++ b/mlocal/frags/build_squashfuse.mk
@@ -5,11 +5,19 @@ squashfuse_dir := $(SOURCEDIR)/third_party/squashfuse
 squashfuse_src := $(SOURCEDIR)/third_party/squashfuse/autogen.sh
 squashfuse_INSTALL := $(DESTDIR)$(LIBEXECDIR)/singularity/bin/squashfuse_ll
 
+# squashfuse currently fails to build with these warnings as errors,
+# which are enforced by our own flags for CGO, or by distributions.
+squashfuse_CFLAGS := $(filter-out -Wstrict-prototypes,$(CFLAGS))
+squashfuse_CFLAGS := $(filter-out -Wunused-parameter,$(squashfuse_CFLAGS))
+squashfuse_CFLAGS := $(filter-out -Wunused-variable,$(squashfuse_CFLAGS))
+squashfuse_CFLAGS += -Wno-unused-variable
+
 $(squashfuse_ll): $(squashfuse_src)
 	@echo " SQUASHFUSE"
+	echo $(squashfuse_CFLAGS)
 	cd $(squashfuse_dir) && ./autogen.sh
-	cd $(squashfuse_dir) && ./configure
-	$(MAKE) -C $(squashfuse_dir) squashfuse_ll
+	cd $(squashfuse_dir) && CFLAGS='$(squashfuse_CFLAGS)' ./configure
+	$(MAKE) CFLAGS='$(squashfuse_CFLAGS)' -C $(squashfuse_dir) squashfuse_ll
 	
 $(squashfuse_INSTALL): $(squashfuse_ll)
 	@echo " INSTALL SQUASHFUSE" $@
@@ -19,7 +27,7 @@ $(squashfuse_INSTALL): $(squashfuse_ll)
 .PHONY:
 squashfuse_CLEAN:
 	@echo " CLEAN SQUASHFUSE"
-	$(MAKE) -C $(squashfuse_dir) clean
+	$(MAKE) -C $(squashfuse_dir) clean || true
 
 INSTALLFILES += $(squashfuse_INSTALL)
 ALL += $(squashfuse_ll)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix builds of the rpm and deb packages after bundling of squashfuse.

* Add additional dependencies for squashfuse compilation across CI, packaging, and INSTALL.md.
* Adapt mlocal frag for CFLAGS set by distros which cause squashfuse compilation to fail.
* Use fuse3 on EL distros, as it is maintained and doesn't require the CRB repo on EL9.
* Use fuse (2) on Ubuntu, as if compiled with the fuse3 version provided by 22.04/20.04 squashfuse+overlay fails to work correctly.



### This fixes or addresses the following GitHub issues:

 - Fixes #1952 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
