### PR TITLE
add indicator for the default remote in `keyserver list` output

### DIFF
--- a/e2e/keyserver/keyserver.go
+++ b/e2e/keyserver/keyserver.go
@@ -46,7 +46,7 @@ func (c ctx) keyserver(t *testing.T) {
 			command: addKeyserver,
 			args:    []string{"--insecure", testKeyserver},
 			listLines: []string{
-				"SylabsCloud*",
+				"SylabsCloud*^",
 				"   #1  https://keys.sylabs.io  🔒",
 				"   #2  http://localhost:11371",
 			},
@@ -79,7 +79,7 @@ func (c ctx) keyserver(t *testing.T) {
 			command: addKeyserver,
 			args:    []string{"--order", "1", testKeyserver},
 			listLines: []string{
-				"SylabsCloud*",
+				"SylabsCloud*^",
 				"   #1  http://localhost:11371  🔒",
 				"   #2  https://keys.sylabs.io  🔒",
 			},
@@ -98,7 +98,7 @@ func (c ctx) keyserver(t *testing.T) {
 			command: removeKeyserver,
 			args:    []string{sylabsKeyserver},
 			listLines: []string{
-				"SylabsCloud*",
+				"SylabsCloud*^",
 				"   #1  http://localhost:11371  🔒",
 			},
 			expectExit: 0,
@@ -116,7 +116,7 @@ func (c ctx) keyserver(t *testing.T) {
 			command: addKeyserver,
 			args:    []string{sylabsKeyserver},
 			listLines: []string{
-				"SylabsCloud*",
+				"SylabsCloud*^",
 				"   #1  http://localhost:11371  🔒",
 				"   #2  https://keys.sylabs.io  🔒",
 			},
@@ -128,7 +128,7 @@ func (c ctx) keyserver(t *testing.T) {
 			command: removeKeyserver,
 			args:    []string{testKeyserver},
 			listLines: []string{
-				"SylabsCloud*",
+				"SylabsCloud*^",
 				"   #1  https://keys.sylabs.io  🔒",
 			},
 			expectExit: 0,

--- a/internal/app/singularity/keyserver_list.go
+++ b/internal/app/singularity/keyserver_list.go
@@ -38,13 +38,22 @@ func KeyserverList(remoteName string, usrConfigFile string) (err error) {
 		return err
 	}
 
+	defaultRemote, err := c.GetDefault()
+	if err != nil {
+		return fmt.Errorf("error getting default remote-endpoint: %w", err)
+	}
+
 	for epName, ep := range c.Remotes {
 		fmt.Println()
 		isSystem := ""
 		if ep.System {
 			isSystem = "*"
 		}
-		fmt.Printf("%s%s\n", epName, isSystem)
+		isDefault := ""
+		if ep == defaultRemote {
+			isDefault = "^"
+		}
+		fmt.Printf("%s%s%s\n", epName, isSystem, isDefault)
 
 		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		if err := ep.UpdateKeyserversConfig(); err != nil {
@@ -67,7 +76,7 @@ func KeyserverList(remoteName string, usrConfigFile string) (err error) {
 	}
 
 	fmt.Println()
-	fmt.Println("(* = system endpoint)")
+	fmt.Println("(* = system endpoint, ^ = default endpoint)")
 
 	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Adds an indicator for the in-use (="default") remote endpoint in the output of `singularity keyserver list`.

