### PR TITLE
WIP - pull: Improved --arch and --platform handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,11 @@
     will be shell evaluated on container startup.
 - A new `oci mode` directive in `singularity.conf` can be set to true to enable
   OCI-mode by default. It can be negated with a new `--no-oci` command line flag.
+- A new `--platform` flag can be used to specify an `OS/Architecture[/Variant]`
+  when pulling images from OCI or library sources. When pulling from library
+  sources the optional variant is igored.
+- The `--arch` flag can now be used to specify a required architecture when pulling
+  images from OCI, as well as library sources.
 
 ### Developer / API
 

--- a/LICENSE_THIRD_PARTY.md
+++ b/LICENSE_THIRD_PARTY.md
@@ -583,9 +583,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The source files:
 
-* `internal/pkg/ociimage/cpuinfo.go`
-* `internal/pkg/ociimage/cpuinfo_linux.go`
-* `internal/pkg/ociimage/cpuinfo_linux_test.go`
+* `internal/pkg/ociplatform/cpuinfo.go`
+* `internal/pkg/ociplatform/cpuinfo_linux.go`
+* `internal/pkg/ociplatform/cpuinfo_linux_test.go`
 
 Contain code from the docker cli project, under the Apache License, Version 2.0.
 

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/containers/image/v5/types"
@@ -129,12 +128,12 @@ func handleLibrary(ctx context.Context, imgCache *cache.Handle, pullFrom string)
 	}
 
 	pullOpts := library.PullOptions{
-		Architecture:  runtime.GOARCH,
 		Endpoint:      currentRemoteEndpoint,
 		LibraryConfig: c,
 		// false to allow OCI execution of native SIF from library
 		RequireOciSif: false,
 		TmpDir:        tmpDir,
+		Platform:      getOCIPlatform(),
 	}
 	return library.Pull(ctx, imgCache, r, pullOpts)
 }

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/build/remotebuilder"
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
+	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
 	fakerootConfig "github.com/sylabs/singularity/v4/internal/pkg/runtime/engine/fakeroot/config"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
@@ -396,6 +397,11 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 
 	}
 
+	dp, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		sylog.Fatalf("%v", err)
+	}
+
 	b, err := build.New(
 		defs,
 		build.Config{
@@ -419,6 +425,9 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 				EncryptionKeyInfo: keyInfo,
 				FixPerms:          buildArgs.fixPerms,
 				SandboxTarget:     sandboxTarget,
+				// Only perform a build with the host DefaultPlatform at present.
+				// TODO: rework --arch handling for remote builds so that local builds can specify --arch and --platform.
+				Platform: *dp,
 			},
 		})
 	if err != nil {

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -254,6 +254,19 @@ func (c ctx) testPullCmd(t *testing.T) {
 			unauthenticated:  true,
 			expectedExitCode: 0,
 		},
+		// forced arch and platform equivalent
+		{
+			desc:             "library non-oci platform",
+			srcURI:           "library://alpine:3.11.5",
+			arch:             "ppc64le",
+			expectedExitCode: 0,
+		},
+		{
+			desc:             "library non-oci platform",
+			srcURI:           "library://alpine:3.11.5",
+			platform:         "linux/ppc64le",
+			expectedExitCode: 0,
+		},
 		// --dir tests
 		{
 			desc:             "library dir",
@@ -319,13 +332,6 @@ func (c ctx) testPullCmd(t *testing.T) {
 			force:            true,
 			expectedExitCode: 0,
 		},
-		// --platform shouldn't be accepted for non OCI-SIF pulls (--arch is used).
-		{
-			desc:             "library non-oci platform",
-			srcURI:           "library://alpine:3.11.5",
-			platform:         "linux/ppc64le",
-			expectedExitCode: 255,
-		},
 		// pulling an OCI-SIF image from library backing registry
 		{
 			desc:   "library oci-sif fallback",
@@ -359,7 +365,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 			// direct oci pull
 			arch:             "ppc64le",
 			oci:              true,
-			expectedExitCode: 255,
+			expectedExitCode: 0,
 		},
 		//
 		// shub:// URIs

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,7 +9,6 @@ package sources
 import (
 	"context"
 	"fmt"
-	"runtime"
 
 	golog "github.com/go-log/log"
 
@@ -73,9 +72,9 @@ func (cp *LibraryConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err 
 	}
 
 	pullOpts := library.PullOptions{
-		Architecture:  runtime.GOARCH,
 		LibraryConfig: libraryConfig,
 		TmpDir:        cp.b.TmpDir,
+		Platform:      cp.b.Opts.Platform,
 	}
 	imagePath, err := library.Pull(ctx, b.Opts.ImgCache, imageRef, pullOpts)
 	if err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/build/sources"
+	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 )
@@ -31,10 +32,15 @@ func TestLibraryConveyor(t *testing.T) {
 
 	b, err := types.NewBundle(filepath.Join(os.TempDir(), "sbuild-library"), os.TempDir())
 	if err != nil {
-		return
+		t.Fatalf("failed to create NewBundle: %v", err)
 	}
 
 	b.Opts.LibraryURL = libraryURL
+	p, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		t.Fatalf("failed to get DefaultPlatform: %v", err)
+	}
+	b.Opts.Platform = *p
 
 	b.Recipe, err = types.NewDefinitionFromURI(libraryURI)
 	if err != nil {
@@ -62,10 +68,15 @@ func TestLibraryPacker(t *testing.T) {
 
 	b, err := types.NewBundle(filepath.Join(os.TempDir(), "sbuild-library"), os.TempDir())
 	if err != nil {
-		return
+		t.Fatalf("failed to create NewBundle: %v", err)
 	}
 
 	b.Opts.LibraryURL = libraryURL
+	p, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		t.Fatalf("failed to get DefaultPlatform: %v", err)
+	}
+	b.Opts.Platform = *p
 
 	b.Recipe, err = types.NewDefinitionFromURI(libraryURI)
 	if err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -128,10 +128,12 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		OCIInsecureSkipTLSVerify: cp.b.Opts.NoHTTPS,
 		DockerAuthConfig:         cp.b.Opts.DockerAuthConfig,
 		DockerDaemonHost:         cp.b.Opts.DockerDaemonHost,
-		OSChoice:                 "linux",
 		AuthFilePath:             syfs.DockerConf(),
 		DockerRegistryUserAgent:  useragent.Value(),
 		BigFilesTemporaryDir:     b.TmpDir,
+		OSChoice:                 cp.b.Opts.Platform.OS,
+		ArchitectureChoice:       cp.b.Opts.Platform.Architecture,
+		VariantChoice:            cp.b.Opts.Platform.Variant,
 	}
 
 	if cp.b.Opts.NoHTTPS {

--- a/internal/pkg/client/oci/nativesif.go
+++ b/internal/pkg/client/oci/nativesif.go
@@ -87,6 +87,7 @@ func convertOciToSIF(ctx context.Context, imgCache *cache.Handle, image, cachedI
 				DockerAuthConfig: opts.OciAuth,
 				DockerDaemonHost: opts.DockerHost,
 				ImgCache:         imgCache,
+				Platform:         opts.Platform,
 			},
 		},
 	)

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	ocitypes "github.com/containers/image/v5/types"
+	gccrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
 	"github.com/sylabs/singularity/v4/internal/pkg/client/ocisif"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
@@ -27,15 +28,11 @@ type PullOptions struct {
 	NoHTTPS    bool
 	NoCleanUp  bool
 	OciSif     bool
-	Platform   string
+	Platform   gccrv1.Platform
 }
 
 // sysCtx provides authentication and tempDir config for containers/image OCI operations
 func sysCtx(opts PullOptions) (*ocitypes.SystemContext, error) {
-	if opts.Platform != "" {
-		return nil, fmt.Errorf("custom platform not supported for OCI -> SIF conversion")
-	}
-
 	// DockerInsecureSkipTLSVerify is set only if --no-https is specified to honor
 	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
 	// can have three possible values true/false and undefined, so we left it as undefined instead
@@ -48,6 +45,9 @@ func sysCtx(opts PullOptions) (*ocitypes.SystemContext, error) {
 		DockerRegistryUserAgent:  useragent.Value(),
 		BigFilesTemporaryDir:     opts.TmpDir,
 		DockerDaemonHost:         opts.DockerHost,
+		OSChoice:                 opts.Platform.OS,
+		ArchitectureChoice:       opts.Platform.Architecture,
+		VariantChoice:            opts.Platform.Variant,
 	}
 	if opts.NoHTTPS {
 		sysCtx.DockerInsecureSkipTLSVerify = ocitypes.NewOptionalBool(true)

--- a/internal/pkg/ociimage/digest.go
+++ b/internal/pkg/ociimage/digest.go
@@ -17,6 +17,7 @@ import (
 	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/opencontainers/go-digest"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
+	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
@@ -135,7 +136,7 @@ func digestFromManifestOrIndex(sysCtx *types.SystemContext, manifestOrIndex []by
 		return "", fmt.Errorf("not a valid image manifest or image index")
 	}
 
-	requiredPlatform := sysCtxToPlatform(sysCtx)
+	requiredPlatform := ociplatform.SysCtxToPlatform(sysCtx)
 	sylog.Debugf("Content is an image index, finding image for %s", requiredPlatform)
 	for _, mf := range ix.Manifests {
 		if mf.Platform == nil {

--- a/internal/pkg/ociimage/digest_test.go
+++ b/internal/pkg/ociimage/digest_test.go
@@ -14,6 +14,7 @@ import (
 	ggcrmutate "github.com/google/go-containerregistry/pkg/v1/mutate"
 	ggcrrandom "github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/opencontainers/go-digest"
+	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	"gotest.tools/v3/assert"
 )
 
@@ -44,7 +45,7 @@ func imageWithIndex(t *testing.T) (rawIndex []byte, imageDigest digest.Digest) {
 			Platform: &ggcrv1.Platform{
 				OS:           runtime.GOOS,
 				Architecture: runtime.GOARCH,
-				Variant:      cpuVariant(),
+				Variant:      ociplatform.CPUVariant(),
 			},
 		},
 	})
@@ -89,7 +90,7 @@ func Test_digestFromManifestOrIndex(t *testing.T) {
 			sysCtx: &types.SystemContext{
 				OSChoice:           runtime.GOOS,
 				ArchitectureChoice: runtime.GOARCH,
-				VariantChoice:      cpuVariant(),
+				VariantChoice:      ociplatform.CPUVariant(),
 			},
 			manifestOrIndex: index,
 			want:            indexImageDigest,
@@ -100,7 +101,7 @@ func Test_digestFromManifestOrIndex(t *testing.T) {
 			sysCtx: &types.SystemContext{
 				OSChoice:           "myOS",
 				ArchitectureChoice: runtime.GOARCH,
-				VariantChoice:      cpuVariant(),
+				VariantChoice:      ociplatform.CPUVariant(),
 			},
 			manifestOrIndex: index,
 			want:            "",
@@ -111,7 +112,7 @@ func Test_digestFromManifestOrIndex(t *testing.T) {
 			sysCtx: &types.SystemContext{
 				OSChoice:           runtime.GOOS,
 				ArchitectureChoice: "myArch",
-				VariantChoice:      cpuVariant(),
+				VariantChoice:      ociplatform.CPUVariant(),
 			},
 			manifestOrIndex: index,
 			want:            "",

--- a/internal/pkg/ociimage/util.go
+++ b/internal/pkg/ociimage/util.go
@@ -6,10 +6,7 @@
 package ociimage
 
 import (
-	"bytes"
-	"context"
 	"fmt"
-	"runtime"
 	"strings"
 
 	"github.com/containers/image/v5/docker"
@@ -19,9 +16,6 @@ import (
 	ocilayout "github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
-	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
 // defaultPolicy is Singularity's default OCI signature verifiction policy - accept anything.
@@ -59,59 +53,4 @@ func ParseImageRef(imageRef string) (types.ImageReference, error) {
 	}
 
 	return srcRef, nil
-}
-
-// sysCtxToPlatform translates the xxxChoice values in a containers/image
-// types.SytemContext to a go-containerregistry v1.Platform.
-func sysCtxToPlatform(sysCtx *types.SystemContext) ggcrv1.Platform {
-	os := sysCtx.OSChoice
-	if os == "" {
-		os = runtime.GOOS
-	}
-	arch := sysCtx.ArchitectureChoice
-	if arch == "" {
-		arch = runtime.GOARCH
-	}
-	variant := sysCtx.VariantChoice
-	if variant == "" {
-		variant = cpuVariant()
-	}
-	return ggcrv1.Platform{
-		Architecture: arch,
-		Variant:      variant,
-		OS:           os,
-	}
-}
-
-// CheckImageRefPlatform ensures that an image reference satisfies platform requirements in sysCtx
-func CheckImageRefPlatform(ctx context.Context, sysCtx *types.SystemContext, imageRef types.ImageReference) error {
-	if sysCtx == nil {
-		return fmt.Errorf("internal error: sysCtx is nil")
-	}
-	img, err := imageRef.NewImage(ctx, sysCtx)
-	if err != nil {
-		return err
-	}
-	defer img.Close()
-
-	rawConfig, err := img.ConfigBlob(ctx)
-	if err != nil {
-		return err
-	}
-	cf, err := v1.ParseConfigFile(bytes.NewBuffer(rawConfig))
-	if err != nil {
-		return err
-	}
-
-	if cf.Platform() == nil {
-		sylog.Warningf("OCI image doesn't declare a platform. It may not be compatible with this system.")
-		return nil
-	}
-
-	requiredPlatform := sysCtxToPlatform(sysCtx)
-	if cf.Platform().Satisfies(requiredPlatform) {
-		return nil
-	}
-
-	return fmt.Errorf("image (%s) does not satisfy required platform (%s)", cf.Platform(), requiredPlatform)
 }

--- a/internal/pkg/ociplatform/cpuinfo.go
+++ b/internal/pkg/ociplatform/cpuinfo.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package ociimage
+package ociplatform
 
 import (
 	"runtime"
@@ -29,7 +29,7 @@ var cpuVariantValue string
 
 var cpuVariantOnce sync.Once
 
-func cpuVariant() string {
+func CPUVariant() string {
 	cpuVariantOnce.Do(func() {
 		if isArmArch(runtime.GOARCH) {
 			var err error

--- a/internal/pkg/ociplatform/cpuinfo_linux.go
+++ b/internal/pkg/ociplatform/cpuinfo_linux.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package ociimage
+package ociplatform
 
 import (
 	"bufio"

--- a/internal/pkg/ociplatform/cpuinfo_linux_test.go
+++ b/internal/pkg/ociplatform/cpuinfo_linux_test.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package ociimage
+package ociplatform
 
 import (
 	"errors"

--- a/internal/pkg/ociplatform/ociplatform.go
+++ b/internal/pkg/ociplatform/ociplatform.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package ociplatform
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/containers/image/v5/types"
+	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/sylabs/singularity/v4/pkg/sylog"
+)
+
+// SysCtxToPlatform translates the xxxChoice values in a containers/image
+// types.SytemContext to a go-containerregistry v1.Platform.
+func SysCtxToPlatform(sysCtx *types.SystemContext) ggcrv1.Platform {
+	os := sysCtx.OSChoice
+	if os == "" {
+		os = runtime.GOOS
+	}
+	arch := sysCtx.ArchitectureChoice
+	if arch == "" {
+		arch = runtime.GOARCH
+	}
+	variant := sysCtx.VariantChoice
+	if variant == "" {
+		variant = CPUVariant()
+	}
+	return ggcrv1.Platform{
+		Architecture: arch,
+		Variant:      variant,
+		OS:           os,
+	}
+}
+
+// CheckImageRefPlatform ensures that an image reference satisfies platform requirements in sysCtx
+func CheckImageRefPlatform(ctx context.Context, sysCtx *types.SystemContext, imageRef types.ImageReference) error {
+	if sysCtx == nil {
+		return fmt.Errorf("internal error: sysCtx is nil")
+	}
+	img, err := imageRef.NewImage(ctx, sysCtx)
+	if err != nil {
+		return err
+	}
+	defer img.Close()
+
+	rawConfig, err := img.ConfigBlob(ctx)
+	if err != nil {
+		return err
+	}
+	cf, err := v1.ParseConfigFile(bytes.NewBuffer(rawConfig))
+	if err != nil {
+		return err
+	}
+
+	if cf.Platform() == nil {
+		sylog.Warningf("OCI image doesn't declare a platform. It may not be compatible with this system.")
+		return nil
+	}
+
+	requiredPlatform := SysCtxToPlatform(sysCtx)
+	if cf.Platform().Satisfies(requiredPlatform) {
+		return nil
+	}
+
+	return fmt.Errorf("image (%s) does not satisfy required platform (%s)", cf.Platform(), requiredPlatform)
+}
+
+func DefaultPlatform() (*ggcrv1.Platform, error) {
+	if runtime.GOOS != "linux" {
+		return nil, fmt.Errorf("%q is not a valid platform OS for singularity", runtime.GOOS)
+	}
+	return &ggcrv1.Platform{
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
+		Variant:      CPUVariant(),
+	}, nil
+}
+
+func PlatformFromString(p string) (*ggcrv1.Platform, error) {
+	plat, err := ggcrv1.ParsePlatform(p)
+	if err != nil {
+		return nil, err
+	}
+	if plat.OS != "linux" {
+		return nil, fmt.Errorf("%q is not a valid platform OS for singularity", plat.OS)
+	}
+	return plat, nil
+}
+
+func PlatformFromArch(a string) (*ggcrv1.Platform, error) {
+	if runtime.GOOS != "linux" {
+		return nil, fmt.Errorf("%q is not a valid platform OS for singularity", runtime.GOOS)
+	}
+	return &ggcrv1.Platform{
+		OS:           runtime.GOOS,
+		Architecture: a,
+		Variant:      "",
+	}, nil
+}

--- a/internal/pkg/ociplatform/ociplatform_test.go
+++ b/internal/pkg/ociplatform/ociplatform_test.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package ociimage
+package ociplatform
 
 import (
 	"reflect"
@@ -26,7 +26,7 @@ func Test_sysCtxToPlatform(t *testing.T) {
 			want: ggcrv1.Platform{
 				OS:           runtime.GOOS,
 				Architecture: runtime.GOARCH,
-				Variant:      cpuVariant(),
+				Variant:      CPUVariant(),
 			},
 		},
 		{
@@ -37,7 +37,7 @@ func Test_sysCtxToPlatform(t *testing.T) {
 			want: ggcrv1.Platform{
 				OS:           "myOS",
 				Architecture: runtime.GOARCH,
-				Variant:      cpuVariant(),
+				Variant:      CPUVariant(),
 			},
 		},
 		{
@@ -48,7 +48,7 @@ func Test_sysCtxToPlatform(t *testing.T) {
 			want: ggcrv1.Platform{
 				OS:           runtime.GOOS,
 				Architecture: "myArch",
-				Variant:      cpuVariant(),
+				Variant:      CPUVariant(),
 			},
 		},
 		{
@@ -78,7 +78,7 @@ func Test_sysCtxToPlatform(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := sysCtxToPlatform(tt.sysCtx); !reflect.DeepEqual(got, tt.want) {
+			if got := SysCtxToPlatform(tt.sysCtx); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("sysCtxToPlatform() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	ocitypes "github.com/containers/image/v5/types"
+	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	scskeyclient "github.com/sylabs/scs-key-client/client"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
@@ -76,6 +77,8 @@ type Options struct {
 	// To warn when the above is needed, we need to know if the target of this
 	// bundle will be a sandbox
 	SandboxTarget bool
+	// Which Platform to use when retrieving images for the build
+	Platform ggcrv1.Platform
 }
 
 // NewEncryptedBundle creates an Encrypted Bundle environment.


### PR DESCRIPTION
## Description of the Pull Request (PR):

When pulling from OCI sources:

* Both OCI-SIF and other pulls will now support `--platform` to specify a source image platform.
* `--arch` can be used to infer `--platform linux/<arch>`.

You can now e.g.

```
singularity pull --platform linux/arm64 docker://alpine
```

... and retrieve an arm64 SIF on a non-arm64 machine.

When pulling from library sources:

* Both OCI-SIF and native SIF pulls will now support `--platform`. When pulling a native SIF via the library native protocol, any variant is ignored.
* `--arch` can be used to infer `--platform linux/<arch>`.

The `--arch` and `--platform` flags have been made common, in anticipation that they can be added to `singularity build`, to select a platform for binfmt_misc/qemu-static assisted cross-platform builds.

### This fixes or addresses the following GitHub issues:

 - Fixes #2015 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
