### PR TITLE
no-compat: bind full /dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,8 @@
 - A new `--no-compat` flag can be used with OCI-mode to reduce OCI runtime
   compatibility and emulate singularity's historic native mode behaviour:
   - `$HOME`, `/tmp`, `/var/tmp` are bind mounted from the host.
+  - The full `/dev` is bind mounted from the host, unless `mount dev = minimal`
+    in `singularity.conf`.
 
 ### Developer / API
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1702,16 +1702,16 @@ func (c actionTests) actionOciNoMount(t *testing.T) {
 			exit:    0,
 		},
 		{
-			name:      "dev",
-			noMount:   "dev",
-			warnMatch: "--no-mount dev is not supported in OCI mode, ignoring.",
-			exit:      0,
+			name:    "dev",
+			noMount: "dev",
+			noMatch: "on /dev",
+			exit:    255, // /dev is required in OCI mode.
 		},
 		{
 			name:    "devpts",
 			noMount: "devpts",
 			noMatch: "on /dev/pts",
-			exit:    0,
+			exit:    255, // /devpts is required in OCI mode.
 		},
 		{
 			name:    "tmp",
@@ -1952,6 +1952,7 @@ func (c actionTests) actionOciNoCompat(t *testing.T) {
 	}
 
 	tests := []test{
+		// $HOME, /tmp, /var/tmp are bound in
 		{
 			name:     "dirBinds",
 			args:     []string{"--no-compat", imageRef, "sh", "-c", "ls /tmp /var/tmp $HOME"},
@@ -1961,6 +1962,12 @@ func (c actionTests) actionOciNoCompat(t *testing.T) {
 				e2e.ExpectOutput(e2e.ContainMatch, filepath.Base(varTmpCanary)),
 				e2e.ExpectOutput(e2e.ContainMatch, filepath.Base(homeCanary)),
 			},
+		},
+		// /dev is bound in - /dev/block doesn't exist in a minimal /dev
+		{
+			name:     "fullDev",
+			args:     []string{"--no-compat", imageRef, "sh", "-c", "ls /dev/block"},
+			exitCode: 0,
 		},
 	}
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -47,7 +47,7 @@ var (
 	ErrUnsupportedOption = errors.New("not supported by OCI launcher")
 	ErrNotImplemented    = errors.New("not implemented by OCI launcher")
 
-	unsupportedNoMount = []string{"dev", "cwd", "bind-paths"}
+	unsupportedNoMount = []string{"cwd", "bind-paths"}
 )
 
 // Launcher will holds configuration for, and will launch a container using an

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -142,6 +142,8 @@ mount sys = {{ if eq .MountSys true }}yes{{ else }}no{{ end }}
 # Should we automatically bind mount /dev within the container? If 'minimal'
 # is chosen, then only 'null', 'zero', 'random', 'urandom', and 'shm' will
 # be included (the same effect as the --contain options)
+#
+# Must be set to 'yes' or 'minimal' to use --oci mode.
 mount dev = {{ .MountDev }}
 
 # MOUNT DEVPTS: [BOOL]
@@ -150,6 +152,8 @@ mount dev = {{ .MountDev }}
 # /dev, or -C is passed?  Note, this requires that your kernel was
 # configured with CONFIG_DEVPTS_MULTIPLE_INSTANCES=y, or that you're
 # running kernel 4.7 or newer.
+#
+# Must be set to 'yes' to use --oci mode.
 mount devpts = {{ if eq .MountDevPts true }}yes{{ else }}no{{ end }}
 
 # MOUNT HOME: [BOOL]


### PR DESCRIPTION
## Description of the Pull Request (PR):

When `--oci` mode is run with `--no-compat`, follow native mode default behaviour of binding the entire `/dev` from the host into the container by default.
    
If `mount dev = minimal` in `singularity.conf` then we don't mount the entire host `/dev`, but use the minimum for an OCI container.

If `mount dev = no` in `singularity.conf` or `--no-mount dev` supplied then report an error as we require dev. Error now, instead of warn, so it's clear we can't acheive the native mode behavior.

If `mount devpts = no` in `singularity.conf` or `--no-mount devpts` supplied then report an error as we require devpts. Error now, instead of warn, so it's clear we can't acheive the native mode behavior.

### This fixes or addresses the following GitHub issues:

 - Fixes #1981 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
