### PR TITLE
oci: support --bind of images (bare)

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2638,46 +2638,46 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	np := testhelper.NoParallel
 
 	return testhelper.Tests{
-		"action URI":                   c.RunFromURI,               // action_URI
-		"exec":                         c.actionExec,               // singularity exec
-		"exec under multiple profiles": c.actionExecMultiProfile,   // singularity exec
-		"persistent overlay":           c.PersistentOverlay,        // Persistent Overlay
-		"persistent overlay unpriv":    c.PersistentOverlayUnpriv,  // Persistent Overlay Unprivileged
-		"run":                          c.actionRun,                // singularity run
-		"shell":                        c.actionShell,              // shell interaction
-		"STDPIPE":                      c.STDPipe,                  // stdin/stdout pipe
-		"action basic profiles":        c.actionBasicProfiles,      // run basic action under different profiles
-		"issue 4488":                   c.issue4488,                // https://github.com/sylabs/singularity/issues/4488
-		"issue 4587":                   c.issue4587,                // https://github.com/sylabs/singularity/issues/4587
-		"issue 4755":                   c.issue4755,                // https://github.com/sylabs/singularity/issues/4755
-		"issue 4768":                   c.issue4768,                // https://github.com/sylabs/singularity/issues/4768
-		"issue 4797":                   c.issue4797,                // https://github.com/sylabs/singularity/issues/4797
-		"issue 4823":                   c.issue4823,                // https://github.com/sylabs/singularity/issues/4823
-		"issue 4836":                   c.issue4836,                // https://github.com/sylabs/singularity/issues/4836
-		"issue 5211":                   c.issue5211,                // https://github.com/sylabs/singularity/issues/5211
-		"issue 5228":                   c.issue5228,                // https://github.com/sylabs/singularity/issues/5228
-		"issue 5271":                   c.issue5271,                // https://github.com/sylabs/singularity/issues/5271
-		"issue 5307":                   c.issue5307,                // https://github.com/sylabs/singularity/issues/5307
-		"issue 5399":                   c.issue5399,                // https://github.com/sylabs/singularity/issues/5399
-		"issue 5455":                   c.issue5455,                // https://github.com/sylabs/singularity/issues/5455
-		"issue 5465":                   c.issue5465,                // https://github.com/sylabs/singularity/issues/5465
-		"issue 5599":                   c.issue5599,                // https://github.com/sylabs/singularity/issues/5599
-		"issue 5631":                   c.issue5631,                // https://github.com/sylabs/singularity/issues/5631
-		"issue 5690":                   c.issue5690,                // https://github.com/sylabs/singularity/issues/5690
-		"network":                      c.actionNetwork,            // test basic networking
-		"binds":                        c.actionBinds,              // test various binds with --bind and --mount
-		"exit and signals":             c.exitSignals,              // test exit and signals propagation
-		"fuse mount":                   c.fuseMount,                // test fusemount option
-		"bind image":                   c.bindImage,                // test bind image with --bind and --mount
-		"no-mount":                     c.actionNoMount,            // test --no-mount
-		"no-setgroups":                 c.actionNoSetgroups,        // test --no-setgroups
-		"compat":                       np(c.actionCompat),         // test --compat
-		"umask":                        np(c.actionUmask),          // test umask propagation
-		"invalidRemote":                np(c.invalidRemote),        // GHSA-5mv9-q7fq-9394
-		"SIFFUSE":                      np(c.actionSIFFUSE),        // test --sif-fuse
-		"NoSIFFUSE":                    np(c.actionNoSIFFUSE),      // test absence of squashfs and CleanupHost()
-		"relWorkdirScratch":            np(c.relWorkdirScratch),    // test relative --workdir with --scratch
-		"ociRelWorkdirScratch":         np(c.ociRelWorkdirScratch), // test relative --workdir with --scratch in OCI mode
+		"action URI":                   c.RunFromURI,                     // action_URI
+		"exec":                         c.actionExec,                     // singularity exec
+		"exec under multiple profiles": c.actionExecMultiProfile,         // singularity exec
+		"persistent overlay":           c.PersistentOverlay,              // Persistent Overlay
+		"persistent overlay unpriv":    c.PersistentOverlayUnpriv,        // Persistent Overlay Unprivileged
+		"run":                          c.actionRun,                      // singularity run
+		"shell":                        c.actionShell,                    // shell interaction
+		"STDPIPE":                      c.STDPipe,                        // stdin/stdout pipe
+		"action basic profiles":        c.actionBasicProfiles,            // run basic action under different profiles
+		"issue 4488":                   c.issue4488,                      // https://github.com/sylabs/singularity/issues/4488
+		"issue 4587":                   c.issue4587,                      // https://github.com/sylabs/singularity/issues/4587
+		"issue 4755":                   c.issue4755,                      // https://github.com/sylabs/singularity/issues/4755
+		"issue 4768":                   c.issue4768,                      // https://github.com/sylabs/singularity/issues/4768
+		"issue 4797":                   c.issue4797,                      // https://github.com/sylabs/singularity/issues/4797
+		"issue 4823":                   c.issue4823,                      // https://github.com/sylabs/singularity/issues/4823
+		"issue 4836":                   c.issue4836,                      // https://github.com/sylabs/singularity/issues/4836
+		"issue 5211":                   c.issue5211,                      // https://github.com/sylabs/singularity/issues/5211
+		"issue 5228":                   c.issue5228,                      // https://github.com/sylabs/singularity/issues/5228
+		"issue 5271":                   c.issue5271,                      // https://github.com/sylabs/singularity/issues/5271
+		"issue 5307":                   c.issue5307,                      // https://github.com/sylabs/singularity/issues/5307
+		"issue 5399":                   c.issue5399,                      // https://github.com/sylabs/singularity/issues/5399
+		"issue 5455":                   c.issue5455,                      // https://github.com/sylabs/singularity/issues/5455
+		"issue 5465":                   c.issue5465,                      // https://github.com/sylabs/singularity/issues/5465
+		"issue 5599":                   c.issue5599,                      // https://github.com/sylabs/singularity/issues/5599
+		"issue 5631":                   c.issue5631,                      // https://github.com/sylabs/singularity/issues/5631
+		"issue 5690":                   c.issue5690,                      // https://github.com/sylabs/singularity/issues/5690
+		"network":                      c.actionNetwork,                  // test basic networking
+		"binds":                        c.actionBinds,                    // test various binds with --bind and --mount
+		"exit and signals":             c.exitSignals,                    // test exit and signals propagation
+		"fuse mount":                   c.fuseMount,                      // test fusemount option
+		"bind image":                   c.bindImage,                      // test bind image with --bind and --mount
+		"no-mount":                     c.actionNoMount,                  // test --no-mount
+		"no-setgroups":                 c.actionNoSetgroups,              // test --no-setgroups
+		"compat":                       np(c.actionCompat),               // test --compat
+		"umask":                        np(c.actionUmask),                // test umask propagation
+		"invalidRemote":                np(c.invalidRemote),              // GHSA-5mv9-q7fq-9394
+		"SIFFUSE":                      np(c.actionSIFFUSE),              // test --sif-fuse
+		"NoSIFFUSE":                    np(c.actionNoSIFFUSE),            // test absence of squashfs and CleanupHost()
+		"relWorkdirScratch":            np(c.relWorkdirScratch),          // test relative --workdir with --scratch
+		"ociRelWorkdirScratch":         np(c.actionOciRelWorkdirScratch), // test relative --workdir with --scratch in OCI mode
 		//
 		// OCI Runtime Mode
 		//
@@ -2695,6 +2695,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociOverlay":           (c.actionOciOverlay),           // --overlay in OCI mode
 		"ociOverlayExtfsPerms": (c.actionOciOverlayExtfsPerms), // permissions in writable extfs overlays mounted with FUSE in OCI mode
 		"ociOverlayTeardown":   np(c.actionOciOverlayTeardown), // proper overlay unmounting in OCI mode
+		"ociBindImage":         c.actionOciBindImage,           // test binding of images in OCI mode
 		"ociNo-mount":          c.actionOciNoMount,             // --no-mount in OCI mode
 		"ociHomeCwdPasswd":     c.actionOciHomeCwdPasswd,       // $HOME is correct in /etc/passwd, and is default cwd
 		"ociAllowSetuid":       c.actionOciAllowSetuid,         // --allow-setuid / check for nosuid mount options

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/launcher"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/fuse"
 	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
 )
 
@@ -39,11 +40,13 @@ func TestNewLauncher(t *testing.T) {
 		{
 			name: "default",
 			want: &Launcher{
-				cfg:             launcher.Options{WritableTmpfs: true},
-				singularityConf: sc,
-				homeHost:        u.HomeDir,
-				homeSrc:         "",
-				homeDest:        u.HomeDir,
+				cfg:                     launcher.Options{WritableTmpfs: true},
+				singularityConf:         sc,
+				homeHost:                u.HomeDir,
+				homeSrc:                 "",
+				homeDest:                u.HomeDir,
+				imageMountsByImagePath:  make(map[string]*fuse.ImageMount),
+				imageMountsByMountpoint: make(map[string]*fuse.ImageMount),
 			},
 		},
 		{
@@ -52,11 +55,13 @@ func TestNewLauncher(t *testing.T) {
 				launcher.OptHome("/home/dest", true, false),
 			},
 			want: &Launcher{
-				cfg:             launcher.Options{HomeDir: "/home/dest", CustomHome: true, WritableTmpfs: true},
-				singularityConf: sc,
-				homeHost:        u.HomeDir,
-				homeSrc:         "",
-				homeDest:        "/home/dest",
+				cfg:                     launcher.Options{HomeDir: "/home/dest", CustomHome: true, WritableTmpfs: true},
+				singularityConf:         sc,
+				homeHost:                u.HomeDir,
+				homeSrc:                 "",
+				homeDest:                "/home/dest",
+				imageMountsByImagePath:  make(map[string]*fuse.ImageMount),
+				imageMountsByMountpoint: make(map[string]*fuse.ImageMount),
 			},
 			wantErr: false,
 		},
@@ -66,11 +71,13 @@ func TestNewLauncher(t *testing.T) {
 				launcher.OptHome("/home/src:/home/dest", true, false),
 			},
 			want: &Launcher{
-				cfg:             launcher.Options{HomeDir: "/home/src:/home/dest", CustomHome: true, WritableTmpfs: true},
-				singularityConf: sc,
-				homeHost:        u.HomeDir,
-				homeSrc:         "/home/src",
-				homeDest:        "/home/dest",
+				cfg:                     launcher.Options{HomeDir: "/home/src:/home/dest", CustomHome: true, WritableTmpfs: true},
+				singularityConf:         sc,
+				homeHost:                u.HomeDir,
+				homeSrc:                 "/home/src",
+				homeDest:                "/home/dest",
+				imageMountsByImagePath:  make(map[string]*fuse.ImageMount),
+				imageMountsByMountpoint: make(map[string]*fuse.ImageMount),
 			},
 			wantErr: false,
 		},
@@ -80,11 +87,13 @@ func TestNewLauncher(t *testing.T) {
 				launcher.OptNoCompat(true),
 			},
 			want: &Launcher{
-				cfg:             launcher.Options{NoCompat: true, WritableTmpfs: false},
-				singularityConf: sc,
-				homeHost:        u.HomeDir,
-				homeSrc:         "",
-				homeDest:        u.HomeDir,
+				cfg:                     launcher.Options{NoCompat: true, WritableTmpfs: false},
+				singularityConf:         sc,
+				homeHost:                u.HomeDir,
+				homeSrc:                 "",
+				homeDest:                u.HomeDir,
+				imageMountsByImagePath:  make(map[string]*fuse.ImageMount),
+				imageMountsByMountpoint: make(map[string]*fuse.ImageMount),
 			},
 			wantErr: false,
 		},
@@ -95,11 +104,13 @@ func TestNewLauncher(t *testing.T) {
 				launcher.OptWritableTmpfs(true),
 			},
 			want: &Launcher{
-				cfg:             launcher.Options{NoCompat: true, WritableTmpfs: true},
-				singularityConf: sc,
-				homeHost:        u.HomeDir,
-				homeSrc:         "",
-				homeDest:        u.HomeDir,
+				cfg:                     launcher.Options{NoCompat: true, WritableTmpfs: true},
+				singularityConf:         sc,
+				homeHost:                u.HomeDir,
+				homeSrc:                 "",
+				homeDest:                u.HomeDir,
+				imageMountsByImagePath:  make(map[string]*fuse.ImageMount),
+				imageMountsByMountpoint: make(map[string]*fuse.ImageMount),
 			},
 			wantErr: false,
 		},

--- a/internal/pkg/runtime/launcher/oci/oci_overlay.go
+++ b/internal/pkg/runtime/launcher/oci/oci_overlay.go
@@ -52,10 +52,10 @@ func WrapWithOverlays(f func() error, bundleDir string, overlayPaths []string, a
 			item.SetAllowSetuid(true)
 		}
 
-		if item.Writable && writableOverlayFound {
+		if writableOverlayFound && !item.Readonly {
 			return fmt.Errorf("you can't specify more than one writable overlay; %#v has already been specified as a writable overlay; use '--overlay %s:ro' instead", s.WritableOverlay, item.SourcePath)
 		}
-		if item.Writable {
+		if !item.Readonly {
 			writableOverlayFound = true
 			s.WritableOverlay = item
 		} else {

--- a/internal/pkg/util/fs/fuse/fuse_mount_linux.go
+++ b/internal/pkg/util/fs/fuse/fuse_mount_linux.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package fuse
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
+	"github.com/sylabs/singularity/v4/pkg/image"
+	"github.com/sylabs/singularity/v4/pkg/sylog"
+)
+
+type ImageMount struct {
+	// Type represents what type of image this mount involves (from among the
+	// values in pkg/image)
+	Type int
+
+	// Readonly represents whether this is a Readonly overlay
+	Readonly bool
+
+	// SourcePath is the path of the image, stripped of any colon-prefixed
+	// options (like ":ro")
+	SourcePath string
+
+	// EnclosingDir is the location of a secure parent-directory in
+	// which to create the actual mountpoint directory
+	EnclosingDir string
+
+	// mountpoint is the directory at which the image will be mounted
+	mountpoint string
+
+	// AllowSetuid is set to true to mount the image the "nosuid" option.
+	AllowSetuid bool
+
+	// AllowDev is set to true to mount the image without the "nodev" option.
+	AllowDev bool
+
+	// AllowOther is set to true to mount the image with the "allow_other" option.
+	AllowOther bool
+}
+
+// Mount mounts an image to a temporary directory. It also verifies that
+// the fusermount utility is present before performing the mount.
+func (i *ImageMount) Mount() (err error) {
+	fuseMountCmd, err := i.determineMountCmd()
+	if err != nil {
+		return err
+	}
+
+	args, err := i.generateCmdArgs()
+	if err != nil {
+		return err
+	}
+
+	fuseCmdLine := fmt.Sprintf("%s %s", fuseMountCmd, strings.Join(args, " "))
+	sylog.Debugf("Executing FUSE mount command: %q", fuseCmdLine)
+	execCmd := exec.Command(fuseMountCmd, args...)
+	execCmd.Stderr = os.Stderr
+	_, err = execCmd.Output()
+	if err != nil {
+		return fmt.Errorf("encountered error while trying to mount image %q as overlay at %s: %w", i.SourcePath, i.mountpoint, err)
+	}
+
+	exitCode := execCmd.ProcessState.ExitCode()
+	if exitCode != 0 {
+		return fmt.Errorf("FUSE mount command %q returned non-zero exit code (%d)", fuseCmdLine, exitCode)
+	}
+
+	return err
+}
+
+func (i *ImageMount) determineMountCmd() (string, error) {
+	var fuseMountTool string
+	switch i.Type {
+	case image.SQUASHFS:
+		fuseMountTool = "squashfuse"
+	case image.EXT3:
+		fuseMountTool = "fuse2fs"
+	default:
+		return "", fmt.Errorf("image %q is not of a type that can be mounted with FUSE (type: %v)", i.SourcePath, i.Type)
+	}
+
+	fuseMountCmd, err := bin.FindBin(fuseMountTool)
+	if err != nil {
+		return "", fmt.Errorf("use of image %q as overlay requires %s to be installed: %w", i.SourcePath, fuseMountTool, err)
+	}
+
+	return fuseMountCmd, nil
+}
+
+func (i *ImageMount) generateCmdArgs() ([]string, error) {
+	args := make([]string, 0, 4)
+
+	switch i.Type {
+	case image.SQUASHFS:
+		i.Readonly = true
+	}
+
+	// Even though fusermount is not needed for this step, we shouldn't perform
+	// the mount unless we have the necessary tools to eventually unmount it
+	_, err := bin.FindBin("fusermount")
+	if err != nil {
+		return args, fmt.Errorf("use of image %q as overlay requires fusermount to be installed: %w", i.SourcePath, err)
+	}
+
+	if i.mountpoint == "" {
+		i.mountpoint, err = os.MkdirTemp(i.EnclosingDir, "mountpoint-")
+		if err != nil {
+			return args, fmt.Errorf("failed to create temporary dir %q for overlay %q: %w", i.mountpoint, i.SourcePath, err)
+		}
+	}
+
+	// Best effort to cleanup temporary dir
+	defer func() {
+		if err != nil {
+			sylog.Debugf("Encountered error with image %q; attempting to remove %q", i.SourcePath, i.mountpoint)
+			os.Remove(i.mountpoint)
+		}
+	}()
+
+	// TODO: Think through what makes sense for file ownership in FUSE-mounted
+	// images, vis a vis id-mappings and user-namespaces.
+	opts := []string{"uid=0", "gid=0"}
+	if i.Readonly {
+		// Not strictly necessary as will be read-only in assembled overlay,
+		// however this stops any erroneous writes through the stagingDir.
+		opts = append(opts, "ro")
+	}
+	// FUSE defaults to nosuid,nodev - attempt to reverse if AllowDev/Setuid requested.
+	if i.AllowDev {
+		opts = append(opts, "dev")
+	}
+	if i.AllowSetuid {
+		opts = append(opts, "suid")
+	}
+	if i.AllowOther {
+		opts = append(opts, "allow_other")
+	}
+
+	if len(opts) > 0 {
+		args = append(args, "-o", strings.Join(opts, ","))
+	}
+
+	args = append(args, i.SourcePath)
+	args = append(args, i.mountpoint)
+
+	return args, nil
+}
+
+func (i ImageMount) GetMountPoint() string {
+	return i.mountpoint
+}
+
+func (i *ImageMount) SetMountPoint(mountpoint string) {
+	i.mountpoint = mountpoint
+}
+
+func (i ImageMount) Unmount() error {
+	return UnmountWithFuse(i.GetMountPoint())
+}
+
+// UnmountWithFuse performs an unmount on the specified directory using
+// fusermount -u.
+func UnmountWithFuse(dir string) error {
+	fusermountCmd, err := bin.FindBin("fusermount")
+	if err != nil {
+		// We should not be creating FUSE-based mounts in the first place
+		// without checking that fusermount is available.
+		return fmt.Errorf("fusermount not available while trying to perform unmount: %w", err)
+	}
+	sylog.Debugf("Executing FUSE unmount command: %s -u %s", fusermountCmd, dir)
+	execCmd := exec.Command(fusermountCmd, "-u", dir)
+	execCmd.Stderr = os.Stderr
+	_, err = execCmd.Output()
+	return err
+}

--- a/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
@@ -67,12 +67,12 @@ func TestItemWritableField(t *testing.T) {
 		t.Fatalf("unexpected error while initializing roItem from string %q: %s", roOverlayStr, err)
 	}
 
-	if !rwItem.Writable {
-		t.Errorf("Writable field of overlay.Item initialized with string %q should be true but is false", rwOverlayStr)
+	if rwItem.Readonly {
+		t.Errorf("Readonly field of overlay.Item initialized with string %q should be false but is true", rwOverlayStr)
 	}
 
-	if roItem.Writable {
-		t.Errorf("Writable field of overlay.Item initialized with string %q should be false but is true", roOverlayStr)
+	if !roItem.Readonly {
+		t.Errorf("Readonly field of overlay.Item initialized with string %q should be true but is false", roOverlayStr)
 	}
 }
 

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -290,22 +290,6 @@ func DetachMount(dir string) error {
 	return nil
 }
 
-// UnmountWithFuse performs an unmount on the specified directory using
-// fusermount -u.
-func UnmountWithFuse(dir string) error {
-	fusermountCmd, err := bin.FindBin("fusermount")
-	if err != nil {
-		// We should not be creating FUSE-based mounts in the first place
-		// without checking that fusermount is available.
-		return fmt.Errorf("fusermount not available while trying to perform unmount: %w", err)
-	}
-	sylog.Debugf("Executing FUSE unmount command: %s -u %s", fusermountCmd, dir)
-	execCmd := exec.Command(fusermountCmd, "-u", dir)
-	execCmd.Stderr = os.Stderr
-	_, err = execCmd.Output()
-	return err
-}
-
 // AbsOverlay takes an overlay description string (a path, optionally followed by a colon with an option string, like ":ro" or ":rw"), and replaces any relative path in the description string with an absolute one.
 func AbsOverlay(desc string) (string, error) {
 	splitted := strings.SplitN(desc, ":", 2)

--- a/internal/pkg/util/fs/overlay/overlay_set_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_set_linux.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
+	fsfuse "github.com/sylabs/singularity/v4/internal/pkg/util/fs/fuse"
 	"github.com/sylabs/singularity/v4/pkg/image"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
@@ -73,7 +74,7 @@ func (s Set) Unmount(rootFsDir string) error {
 	if useKernelMount {
 		err = DetachMount(rootFsDir)
 	} else {
-		err = UnmountWithFuse(rootFsDir)
+		err = fsfuse.UnmountWithFuse(rootFsDir)
 	}
 
 	if err != nil {

--- a/pkg/ocibundle/tools/overlay_linux.go
+++ b/pkg/ocibundle/tools/overlay_linux.go
@@ -38,7 +38,7 @@ func CreateOverlay(bundlePath string) error {
 	olSet := overlay.Set{WritableOverlay: &overlay.Item{
 		SourcePath: olDir,
 		Type:       image.SANDBOX,
-		Writable:   true,
+		Readonly:   false,
 	}}
 
 	return olSet.Mount(RootFs(bundlePath).Path())
@@ -99,7 +99,7 @@ func CreateOverlayTmpfs(bundlePath string, sizeMiB int, allowSetuid bool) (strin
 	oi := overlay.Item{
 		SourcePath: olDir,
 		Type:       image.SANDBOX,
-		Writable:   true,
+		Readonly:   false,
 	}
 	oi.SetAllowSetuid(allowSetuid)
 	olSet := overlay.Set{WritableOverlay: &oi}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add support for bind-mounting bare images in OCI mode (using `-B`/`--bind`, with [identical syntax](https://docs.sylabs.io/guides/latest/user-guide/bind_paths_and_mounts.html#image-mounts) to the corresponding native-mode flag).


### This fixes or addresses the following GitHub issues:

 - Fixes #1471 

