### PR TITLE
feat: --no-pid action flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@
   which invokes start script within the `%appstart <name>` section in the
   definition file. The `instance stop` command still only requires the instance
   name.
+- A new `--no-pid` flag for `singularity run/shell/exec` disables the PID namespace
+  inferred by `--containall` and `--compat`.
 
 ### Developer / API
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -60,11 +60,12 @@ var (
 	noUmask         bool
 	disableCache    bool
 
-	netNamespace  bool
-	utsNamespace  bool
-	userNamespace bool
-	pidNamespace  bool
-	ipcNamespace  bool
+	netNamespace   bool
+	utsNamespace   bool
+	userNamespace  bool
+	pidNamespace   bool
+	noPidNamespace bool
+	ipcNamespace   bool
 
 	allowSUID bool
 	keepPrivs bool
@@ -496,6 +497,16 @@ var actionPidNamespaceFlag = cmdline.Flag{
 	EnvKeys:      []string{"PID", "UNSHARE_PID"},
 }
 
+// --no-pid
+var actionNoPidNamespaceFlag = cmdline.Flag{
+	ID:           "actionNoPidNamespaceFlag",
+	Value:        &noPidNamespace,
+	DefaultValue: false,
+	Name:         "no-pid",
+	Usage:        "do not run container in a new PID namespace",
+	EnvKeys:      []string{"NO_PID"},
+}
+
 // -i|--ipc
 var actionIpcNamespaceFlag = cmdline.Flag{
 	ID:           "actionIpcNamespaceFlag",
@@ -842,6 +853,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&commonPromptForPassphraseFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonPEMFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPidNamespaceFlag, actionsCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoPidNamespaceFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionCwdFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPwdFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionScratchFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -288,11 +288,12 @@ var TestCmd = &cobra.Command{
 
 func launchContainer(cmd *cobra.Command, ep launcher.ExecParams) error {
 	ns := launcher.Namespaces{
-		User: userNamespace,
-		UTS:  utsNamespace,
-		PID:  pidNamespace,
-		IPC:  ipcNamespace,
-		Net:  netNamespace,
+		User:  userNamespace,
+		UTS:   utsNamespace,
+		PID:   pidNamespace,
+		IPC:   ipcNamespace,
+		Net:   netNamespace,
+		NoPID: noPidNamespace,
 	}
 
 	cgJSON, err := getCgroupsJSON()

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -180,6 +180,23 @@ func (c actionTests) actionExec(t *testing.T) {
 			argv: []string{"--no-home", c.env.ImagePath, "ls", "-ld", user.Dir},
 			exit: 1,
 		},
+		// PID namespace, and override, in --containall mode. Uses --no-init to be able to check PID=1
+		{
+			name: "ContainAllPID",
+			argv: []string{"--containall", "--no-init", c.env.ImagePath, "sh", "-c", "echo $$"},
+			exit: 0,
+			wantOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ExactMatch, "1"),
+			},
+		},
+		{
+			name: "ContainAllNoPID",
+			argv: []string{"--containall", "--no-init", "--no-pid", c.env.ImagePath, "sh", "-c", "echo $$"},
+			exit: 0,
+			wantOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.UnwantedExactMatch, "1"),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -318,6 +318,23 @@ func (c actionTests) actionOciExec(t *testing.T) {
 				e2e.ExpectOutput(e2e.ExactMatch, `hosts`),
 			},
 		},
+		// Default PID namespace, and override.
+		{
+			name: "DefaultPID",
+			argv: []string{c.env.OCISIFPath, "sh", "-c", "echo $$"},
+			exit: 0,
+			wantOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ExactMatch, "1"),
+			},
+		},
+		{
+			name: "NoPID",
+			argv: []string{"--no-pid", c.env.OCISIFPath, "sh", "-c", "echo $$"},
+			exit: 0,
+			wantOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.UnwantedExactMatch, "1"),
+			},
+		},
 	}
 	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -297,6 +297,11 @@ func (l *Launcher) Exec(ctx context.Context, ep launcher.ExecParams) error {
 		}
 	}
 
+	// --no-pid disables PID inferred above
+	if l.cfg.Namespaces.NoPID {
+		l.cfg.Namespaces.PID = false
+	}
+
 	// Setup instance specific configuration if required.
 	if ep.Instance != "" {
 		l.generator.AddProcessEnv("SINGULARITY_INSTANCE", ep.Instance)

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -16,13 +16,10 @@ import (
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
-// defaultNamespaces matching native runtime with --compat / --containall.
+// defaultNamespaces matching native runtime with --compat / --containall, except PID which can be disabled.
 var defaultNamespaces = []specs.LinuxNamespace{
 	{
 		Type: specs.IPCNamespace,
-	},
-	{
-		Type: specs.PIDNamespace,
 	},
 	{
 		Type: specs.MountNamespace,
@@ -77,7 +74,14 @@ func addNamespaces(spec *specs.Spec, ns launcher.Namespaces) error {
 	}
 
 	if ns.PID {
-		sylog.Infof("--oci runtime always uses a PID namespace, pid flag is redundant.")
+		sylog.Infof("--oci runtime uses a PID namespace by default, pid flag is redundant.")
+	}
+
+	if !ns.NoPID {
+		spec.Linux.Namespaces = append(
+			spec.Linux.Namespaces,
+			specs.LinuxNamespace{Type: specs.PIDNamespace},
+		)
 	}
 
 	if ns.User {

--- a/internal/pkg/runtime/launcher/oci/spec_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux_test.go
@@ -20,6 +20,15 @@ func Test_addNamespaces(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	defaultPlusPID := append(defaultNamespaces,
+		specs.LinuxNamespace{Type: specs.PIDNamespace})
+	defaultPlusNetPID := append(defaultNamespaces,
+		specs.LinuxNamespace{Type: specs.NetworkNamespace},
+		specs.LinuxNamespace{Type: specs.PIDNamespace})
+	defaultPlusPIDUTS := append(defaultNamespaces,
+		specs.LinuxNamespace{Type: specs.PIDNamespace},
+		specs.LinuxNamespace{Type: specs.UTSNamespace})
+
 	tests := []struct {
 		name   string
 		ns     launcher.Namespaces
@@ -28,32 +37,37 @@ func Test_addNamespaces(t *testing.T) {
 		{
 			name:   "none",
 			ns:     launcher.Namespaces{},
+			wantNS: defaultPlusPID,
+		},
+		{
+			name:   "nopid",
+			ns:     launcher.Namespaces{NoPID: true},
 			wantNS: defaultNamespaces,
 		},
 		{
 			name:   "pid",
 			ns:     launcher.Namespaces{PID: true},
-			wantNS: defaultNamespaces,
+			wantNS: defaultPlusPID,
 		},
 		{
 			name:   "ipc",
 			ns:     launcher.Namespaces{IPC: true},
-			wantNS: defaultNamespaces,
+			wantNS: defaultPlusPID,
 		},
 		{
 			name:   "user",
 			ns:     launcher.Namespaces{User: true},
-			wantNS: defaultNamespaces,
+			wantNS: defaultPlusPID,
 		},
 		{
 			name:   "net",
 			ns:     launcher.Namespaces{Net: true},
-			wantNS: append(defaultNamespaces, specs.LinuxNamespace{Type: specs.NetworkNamespace}),
+			wantNS: defaultPlusNetPID,
 		},
 		{
 			name:   "uts",
 			ns:     launcher.Namespaces{UTS: true},
-			wantNS: append(defaultNamespaces, specs.LinuxNamespace{Type: specs.UTSNamespace}),
+			wantNS: defaultPlusPIDUTS,
 		},
 	}
 

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -21,6 +21,8 @@ type Namespaces struct {
 	PID  bool
 	IPC  bool
 	Net  bool
+	// NoPID will force the PID namespace not to be used, even if set by default / other flags.
+	NoPID bool
 }
 
 // Options accumulates launch configuration from passed functional options. Note


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add a new flag, `--no-pid` which prevents the use of a PID namespace, when running a container with `--compat` / `--containall` / `--oci` which infer `--pid`.

Allows working around potential issues with applications across parallel container executions that expect to be working in a common PID namespace.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
