### PR TITLE
no-compat: bind mount bind paths from singularity.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
   - `$HOME`, `/tmp`, `/var/tmp` are bind mounted from the host.
   - The full `/dev` is bind mounted from the host, unless `mount dev = minimal`
     in `singularity.conf`.
+  - `bind path` entries in `singularity.conf` are mounted into the container.
 
 ### Developer / API
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -47,7 +47,7 @@ var (
 	ErrUnsupportedOption = errors.New("not supported by OCI launcher")
 	ErrNotImplemented    = errors.New("not implemented by OCI launcher")
 
-	unsupportedNoMount = []string{"cwd", "bind-paths"}
+	unsupportedNoMount = []string{"cwd"}
 )
 
 // Launcher will holds configuration for, and will launch a container using an
@@ -499,6 +499,11 @@ func (l *Launcher) prepareResolvConf(bundlePath string) (*specs.Mount, error) {
 
 	if !l.singularityConf.ConfigResolvConf {
 		sylog.Debugf("Skipping creation of %s due to singularity.conf", containerResolvConfPath)
+		return nil, nil
+	}
+
+	if slice.ContainsString(l.cfg.NoMount, hostResolvConfPath) {
+		sylog.Debugf("Skipping mount of %s due to --no-mount", hostResolvConfPath)
 		return nil, nil
 	}
 

--- a/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
@@ -328,7 +328,7 @@ func TestLauncher_addBindMounts(t *testing.T) {
 				l.cfg.AllowSUID = true
 			}
 			mounts := &[]specs.Mount{}
-			err := l.addBindMounts(mounts)
+			err := l.addUserBindMounts(mounts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("addBindMount() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -185,9 +185,12 @@ mount hostfs = {{ if eq .MountHostfs true }}yes{{ else }}no{{ end }}
 # the container. The file or directory must exist within the container on
 # which to attach to. you can specify a different source and destination
 # path (respectively) with a colon; otherwise source and dest are the same.
-# NOTE: these are ignored if singularity is invoked with --contain except
+#
+# In native mode, these are ignored if singularity is invoked with --contain except
 # for /etc/hosts and /etc/localtime. When invoked with --contain and --net,
 # /etc/hosts would contain a default generated content for localhost resolution.
+#
+# In OCI mode these are only mounted when --no-compat is specified.
 #bind path = /etc/singularity/default-nsswitch.conf:/etc/nsswitch.conf
 #bind path = /opt
 #bind path = /scratch


### PR DESCRIPTION
## Description of the Pull Request (PR):

When `--oci` mode is run with `--no-compat`, bind the `bind path` entries listed in `singularity.conf` into the container.

Individual entries can be disabled with `--no-mount <dest>`. All entries can be disabled with `--no-mount bind-paths`.


### This fixes or addresses the following GitHub issues:

 - Fixes #1978


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
