### PR TITLE
oci: PATH handling for native SIF images

### DIFF
--- a/e2e/env/oci.go
+++ b/e2e/env/oci.go
@@ -16,7 +16,12 @@ import (
 
 func (c ctx) ociSingularityEnv(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.env)
-	defaultImage := "oci-sif:" + c.env.OCISIFPath
+	e2e.EnsureImage(t, c.env)
+
+	ociSIFDefaultPath := c.env.OCISIFPath
+	nativeSIFDefaultPath := e2e.BusyboxSIF(t)
+	nativeSIFCustomPath := c.env.ImagePath
+	customPath := defaultPath + ":/go/bin:/usr/local/go/bin"
 
 	// Append or prepend this path.
 	partialPath := "/foo"
@@ -28,68 +33,99 @@ func (c ctx) ociSingularityEnv(t *testing.T) {
 	trailingCommaPath := "/usr/bin:/bin,"
 
 	tests := []struct {
-		name  string
-		image string
-		path  string
-		env   []string
+		name   string
+		images []string
+		path   string
+		env    []string
 	}{
 		{
-			name:  "DefaultPath",
-			image: defaultImage,
-			path:  defaultPath,
-			env:   []string{},
+			name:   "DefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath},
+			path:   defaultPath,
+			env:    []string{},
 		},
 		{
-			name:  "AppendToDefaultPath",
-			image: defaultImage,
-			path:  defaultPath + ":" + partialPath,
-			env:   []string{"SINGULARITYENV_APPEND_PATH=/foo"},
+			name:   "CustomPath",
+			images: []string{nativeSIFCustomPath},
+			path:   customPath,
+			env:    []string{},
 		},
 		{
-			name:  "PrependToDefaultPath",
-			image: defaultImage,
-			path:  partialPath + ":" + defaultPath,
-			env:   []string{"SINGULARITYENV_PREPEND_PATH=/foo"},
+			name:   "AppendToDefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath},
+			path:   defaultPath + ":" + partialPath,
+			env:    []string{"SINGULARITYENV_APPEND_PATH=" + partialPath},
 		},
 		{
-			name:  "OverwriteDefaultPath",
-			image: defaultImage,
-			path:  overwrittenPath,
-			env:   []string{"SINGULARITYENV_PATH=" + overwrittenPath},
+			name:   "AppendToCustomPath",
+			images: []string{nativeSIFCustomPath},
+			path:   customPath + ":" + partialPath,
+			env:    []string{"SINGULARITYENV_APPEND_PATH=" + partialPath},
 		},
 		{
-			name:  "OverwriteTrailingCommaPath",
-			image: defaultImage,
-			path:  trailingCommaPath,
-			env:   []string{"SINGULARITYENV_PATH=" + trailingCommaPath},
+			name:   "PrependToDefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath},
+			path:   partialPath + ":" + defaultPath,
+			env:    []string{"SINGULARITYENV_PREPEND_PATH=" + partialPath},
+		},
+		{
+			name:   "PrependToCustomPath",
+			images: []string{nativeSIFCustomPath},
+			path:   partialPath + ":" + customPath,
+			env:    []string{"SINGULARITYENV_PREPEND_PATH=" + partialPath},
+		},
+		{
+			name:   "OverwriteDefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath},
+			path:   overwrittenPath,
+			env:    []string{"SINGULARITYENV_PATH=" + overwrittenPath},
+		},
+		{
+			name:   "OverwriteCustomPath",
+			images: []string{nativeSIFCustomPath},
+			path:   overwrittenPath,
+			env:    []string{"SINGULARITYENV_PATH=" + overwrittenPath},
+		},
+		{
+			name:   "OverwriteTrailingCommaPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath},
+			path:   trailingCommaPath,
+			env:    []string{"SINGULARITYENV_PATH=" + trailingCommaPath},
 		},
 	}
 
 	for _, tt := range tests {
 		testEnv := append(os.Environ(), tt.env...)
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.OCIUserProfile),
-			e2e.WithCommand("exec"),
-			e2e.WithEnv(testEnv),
-			e2e.WithRootlessEnv(),
-			e2e.WithArgs(tt.image, "/bin/sh", "-c", "echo $PATH"),
-			e2e.ExpectExit(
-				0,
-				e2e.ExpectOutput(e2e.ExactMatch, tt.path),
-			),
-		)
+		for _, img := range tt.images {
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest(tt.name),
+				e2e.WithProfile(e2e.OCIUserProfile),
+				e2e.WithCommand("exec"),
+				e2e.WithEnv(testEnv),
+				e2e.WithRootlessEnv(),
+				e2e.WithArgs(img, "/bin/sh", "-c", "echo $PATH"),
+				e2e.ExpectExit(
+					0,
+					e2e.ExpectOutput(e2e.ExactMatch, tt.path),
+				),
+			)
+		}
 	}
 }
 
 func (c ctx) ociEnvOption(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.env)
-	defaultImage := "oci-sif:" + c.env.OCISIFPath
+	e2e.EnsureImage(t, c.env)
+
+	ociSIFDefaultPath := c.env.OCISIFPath
+	nativeSIFDefaultPath := e2e.BusyboxSIF(t)
+	nativeSIFCustomPath := c.env.ImagePath
+	customPath := defaultPath + ":/go/bin:/usr/local/go/bin"
 
 	tests := []struct {
 		name     string
-		image    string
+		images   []string
 		envOpt   []string
 		hostEnv  []string
 		matchEnv string
@@ -97,77 +133,110 @@ func (c ctx) ociEnvOption(t *testing.T) {
 	}{
 		{
 			name:     "DefaultPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			matchEnv: "PATH",
 			matchVal: defaultPath,
 		},
 		{
 			name:     "DefaultPathOverride",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"PATH=/"},
 			matchEnv: "PATH",
 			matchVal: "/",
 		},
 		{
 			name:     "AppendDefaultPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"APPEND_PATH=/foo"},
 			matchEnv: "PATH",
 			matchVal: defaultPath + ":/foo",
 		},
 		{
 			name:     "PrependDefaultPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"PREPEND_PATH=/foo"},
 			matchEnv: "PATH",
 			matchVal: "/foo:" + defaultPath,
 		},
 		{
+			name:     "DefaultPathImage",
+			images:   []string{nativeSIFCustomPath},
+			matchEnv: "PATH",
+			matchVal: customPath,
+		},
+		{
+			name:     "DefaultPathTestImageOverride",
+			images:   []string{nativeSIFCustomPath},
+			envOpt:   []string{"PATH=/"},
+			matchEnv: "PATH",
+			matchVal: "/",
+		},
+		{
+			name:     "AppendDefaultPathTestImage",
+			images:   []string{nativeSIFCustomPath},
+			envOpt:   []string{"APPEND_PATH=/foo"},
+			matchEnv: "PATH",
+			matchVal: customPath + ":/foo",
+		},
+		{
+			name:     "PrependDefaultPathTestImage",
+			images:   []string{nativeSIFCustomPath},
+			envOpt:   []string{"PREPEND_PATH=/foo"},
+			matchEnv: "PATH",
+			matchVal: "/foo:" + customPath,
+		},
+		{
 			name:     "TestMultiLine",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"MULTI=Hello\nWorld"},
 			matchEnv: "MULTI",
 			matchVal: "Hello\nWorld",
 		},
 		{
 			name:     "TestEscapedNewline",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"ESCAPED=Hello\\nWorld"},
 			matchEnv: "ESCAPED",
 			matchVal: "Hello\\nWorld",
 		},
 		{
 			name:     "TestInvalidKey",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"BASH_FUNC_ml%%=TEST"},
 			matchEnv: "BASH_FUNC_ml%%",
 			matchVal: "",
 		},
 		{
 			name:     "TestDefaultLdLibraryPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: singularityLibs,
 		},
 		{
 			name:     "TestCustomTrailingCommaPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo,"},
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo,:" + singularityLibs,
 		},
 		{
 			name:     "TestCustomLdLibraryPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo"},
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo:" + singularityLibs,
 		},
 		{
-			name:     "SINGULARITY_NAME",
-			image:    defaultImage,
+			name:     "SINGULARITY_NAME_OCI_SIF",
+			images:   []string{ociSIFDefaultPath},
 			matchEnv: "SINGULARITY_NAME",
-			matchVal: defaultImage,
+			matchVal: ociSIFDefaultPath,
+		},
+		{
+			name:     "SINGULARITY_NAME_NATIVE_SIF",
+			images:   []string{nativeSIFDefaultPath},
+			matchEnv: "SINGULARITY_NAME",
+			matchVal: nativeSIFDefaultPath,
 		},
 	}
 
@@ -177,26 +246,31 @@ func (c ctx) ociEnvOption(t *testing.T) {
 		if tt.envOpt != nil {
 			args = append(args, "--env", strings.Join(tt.envOpt, ","))
 		}
-		args = append(args, tt.image, "/bin/sh", "-c", "echo \"${"+tt.matchEnv+"}\"")
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.OCIUserProfile),
-			e2e.WithCommand("exec"),
-			e2e.WithEnv(testEnv),
-			e2e.WithRootlessEnv(),
-			e2e.WithArgs(args...),
-			e2e.ExpectExit(
-				0,
-				e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
-			),
-		)
+		for _, img := range tt.images {
+			args = append(args, img, "/bin/sh", "-c", "echo \"${"+tt.matchEnv+"}\"")
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest(tt.name),
+				e2e.WithProfile(e2e.OCIUserProfile),
+				e2e.WithCommand("exec"),
+				e2e.WithEnv(testEnv),
+				e2e.WithRootlessEnv(),
+				e2e.WithArgs(args...),
+				e2e.ExpectExit(
+					0,
+					e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
+				),
+			)
+		}
 	}
 }
 
 func (c ctx) ociEnvFile(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.env)
-	defaultImage := "oci-sif:" + c.env.OCISIFPath
+	e2e.EnsureImage(t, c.env)
+
+	ociSIFDefaultPath := c.env.OCISIFPath
+	nativeSIFDefaultPath := e2e.BusyboxSIF(t)
 
 	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "envfile-", "")
 	defer cleanup(t)
@@ -204,7 +278,7 @@ func (c ctx) ociEnvFile(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		image    string
+		images   []string
 		envFile  string
 		envOpt   []string
 		hostEnv  []string
@@ -212,88 +286,82 @@ func (c ctx) ociEnvFile(t *testing.T) {
 		matchVal string
 	}{
 		{
-			name:     "DefaultPathOverride",
-			image:    defaultImage,
-			envFile:  "PATH=/",
+			name:   "DefaultPathOverride",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envFile: "PATH=/",
 			matchEnv: "PATH",
 			matchVal: "/",
 		},
 		{
-			name:     "DefaultPathOverrideEnvOptionPrecedence",
-			image:    defaultImage,
-			envOpt:   []string{"PATH=/etc"},
+			name:   "DefaultPathOverrideEnvOptionPrecedence",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envOpt: []string{"PATH=/etc"},
 			envFile:  "PATH=/",
 			matchEnv: "PATH",
 			matchVal: "/etc",
 		},
 		{
-			name:     "DefaultPathOverrideEnvOptionPrecedence",
-			image:    defaultImage,
-			envOpt:   []string{"PATH=/etc"},
+			name:   "DefaultPathOverrideEnvOptionPrecedence",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envOpt: []string{"PATH=/etc"},
 			envFile:  "PATH=/",
 			matchEnv: "PATH",
 			matchVal: "/etc",
 		},
 		{
-			name:     "AppendDefaultPath",
-			image:    defaultImage,
-			envFile:  "APPEND_PATH=/",
+			name:   "AppendDefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envFile: "APPEND_PATH=/",
 			matchEnv: "PATH",
 			matchVal: defaultPath + ":/",
 		},
 		{
-			name:     "PrependDefaultPath",
-			image:    defaultImage,
-			envFile:  "PREPEND_PATH=/",
+			name:   "PrependDefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envFile: "PREPEND_PATH=/",
 			matchEnv: "PATH",
 			matchVal: "/:" + defaultPath,
 		},
 		{
-			name:     "DefaultLdLibraryPath",
-			image:    defaultImage,
-			matchEnv: "LD_LIBRARY_PATH",
+			name:   "DefaultLdLibraryPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, matchEnv: "LD_LIBRARY_PATH",
 			matchVal: singularityLibs,
 		},
 		{
-			name:     "CustomLdLibraryPath",
-			image:    defaultImage,
-			envFile:  "LD_LIBRARY_PATH=/foo",
+			name:   "CustomLdLibraryPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envFile: "LD_LIBRARY_PATH=/foo",
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo:" + singularityLibs,
 		},
 		{
-			name:     "CustomTrailingCommaPath",
-			image:    defaultImage,
-			envFile:  "LD_LIBRARY_PATH=/foo,",
+			name:   "CustomTrailingCommaPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envFile: "LD_LIBRARY_PATH=/foo,",
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo,:" + singularityLibs,
 		},
 	}
 
 	for _, tt := range tests {
-		testEnv := append(os.Environ(), tt.hostEnv...)
-		args := make([]string, 0)
-		if tt.envOpt != nil {
-			args = append(args, "--env", strings.Join(tt.envOpt, ","))
-		}
-		if tt.envFile != "" {
-			os.WriteFile(p, []byte(tt.envFile), 0o644)
-			args = append(args, "--env-file", p)
-		}
-		args = append(args, tt.image, "/bin/sh", "-c", "echo $"+tt.matchEnv)
+		for _, img := range tt.images {
+			testEnv := append(os.Environ(), tt.hostEnv...)
+			args := make([]string, 0)
+			if tt.envOpt != nil {
+				args = append(args, "--env", strings.Join(tt.envOpt, ","))
+			}
+			if tt.envFile != "" {
+				os.WriteFile(p, []byte(tt.envFile), 0o644)
+				args = append(args, "--env-file", p)
+			}
+			args = append(args, img, "/bin/sh", "-c", "echo $"+tt.matchEnv)
 
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.OCIUserProfile),
-			e2e.WithCommand("exec"),
-			e2e.WithEnv(testEnv),
-			e2e.WithRootlessEnv(),
-			e2e.WithArgs(args...),
-			e2e.ExpectExit(
-				0,
-				e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
-			),
-		)
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest(tt.name),
+				e2e.WithProfile(e2e.OCIUserProfile),
+				e2e.WithCommand("exec"),
+				e2e.WithEnv(testEnv),
+				e2e.WithRootlessEnv(),
+				e2e.WithArgs(args...),
+				e2e.ExpectExit(
+					0,
+					e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
+				),
+			)
+		}
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -99,7 +99,7 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, bund
 		Args:            args,
 		Capabilities:    caps,
 		Cwd:             cwd,
-		Env:             getProcessEnv(imgSpec, rtEnv),
+		Env:             getProcessEnv(imgSpec, rtEnv, l.nativeSIF),
 		NoNewPrivileges: noNewPrivs,
 		User:            u,
 		Terminal:        getProcessTerminal(),
@@ -246,7 +246,7 @@ func reverseMapByRange(targetUID, targetGID uint32, subuidRange, subgidRange spe
 // getProcessEnv combines the image config ENV with the ENV requested at runtime.
 // APPEND_PATH and PREPEND_PATH are honored as with the native singularity runtime.
 // LD_LIBRARY_PATH is modified to always include the singularity lib bind directory.
-func getProcessEnv(imageSpec imgspecv1.Image, runtimeEnv map[string]string) []string {
+func getProcessEnv(imageSpec imgspecv1.Image, runtimeEnv map[string]string, nativeSIF bool) []string {
 	path := ""
 	appendPath := ""
 	prependPath := ""
@@ -262,7 +262,10 @@ func getProcessEnv(imageSpec imgspecv1.Image, runtimeEnv map[string]string) []st
 		if len(e) < 2 {
 			continue
 		}
-		if e[0] == "PATH" {
+		// The image config PATH is not accurate for native SIF images - it is a
+		// default, and a PATH may be declared in the image /.singularity.d/env
+		// scripts. Ignore, so we can pick that up.
+		if e[0] == "PATH" && !nativeSIF {
 			path = e[1]
 		}
 		if e[0] == "LD_LIBRARY_PATH" {
@@ -286,24 +289,49 @@ func getProcessEnv(imageSpec imgspecv1.Image, runtimeEnv map[string]string) []st
 		}
 	}
 
+	// Handle PATH differently beteween OCI and native images
+	if nativeSIF {
+		setNativePath(g, prependPath, path, appendPath)
+	} else {
+		setOCIPath(g, prependPath, path, appendPath)
+	}
+
+	// Ensure LD_LIBRARY_PATH always contains singularity lib binding dir.
+	// This is handled by environment scripts in native SIF images.
+	if !nativeSIF && !strings.Contains(ldLibraryPath, singularityLibs) {
+		ldLibraryPath = strings.TrimPrefix(ldLibraryPath+":"+singularityLibs, ":")
+	}
+	if ldLibraryPath != "" {
+		g.AddProcessEnv("LD_LIBRARY_PATH", ldLibraryPath)
+	}
+
+	return g.Config.Process.Env
+}
+
+func setOCIPath(g *generate.Generator, prependPath, path, appendPath string) {
 	// Compute and set optionally APPEND-ed / PREPEND-ed PATH.
 	if appendPath != "" {
-		path = path + ":" + appendPath
+		path = strings.TrimSuffix(path, ":") + ":" + appendPath
 	}
 	if prependPath != "" {
-		path = prependPath + ":" + path
+		path = prependPath + ":" + strings.TrimPrefix(path, ":")
 	}
 	if path != "" {
 		g.AddProcessEnv("PATH", path)
 	}
+}
 
-	// Ensure LD_LIBRARY_PATH always contains singularity lib binding dir.
-	if !strings.Contains(ldLibraryPath, singularityLibs) {
-		ldLibraryPath = strings.TrimPrefix(ldLibraryPath+":"+singularityLibs, ":")
+func setNativePath(g *generate.Generator, prependPath, path, appendPath string) {
+	// Set env vars used by Singularity env script to handle PATH.
+	if prependPath != "" {
+		g.AddProcessEnv("SING_USER_DEFINED_PREPEND_PATH", prependPath)
 	}
-	g.AddProcessEnv("LD_LIBRARY_PATH", ldLibraryPath)
-
-	return g.Config.Process.Env
+	if path != "" {
+		g.AddProcessEnv("SING_USER_DEFINED_PATH", path)
+	}
+	if appendPath != "" {
+		g.AddProcessEnv("SING_USER_DEFINED_APPEND_PATH", appendPath)
+	}
 }
 
 // defaultEnv returns default environment variables set in the container.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pass the correct env vars into native SIF images to handle SINGULARITYENV_PATH / SINGULARITYENV_APPEND_PATH / SINGULARITYENV_PREPEND_PATH. These are processed inside the image, by a /.singularity.d/env script.

Don't modify LD_LIBRARY_PATH for native SIF images, as this is handled by a /.singularity.d/env script.

Expand tests for OCI-mode env var handling to cover these circumstances.


### This fixes or addresses the following GitHub issues:

 - Fixes #1900


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
