### PR TITLE
Revise CWD creation / symlink handling in native mode (apptainer 1365,1374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 - When `singularity registry login` is used to login to a public OCI registry,
   the password is not verified at login time.
 - Improved the clarity of `singularity key list` output.
+- Do not mount current working directory when its path in the container and on
+  the host contain symlinks to different locations. 
 
 ### New Features & Functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,11 @@
   the password is not verified at login time.
 - Improved the clarity of `singularity key list` output.
 - Do not mount current working directory when its path in the container and on
-  the host contain symlinks to different locations. 
+  the host contain symlinks to different locations.
+- Create current working directory in container when it doesn't exist, so that
+  it can be entered. You must now specify `--no-mount home,cwd` instead of just
+  `--no-mount home` to avoid mounting from `$HOME` if you run `singularity` from
+  inside `$HOME`.
 
 ### New Features & Functionality
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2332,6 +2332,17 @@ func (c actionTests) actionNoMount(t *testing.T) {
 			testDefault:   true,
 			testContained: true,
 			exit:          0,
+			// run from / to avoid /home mount via CWD mount
+			cwd: "/",
+		},
+		{
+			// test by excluding both home and cwd without chdir
+			name:          "home,cwd",
+			noMount:       "home,cwd",
+			noMatch:       "on /home",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
 		},
 		{
 			// /srv is an LSB directory we should be able to rely on for our CWD test

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -9,6 +9,7 @@ package singularity
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -84,6 +85,7 @@ type container struct {
 	suidFlag      uintptr
 	devSourcePath string
 	imageBind     map[string]string
+	skipCwd       bool
 }
 
 //nolint:maintidx
@@ -164,6 +166,14 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 
 	p := &mount.Points{}
 	system := &mount.System{Points: p, Mount: c.mount}
+
+	createCwdDirTag := mount.AuthorizedTag(mount.LayerTag)
+	if c.engine.EngineConfig.GetSessionLayer() == singularity.UnderlayLayer {
+		createCwdDirTag = mount.PreLayerTag
+	}
+	if err := system.RunBeforeTag(createCwdDirTag, c.createCwdDir); err != nil {
+		return err
+	}
 
 	if err := c.setupSessionLayout(system); err != nil {
 		return err
@@ -1828,48 +1838,22 @@ func (c *container) isMounted(dest string) bool {
 }
 
 func (c *container) addCwdMount(system *mount.System) error {
-	if c.engine.EngineConfig.GetContain() {
-		sylog.Verbosef("Not mounting current directory: contain was requested")
+	if c.skipCwd {
 		return nil
 	}
-	if !c.engine.EngineConfig.File.UserBindControl {
-		sylog.Warningf("Not mounting current directory: user bind control is disabled by system administrator")
-		return nil
-	}
-	if c.engine.EngineConfig.GetNoCwd() {
-		sylog.Debugf("Skipping current directory mount by user request.")
-		return nil
-	}
+
 	cwdHost := filepath.Clean(c.engine.EngineConfig.GetCwd())
 	if cwdHost == "" {
 		sylog.Warningf("No current working directory set: skipping mount")
+		return nil
 	}
 
 	cwdHostResolved, err := filepath.EvalSymlinks(cwdHost)
 	if err != nil {
 		return fmt.Errorf("could not obtain current directory path: %s", err)
 	}
-	sylog.Debugf("Using %s as current working directory", cwdHost)
 
-	cwdPaths := []string{cwdHost}
 	cwdHostSymlink := cwdHost != cwdHostResolved
-
-	// handle new symlink /bin -> usr/bin, /sbin -> usr/sbin ...
-	if cwdHostSymlink {
-		cwdPaths = append(cwdPaths, cwdHostResolved)
-	}
-
-	for _, cwdPath := range cwdPaths {
-		switch cwdPath {
-		case "/", "/etc", "/bin", "/mnt", "/usr", "/var", "/opt", "/sbin", "/lib", "/lib64":
-			sylog.Verbosef("Not mounting CWD within operating system directory: %s", cwdPath)
-			return nil
-		}
-		if strings.HasPrefix(cwdPath, "/sys") || strings.HasPrefix(cwdPath, "/proc") || strings.HasPrefix(cwdPath, "/dev") {
-			sylog.Verbosef("Not mounting CWD within virtual directory: %s", cwdPath)
-			return nil
-		}
-	}
 
 	cwdContainerResolved := fs.EvalRelative(cwdHost, c.session.FinalPath())
 	cwdContainerResolved = filepath.Join(c.session.FinalPath(), cwdContainerResolved)
@@ -1905,9 +1889,112 @@ func (c *container) addCwdMount(system *mount.System) error {
 
 	flags := uintptr(syscall.MS_BIND | c.suidFlag | syscall.MS_NODEV | syscall.MS_REC)
 	if err := system.Points.AddBind(mount.CwdTag, cwdHost, cwdHost, flags); err != nil {
+		if errors.Is(err, mount.ErrMountExists) {
+			return nil
+		}
 		return fmt.Errorf("could not bind cwd directory %s into container: %s", cwdHost, err)
 	}
 	return system.Points.AddRemount(mount.CwdTag, cwdHost, flags)
+}
+
+func (c *container) createCwdDir(system *mount.System) error {
+	if c.engine.EngineConfig.GetContain() {
+		c.skipCwd = true
+		sylog.Verbosef("Not mounting current directory: contain was requested")
+		return nil
+	}
+	if !c.engine.EngineConfig.File.UserBindControl {
+		c.skipCwd = true
+		sylog.Warningf("Not mounting current directory: user bind control is disabled by system administrator")
+		return nil
+	}
+	if c.engine.EngineConfig.GetNoCwd() {
+		c.skipCwd = true
+		sylog.Debugf("Skipping current directory mount by user request.")
+		return nil
+	}
+
+	cwdHost := filepath.Clean(c.engine.EngineConfig.GetCwd())
+	if cwdHost == "" || cwdHost == "/" {
+		c.skipCwd = true
+		sylog.Warningf("No current working directory set: skipping mount")
+		return nil
+	} else if cwdHost[0] != '/' {
+		return fmt.Errorf("current working directory %s is not an absolute path", cwdHost)
+	}
+
+	cwdHostResolved, err := filepath.EvalSymlinks(cwdHost)
+	if err != nil {
+		return fmt.Errorf("could not obtain current directory path: %s", err)
+	}
+	sylog.Debugf("Using %s as current working directory", cwdHost)
+
+	cwdPaths := []string{cwdHost}
+	cwdHostSymlink := cwdHost != cwdHostResolved
+
+	// handle new symlink /bin -> usr/bin, /sbin -> usr/sbin ...
+	if cwdHostSymlink {
+		cwdPaths = append(cwdPaths, cwdHostResolved)
+	}
+
+	for _, cwdPath := range cwdPaths {
+		switch cwdPath {
+		case "/", "/etc", "/bin", "/mnt", "/usr", "/var", "/opt", "/sbin", "/lib", "/lib64":
+			sylog.Verbosef("Not mounting CWD within operating system directory: %s", cwdPath)
+			c.skipCwd = true
+			return nil
+		}
+		if strings.HasPrefix(cwdPath, "/sys") || strings.HasPrefix(cwdPath, "/proc") || strings.HasPrefix(cwdPath, "/dev") {
+			sylog.Verbosef("Not mounting CWD within virtual directory: %s", cwdPath)
+			c.skipCwd = true
+			return nil
+		}
+	}
+
+	pathComponents := strings.Split(cwdHost, string(os.PathSeparator))
+	existingPath := false
+	path := ""
+
+	// check if first or last path component exists in container either
+	// in container image or via user/home binds
+	for i, pathComponent := range pathComponents[1:] {
+		if i == 0 {
+			path = filepath.Join(string(os.PathSeparator), pathComponent)
+		} else {
+			path = filepath.Join(path, pathComponent)
+		}
+		_, err := c.session.GetOverridePath(path)
+		existingPath = err == nil
+		if err != nil {
+			pathContainerResolved := fs.EvalRelative(path, c.session.RootFsPath())
+			if pathContainerResolved != path {
+				return nil
+			}
+			info, err := c.rpcOps.Lstat(filepath.Join(c.session.RootFsPath(), pathContainerResolved))
+			if err != nil {
+				existingPath = false
+			} else if !info.IsDir() {
+				existingPath = true
+			}
+		}
+	}
+
+	if !existingPath && c.session.Layer != nil {
+		if c.engine.EngineConfig.GetSessionLayer() == singularity.UnderlayLayer {
+			flags := uintptr(syscall.MS_BIND | c.suidFlag | syscall.MS_NODEV | syscall.MS_REC)
+			if err := system.Points.AddBind(mount.CwdTag, cwdHost, cwdHost, flags); err != nil {
+				return fmt.Errorf("could not bind cwd directory %s into container: %s", cwdHost, err)
+			}
+			return system.Points.AddRemount(mount.CwdTag, cwdHost, flags)
+		}
+		sessionPath := filepath.Join(c.session.Layer.Dir(), cwdHost)
+		// ignore error and let addCwdMount failing properly
+		if err := c.session.AddDir(sessionPath); err != nil {
+			sylog.Warningf("Not creating container current working directory: %s", err)
+		}
+	}
+
+	return nil
 }
 
 func (c *container) addLibsMount(system *mount.System) error {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1840,58 +1840,74 @@ func (c *container) addCwdMount(system *mount.System) error {
 		sylog.Debugf("Skipping current directory mount by user request.")
 		return nil
 	}
-	cwd := c.engine.EngineConfig.GetCwd()
-	if cwd == "" {
+	cwdHost := filepath.Clean(c.engine.EngineConfig.GetCwd())
+	if cwdHost == "" {
 		sylog.Warningf("No current working directory set: skipping mount")
 	}
 
-	current, err := filepath.EvalSymlinks(cwd)
+	cwdHostResolved, err := filepath.EvalSymlinks(cwdHost)
 	if err != nil {
 		return fmt.Errorf("could not obtain current directory path: %s", err)
 	}
-	sylog.Debugf("Using %s as current working directory", cwd)
+	sylog.Debugf("Using %s as current working directory", cwdHost)
 
-	switch current {
-	case "/", "/etc", "/bin", "/mnt", "/usr", "/var", "/opt", "/sbin", "/lib", "/lib64":
-		sylog.Verbosef("Not mounting CWD within operating system directory: %s", current)
-		return nil
-	}
-	if strings.HasPrefix(current, "/sys") || strings.HasPrefix(current, "/proc") || strings.HasPrefix(current, "/dev") {
-		sylog.Verbosef("Not mounting CWD within virtual directory: %s", current)
-		return nil
+	cwdPaths := []string{cwdHost}
+	cwdHostSymlink := cwdHost != cwdHostResolved
+
+	// handle new symlink /bin -> usr/bin, /sbin -> usr/sbin ...
+	if cwdHostSymlink {
+		cwdPaths = append(cwdPaths, cwdHostResolved)
 	}
 
-	dest := fs.EvalRelative(cwd, c.session.FinalPath())
-	dest = filepath.Join(c.session.FinalPath(), dest)
+	for _, cwdPath := range cwdPaths {
+		switch cwdPath {
+		case "/", "/etc", "/bin", "/mnt", "/usr", "/var", "/opt", "/sbin", "/lib", "/lib64":
+			sylog.Verbosef("Not mounting CWD within operating system directory: %s", cwdPath)
+			return nil
+		}
+		if strings.HasPrefix(cwdPath, "/sys") || strings.HasPrefix(cwdPath, "/proc") || strings.HasPrefix(cwdPath, "/dev") {
+			sylog.Verbosef("Not mounting CWD within virtual directory: %s", cwdPath)
+			return nil
+		}
+	}
 
-	fi, err := c.rpcOps.Stat(dest)
+	cwdContainerResolved := fs.EvalRelative(cwdHost, c.session.FinalPath())
+	cwdContainerResolved = filepath.Join(c.session.FinalPath(), cwdContainerResolved)
+	cwdContainerSymlink := cwdContainerResolved != cwdHost
+
+	fi, err := c.rpcOps.Stat(cwdContainerResolved)
 	if err != nil {
 		if os.IsNotExist(err) {
-			sylog.Verbosef("Not mounting CWD, %s doesn't exist within container", cwd)
+			sylog.Verbosef("Not mounting CWD, %s doesn't exist within container", cwdContainerResolved)
 		}
-		sylog.Verbosef("Not mounting CWD, while getting %s information: %s", cwd, err)
+		sylog.Verbosef("Not mounting CWD, while getting %s information: %s", cwdContainerResolved, err)
 		return nil
 	}
 	cst := fi.Sys().(*syscall.Stat_t)
 
 	var hst syscall.Stat_t
-	if err := syscall.Stat(cwd, &hst); err != nil {
+	if err := syscall.Stat(cwdHost, &hst); err != nil {
 		return err
 	}
+
 	// same ino/dev, the current working directory is available within the container
 	if hst.Dev == cst.Dev && hst.Ino == cst.Ino {
-		sylog.Verbosef("%s found within container", cwd)
+		sylog.Verbosef("%s found within container", cwdHost)
 		return nil
-	} else if c.isMounted(dest) {
-		sylog.Verbosef("Not mounting CWD (already mounted in container): %s", cwd)
+	} else if c.isMounted(cwdContainerResolved) {
+		sylog.Verbosef("Not mounting CWD (already mounted in container): %s", cwdHost)
+		return nil
+	} else if cwdHostSymlink && cwdContainerSymlink && cwdContainerResolved != cwdHostResolved {
+		// symlink case when both destination exists on host and in container but are differents
+		sylog.Verbosef("Not mounting CWD, detected symlinks with different destination between host/container")
 		return nil
 	}
 
 	flags := uintptr(syscall.MS_BIND | c.suidFlag | syscall.MS_NODEV | syscall.MS_REC)
-	if err := system.Points.AddBind(mount.CwdTag, cwd, cwd, flags); err != nil {
-		return fmt.Errorf("could not bind cwd directory %s into container: %s", cwd, err)
+	if err := system.Points.AddBind(mount.CwdTag, cwdHost, cwdHost, flags); err != nil {
+		return fmt.Errorf("could not bind cwd directory %s into container: %s", cwdHost, err)
 	}
-	return system.Points.AddRemount(mount.CwdTag, cwd, flags)
+	return system.Points.AddRemount(mount.CwdTag, cwdHost, flags)
 }
 
 func (c *container) addLibsMount(system *mount.System) error {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Cherry-pick two Apptainer PRs:

Create current working directory in container
https://github.com/apptainer/apptainer/pull/1374

fix: Handle CWD symlink differences between host/container
https://github.com/apptainer/apptainer/pull/1365

The effect of these cherry-picks is that we will now create the host CWD path in the container, if it is not already present, so that it can be mounted & entered in more cases.

However, if the CWD exists on the container and inside the host with a path containing symlinks to different locations, we will not perform the mount. There is no other sensible choice in this case.

### This fixes or addresses the following GitHub issues:

 - Fixes #1726 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
