### PR TITLE
oci: enable signal propagation

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2698,5 +2698,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociNo-mount":          c.actionOciNoMount,             // --no-mount in OCI mode
 		"ociHomeCwdPasswd":     c.actionOciHomeCwdPasswd,       // $HOME is correct in /etc/passwd, and is default cwd
 		"ociAllowSetuid":       c.actionOciAllowSetuid,         // --allow-setuid / check for nosuid mount options
+		"ociExitSignals":       c.ociExitSignals,               // test exit and signals propagation
 	}
 }

--- a/internal/app/singularity/oci_linux.go
+++ b/internal/app/singularity/oci_linux.go
@@ -81,11 +81,7 @@ func OciExec(containerID string, cmdArgs []string) error {
 
 // OciKill kills container process
 func OciKill(containerID string, killSignal string) error {
-	systemdCgroups, err := systemdCgroups()
-	if err != nil {
-		return err
-	}
-	return oci.Kill(containerID, killSignal, systemdCgroups)
+	return oci.Kill(containerID, killSignal)
 }
 
 // OciPause pauses processes in a container


### PR DESCRIPTION
## Description of the Pull Request (PR):

When we are using os.exec in the OCI-mode execution flow, we must handle any signals we receive, and proxy them to the container.

For non-root users, we are using the fakeroot starter (which already proxies signals) to re-exec singularity in a userns. Proxy signals to the container via `runc/crun kill`.

For root users, we are using os.Exec to re-exec singularity in a userns, so we need to add signal proxying across this boundary in `rootless.RunInMountNS`.

Also, we need to propagate signals to exit codes correctly.

### This fixes or addresses the following GitHub issues:

 - Fixes #1779 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
