### PR TITLE
oci: host environment handling for --no-compat

### DIFF
--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -648,5 +648,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"oci environment option":         c.ociEnvOption,
 		"oci environment file":           c.ociEnvFile,
 		"oci native env eval":            c.ociNativeEnvEval,
+		"oci nocompat host":              c.ociNoCompatHost,
 	}
 }

--- a/internal/pkg/util/env/clean.go
+++ b/internal/pkg/util/env/clean.go
@@ -119,3 +119,26 @@ func AddHostEnv(key string, cleanEnv bool) bool {
 	}
 	return true
 }
+
+// HostEnvMap returns a map of host env vars to pass into the container.
+func HostEnvMap(hostEnvs []string, cleanEnv bool) map[string]string {
+	hostEnv := map[string]string{}
+
+	for _, envVar := range hostEnvs {
+		if strings.HasPrefix(envVar, SingularityEnvPrefix) {
+			continue
+		}
+		parts := strings.SplitN(envVar, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+
+		if !AddHostEnv(parts[0], cleanEnv) {
+			continue
+		}
+
+		hostEnv[parts[0]] = parts[1]
+	}
+
+	return hostEnv
+}

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -29,10 +29,10 @@ func SetFromList(environ []string) error {
 }
 
 // SingularityEnvMap returns a map of SINGULARITYENV_ prefixed env vars to their values.
-func SingularityEnvMap() map[string]string {
+func SingularityEnvMap(hostEnv []string) map[string]string {
 	singularityEnv := map[string]string{}
 
-	for _, envVar := range os.Environ() {
+	for _, envVar := range hostEnv {
 		if !strings.HasPrefix(envVar, SingularityEnvPrefix) {
 			continue
 		}
@@ -49,8 +49,8 @@ func SingularityEnvMap() map[string]string {
 
 // FileMap returns a map of KEY=VAL env vars from an environment file f. The env
 // file is shell evaluated using mvdan/sh with arguments and environment set
-// from args and currentEnv.
-func FileMap(ctx context.Context, f string, args []string, currentEnv []string) (map[string]string, error) {
+// from args and hostEnv.
+func FileMap(ctx context.Context, f string, args []string, hostEnv []string) (map[string]string, error) {
 	envMap := map[string]string{}
 
 	content, err := os.ReadFile(f)
@@ -60,7 +60,7 @@ func FileMap(ctx context.Context, f string, args []string, currentEnv []string) 
 
 	// Use the embedded shell interpreter to evaluate the env file, with an empty starting environment.
 	// Shell takes care of comments, quoting etc. for us and keeps compatibility with native runtime.
-	env, err := interpreter.EvaluateEnv(ctx, content, args, currentEnv)
+	env, err := interpreter.EvaluateEnv(ctx, content, args, hostEnv)
 	if err != nil {
 		return envMap, fmt.Errorf("while processing %s: %w", f, err)
 	}

--- a/internal/pkg/util/env/env_test.go
+++ b/internal/pkg/util/env/env_test.go
@@ -72,30 +72,30 @@ func TestSetFromList(t *testing.T) {
 
 func TestSingularityEnvMap(t *testing.T) {
 	tests := []struct {
-		name   string
-		setEnv map[string]string
-		want   map[string]string
+		name    string
+		hostEnv []string
+		want    map[string]string
 	}{
 		{
-			name:   "None",
-			setEnv: map[string]string{},
-			want:   map[string]string{},
+			name:    "None",
+			hostEnv: []string{},
+			want:    map[string]string{},
 		},
 		{
-			name:   "NonPrefixed",
-			setEnv: map[string]string{"FOO": "bar"},
-			want:   map[string]string{},
+			name:    "NonPrefixed",
+			hostEnv: []string{"FOO=bar"},
+			want:    map[string]string{},
 		},
 		{
-			name:   "PrefixedSingle",
-			setEnv: map[string]string{"SINGULARITYENV_FOO": "bar"},
-			want:   map[string]string{"FOO": "bar"},
+			name:    "PrefixedSingle",
+			hostEnv: []string{"SINGULARITYENV_FOO=bar"},
+			want:    map[string]string{"FOO": "bar"},
 		},
 		{
 			name: "PrefixedMultiple",
-			setEnv: map[string]string{
-				"SINGULARITYENV_FOO": "bar",
-				"SINGULARITYENV_ABC": "123",
+			hostEnv: []string{
+				"SINGULARITYENV_FOO=bar",
+				"SINGULARITYENV_ABC=123",
 			},
 			want: map[string]string{
 				"FOO": "bar",
@@ -105,13 +105,7 @@ func TestSingularityEnvMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for k, v := range tt.setEnv {
-				os.Setenv(k, v)
-				t.Cleanup(func() {
-					os.Unsetenv(k)
-				})
-			}
-			if got := SingularityEnvMap(); !reflect.DeepEqual(got, tt.want) {
+			if got := SingularityEnvMap(tt.hostEnv); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("singularityEnvMap() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Description of the Pull Request (PR):

In `-oci` mode, make `--no-compat` handle host environment in the same manner as the native runtime.

Most environment variables on the host are passed into the container, as long as they haven't been overridden by the container image or the user.

For OCI-SIF images, this is handled when computing the runtime config.

For native SIF images, this is handled by injecting the variables through a shell script that runs in `/.singularity.d/env` processing.

Note that we now always set `TERM` and proxy environment variables in the container using these mechanisms, regardless of `--no-compat`. The proxy env vars are important for frictionless use of Singularity in isolated environments.

### This fixes or addresses the following GitHub issues:

 - Fixes #1979


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
