### PR TITLE
oci: Implement --allow-setuid, match nosuid mount to native mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "go.lintTool":"golangci-lint",
+    "go.lintFlags": [
+        "--fast"
+    ],
+    "go.buildFlags": [
+        "-tags=apparmor,containers_image_openpgp,fakeroot_engine,seccomp,selinux,singularity_engine,sylog"
+    ],
+    "go.testTags": "apparmor,containers_image_openpgp,fakeroot_engine,seccomp,selinux,singularity_engine,sylog,e2e_test,integration_test"
+}

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2679,5 +2679,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociOverlayTeardown":   np(c.actionOciOverlayTeardown), // proper overlay unmounting in OCI mode
 		"ociNo-mount":          c.actionOciNoMount,             // --no-mount in OCI mode
 		"ociHomeCwdPasswd":     c.actionOciHomeCwdPasswd,       // $HOME is correct in /etc/passwd, and is default cwd
+		"ociAllowSetuid":       c.actionOciAllowSetuid,         // --allow-setuid / check for nosuid mount options
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -211,28 +211,6 @@ func Run(ctx context.Context, containerID, bundlePath, pidFile string, systemdCg
 	return cmd.Run()
 }
 
-// RunWrapped runs a container via the OCI runtime, wrapped with prep / cleanup steps.
-func RunWrapped(ctx context.Context, containerID, bundlePath, pidFile string, overlayPaths []string, systemdCgroups bool) error {
-	absBundle, err := filepath.Abs(bundlePath)
-	if err != nil {
-		return fmt.Errorf("failed to determine bundle absolute path: %s", err)
-	}
-
-	if err := os.Chdir(absBundle); err != nil {
-		return fmt.Errorf("failed to change directory to %s: %s", absBundle, err)
-	}
-
-	runFunc := func() error {
-		return Run(ctx, containerID, absBundle, pidFile, systemdCgroups)
-	}
-
-	if len(overlayPaths) > 0 {
-		return WrapWithOverlays(runFunc, absBundle, overlayPaths)
-	}
-
-	return WrapWithWritableTmpFs(runFunc, absBundle)
-}
-
 // Start starts a previously created container
 func Start(containerID string, systemdCgroups bool) error {
 	runtimeBin, err := runtime()

--- a/internal/pkg/util/crypt/crypt_dev_test.go
+++ b/internal/pkg/util/crypt/crypt_dev_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
-	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/squashfs"
 )
 
 func TestEncrypt(t *testing.T) {
@@ -47,9 +47,9 @@ func TestEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create dummy file %s: %s", dummyRootFile, err)
 	}
-	squashfsBin, err := squashfs.GetPath()
+	mksquashfsBin, err := bin.FindBin("mksquashfs")
 	if err != nil {
-		t.Fatalf("failed to get path to squashfs binary: %s", err)
+		t.Fatalf("failed to get path to mksquashfs binary: %s", err)
 	}
 	tempTargetFile, err := os.CreateTemp("", "")
 	if err != nil {
@@ -61,7 +61,7 @@ func TestEncrypt(t *testing.T) {
 	}
 	defer os.Remove(tempTargetFile.Name())
 	squashfsArgs := []string{dummyDir, tempTargetFile.Name(), "-noappend"}
-	cmd := exec.Command(squashfsBin, squashfsArgs...)
+	cmd := exec.Command(mksquashfsBin, squashfsArgs...)
 	err = cmd.Run()
 	if err != nil {
 		t.Fatalf("failed to create squashfs file: %s", err)

--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,55 +13,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
-	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
 )
-
-func getConfig() (*singularityconf.File, error) {
-	// if the caller has set the current config use it
-	// otherwise parse the default configuration file
-	cfg := singularityconf.GetCurrentConfig()
-	if cfg == nil {
-		var err error
-
-		configFile := buildcfg.SINGULARITY_CONF_FILE
-		cfg, err = singularityconf.Parse(configFile)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse singularity.conf file: %s", err)
-		}
-	}
-	return cfg, nil
-}
-
-// GetPath figures out where the mksquashfs binary is
-// and return an error is not available or not usable.
-func GetPath() (string, error) {
-	return bin.FindBin("mksquashfs")
-}
-
-func GetProcs() (uint, error) {
-	c, err := getConfig()
-	if err != nil {
-		return 0, err
-	}
-	// proc is either "" or the string value in the conf file
-	proc := c.MksquashfsProcs
-
-	return proc, err
-}
-
-func GetMem() (string, error) {
-	c, err := getConfig()
-	if err != nil {
-		return "", err
-	}
-	// mem is either "" or the string value in the conf file
-	mem := c.MksquashfsMem
-
-	return mem, err
-}
 
 func FUSEMount(ctx context.Context, offset uint64, path, mountPath string) error {
 	args := []string{

--- a/internal/pkg/util/fs/squashfs/squashfs_singularity.go
+++ b/internal/pkg/util/fs/squashfs/squashfs_singularity.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build singularity_engine
+
+package squashfs
+
+import (
+	"fmt"
+
+	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
+	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
+)
+
+func getConfig() (*singularityconf.File, error) {
+	// if the caller has set the current config use it
+	// otherwise parse the default configuration file
+	cfg := singularityconf.GetCurrentConfig()
+	if cfg == nil {
+		var err error
+
+		configFile := buildcfg.SINGULARITY_CONF_FILE
+		cfg, err = singularityconf.Parse(configFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse singularity.conf file: %s", err)
+		}
+	}
+	return cfg, nil
+}
+
+// GetPath figures out where the mksquashfs binary is
+// and return an error is not available or not usable.
+func GetPath() (string, error) {
+	return bin.FindBin("mksquashfs")
+}
+
+func GetProcs() (uint, error) {
+	c, err := getConfig()
+	if err != nil {
+		return 0, err
+	}
+	// proc is either "" or the string value in the conf file
+	proc := c.MksquashfsProcs
+
+	return proc, err
+}
+
+func GetMem() (string, error) {
+	c, err := getConfig()
+	if err != nil {
+		return "", err
+	}
+	// mem is either "" or the string value in the conf file
+	mem := c.MksquashfsMem
+
+	return mem, err
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In native mode, things are nosuid mounted by default, and `--allow-setuid` is available to the root user to relax this.

In OCI mode, the `nosuid` option on mounts is not security critical as when run by an unpriv user, we always perform the mounts within a root-mapped user namespace.

Regardless, match the behavior with native mode by default, and allow any user to specify `--allow-setuid` to remove the `nosuid` from appropriate mounts.

This requires making behaviour configurable for the `OverlayItem` mounts underlying an `OverlaySet`, as well as for mounts added by the launcher to the OCI runtime config.

Includes some tidy up of overlay item option handling, and adds tests to check mount options on overlay items.

### This fixes or addresses the following GitHub issues:

 - Fixes #1469 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
