### PR TITLE
WIP: remove deleted global endpoints from user's remote.yaml in SyncFrom()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,9 @@
 - Fix interaction between `--workdir` when given relative path and `--scratch`.
 - Set correct `$HOME` in `--oci` mode when `mount home = no` in
   `singularity.conf`.
+- Fixed a bug where records of deleted global remote-endpoints would persist in
+  the user's config, showing up in `singularity remote list`, and would not be
+  removable through the CLI.
 
 ## 3.11.4 \[2023-06-22\]
 

--- a/e2e/remote/regressions.go
+++ b/e2e/remote/regressions.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package remote
+
+import (
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/internal/pkg/remote"
+)
+
+func (c *ctx) issue1948(t *testing.T) {
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("add global issue1948 remote (root)"),
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("remote"),
+		e2e.WithArgs("add", "--global", "issue1948", "https://issue1948.example.com"),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("use SylabsCloud remote (user)"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("remote"),
+		e2e.WithArgs("use", remote.DefaultRemoteName),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("list remotes (user)"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("remote"),
+		e2e.WithArgs("list"),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("remove global issue1948 remote (root)"),
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("remote"),
+		e2e.WithArgs("remove", "--global", "issue1948"),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("list remotes again (user)"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("remote"),
+		e2e.WithArgs("list"),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.UnwantedContainMatch, "issue1948"),
+		),
+	)
+}

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -680,5 +680,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"test help":      c.remoteTestHelp,
 		"use":            c.remoteUse,
 		"use exclusive":  np(c.remoteUseExclusive),
+		"issue 1948":     np(c.issue1948),
 	}
 }

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -138,7 +138,7 @@ func (c *Config) SyncFrom(sys *Config) error {
 	// Remove synced remotes in the user's config if they are designated as
 	// system remotes but the corresponding system remote no longer exists
 	for name, e := range c.Remotes {
-		if !e.System {
+		if (!e.System) || (name == c.DefaultRemote) {
 			continue
 		}
 

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -135,6 +135,18 @@ func (c *Config) SyncFrom(sys *Config) error {
 		}
 	}
 
+	// Remove synced remotes in the user's config if they are designated as
+	// system remotes but the corresponding system remote no longer exists
+	for name, e := range c.Remotes {
+		if !e.System {
+			continue
+		}
+
+		if _, ok := sys.Remotes[name]; !ok {
+			delete(c.Remotes, name)
+		}
+	}
+
 	// set system default to user default if no user default specified
 	if c.DefaultRemote == "" && sys.DefaultRemote != "" {
 		c.DefaultRemote = sys.DefaultRemote


### PR DESCRIPTION
## Description of the Pull Request (PR):

After certain sequences of `singularity remote` / `sudo singularity remote` commands, the user's `remote.yaml` would contain previously-synced entries for now-deleted global(=system-level) remote endpoints. These "zombie" remote endpoints would then show up in `singularity remote list`, but would not be removable via the CLI, requiring manual editing of the user's `remote.yaml` file to get rid of them.

This PR fixes that bug by adding a scan in SyncFrom() (internal/pkg/remote/remote.go:108) that looks for remote-endpoints in the user-level config that are specified as system-level, but do not correspond to an existing system-level endpoint.

### Behavior in multiple-installation scenarios

Suppose there are two installations of Singularity on the same system - call them installation X and installation Y.

If there is a remote endpoint in installation X's global `remote.yaml` that is not found in installation Y's global `remote.yaml`, the synced record for that remote endpoint will be removed from the user's `remote.yaml` file when the user runs a command involving remote endpoints using installation Y.

But the next time the user runs a command involving remote endpoints using installation X, the previously-deleted synced information will be synced back into the user's `remote.yaml` by the SyncFrom() function prior to executing the command in question.

For added protection, the newly-added code also refrains from deleting synced information corresponding to the in-use (="default") endpoint in the user's config, _even_ that synced entry meets the criteria (=it is designated as a system-level endpoint but the currently running Singularity installation has no corresponding endpoint in its global `remote.yaml`).

### This fixes or addresses the following GitHub issues:

 - Fixes #1948 

