### PR TITLE
no-compat: read-only unless --writable-tmpfs requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@
   - `bind path` entries in `singularity.conf` are mounted into the container.
   - The current working directory is mounted into the container, and is the
     entry point into the container.
+  - The container is read-only unless `--writable-tmpfs` is also used.
 
 ### Developer / API
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -2010,6 +2010,17 @@ func (c actionTests) actionOciNoCompat(t *testing.T) {
 				e2e.ExpectOutput(e2e.ExactMatch, canaryContent),
 			},
 		},
+		// Read-only unless `--writable-tmpfs` also used.
+		{
+			name:     "readOnly",
+			args:     []string{"--no-compat", imageRef, "sh", "-c", "touch /test"},
+			exitCode: 1,
+		},
+		{
+			name:     "writableTmpfs",
+			args:     []string{"--no-compat", "--writable-tmpfs", imageRef, "sh", "-c", "touch /test"},
+			exitCode: 0,
+		},
 	}
 
 	oldUmask := syscall.Umask(0)

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -135,6 +135,15 @@ func (c configTests) configGlobal(t *testing.T) {
 			e2e.ExpectExit(0),
 		)
 	}
+	unsetDirective := func(t *testing.T, directive, value string) {
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.RootProfile),
+			e2e.WithCommand("config global"),
+			e2e.WithArgs("--unset", directive, value),
+			e2e.ExpectExit(0),
+		)
+	}
 	resetDirective := func(t *testing.T, directive string) {
 		c.env.RunSingularity(
 			t,
@@ -159,6 +168,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		cwd               string
 		directive         string
 		directiveValue    string
+		unset             bool // unset instead of reset
 		exit              int
 		resultOp          e2e.SingularityCmdResultOp
 	}{
@@ -353,6 +363,7 @@ func (c configTests) configGlobal(t *testing.T) {
 			profile:        e2e.UserProfile,
 			directive:      "bind path",
 			directiveValue: "/etc/passwd:/passwd",
+			unset:          true,
 			exit:           0,
 		},
 		{
@@ -698,7 +709,11 @@ func (c configTests) configGlobal(t *testing.T) {
 				setDirective(t, tt.directive, tt.directiveValue)
 			}),
 			e2e.PostRun(func(t *testing.T) {
-				resetDirective(t, tt.directive)
+				if tt.unset {
+					unsetDirective(t, tt.directive, tt.directiveValue)
+				} else {
+					resetDirective(t, tt.directive)
+				}
 			}),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.argv...),

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -39,6 +39,7 @@ func TestNewLauncher(t *testing.T) {
 		{
 			name: "default",
 			want: &Launcher{
+				cfg:             launcher.Options{WritableTmpfs: true},
 				singularityConf: sc,
 				homeHost:        u.HomeDir,
 				homeSrc:         "",
@@ -51,7 +52,7 @@ func TestNewLauncher(t *testing.T) {
 				launcher.OptHome("/home/dest", true, false),
 			},
 			want: &Launcher{
-				cfg:             launcher.Options{HomeDir: "/home/dest", CustomHome: true},
+				cfg:             launcher.Options{HomeDir: "/home/dest", CustomHome: true, WritableTmpfs: true},
 				singularityConf: sc,
 				homeHost:        u.HomeDir,
 				homeSrc:         "",
@@ -65,11 +66,40 @@ func TestNewLauncher(t *testing.T) {
 				launcher.OptHome("/home/src:/home/dest", true, false),
 			},
 			want: &Launcher{
-				cfg:             launcher.Options{HomeDir: "/home/src:/home/dest", CustomHome: true},
+				cfg:             launcher.Options{HomeDir: "/home/src:/home/dest", CustomHome: true, WritableTmpfs: true},
 				singularityConf: sc,
 				homeHost:        u.HomeDir,
 				homeSrc:         "/home/src",
 				homeDest:        "/home/dest",
+			},
+			wantErr: false,
+		},
+		{
+			name: "no-compat",
+			opts: []launcher.Option{
+				launcher.OptNoCompat(true),
+			},
+			want: &Launcher{
+				cfg:             launcher.Options{NoCompat: true, WritableTmpfs: false},
+				singularityConf: sc,
+				homeHost:        u.HomeDir,
+				homeSrc:         "",
+				homeDest:        u.HomeDir,
+			},
+			wantErr: false,
+		},
+		{
+			name: "no-compat_writable-tmpfs",
+			opts: []launcher.Option{
+				launcher.OptNoCompat(true),
+				launcher.OptWritableTmpfs(true),
+			},
+			want: &Launcher{
+				cfg:             launcher.Options{NoCompat: true, WritableTmpfs: true},
+				singularityConf: sc,
+				homeHost:        u.HomeDir,
+				homeSrc:         "",
+				homeDest:        u.HomeDir,
 			},
 			wantErr: false,
 		},

--- a/internal/pkg/runtime/launcher/oci/oci_overlay.go
+++ b/internal/pkg/runtime/launcher/oci/oci_overlay.go
@@ -14,10 +14,11 @@ import (
 	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
 )
 
-// WrapWithWritableTmpFs runs a function wrapped with prep / cleanup steps for a writable tmpfs.
+// WrapWithWritableTmpFs runs a function wrapped with prep / cleanup steps for a
+// tmpfs. This tmpfs is always writable so that the launcher and runtime are
+// able to add content to the container. Whether it is writable from inside the
+// container is controlled by the runtime config.
 func WrapWithWritableTmpFs(f func() error, bundleDir string, allowSetuid bool) error {
-	// TODO: --oci mode always emulating --compat, which uses --writable-tmpfs.
-	//       Provide a way of disabling this, for a read only rootfs.
 	overlayDir, err := prepareWritableTmpfs(bundleDir, allowSetuid)
 	sylog.Debugf("Done with prepareWritableTmpfs; overlayDir is: %q", overlayDir)
 	if err != nil {

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -34,8 +34,7 @@ func minimalSpec() specs.Spec {
 		Version: specs.Version,
 	}
 	config.Root = &specs.Root{
-		Path: "rootfs",
-		// TODO - support read-only. At present we always have a writable tmpfs overlay, like native runtime --compat.
+		Path:     "rootfs",
 		Readonly: false,
 	}
 	config.Process = &specs.Process{


### PR DESCRIPTION
## Description of the Pull Request (PR):
 
When running in OCI-mode with `--no-compat`, the container rootfs should be read-only by default, as in native mode.
    
Allow `--writable-tmpfs` to re-enable the writable tmpfs behaviour.

### This fixes or addresses the following GitHub issues:

 - Fixes #1980 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
