### PR TITLE
oci: allow override of native SIF container env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,8 @@
   - The container is read-only unless `--writable-tmpfs` is also used.
   - The host umask is propagated into the container, unless `--no-umask` is also
     used.
+  - When a native (non-OCI-SIF) image is run in OCI-mode, environment variables
+    will be shell evaluated on container startup.
 
 ### Developer / API
 

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -647,5 +647,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"oci environment singularityenv": c.ociSingularityEnv,
 		"oci environment option":         c.ociEnvOption,
 		"oci environment file":           c.ociEnvFile,
+		"oci native env eval":            c.ociNativeEnvEval,
 	}
 }

--- a/e2e/env/oci.go
+++ b/e2e/env/oci.go
@@ -16,7 +16,12 @@ import (
 
 func (c ctx) ociSingularityEnv(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.env)
-	defaultImage := "oci-sif:" + c.env.OCISIFPath
+	e2e.EnsureImage(t, c.env)
+
+	ociSIFDefaultPath := c.env.OCISIFPath
+	nativeSIFDefaultPath := e2e.BusyboxSIF(t)
+	nativeSIFCustomPath := c.env.ImagePath
+	customPath := defaultPath + ":/go/bin:/usr/local/go/bin"
 
 	// Append or prepend this path.
 	partialPath := "/foo"
@@ -28,68 +33,99 @@ func (c ctx) ociSingularityEnv(t *testing.T) {
 	trailingCommaPath := "/usr/bin:/bin,"
 
 	tests := []struct {
-		name  string
-		image string
-		path  string
-		env   []string
+		name   string
+		images []string
+		path   string
+		env    []string
 	}{
 		{
-			name:  "DefaultPath",
-			image: defaultImage,
-			path:  defaultPath,
-			env:   []string{},
+			name:   "DefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath},
+			path:   defaultPath,
+			env:    []string{},
 		},
 		{
-			name:  "AppendToDefaultPath",
-			image: defaultImage,
-			path:  defaultPath + ":" + partialPath,
-			env:   []string{"SINGULARITYENV_APPEND_PATH=/foo"},
+			name:   "CustomPath",
+			images: []string{nativeSIFCustomPath},
+			path:   customPath,
+			env:    []string{},
 		},
 		{
-			name:  "PrependToDefaultPath",
-			image: defaultImage,
-			path:  partialPath + ":" + defaultPath,
-			env:   []string{"SINGULARITYENV_PREPEND_PATH=/foo"},
+			name:   "AppendToDefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath},
+			path:   defaultPath + ":" + partialPath,
+			env:    []string{"SINGULARITYENV_APPEND_PATH=" + partialPath},
 		},
 		{
-			name:  "OverwriteDefaultPath",
-			image: defaultImage,
-			path:  overwrittenPath,
-			env:   []string{"SINGULARITYENV_PATH=" + overwrittenPath},
+			name:   "AppendToCustomPath",
+			images: []string{nativeSIFCustomPath},
+			path:   customPath + ":" + partialPath,
+			env:    []string{"SINGULARITYENV_APPEND_PATH=" + partialPath},
 		},
 		{
-			name:  "OverwriteTrailingCommaPath",
-			image: defaultImage,
-			path:  trailingCommaPath,
-			env:   []string{"SINGULARITYENV_PATH=" + trailingCommaPath},
+			name:   "PrependToDefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath},
+			path:   partialPath + ":" + defaultPath,
+			env:    []string{"SINGULARITYENV_PREPEND_PATH=" + partialPath},
+		},
+		{
+			name:   "PrependToCustomPath",
+			images: []string{nativeSIFCustomPath},
+			path:   partialPath + ":" + customPath,
+			env:    []string{"SINGULARITYENV_PREPEND_PATH=" + partialPath},
+		},
+		{
+			name:   "OverwriteDefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath},
+			path:   overwrittenPath,
+			env:    []string{"SINGULARITYENV_PATH=" + overwrittenPath},
+		},
+		{
+			name:   "OverwriteCustomPath",
+			images: []string{nativeSIFCustomPath},
+			path:   overwrittenPath,
+			env:    []string{"SINGULARITYENV_PATH=" + overwrittenPath},
+		},
+		{
+			name:   "OverwriteTrailingCommaPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath},
+			path:   trailingCommaPath,
+			env:    []string{"SINGULARITYENV_PATH=" + trailingCommaPath},
 		},
 	}
 
 	for _, tt := range tests {
 		testEnv := append(os.Environ(), tt.env...)
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.OCIUserProfile),
-			e2e.WithCommand("exec"),
-			e2e.WithEnv(testEnv),
-			e2e.WithRootlessEnv(),
-			e2e.WithArgs(tt.image, "/bin/sh", "-c", "echo $PATH"),
-			e2e.ExpectExit(
-				0,
-				e2e.ExpectOutput(e2e.ExactMatch, tt.path),
-			),
-		)
+		for _, img := range tt.images {
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest(tt.name),
+				e2e.WithProfile(e2e.OCIUserProfile),
+				e2e.WithCommand("exec"),
+				e2e.WithEnv(testEnv),
+				e2e.WithRootlessEnv(),
+				e2e.WithArgs(img, "/bin/sh", "-c", "echo $PATH"),
+				e2e.ExpectExit(
+					0,
+					e2e.ExpectOutput(e2e.ExactMatch, tt.path),
+				),
+			)
+		}
 	}
 }
 
 func (c ctx) ociEnvOption(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.env)
-	defaultImage := "oci-sif:" + c.env.OCISIFPath
+	e2e.EnsureImage(t, c.env)
+
+	ociSIFDefaultPath := c.env.OCISIFPath
+	nativeSIFDefaultPath := e2e.BusyboxSIF(t)
+	nativeSIFCustomPath := c.env.ImagePath
+	customPath := defaultPath + ":/go/bin:/usr/local/go/bin"
 
 	tests := []struct {
 		name     string
-		image    string
+		images   []string
 		envOpt   []string
 		hostEnv  []string
 		matchEnv string
@@ -97,77 +133,110 @@ func (c ctx) ociEnvOption(t *testing.T) {
 	}{
 		{
 			name:     "DefaultPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			matchEnv: "PATH",
 			matchVal: defaultPath,
 		},
 		{
 			name:     "DefaultPathOverride",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"PATH=/"},
 			matchEnv: "PATH",
 			matchVal: "/",
 		},
 		{
 			name:     "AppendDefaultPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"APPEND_PATH=/foo"},
 			matchEnv: "PATH",
 			matchVal: defaultPath + ":/foo",
 		},
 		{
 			name:     "PrependDefaultPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"PREPEND_PATH=/foo"},
 			matchEnv: "PATH",
 			matchVal: "/foo:" + defaultPath,
 		},
 		{
+			name:     "DefaultPathImage",
+			images:   []string{nativeSIFCustomPath},
+			matchEnv: "PATH",
+			matchVal: customPath,
+		},
+		{
+			name:     "DefaultPathTestImageOverride",
+			images:   []string{nativeSIFCustomPath},
+			envOpt:   []string{"PATH=/"},
+			matchEnv: "PATH",
+			matchVal: "/",
+		},
+		{
+			name:     "AppendDefaultPathTestImage",
+			images:   []string{nativeSIFCustomPath},
+			envOpt:   []string{"APPEND_PATH=/foo"},
+			matchEnv: "PATH",
+			matchVal: customPath + ":/foo",
+		},
+		{
+			name:     "PrependDefaultPathTestImage",
+			images:   []string{nativeSIFCustomPath},
+			envOpt:   []string{"PREPEND_PATH=/foo"},
+			matchEnv: "PATH",
+			matchVal: "/foo:" + customPath,
+		},
+		{
 			name:     "TestMultiLine",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"MULTI=Hello\nWorld"},
 			matchEnv: "MULTI",
 			matchVal: "Hello\nWorld",
 		},
 		{
 			name:     "TestEscapedNewline",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"ESCAPED=Hello\\nWorld"},
 			matchEnv: "ESCAPED",
 			matchVal: "Hello\\nWorld",
 		},
 		{
 			name:     "TestInvalidKey",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"BASH_FUNC_ml%%=TEST"},
 			matchEnv: "BASH_FUNC_ml%%",
 			matchVal: "",
 		},
 		{
 			name:     "TestDefaultLdLibraryPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: singularityLibs,
 		},
 		{
 			name:     "TestCustomTrailingCommaPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo,"},
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo,:" + singularityLibs,
 		},
 		{
 			name:     "TestCustomLdLibraryPath",
-			image:    defaultImage,
+			images:   []string{ociSIFDefaultPath, nativeSIFDefaultPath},
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo"},
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo:" + singularityLibs,
 		},
 		{
-			name:     "SINGULARITY_NAME",
-			image:    defaultImage,
+			name:     "SINGULARITY_NAME_OCI_SIF",
+			images:   []string{ociSIFDefaultPath},
 			matchEnv: "SINGULARITY_NAME",
-			matchVal: defaultImage,
+			matchVal: ociSIFDefaultPath,
+		},
+		{
+			name:     "SINGULARITY_NAME_NATIVE_SIF",
+			images:   []string{nativeSIFDefaultPath},
+			matchEnv: "SINGULARITY_NAME",
+			matchVal: nativeSIFDefaultPath,
 		},
 	}
 
@@ -177,26 +246,31 @@ func (c ctx) ociEnvOption(t *testing.T) {
 		if tt.envOpt != nil {
 			args = append(args, "--env", strings.Join(tt.envOpt, ","))
 		}
-		args = append(args, tt.image, "/bin/sh", "-c", "echo \"${"+tt.matchEnv+"}\"")
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.OCIUserProfile),
-			e2e.WithCommand("exec"),
-			e2e.WithEnv(testEnv),
-			e2e.WithRootlessEnv(),
-			e2e.WithArgs(args...),
-			e2e.ExpectExit(
-				0,
-				e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
-			),
-		)
+		for _, img := range tt.images {
+			args = append(args, img, "/bin/sh", "-c", "echo \"${"+tt.matchEnv+"}\"")
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest(tt.name),
+				e2e.WithProfile(e2e.OCIUserProfile),
+				e2e.WithCommand("exec"),
+				e2e.WithEnv(testEnv),
+				e2e.WithRootlessEnv(),
+				e2e.WithArgs(args...),
+				e2e.ExpectExit(
+					0,
+					e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
+				),
+			)
+		}
 	}
 }
 
 func (c ctx) ociEnvFile(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.env)
-	defaultImage := "oci-sif:" + c.env.OCISIFPath
+	e2e.EnsureImage(t, c.env)
+
+	ociSIFDefaultPath := c.env.OCISIFPath
+	nativeSIFDefaultPath := e2e.BusyboxSIF(t)
 
 	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "envfile-", "")
 	defer cleanup(t)
@@ -204,7 +278,7 @@ func (c ctx) ociEnvFile(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		image    string
+		images   []string
 		envFile  string
 		envOpt   []string
 		hostEnv  []string
@@ -212,88 +286,82 @@ func (c ctx) ociEnvFile(t *testing.T) {
 		matchVal string
 	}{
 		{
-			name:     "DefaultPathOverride",
-			image:    defaultImage,
-			envFile:  "PATH=/",
+			name:   "DefaultPathOverride",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envFile: "PATH=/",
 			matchEnv: "PATH",
 			matchVal: "/",
 		},
 		{
-			name:     "DefaultPathOverrideEnvOptionPrecedence",
-			image:    defaultImage,
-			envOpt:   []string{"PATH=/etc"},
+			name:   "DefaultPathOverrideEnvOptionPrecedence",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envOpt: []string{"PATH=/etc"},
 			envFile:  "PATH=/",
 			matchEnv: "PATH",
 			matchVal: "/etc",
 		},
 		{
-			name:     "DefaultPathOverrideEnvOptionPrecedence",
-			image:    defaultImage,
-			envOpt:   []string{"PATH=/etc"},
+			name:   "DefaultPathOverrideEnvOptionPrecedence",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envOpt: []string{"PATH=/etc"},
 			envFile:  "PATH=/",
 			matchEnv: "PATH",
 			matchVal: "/etc",
 		},
 		{
-			name:     "AppendDefaultPath",
-			image:    defaultImage,
-			envFile:  "APPEND_PATH=/",
+			name:   "AppendDefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envFile: "APPEND_PATH=/",
 			matchEnv: "PATH",
 			matchVal: defaultPath + ":/",
 		},
 		{
-			name:     "PrependDefaultPath",
-			image:    defaultImage,
-			envFile:  "PREPEND_PATH=/",
+			name:   "PrependDefaultPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envFile: "PREPEND_PATH=/",
 			matchEnv: "PATH",
 			matchVal: "/:" + defaultPath,
 		},
 		{
-			name:     "DefaultLdLibraryPath",
-			image:    defaultImage,
-			matchEnv: "LD_LIBRARY_PATH",
+			name:   "DefaultLdLibraryPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, matchEnv: "LD_LIBRARY_PATH",
 			matchVal: singularityLibs,
 		},
 		{
-			name:     "CustomLdLibraryPath",
-			image:    defaultImage,
-			envFile:  "LD_LIBRARY_PATH=/foo",
+			name:   "CustomLdLibraryPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envFile: "LD_LIBRARY_PATH=/foo",
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo:" + singularityLibs,
 		},
 		{
-			name:     "CustomTrailingCommaPath",
-			image:    defaultImage,
-			envFile:  "LD_LIBRARY_PATH=/foo,",
+			name:   "CustomTrailingCommaPath",
+			images: []string{ociSIFDefaultPath, nativeSIFDefaultPath}, envFile: "LD_LIBRARY_PATH=/foo,",
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo,:" + singularityLibs,
 		},
 	}
 
 	for _, tt := range tests {
-		testEnv := append(os.Environ(), tt.hostEnv...)
-		args := make([]string, 0)
-		if tt.envOpt != nil {
-			args = append(args, "--env", strings.Join(tt.envOpt, ","))
-		}
-		if tt.envFile != "" {
-			os.WriteFile(p, []byte(tt.envFile), 0o644)
-			args = append(args, "--env-file", p)
-		}
-		args = append(args, tt.image, "/bin/sh", "-c", "echo $"+tt.matchEnv)
+		for _, img := range tt.images {
+			testEnv := append(os.Environ(), tt.hostEnv...)
+			args := make([]string, 0)
+			if tt.envOpt != nil {
+				args = append(args, "--env", strings.Join(tt.envOpt, ","))
+			}
+			if tt.envFile != "" {
+				os.WriteFile(p, []byte(tt.envFile), 0o644)
+				args = append(args, "--env-file", p)
+			}
+			args = append(args, img, "/bin/sh", "-c", "echo $"+tt.matchEnv)
 
-		c.env.RunSingularity(
-			t,
-			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.OCIUserProfile),
-			e2e.WithCommand("exec"),
-			e2e.WithEnv(testEnv),
-			e2e.WithRootlessEnv(),
-			e2e.WithArgs(args...),
-			e2e.ExpectExit(
-				0,
-				e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
-			),
-		)
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest(tt.name),
+				e2e.WithProfile(e2e.OCIUserProfile),
+				e2e.WithCommand("exec"),
+				e2e.WithEnv(testEnv),
+				e2e.WithRootlessEnv(),
+				e2e.WithArgs(args...),
+				e2e.ExpectExit(
+					0,
+					e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
+				),
+			)
+		}
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -32,7 +32,9 @@ const singularityLibs = "/.singularity.d/libs"
 // Set Singularity> prompt, try bash --norc, fall back to sh.
 var ociShellScript = "export PS1='Singularity> '; test -x /bin/bash && exec /bin/bash --norc || exec /bin/sh"
 
-func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, bundle string, ep launcher.ExecParams, u specs.User) (*specs.Process, error) {
+// getProcess creates and returns an specs.Process struct defining the execution behavior of the container.
+// The userEnv map returned also holds all user-requested environment variables (i.e. not those from the image).
+func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, bundle string, ep launcher.ExecParams, u specs.User) (process *specs.Process, userEnv map[string]string, err error) {
 	// Assemble the runtime & user-requested environment, which will be merged
 	// with the image ENV and set in the container at runtime.
 	rtEnv := defaultEnv(ep.Image, bundle)
@@ -49,7 +51,7 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, bund
 	if l.cfg.EnvFile != "" {
 		e, err := envFileMap(ctx, l.cfg.EnvFile)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		rtEnv = mergeMap(rtEnv, e)
 	}
@@ -63,7 +65,7 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, bund
 
 	cwd, err := l.getProcessCwd()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// OCI default is NoNewPrivileges = false
@@ -75,7 +77,7 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, bund
 
 	caps, err := l.getProcessCapabilities(u.UID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var args []string
@@ -84,7 +86,7 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, bund
 		// Native SIF image must run via in-container action script
 		args, err = ep.ActionScriptArgs()
 		if err != nil {
-			return nil, fmt.Errorf("while getting ProcessArgs: %w", err)
+			return nil, nil, fmt.Errorf("while getting ProcessArgs: %w", err)
 		}
 		sylog.Debugf("Native SIF container process/args: %v", args)
 	case ep.Action == "shell":
@@ -105,7 +107,7 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, bund
 		Terminal:        getProcessTerminal(),
 	}
 
-	return &p, nil
+	return &p, rtEnv, nil
 }
 
 // getProcessTerminal determines whether the container process should run with a terminal.


### PR DESCRIPTION
_Stacked on #1991_ - content of this PR is in 2nd commit.

## Description of the Pull Request (PR):

When entering a native SIF container, we apply the container-defined environment by sourcing scripts in `/.singularity.d/env` from the relevant action script.

Any environment variable set in these scripts will replace any value set from the OCI runtime config.

To allow `SINGULARITYENV_` / `--env` / `--env-file` to override container-defined env vars, we have to inject them via a script that exports them in `/singularity.d/env`.

We use the script filename `98-singularityenv.sh` as it must:

* Run *after* `95-apps.sh` which sets SCIF App specific variables (which we should be able to override).
* Run *before* `99-base.sh` which mutates `LD_LIBRARY_PATH`.

In addition, we have to consider that:

* In OCI mode, by default we emulate native mode `--compat`. This implies `--no-eval`, where environment variables injected should not be subjected to shell evaluation.
* We have a `--no-compat` flag, that needs to emulate native mode defaults. In this case, environment variables injected should be subjected to shell evaluation.

In general... this is painfully complex, relies on knowledge of where / when various scripts are executed, and may not have the best code structure. However, it works and, the tests enforce the correct behavior. Let's tidy up further later if that's okay? :-)


### This fixes or addresses the following GitHub issues:

 - Fixes #1990 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
