### PR TITLE
conf: Add better warnings r.e. user namespaces & container limits

### DIFF
--- a/internal/pkg/syecl/syecl.toml.example
+++ b/internal/pkg/syecl/syecl.toml.example
@@ -5,6 +5,26 @@
 # location of the sif file in the file system and by checking against a list of
 # signing entities.
 #
+# *****************************************************************************
+# WARNING
+#
+# The ECL is not effective if unprivileged user namespaces are enabled. It is
+# only effectively applied when Singularity is running using the native runtime
+# in setuid mode, and unprivileged container execution is not possible on the
+# host.
+#
+# You must disable unprivileged user namespace creation on the host if you rely
+# on the ECL to limit container execution. This will disable OCI mode, which is
+# unprivileged and cannot enforce the ECL.
+#
+# The ECL only applies to SIF container images. To block execution of other
+# images (e.g. ext3 or sandbox containers), you must also disable them in
+# singularity.conf
+#
+# See the 'Security' and 'Configuration Files' sections of the Admin Guide for
+# more information.
+# *****************************************************************************
+#
 # The current possible list modes are: whitelist, whitestrict and blacklist.
 #
 # Example:

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -238,12 +238,30 @@ mount slave = {{ if eq .MountSlave true }}yes{{ else }}no{{ end }}
 # In --oci mode, each tmpfs mount in the container can be up to this size.
 sessiondir max size = {{ .SessiondirMaxSize }}
 
+# *****************************************************************************
+# WARNING
+#
+# The 'limit container' and 'allow container' directives are not effective if
+# unprivileged user namespaces are enabled. They are only effectively applied
+# when Singularity is running using the native runtime in setuid mode, and
+# unprivileged container execution is not possible on the host.
+#
+# You must disable unprivileged user namespace creation on the host if you rely
+# on the these directives to limit container execution. This will disable OCI
+# mode, which is unprivileged and cannot enforce these limits.
+#
+# See the 'Security' and 'Configuration Files' sections of the Admin Guide for
+# more information.
+# *****************************************************************************
+
 # LIMIT CONTAINER OWNERS: [STRING]
 # DEFAULT: NULL
 # Only allow containers to be used that are owned by a given user. If this
 # configuration is undefined (commented or set to NULL), all containers are
-# allowed to be used. This feature only applies when Singularity is running in
-# SUID mode and the user is non-root.
+# allowed to be used. 
+#
+# Only effective in setuid mode, with unprivileged user namespace creation disabled.
+# Ignored for the root user.
 #limit container owners = gmk, singularity, nobody
 {{ range $index, $owner := .LimitContainerOwners }}
 {{- if eq $index 0 }}limit container owners = {{ else }}, {{ end }}{{$owner}}
@@ -253,8 +271,10 @@ sessiondir max size = {{ .SessiondirMaxSize }}
 # DEFAULT: NULL
 # Only allow containers to be used that are owned by a given group. If this
 # configuration is undefined (commented or set to NULL), all containers are
-# allowed to be used. This feature only applies when Singularity is running in
-# SUID mode and the user is non-root.
+# allowed to be used.
+#
+# Only effective in setuid mode, with unprivileged user namespace creation disabled.
+# Ignored for the root user.
 #limit container groups = group1, singularity, nobody
 {{ range $index, $group := .LimitContainerGroups }}
 {{- if eq $index 0 }}limit container groups = {{ else }}, {{ end }}{{$group}}
@@ -264,9 +284,10 @@ sessiondir max size = {{ .SessiondirMaxSize }}
 # DEFAULT: NULL
 # Only allow containers to be used that are located within an allowed path
 # prefix. If this configuration is undefined (commented or set to NULL),
-# containers will be allowed to run from anywhere on the file system. This
-# feature only applies when Singularity is running in SUID mode and the user is
-# non-root.
+# containers will be allowed to run from anywhere on the file system.
+#
+# Only effective in setuid mode, with unprivileged user namespace creation disabled.
+# Ignored for the root user.
 #limit container paths = /scratch, /tmp, /global
 {{ range $index, $path := .LimitContainerPaths }}
 {{- if eq $index 0 }}limit container paths = {{ else }}, {{ end }}{{$path}}
@@ -275,7 +296,10 @@ sessiondir max size = {{ .SessiondirMaxSize }}
 # ALLOW CONTAINER ${TYPE}: [BOOL]
 # DEFAULT: yes
 # This feature limits what kind of containers that Singularity will allow
-# users to use (note this does not apply for root).
+# users to use.
+#
+# Only effective in setuid mode, with unprivileged user namespace creation disabled.
+# Ignored for the root user.
 #
 # Allow use of unencrypted SIF containers
 allow container sif = {{ if eq .AllowContainerSIF true}}yes{{ else }}no{{ end }}


### PR DESCRIPTION
## Description of the Pull Request (PR):

It is trivial for a user to bypass configured container executions restrictions if the host has unprivileged user namespace creation enabled. This is not something SingularityCE can guard against, except by making it clear to administrators at the point they would configure those limits.

Add warnings to the relevant configuration files.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
