### PR TITLE
no-compat: propagate host umask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,8 @@
   - The current working directory is mounted into the container, and is the
     entry point into the container.
   - The container is read-only unless `--writable-tmpfs` is also used.
+  - The host umask is propagated into the container, unless `--no-umask` is also
+    used.
 
 ### Developer / API
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -2021,6 +2021,19 @@ func (c actionTests) actionOciNoCompat(t *testing.T) {
 			args:     []string{"--no-compat", "--writable-tmpfs", imageRef, "sh", "-c", "touch /test"},
 			exitCode: 0,
 		},
+		// Propagate umask, unless `--no-umask` (default is 0022, test sets 0000)
+		{
+			name:     "umask",
+			args:     []string{"--no-compat", c.env.ImagePath, "sh", "-c", "umask"},
+			exitCode: 0,
+			expect:   []e2e.SingularityCmdResultOp{e2e.ExpectOutput(e2e.ContainMatch, "0000")},
+		},
+		{
+			name:     "no-umask",
+			args:     []string{"--no-compat", "--no-umask", c.env.ImagePath, "sh", "-c", "umask"},
+			exitCode: 0,
+			expect:   []e2e.SingularityCmdResultOp{e2e.ExpectOutput(e2e.ContainMatch, "0022")},
+		},
 	}
 
 	oldUmask := syscall.Umask(0)


### PR DESCRIPTION
## Description of the Pull Request (PR):

When `--oci` mode is run with `--no-compat`, propagate the host umask into the container unless `--no-umask` is also used.

This matches native mode umask behaviour.

### This fixes or addresses the following GitHub issues:

 - Fixes #1982 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
