### PR TITLE
pull: use .oci.sif suffix for pull --oci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@
   it can be entered. You must now specify `--no-mount home,cwd` instead of just
   `--no-mount home` to avoid mounting from `$HOME` if you run `singularity` from
   inside `$HOME`.
+- Running `singularity pull --oci` without a specific output filename will now
+  create an image with the `.oci.sif` suffix instead of `.sif`.
 
 ### New Features & Functionality
 

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -195,14 +195,19 @@ func pullRun(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Bad URI %s", pullFrom)
 	}
 
+	suffix := "sif"
+	if pullOci {
+		suffix = "oci.sif"
+	}
+
 	pullTo := pullImageName
 	if pullTo == "" {
 		pullTo = args[0]
 		if len(args) == 1 {
 			if transport == "" {
-				pullTo = uri.GetName("library://" + pullFrom)
+				pullTo = uri.Filename("library://"+pullFrom, suffix)
 			} else {
-				pullTo = uri.GetName(pullFrom) // TODO: If not library/shub & no name specified, simply put to cache
+				pullTo = uri.Filename(pullFrom, suffix) // TODO: If not library/shub & no name specified, simply put to cache
 			}
 		}
 	}

--- a/e2e/pull/concurrency.go
+++ b/e2e/pull/concurrency.go
@@ -139,14 +139,14 @@ func (c ctx) testConcurrentPulls(t *testing.T) {
 				desc:             "",
 				srcURI:           srcURI,
 				expectedExitCode: tt.expectedExitCode,
-				expectedImage:    getImageNameFromURI(srcURI),
+				expectedImage:    getImageNameFromURI(srcURI, false),
 				envVars:          tt.envVars,
 			}
 
 			// No explicit image path specified. Will use temp dir as working directory,
 			// so we pull into a clean location.
 			ts.workDir = tmpdir
-			imageName := getImageNameFromURI(ts.srcURI)
+			imageName := getImageNameFromURI(ts.srcURI, false)
 			ts.expectedImage = filepath.Join(tmpdir, imageName)
 
 			// if there's a pullDir, that's where we expect to find the image

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -124,7 +124,7 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 	checkPullResult(t, tt)
 }
 
-func getImageNameFromURI(imgURI string) string {
+func getImageNameFromURI(imgURI string, oci bool) string {
 	// XXX(mem): this function should be part of the code, not the test
 	switch transport, ref := uri.Split(imgURI); {
 	case ref == "":
@@ -134,7 +134,12 @@ func getImageNameFromURI(imgURI string) string {
 		imgURI = "library://" + imgURI
 	}
 
-	return uri.GetName(imgURI)
+	suffix := "sif"
+	if oci {
+		suffix = "oci.sif"
+	}
+
+	return uri.Filename(imgURI, suffix)
 }
 
 func (c *ctx) setup(t *testing.T) {
@@ -452,7 +457,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 				// No explicit image path specified. Will use temp dir as working directory,
 				// so we pull into a clean location.
 				tt.workDir = tmpdir
-				imageName := getImageNameFromURI(tt.srcURI)
+				imageName := getImageNameFromURI(tt.srcURI, tt.oci)
 				tt.expectedImage = filepath.Join(tmpdir, imageName)
 
 				// if there's a pullDir, that's where we expect to find the image

--- a/internal/pkg/util/uri/uri.go
+++ b/internal/pkg/util/uri/uri.go
@@ -52,11 +52,12 @@ func IsValid(source string) (valid bool, err error) {
 	return false, fmt.Errorf("invalid uri %s", source)
 }
 
-// GetName turns a transport:ref URI into a name containing the top-level identifier
-// of the image. For example, docker://sylabsio/lolcow returns lolcow
+// Filename turns a transport:ref URI into a filename containing the top-level
+// identifier of the image. For example, docker://sylabsio/lolcow:latest returns
+// lolcow_latest.<suffix>
 //
 // Returns "" when not in transport:ref format
-func GetName(uri string) string {
+func Filename(uri string, suffix string) string {
 	transport, ref := Split(uri)
 	if transport == "" {
 		return ""
@@ -83,7 +84,7 @@ func GetName(uri string) string {
 		}
 	}
 
-	return fmt.Sprintf("%s_%s.sif", container, tags[0])
+	return fmt.Sprintf("%s_%s.%s", container, tags[0], suffix)
 }
 
 // Split splits a URI into it's components which can be used directly through containers/image

--- a/internal/pkg/util/uri/uri_test.go
+++ b/internal/pkg/util/uri/uri_test.go
@@ -13,17 +13,18 @@ func Test_GetName(t *testing.T) {
 	tests := []struct {
 		name     string
 		uri      string
+		suffix   string
 		expected string
 	}{
-		{"docker basic", "docker://ubuntu", "ubuntu_latest.sif"},
-		{"docker scoped", "docker://user/image", "image_latest.sif"},
-		{"dave's magical lolcow", "docker://sylabs.io/lolcow", "lolcow_latest.sif"},
-		{"docker w/ tags", "docker://sylabs.io/lolcow:3.7", "lolcow_3.7.sif"},
+		{"docker basic", "docker://ubuntu", "sif", "ubuntu_latest.sif"},
+		{"docker scoped", "docker://user/image", "oci.sif", "image_latest.oci.sif"},
+		{"dave's magical lolcow", "docker://sylabs.io/lolcow", "sif", "lolcow_latest.sif"},
+		{"docker w/ tags", "docker://sylabs.io/lolcow:3.7", "sif", "lolcow_3.7.sif"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if n := GetName(tt.uri); n != tt.expected {
+			if n := Filename(tt.uri, tt.suffix); n != tt.expected {
 				t.Errorf("incorrectly parsed name as \"%v\" (expected \"%s\")", n, tt.expected)
 			}
 		})


### PR DESCRIPTION
### Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
When a user performs a `singularity pull --oci` without specifying a specific output filename, use `.oci.sif` for the suffix of the generated filename.



### This fixes or addresses the following GitHub issues:

 - Fixes #1885 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
