### PR TITLE
--no-compat, add flag and $HOME /tmp /var/tmp binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,9 @@
   name.
 - A new `--no-pid` flag for `singularity run/shell/exec` disables the PID namespace
   inferred by `--containall` and `--compat`.
+- A new `--no-compat` flag can be used with OCI-mode to reduce OCI runtime
+  compatibility and emulate singularity's historic native mode behaviour:
+  - `$HOME`, `/tmp`, `/var/tmp` are bind mounted from the host.
 
 ### Developer / API
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -44,6 +44,7 @@ var (
 	noSetgroups     bool
 	isCleanEnv      bool
 	isCompat        bool
+	noCompat        bool
 	isContained     bool
 	isContainAll    bool
 	isWritable      bool
@@ -361,6 +362,16 @@ var actionCompatFlag = cmdline.Flag{
 	Name:         "compat",
 	Usage:        "apply settings for increased OCI/Docker compatibility. Infers --containall, --no-init, --no-umask, --no-eval, --writable-tmpfs.",
 	EnvKeys:      []string{"COMPAT"},
+}
+
+// --no-compat
+var actionNoCompatFlag = cmdline.Flag{
+	ID:           "actionNoCompatFlag",
+	Value:        &noCompat,
+	DefaultValue: false,
+	Name:         "no-compat",
+	Usage:        "(--oci mode) do not apply settings for increased OCI/Docker compatibility. Emulate native runtime defaults without --contain etc.",
+	EnvKeys:      []string{"NO_COMPAT"},
 }
 
 // -c|--contain
@@ -823,6 +834,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionBindFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionCleanEnvFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionCompatFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoCompatFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionContainAllFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionContainFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionContainLibsFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -64,6 +64,9 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 	// Excludes uts/user/net namespaces as these are restrictive for many Singularity
 	// installs.
 	if isCompat {
+		if noCompat {
+			sylog.Fatalf("Cannot use --no-compat with --compat: incompatible options")
+		}
 		isContainAll = true
 		isWritableTmpfs = true
 		noInit = true
@@ -357,6 +360,7 @@ func launchContainer(cmd *cobra.Command, ep launcher.ExecParams) error {
 		launcher.OptCacheDisabled(disableCache),
 		launcher.OptDevice(device),
 		launcher.OptCdiDirs(cdiDirs),
+		launcher.OptNoCompat(noCompat),
 	}
 
 	// Explicitly use the interface type here, as we will add alternative launchers later...

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2691,6 +2691,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociCdi":               c.actionOciCdi,                 // singularity exec --oci --cdi
 		"ociIDMaps":            c.actionOciIDMaps,              // check uid/gid mapping on host for --oci as user / --fakeroot
 		"ociCompat":            np(c.actionOciCompat),          // --oci equivalence to native mode --compat
+		"ociNoCompat":          np(c.actionOciNoCompat),        // --oci equivalence to native mode defaults with --no-compat
 		"ociOverlay":           (c.actionOciOverlay),           // --overlay in OCI mode
 		"ociOverlayExtfsPerms": (c.actionOciOverlayExtfsPerms), // permissions in writable extfs overlays mounted with FUSE in OCI mode
 		"ociOverlayTeardown":   np(c.actionOciOverlayTeardown), // proper overlay unmounting in OCI mode

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -78,6 +78,10 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 		return nil, fmt.Errorf("CDI device mappings unsupported in native launcher")
 	}
 
+	if lo.NoCompat {
+		sylog.Warningf("--no-compat applies to --oci mode only, ignoring")
+	}
+
 	// Initialize empty default Singularity Engine and OCI configuration
 	engineConfig := singularityConfig.NewConfig()
 	engineConfig.File = singularityconf.GetCurrentConfig()

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -40,6 +40,7 @@ func TestNewLauncher(t *testing.T) {
 			name: "default",
 			want: &Launcher{
 				singularityConf: sc,
+				homeHost:        u.HomeDir,
 				homeSrc:         "",
 				homeDest:        u.HomeDir,
 			},
@@ -52,6 +53,7 @@ func TestNewLauncher(t *testing.T) {
 			want: &Launcher{
 				cfg:             launcher.Options{HomeDir: "/home/dest", CustomHome: true},
 				singularityConf: sc,
+				homeHost:        u.HomeDir,
 				homeSrc:         "",
 				homeDest:        "/home/dest",
 			},
@@ -65,6 +67,7 @@ func TestNewLauncher(t *testing.T) {
 			want: &Launcher{
 				cfg:             launcher.Options{HomeDir: "/home/src:/home/dest", CustomHome: true},
 				singularityConf: sc,
+				homeHost:        u.HomeDir,
 				homeSrc:         "/home/src",
 				homeDest:        "/home/dest",
 			},

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -154,6 +154,11 @@ type Options struct {
 
 	// CdiDirs contains the list of directories in which CDI should look for device definition JSON files
 	CdiDirs []string
+
+	// NoCompat indicates the container should be run in non-OCI compatible
+	// mode, i.e. with default mounts etc. as native mode. Effective for the OCI
+	// launcher only.
+	NoCompat bool
 }
 
 type Option func(co *Options) error
@@ -532,6 +537,14 @@ func OptDevice(op []string) Option {
 func OptCdiDirs(op []string) Option {
 	return func(lo *Options) error {
 		lo.CdiDirs = op
+		return nil
+	}
+}
+
+// OptNoCompat disable OCI compatible mode, for singularity native mode default behaviors.
+func OptNoCompat(b bool) Option {
+	return func(lo *Options) error {
+		lo.NoCompat = b
 		return nil
 	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

**cmd: Add --no-compat flag**

Add a --no-compat flag intended to disable default --compat like behaviour for OCI mode, and revert to default native runtime behaviour.

Pass down to launchers.

**no-compat: bind $HOME /tmp /var/tmp**

When --oci mode is run with --no-compat:

 * Bind $HOME into the container, unless disabled otherwise.
 * Bind /tmp /var/tmp into the container, unless disabled otherwise.
    
### This fixes or addresses the following GitHub issues:

 - Fixes #1977 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
