### PR TITLE
chore: remove unused oci run-wrapped command

### DIFF
--- a/docs/content.go
+++ b/docs/content.go
@@ -993,9 +993,6 @@ Enterprise Performance Computing (EPC)`
   $ singularity oci attach mycontainer
   $ singularity oci delete mycontainer`
 
-	// Internal oci launcher use only - no user-facing docs
-	OciRunWrappedUse string = `run-wrapped -b <bundle_path> [-o <overlay_dir>] [run options...] <container_ID>`
-
 	OciUpdateUse   string = `update [update options...] <container_ID>`
 	OciUpdateShort string = `Update container cgroups resources (root user only)`
 	OciUpdateLong  string = `

--- a/internal/app/singularity/oci_linux.go
+++ b/internal/app/singularity/oci_linux.go
@@ -43,16 +43,6 @@ func OciRun(ctx context.Context, containerID string, args *OciArgs) error {
 	return oci.Run(ctx, containerID, args.BundlePath, args.PidFile, systemdCgroups)
 }
 
-// OciRun runs a container via the OCI runtime, wrapped with prep / cleanup steps.
-func OciRunWrapped(ctx context.Context, containerID string, args *OciArgs) error {
-	systemdCgroups, err := systemdCgroups()
-	if err != nil {
-		return err
-	}
-
-	return oci.RunWrapped(ctx, containerID, args.BundlePath, args.PidFile, args.OverlayPaths, systemdCgroups)
-}
-
 // OciCreate creates a container from an OCI bundle
 func OciCreate(containerID string, args *OciArgs) error {
 	systemdCgroups, err := systemdCgroups()


### PR DESCRIPTION
## Description of the Pull Request (PR):

The hidden OCI run-wrapped command has not been used since we changed the OCI mode flow to enter a user namespace as early as possible.

Remove the redundant code.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
