### PR TITLE
no-compat: bind and enter cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@
   - The full `/dev` is bind mounted from the host, unless `mount dev = minimal`
     in `singularity.conf`.
   - `bind path` entries in `singularity.conf` are mounted into the container.
+  - The current working directory is mounted into the container, and is the
+    entry point into the container.
 
 ### Developer / API
 

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -136,11 +136,18 @@ func getProcessArgs(imageSpec imgspecv1.Image, ep launcher.ExecParams) []string 
 }
 
 // getProcessCwd computes the Cwd that the container process should start in.
-// Currently this is the user's tmpfs home directory (see --containall).
-// Because this is called after mounts have already been computed, we can count on l.cfg.HomeDir containing the right value, incorporating any custom home dir overrides (i.e., --home).
+// Default in OCI mode, like native --compat, is $HOME.
+// In native emulation (--no-compat), we use the CWD.
+// Can be overridden with a custom value via --cwd/pwd.
+
+// Because this is called after mounts have already been computed, we can count on homeDest containing the right value, incorporating any custom home dir overrides (i.e., --home).
 func (l *Launcher) getProcessCwd() (dir string, err error) {
 	if len(l.cfg.CwdPath) > 0 {
 		return l.cfg.CwdPath, nil
+	}
+
+	if l.cfg.NoCompat {
+		return os.Getwd()
 	}
 
 	return l.homeDest, nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

When `--oci` mode is run with `--no-compat`, bind the CWD from the host, and enter the container there.

The CWD bind can be disabled with `--no-mount cwd`.

### This fixes or addresses the following GitHub issues:

 - Fixes #1988


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
