### PR TITLE
chore: bump go to min 1.20 / CI 1.21.0 & golang-ci-lint to 1.54.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.20.5'
+    default: '1.21.0'
 
 executors:
   node:
@@ -38,7 +38,7 @@ executors:
       - image: ubuntu:22.04
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.51.1
+      - image: golangci/golangci-lint:v1.54.0
   ubuntu-machine:
     machine:
       image: ubuntu-2204:2022.10.2

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,7 +90,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.20.5 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.21.0 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -369,7 +369,7 @@ var buildCmd = &cobra.Command{
 	TraverseChildren: true,
 }
 
-func preRun(cmd *cobra.Command, args []string) {
+func preRun(cmd *cobra.Command, _ []string) {
 	if isOCI {
 		sylog.Fatalf("Builds are not yet supported in OCI-mode. Omit --oci, or use --no-oci, to build a non-OCI Singularity container.")
 	}
@@ -379,7 +379,7 @@ func preRun(cmd *cobra.Command, args []string) {
 	}
 
 	if buildArgs.fakeroot && !buildArgs.remote {
-		fakerootExec(args)
+		fakerootExec()
 	}
 
 	// Always perform remote build when builder flag is set

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -41,7 +41,7 @@ import (
 	"github.com/sylabs/singularity/v4/pkg/util/cryptkey"
 )
 
-func fakerootExec(cmdArgs []string) {
+func fakerootExec() {
 	if buildArgs.nvccli && !buildArgs.noTest {
 		sylog.Warningf("Due to writable-tmpfs limitations, %%test sections will fail with --nvccli & --fakeroot")
 		sylog.Infof("Use -T / --notest to disable running tests during the build")

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -97,7 +97,7 @@ func init() {
 	})
 }
 
-func checkGlobal(cmd *cobra.Command, args []string) {
+func checkGlobal(cmd *cobra.Command, _ []string) {
 	if !keyGlobalPubKey || os.Geteuid() == 0 || buildcfg.SINGULARITY_SUID_INSTALL == 0 {
 		return
 	}

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -72,7 +72,7 @@ var KeyExportCmd = &cobra.Command{
 	Example: docs.KeyExportExample,
 }
 
-func exportRun(cmd *cobra.Command, args []string) {
+func exportRun(_ *cobra.Command, args []string) {
 	var opts []sypgp.HandleOpt
 	path := ""
 

--- a/cmd/internal/cli/key_import.go
+++ b/cmd/internal/cli/key_import.go
@@ -41,7 +41,7 @@ var (
 	}
 )
 
-func importRun(cmd *cobra.Command, args []string) {
+func importRun(_ *cobra.Command, args []string) {
 	var opts []sypgp.HandleOpt
 	path := ""
 

--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -88,7 +88,7 @@ type keyNewPairOptions struct {
 	PushToKeyStore bool
 }
 
-func runNewPairCmd(cmd *cobra.Command, args []string) {
+func runNewPairCmd(cmd *cobra.Command, _ []string) {
 	keyring := sypgp.NewHandle("")
 
 	opts, err := collectInput(cmd)

--- a/cmd/internal/cli/key_pull.go
+++ b/cmd/internal/cli/key_pull.go
@@ -58,7 +58,7 @@ func doKeyPullCmd(ctx context.Context, fingerprint string, co ...client.Option) 
 	keyring := sypgp.NewHandle(path, opts...)
 
 	// get matching keyring
-	el, err := sypgp.FetchPubkey(ctx, fingerprint, false, co...)
+	el, err := sypgp.FetchPubkey(ctx, fingerprint, co...)
 	if err != nil {
 		return fmt.Errorf("unable to pull key from server: %v", err)
 	}

--- a/cmd/internal/cli/pgp.go
+++ b/cmd/internal/cli/pgp.go
@@ -145,7 +145,7 @@ func isGlobal(e *openpgp.Entity) bool {
 }
 
 // outputVerify outputs a textual representation of r to stdout.
-func outputVerify(f *sif.FileImage, r integrity.VerifyResult) bool {
+func outputVerify(_ *sif.FileImage, r integrity.VerifyResult) bool {
 	e := r.Entity()
 
 	// Print signing entity info.

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -255,7 +255,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Warningf("Pull from shub:// is a direct download, --arch and --platform have no effect.")
 		}
 
-		_, err := shub.PullToFile(ctx, imgCache, pullTo, pullFrom, tmpDir, noHTTPS)
+		_, err := shub.PullToFile(ctx, imgCache, pullTo, pullFrom, noHTTPS)
 		if err != nil {
 			sylog.Fatalf("While pulling shub image: %v\n", err)
 		}
@@ -272,7 +272,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 		}
 
-		_, err = oras.PullToFile(ctx, imgCache, pullTo, pullFrom, tmpDir, ociAuth)
+		_, err = oras.PullToFile(ctx, imgCache, pullTo, pullFrom, ociAuth)
 		if err != nil {
 			sylog.Fatalf("While pulling image from oci registry: %v", err)
 		}
@@ -284,7 +284,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Warningf("Pull from http[s]:// is a direct download, --arch and --platform have no effect.")
 		}
 
-		_, err := net.PullToFile(ctx, imgCache, pullTo, pullFrom, tmpDir)
+		_, err := net.PullToFile(ctx, imgCache, pullTo, pullFrom)
 		if err != nil {
 			sylog.Fatalf("While pulling from image from http(s): %v\n", err)
 		}

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -692,7 +692,7 @@ func singularityExec(image string, args []string) (string, error) {
 }
 
 // CheckRoot ensures that a command is executed with root privileges.
-func CheckRoot(cmd *cobra.Command, args []string) {
+func CheckRoot(cmd *cobra.Command, _ []string) {
 	if os.Geteuid() != 0 {
 		sylog.Fatalf("%q command requires root privileges", cmd.CommandPath())
 	}
@@ -700,7 +700,7 @@ func CheckRoot(cmd *cobra.Command, args []string) {
 
 // CheckRootOrUnpriv ensures that a command is executed with root
 // privileges or that Singularity is installed unprivileged.
-func CheckRootOrUnpriv(cmd *cobra.Command, args []string) {
+func CheckRootOrUnpriv(cmd *cobra.Command, _ []string) {
 	if os.Geteuid() != 0 && buildcfg.SINGULARITY_SUID_INSTALL == 1 {
 		sylog.Fatalf("%q command requires root privileges or an unprivileged installation", cmd.CommandPath())
 	}

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1407,7 +1407,7 @@ func (c actionTests) actionOciOverlay(t *testing.T) {
 
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tt := range tests {
-				if !haveAllCommands(t, tt.requiredCmds) {
+				if !haveAllCommands(tt.requiredCmds) {
 					continue
 				}
 
@@ -1427,7 +1427,7 @@ func (c actionTests) actionOciOverlay(t *testing.T) {
 	}
 }
 
-func haveAllCommands(t *testing.T, cmds []string) bool {
+func haveAllCommands(cmds []string) bool {
 	for _, c := range cmds {
 		if _, err := bin.FindBin(c); err != nil {
 			return false
@@ -1792,7 +1792,7 @@ func (c actionTests) actionOciBindImage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if !haveAllCommands(t, tt.requiredCmds) {
+		if !haveAllCommands(tt.requiredCmds) {
 			continue
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/singularity/v4
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2

--- a/internal/app/singularity/keyserver_list.go
+++ b/internal/app/singularity/keyserver_list.go
@@ -18,6 +18,9 @@ import (
 )
 
 // KeyserverList prints information about remote configurations
+// FIXME - remoteName is not being honored
+//
+//nolint:revive
 func KeyserverList(remoteName string, usrConfigFile string) (err error) {
 	c := &remote.Config{}
 

--- a/internal/app/singularity/oci_linux.go
+++ b/internal/app/singularity/oci_linux.go
@@ -103,7 +103,7 @@ func OciResume(containerID string) error {
 }
 
 // OciState queries container state
-func OciState(containerID string, args *OciArgs) error {
+func OciState(containerID string, _ *OciArgs) error {
 	systemdCgroups, err := systemdCgroups()
 	if err != nil {
 		return err

--- a/internal/app/singularity/plugin_compile_linux.go
+++ b/internal/app/singularity/plugin_compile_linux.go
@@ -213,7 +213,7 @@ func buildPlugin(sourceDir string, bTool buildToolchain) (string, error) {
 // generateManifest takes the path to the plugin source, extracts
 // plugin's manifest by loading it into memory and stores it's json
 // representation in a separate file.
-func generateManifest(sourceDir string, bTool buildToolchain) (string, error) {
+func generateManifest(sourceDir string, _ buildToolchain) (string, error) {
 	in := pluginObjPath(sourceDir)
 	out := pluginManifestPath(sourceDir)
 

--- a/internal/app/singularity/plugin_disable_linux.go
+++ b/internal/app/singularity/plugin_disable_linux.go
@@ -8,6 +8,6 @@ package singularity
 import "github.com/sylabs/singularity/v4/internal/pkg/plugin"
 
 // DisablePlugin disables the named plugin.
-func DisablePlugin(name, libexecdir string) error {
+func DisablePlugin(name, _ string) error {
 	return plugin.Disable(name)
 }

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -395,7 +395,7 @@ func copyFiles(b *types.Bundle, a *App) error {
 			dst = splitLine[1]
 		}
 
-		if err := copy(src, filepath.Join(appBase, dst)); err != nil {
+		if err := copyWithfLr(src, filepath.Join(appBase, dst)); err != nil {
 			return err
 		}
 	}
@@ -455,17 +455,18 @@ func appData(b *types.Bundle, a *App) string {
 	return filepath.Join(b.RootfsPath, "/scif/data/", a.Name)
 }
 
-func copy(src, dst string) error {
+// FIXME: Replace with Go, or existing util function?
+func copyWithfLr(src, dst string) error {
 	cp, err := bin.FindBin("cp")
 	if err != nil {
 		return err
 	}
 
 	var stderr bytes.Buffer
-	copy := exec.Command(cp, "-fLr", src, dst)
-	copy.Stderr = &stderr
+	copyCmd := exec.Command(cp, "-fLr", src, dst)
+	copyCmd.Stderr = &stderr
 	sylog.Debugf("Copying %v to %v", src, dst)
-	if err := copy.Run(); err != nil {
+	if err := copyCmd.Run(); err != nil {
 		return fmt.Errorf("while copying %v to %v: %v: %v", src, dst, err, stderr.String())
 	}
 

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -84,10 +84,10 @@ func CopyFromHost(src, dstRel, dstRootfs string) error {
 		if err != nil {
 			return err
 		}
-		copy := exec.Command(cp, args...)
-		copy.Stdout = &output
-		copy.Stderr = &stderr
-		if err := copy.Run(); err != nil {
+		copyCmd := exec.Command(cp, args...)
+		copyCmd.Stdout = &output
+		copyCmd.Stderr = &stderr
+		if err := copyCmd.Run(); err != nil {
 			return fmt.Errorf("while copying %s to %s: %v: %s", paths, dstResolved, args, stderr.String())
 		}
 

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -188,8 +188,8 @@ func insertDefinition(b *types.Bundle) error {
 		}
 
 		// name is "Singularity" concatenated with an index based on number of other files in bootstrap_history
-		len := strconv.Itoa(len(files))
-		histName := "Singularity" + len
+		numFiles := strconv.Itoa(len(files))
+		histName := "Singularity" + numFiles
 		// move old definition into bootstrap_history
 		err = os.Rename(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history", histName))
 		if err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -39,7 +39,7 @@ type ArchConveyorPacker struct {
 
 // prepareFakerootEnv prepares a build environment to
 // make fakeroot working with pacstrap.
-func (cp *ArchConveyorPacker) prepareFakerootEnv(ctx context.Context) (func(), error) {
+func (cp *ArchConveyorPacker) prepareFakerootEnv() (func(), error) {
 	truePath, err := bin.FindBin("true")
 	if err != nil {
 		return nil, fmt.Errorf("while searching true command: %s", err)
@@ -107,7 +107,9 @@ func (cp *ArchConveyorPacker) prepareFakerootEnv(ctx context.Context) (func(), e
 }
 
 // Get just stores the source
-func (cp *ArchConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err error) {
+//
+// FIXME: use context for cancellation.
+func (cp *ArchConveyorPacker) Get(_ context.Context, b *types.Bundle) (err error) {
 	cp.b = b
 
 	// check for pacstrap on system
@@ -128,7 +130,7 @@ func (cp *ArchConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 
 	insideUserNs, setgroupsAllowed := namespaces.IsInsideUserNamespace(os.Getpid())
 	if insideUserNs && setgroupsAllowed {
-		umountFn, err := cp.prepareFakerootEnv(ctx)
+		umountFn, err := cp.prepareFakerootEnv()
 		if umountFn != nil {
 			defer umountFn()
 		}

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -29,7 +29,9 @@ type BusyBoxConveyorPacker struct {
 }
 
 // Get just stores the source
-func (c *BusyBoxConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
+//
+// FIXME: use context for cancellation.
+func (c *BusyBoxConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
 	c.b = b
 
 	// get mirrorURL, OSVerison, and Includes components to definition

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -100,13 +100,13 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 
 	f, err := os.Create(filepath.Join(c.b.RootfsPath, "/bin/busybox"))
 	if err != nil {
-		return
+		return "", err
 	}
 	defer f.Close()
 
 	bytesWritten, err := io.Copy(f, resp.Body)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	// Simple check to make sure file received is the correct size
@@ -116,7 +116,7 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 
 	err = os.Chmod(f.Name(), 0o755)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	return filepath.Join(c.b.RootfsPath, "/bin/busybox"), nil

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -278,17 +278,17 @@ func (cp *OCIConveyorPacker) insertBaseEnv() (err error) {
 	return
 }
 
-func (cp *OCIConveyorPacker) insertRunScript() (err error) {
+func (cp *OCIConveyorPacker) insertRunScript() error {
 	f, err := os.Create(cp.b.RootfsPath + "/.singularity.d/runscript")
 	if err != nil {
-		return
+		return err
 	}
 
 	defer f.Close()
 
 	_, err = f.WriteString("#!/bin/sh\n")
 	if err != nil {
-		return
+		return err
 	}
 
 	if len(cp.imgConfig.Entrypoint) > 0 {
@@ -296,12 +296,12 @@ func (cp *OCIConveyorPacker) insertRunScript() (err error) {
 			shell.EscapeSingleQuotes(shell.ArgsQuoted(cp.imgConfig.Entrypoint)) +
 			"'\n")
 		if err != nil {
-			return
+			return err
 		}
 	} else {
 		_, err = f.WriteString("OCI_ENTRYPOINT=''\n")
 		if err != nil {
-			return
+			return err
 		}
 	}
 
@@ -310,12 +310,12 @@ func (cp *OCIConveyorPacker) insertRunScript() (err error) {
 			shell.EscapeSingleQuotes(shell.ArgsQuoted(cp.imgConfig.Cmd)) +
 			"'\n")
 		if err != nil {
-			return
+			return err
 		}
 	} else {
 		_, err = f.WriteString("OCI_CMD=''\n")
 		if err != nil {
-			return
+			return err
 		}
 	}
 
@@ -348,30 +348,30 @@ func (cp *OCIConveyorPacker) insertRunScript() (err error) {
 
 	_, err = f.WriteString(runscript.String())
 	if err != nil {
-		return
+		return err
 	}
 
 	f.Sync()
 
 	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/runscript", 0o755)
 	if err != nil {
-		return
+		return err
 	}
 
 	return nil
 }
 
-func (cp *OCIConveyorPacker) insertEnv() (err error) {
+func (cp *OCIConveyorPacker) insertEnv() error {
 	f, err := os.Create(cp.b.RootfsPath + "/.singularity.d/env/10-docker2singularity.sh")
 	if err != nil {
-		return
+		return err
 	}
 
 	defer f.Close()
 
 	_, err = f.WriteString("#!/bin/sh\n")
 	if err != nil {
-		return
+		return err
 	}
 
 	for _, element := range cp.imgConfig.Env {
@@ -388,7 +388,7 @@ func (cp *OCIConveyorPacker) insertEnv() (err error) {
 		}
 		_, err = f.WriteString(export)
 		if err != nil {
-			return
+			return err
 		}
 	}
 
@@ -396,7 +396,7 @@ func (cp *OCIConveyorPacker) insertEnv() (err error) {
 
 	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/env/10-docker2singularity.sh", 0o755)
 	if err != nil {
-		return
+		return err
 	}
 
 	return nil

--- a/internal/pkg/build/sources/conveyorPacker_scratch.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch.go
@@ -25,7 +25,7 @@ type ScratchConveyorPacker struct {
 }
 
 // Get just stores the source
-func (c *ScratchConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
+func (c *ScratchConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
 	c.b = b
 
 	return nil

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -44,7 +44,9 @@ type YumConveyorPacker struct {
 }
 
 // Get downloads container information from the specified source
-func (c *YumConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
+//
+// FIXME: use context for cancellation.
+func (c *YumConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
 	c.b = b
 
 	// check for dnf or yum on system

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -53,7 +53,7 @@ func machine() (string, error) {
 // FIXME: use context for cancellation.
 //
 //nolint:maintidx
-func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) (err error) {
+func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) error {
 	var suseconnectProduct, suseconnectModver string
 	var suseconnectPath string
 	var pgpfile string
@@ -70,7 +70,7 @@ func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) (err err
 	// check for rpm on system
 	err = rpmPathCheck()
 	if err != nil {
-		return
+		return err
 	}
 
 	include := cp.b.Recipe.Header["include"]

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -50,8 +50,10 @@ func machine() (string, error) {
 
 // Get downloads container information from the specified source
 //
+// FIXME: use context for cancellation.
+//
 //nolint:maintidx
-func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err error) {
+func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) (err error) {
 	var suseconnectProduct, suseconnectModver string
 	var suseconnectPath string
 	var pgpfile string

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -129,10 +129,7 @@ func downloadWrapper(ctx context.Context, c *scslibrary.Client, imagePath, arch 
 		}
 	}(time.Now())
 
-	if err := DownloadImage(ctx, c, imagePath, arch, libraryRef, pb); err != nil {
-		return err
-	}
-	return nil
+	return DownloadImage(ctx, c, imagePath, arch, libraryRef, pb)
 }
 
 // pullOCI pulls a single layer squashfs OCI image from the library into an OCI-SIF file.

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -189,7 +189,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, tmpDir s
 }
 
 // PullToFile will pull an http(s) image to the specified location, through the cache, or directly if cache is disabled
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom string) (imagePath string, err error) {
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo

--- a/internal/pkg/client/ocisif/ocisif.go
+++ b/internal/pkg/client/ocisif/ocisif.go
@@ -171,7 +171,7 @@ func createOciSif(ctx context.Context, sysCtx *ocitypes.SystemContext, imgCache 
 	// If the image has a single squashfs layer, then we can write it directly to oci-sif.
 	if (len(mf.Layers)) == 1 && (mf.Layers[0].MediaType == SquashfsLayerMediaType) {
 		sylog.Infof("Writing OCI-SIF image")
-		return writeLayoutToOciSif(layoutDir, digest, imageDest, workDir)
+		return writeLayoutToOciSif(layoutDir, digest, imageDest)
 	}
 
 	// Otherwise, squashing and converting layers to squashfs is required.
@@ -180,7 +180,7 @@ func createOciSif(ctx context.Context, sysCtx *ocitypes.SystemContext, imgCache 
 }
 
 // writeLayoutToOciSif will write an image from an OCI layout to an oci-sif without applying any mutations.
-func writeLayoutToOciSif(layoutDir string, digest v1.Hash, imageDest, workDir string) error {
+func writeLayoutToOciSif(layoutDir string, digest v1.Hash, imageDest string) error {
 	lp, err := layout.FromPath(layoutDir)
 	if err != nil {
 		return fmt.Errorf("while opening layout: %w", err)
@@ -245,7 +245,9 @@ func convertLayoutToOciSif(layoutDir string, digest v1.Hash, imageDest, workDir 
 }
 
 // PushOCISIF pushes a single image from sourceFile to the OCI registry destRef.
-func PushOCISIF(ctx context.Context, sourceFile, destRef string, ociAuth *ocitypes.DockerAuthConfig) error {
+//
+// FIXME: Use context for cancellation.
+func PushOCISIF(_ context.Context, sourceFile, destRef string, ociAuth *ocitypes.DockerAuthConfig) error {
 	destRef = strings.TrimPrefix(destRef, "docker://")
 	destRef = strings.TrimPrefix(destRef, "//")
 	ref, err := name.ParseReference(destRef)

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -28,7 +28,9 @@ import (
 )
 
 // DownloadImage downloads a SIF image specified by an oci reference to a file using the included credentials
-func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
+//
+// FIXME: use context for cancellation.
+func DownloadImage(_ context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 	im, err := remoteImage(ref, ociAuth)
 	if err != nil {
 		return err
@@ -98,7 +100,9 @@ func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.Dock
 
 // UploadImage uploads the image specified by path and pushes it to the provided oci reference,
 // it will use credentials if supplied
-func UploadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
+//
+// FIXME: use context for cancellation.
+func UploadImage(_ context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 	// ensure that are uploading a SIF
 	if err := ensureSIF(path); err != nil {
 		return err
@@ -141,7 +145,9 @@ func ensureSIF(filepath string) error {
 }
 
 // RefHash returns the digest of the SIF layer of the OCI manifest for supplied ref
-func RefHash(ctx context.Context, ref string, ociAuth *ocitypes.DockerAuthConfig) (v1.Hash, error) {
+//
+// FIXME: use context for cancellation.
+func RefHash(_ context.Context, ref string, ociAuth *ocitypes.DockerAuthConfig) (v1.Hash, error) {
 	im, err := remoteImage(ref, ociAuth)
 	if err != nil {
 		return v1.Hash{}, err

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -79,7 +79,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 }
 
 // PullToFile will pull an oras image to the specified location, through the cache, or directly if cache is disabled
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom string, ociAuth *ocitypes.DockerAuthConfig) (imagePath string, err error) {
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo

--- a/internal/pkg/client/shub/pull.go
+++ b/internal/pkg/client/shub/pull.go
@@ -192,7 +192,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 }
 
 // PullToFile will pull a shub image to the specified location, through the cache, or directly if cache is disabled
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string, noHTTPS bool) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom string, noHTTPS bool) (imagePath string, err error) {
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo

--- a/internal/pkg/image/unpacker/squashfs_test.go
+++ b/internal/pkg/image/unpacker/squashfs_test.go
@@ -56,7 +56,11 @@ func testSquashfs(t *testing.T, tmpParent string) {
 		t.Skip("unsquashfs not found")
 	}
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp(tmpParent, "test-squashfs-")
+	if err != nil {
+		t.Fatalf("while creating tmpdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
 
 	// create archive with files present in this directory
 	archive := createArchive(t)

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -236,6 +236,6 @@ func (h *keyserverHandler) login(u *url.URL, username, password string, insecure
 	}, nil
 }
 
-func (h *keyserverHandler) logout(u *url.URL) error {
+func (h *keyserverHandler) logout(_ *url.URL) error {
 	return nil
 }

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -88,13 +88,13 @@ func TestWriteToReadFrom(t *testing.T) {
 
 			test.c.WriteTo(&r)
 
-			new, err := ReadFrom(&r)
+			newConfig, err := ReadFrom(&r)
 			if err != nil {
 				t.Errorf("unexpected failure running %s test: %s", test.name, err)
 			}
 
-			if !reflect.DeepEqual(test.c, *new) {
-				t.Errorf("failed to read/write config:\n\thave: %v\n\twant: %v", test.c, *new)
+			if !reflect.DeepEqual(test.c, *newConfig) {
+				t.Errorf("failed to read/write config:\n\thave: %v\n\twant: %v", test.c, *newConfig)
 			}
 		})
 	}

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -250,7 +250,7 @@ func fakerootSeccompProfile() *specs.LinuxSeccomp {
 //
 // This will be executed as a fake root user in a new user
 // namespace (PrepareConfig will set both).
-func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
+func (e *EngineOperations) StartProcess(_ net.Conn) error {
 	const (
 		mountInfo    = "/proc/self/mountinfo"
 		selinuxMount = "/sys/fs/selinux"
@@ -373,12 +373,12 @@ func (e *EngineOperations) CleanupContainer(context.Context, error, syscall.Wait
 }
 
 // CleanupHost does nothing for the fakeroot engine.
-func (e *EngineOperations) CleanupHost(ctx context.Context) error {
+func (e *EngineOperations) CleanupHost(context.Context) error {
 	return nil
 }
 
 // PostStartProcess does nothing for the fakeroot engine.
-func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error {
+func (e *EngineOperations) PostStartProcess(context.Context, int) error {
 	return nil
 }
 

--- a/internal/pkg/runtime/engine/singularity/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/singularity/cleanup_linux.go
@@ -128,7 +128,7 @@ func umount(lazy bool) (err error) {
 
 	oldEffective, err = capabilities.SetProcessEffective(caps)
 	if err != nil {
-		return
+		return err
 	}
 	defer func() {
 		_, e := capabilities.SetProcessEffective(oldEffective)

--- a/internal/pkg/runtime/engine/singularity/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/singularity/cleanup_linux.go
@@ -36,7 +36,7 @@ import (
 // For better understanding of runtime flow in general refer to
 // https://github.com/opencontainers/runtime-spec/blob/master/runtime.md#lifecycle.
 // CleanupContainer is performing step 8/9 here.
-func (e *EngineOperations) CleanupContainer(ctx context.Context, fatal error, status syscall.WaitStatus) error {
+func (e *EngineOperations) CleanupContainer(ctx context.Context, _ error, _ syscall.WaitStatus) error {
 	// firstly stop all fuse drivers before any image removal
 	// by image driver interruption or image cleanup for hybrid
 	// fakeroot workflow

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -408,7 +408,7 @@ func (c *container) mount(point *mount.Point, system *mount.System) error {
 // configuration directive, when applied master process
 // won't see mount done by RPC server anymore. Typically
 // called after SharedTag mounts
-func (c *container) setPropagationMount(system *mount.System) error {
+func (c *container) setPropagationMount(*mount.System) error {
 	pflags := uintptr(syscall.MS_REC)
 
 	if c.engine.EngineConfig.File.MountSlave {
@@ -426,7 +426,7 @@ func (c *container) setPropagationMount(system *mount.System) error {
 // point preventing this process from accessing /proc/<rpc_pid>/mountinfo
 // without error, so we bind mount /proc/self/mountinfo from RPC process
 // to a session file and read mount information from there.
-func (c *container) addMountInfo(system *mount.System) error {
+func (c *container) addMountInfo(*mount.System) error {
 	const (
 		mountinfo = "/mountinfo"
 		self      = "/proc/self/mountinfo"
@@ -444,7 +444,7 @@ func (c *container) addMountInfo(system *mount.System) error {
 	return nil
 }
 
-func (c *container) chdirFinal(system *mount.System) error {
+func (c *container) chdirFinal(*mount.System) error {
 	if _, err := c.rpcOps.Chdir(c.session.FinalPath()); err != nil {
 		return err
 	}
@@ -747,7 +747,7 @@ func (c *container) addRootfsMount(system *mount.System) error {
 	return nil
 }
 
-func (c *container) overlayUpperWork(system *mount.System) error {
+func (c *container) overlayUpperWork(*mount.System) error {
 	ov := c.session.Layer.(*overlay.Overlay)
 
 	createUpperWork := func(path, label string) error {
@@ -1537,7 +1537,7 @@ func (c *container) addHomeLayer(system *mount.System, source, dest string) erro
 
 // addHomeNoLayer is responsible for staging the home directory and adding the base
 // directory of the staged home into the container when overlay/underlay are unavailable
-func (c *container) addHomeNoLayer(system *mount.System, source, dest string) error {
+func (c *container) addHomeNoLayer(system *mount.System, dest string) error {
 	flags := uintptr(syscall.MS_BIND | syscall.MS_REC)
 
 	homeBase := fs.RootDir(dest)
@@ -1591,7 +1591,7 @@ func (c *container) addHomeMount(system *mount.System) error {
 	sessionLayer := c.engine.EngineConfig.GetSessionLayer()
 	sylog.Debugf("Adding home directory mount [%v:%v] to list using layer: %s\n", stagingDir, dest, sessionLayer)
 	if !c.isLayerEnabled() {
-		return c.addHomeNoLayer(system, stagingDir, dest)
+		return c.addHomeNoLayer(system, dest)
 	}
 	return c.addHomeLayer(system, stagingDir, dest)
 }

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -321,7 +321,7 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 // and thus no additional privileges can be gained.
 //
 // Here, however, singularity engine does not escalate privileges.
-func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error {
+func (e *EngineOperations) PostStartProcess(_ context.Context, pid int) error {
 	sylog.Debugf("Post start process")
 
 	callbackType := (singularitycallback.PostStartProcess)(nil)
@@ -670,7 +670,7 @@ func injectEnvHandler(senv map[string]string, noEval bool) interpreter.OpenHandl
 	}
 }
 
-func runtimeVarsHandler(senv map[string]string) interpreter.OpenHandler {
+func runtimeVarsHandler() interpreter.OpenHandler {
 	var once sync.Once
 
 	return func(path string, _ int, _ os.FileMode) (io.ReadWriteCloser, error) {
@@ -685,7 +685,7 @@ func runtimeVarsHandler(senv map[string]string) interpreter.OpenHandler {
 }
 
 // sylogBuiltin allows to use sylog logger from shell script.
-func sylogBuiltin(ctx context.Context, argv []string) error {
+func sylogBuiltin(_ context.Context, argv []string) error {
 	if len(argv) < 2 {
 		return fmt.Errorf("sylog builtin requires two arguments")
 	}
@@ -705,7 +705,7 @@ func sylogBuiltin(ctx context.Context, argv []string) error {
 }
 
 // getAllEnvBuiltin display all exported variables in the form KEY=VALUE.
-func getAllEnvBuiltin(shell *interpreter.Shell) interpreter.ShellBuiltin {
+func getAllEnvBuiltin() interpreter.ShellBuiltin {
 	return func(ctx context.Context, argv []string) error {
 		hc := interp.HandlerCtx(ctx)
 
@@ -739,7 +739,7 @@ func getAllEnvBuiltin(shell *interpreter.Shell) interpreter.ShellBuiltin {
 
 // fixPathBuiltin takes the current path value to fix it by injecting
 // missing default path and returns value on shell interpreter output.
-func fixPathBuiltin(ctx context.Context, argv []string) error {
+func fixPathBuiltin(ctx context.Context, _ []string) error {
 	hc := interp.HandlerCtx(ctx)
 
 	currentPath := filepath.SplitList(hc.Env.Get("PATH").String())
@@ -765,7 +765,7 @@ func fixPathBuiltin(ctx context.Context, argv []string) error {
 
 // hashBuiltin is a noop function for hash bash builtin, since we don't
 // store resolved path in a hash table, there is nothing to do.
-func hashBuiltin(ctx context.Context, argv []string) error {
+func hashBuiltin(context.Context, []string) error {
 	return nil
 }
 
@@ -815,10 +815,10 @@ func runActionScript(engineConfig *singularityConfig.EngineConfig) ([]string, []
 	senv := engineConfig.GetSingularityEnv()
 	shell.RegisterOpenHandler("/.inject-singularity-env.sh", injectEnvHandler(senv, engineConfig.GetNoEval()))
 
-	shell.RegisterOpenHandler("/.singularity.d/env/99-runtimevars.sh", runtimeVarsHandler(senv))
+	shell.RegisterOpenHandler("/.singularity.d/env/99-runtimevars.sh", runtimeVarsHandler())
 
 	// register few builtin
-	shell.RegisterShellBuiltin("getallenv", getAllEnvBuiltin(shell))
+	shell.RegisterShellBuiltin("getallenv", getAllEnvBuiltin())
 	shell.RegisterShellBuiltin("sylog", sylogBuiltin)
 	shell.RegisterShellBuiltin("fixpath", fixPathBuiltin)
 	shell.RegisterShellBuiltin("hash", hashBuiltin)

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -138,7 +138,7 @@ func (t *Methods) Decrypt(arguments *args.CryptArgs, reply *string) (err error) 
 }
 
 // Mkdir performs a mkdir with the specified arguments.
-func (t *Methods) Mkdir(arguments *args.MkdirArgs, reply *int) (err error) {
+func (t *Methods) Mkdir(arguments *args.MkdirArgs, _ *int) (err error) {
 	mainthread.Execute(func() {
 		oldmask := syscall.Umask(0)
 		err = os.Mkdir(arguments.Path, arguments.Perm)
@@ -148,7 +148,7 @@ func (t *Methods) Mkdir(arguments *args.MkdirArgs, reply *int) (err error) {
 }
 
 // Chroot performs a chroot with the specified arguments.
-func (t *Methods) Chroot(arguments *args.ChrootArgs, reply *int) (err error) {
+func (t *Methods) Chroot(arguments *args.ChrootArgs, _ *int) (err error) {
 	root := arguments.Root
 
 	if root != "." {
@@ -304,12 +304,12 @@ func (t *Methods) LoopDevice(arguments *args.LoopArgs, reply *int) (err error) {
 }
 
 // SetHostname sets hostname with the specified arguments.
-func (t *Methods) SetHostname(arguments *args.HostnameArgs, reply *int) error {
+func (t *Methods) SetHostname(arguments *args.HostnameArgs, _ *int) error {
 	return syscall.Sethostname([]byte(arguments.Hostname))
 }
 
 // Chdir changes current working directory to path.
-func (t *Methods) Chdir(arguments *args.ChdirArgs, reply *int) error {
+func (t *Methods) Chdir(arguments *args.ChdirArgs, _ *int) error {
 	return mainthread.Chdir(arguments.Dir)
 }
 
@@ -332,7 +332,7 @@ func (t *Methods) Lstat(arguments *args.StatArgs, reply *args.StatReply) error {
 }
 
 // SendFuseFd send fuse file descriptor over unix socket.
-func (t *Methods) SendFuseFd(arguments *args.SendFuseFdArgs, reply *int) error {
+func (t *Methods) SendFuseFd(arguments *args.SendFuseFdArgs, _ *int) error {
 	usernsFd, err := unix.Open("/proc/self/ns/user", unix.O_RDONLY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return fmt.Errorf("while opening /proc/self/ns/user: %s", err)
@@ -349,7 +349,7 @@ func (t *Methods) SendFuseFd(arguments *args.SendFuseFdArgs, reply *int) error {
 }
 
 // Symlink performs a symlink with the specified arguments.
-func (t *Methods) Symlink(arguments *args.SymlinkArgs, reply *int) error {
+func (t *Methods) Symlink(arguments *args.SymlinkArgs, _ *int) error {
 	return os.Symlink(arguments.Old, arguments.New)
 }
 
@@ -372,12 +372,12 @@ func (t *Methods) ReadDir(arguments *args.ReadDirArgs, reply *args.ReadDirReply)
 }
 
 // Chown performs a chown with the specified arguments.
-func (t *Methods) Chown(arguments *args.ChownArgs, reply *int) error {
+func (t *Methods) Chown(arguments *args.ChownArgs, _ *int) error {
 	return os.Chown(arguments.Name, arguments.UID, arguments.GID)
 }
 
 // Lchown performs a lchown with the specified arguments.
-func (t *Methods) Lchown(arguments *args.ChownArgs, reply *int) error {
+func (t *Methods) Lchown(arguments *args.ChownArgs, _ *int) error {
 	return os.Lchown(arguments.Name, arguments.UID, arguments.GID)
 }
 
@@ -400,7 +400,7 @@ func (t *Methods) Umask(arguments *args.UmaskArgs, reply *int) (err error) {
 }
 
 // WriteFile creates an empty file if it doesn't exist or a file with the provided data.
-func (t *Methods) WriteFile(arguments *args.WriteFileArgs, reply *int) error {
+func (t *Methods) WriteFile(arguments *args.WriteFileArgs, _ *int) error {
 	f, err := os.OpenFile(arguments.Filename, os.O_CREATE|os.O_WRONLY|os.O_EXCL, arguments.Perm)
 	if err != nil {
 		if !os.IsExist(err) {
@@ -418,7 +418,7 @@ func (t *Methods) WriteFile(arguments *args.WriteFileArgs, reply *int) error {
 }
 
 // NvCCLI will call nvidia-container-cli to configure GPU(s) for the container.
-func (t *Methods) NvCCLI(arguments *args.NvCCLIArgs, reply *int) (err error) {
+func (t *Methods) NvCCLI(arguments *args.NvCCLIArgs, _ *int) (err error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -174,7 +174,7 @@ func (t *Methods) Chroot(arguments *args.ChrootArgs, _ *int) (err error) {
 
 	oldEffective, err = capabilities.SetProcessEffective(caps)
 	if err != nil {
-		return
+		return err
 	}
 	defer func() {
 		_, e := capabilities.SetProcessEffective(oldEffective)

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -399,11 +399,7 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 		return err
 	}
 
-	if err := b.Update(ctx, spec); err != nil {
-		return err
-	}
-
-	return nil
+	return b.Update(ctx, spec)
 }
 
 // prepareEtc creates modified container-specific /etc files and adds them to

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -598,7 +598,7 @@ func (l *Launcher) addBindMount(mounts *[]specs.Mount, b bind.Path, allowSUID bo
 			return nil
 		}
 
-		im, err := l.prepareImageBindMount(b, allowSUID)
+		im, err := l.prepareImageBindMount(b)
 		if err != nil {
 			return err
 		}
@@ -653,7 +653,7 @@ func (l *Launcher) addBindMount(mounts *[]specs.Mount, b bind.Path, allowSUID bo
 	return nil
 }
 
-func (l *Launcher) prepareImageBindMount(bindPath bind.Path, allowSUID bool) (*fuse.ImageMount, error) {
+func (l *Launcher) prepareImageBindMount(bindPath bind.Path) (*fuse.ImageMount, error) {
 	imagePath := bindPath.Source
 	img, err := image.Init(imagePath, false)
 	if err != nil {

--- a/internal/pkg/runtime/launcher/oci/oci_attach_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_attach_linux.go
@@ -53,7 +53,9 @@ const (
 )
 
 // Attach attaches the console to a running container
-func Attach(ctx context.Context, containerID string) error {
+//
+// FIXME: use context for cancellation, or remove.
+func Attach(_ context.Context, containerID string) error {
 	streams := attachStreams{
 		OutputStream: os.Stdout,
 		ErrorStream:  os.Stderr,

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -22,7 +22,9 @@ import (
 )
 
 // Delete deletes container resources
-func Delete(ctx context.Context, containerID string, systemdCgroups bool) error {
+//
+// FIXME: use context for cancellation, or remove.
+func Delete(_ context.Context, containerID string, systemdCgroups bool) error {
 	runtimeBin, err := runtime()
 	if err != nil {
 		return err
@@ -175,7 +177,9 @@ func Resume(containerID string, systemdCgroups bool) error {
 }
 
 // Run runs a container (equivalent to create/start/delete)
-func Run(ctx context.Context, containerID, bundlePath, pidFile string, systemdCgroups bool) error {
+//
+// FIXME: use context for cancellation, or remove.
+func Run(_ context.Context, containerID, bundlePath, pidFile string, systemdCgroups bool) error {
 	runtimeBin, err := runtime()
 	if err != nil {
 		return err

--- a/internal/pkg/signature/verify_test.go
+++ b/internal/pkg/signature/verify_test.go
@@ -101,7 +101,7 @@ type mockHKP struct {
 	e *openpgp.Entity
 }
 
-func (m mockHKP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (m mockHKP) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/pgp-keys")
 
 	wr, err := armor.Encode(w, openpgp.PublicKeyType, nil)

--- a/internal/pkg/sypgp/sypgp.go
+++ b/internal/pkg/sypgp/sypgp.go
@@ -837,7 +837,7 @@ func date(s string) string {
 }
 
 // FetchPubkey pulls a public key from the Key Service.
-func FetchPubkey(ctx context.Context, fingerprint string, noPrompt bool, opts ...client.Option) (openpgp.EntityList, error) {
+func FetchPubkey(ctx context.Context, fingerprint string, opts ...client.Option) (openpgp.EntityList, error) {
 	// Decode fingerprint and ensure proper length.
 	var fp []byte
 	fp, err := hex.DecodeString(fingerprint)

--- a/internal/pkg/sypgp/sypgp_test.go
+++ b/internal/pkg/sypgp/sypgp_test.go
@@ -38,7 +38,7 @@ type mockPKSLookup struct {
 	el   openpgp.EntityList
 }
 
-func (ms *mockPKSLookup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (ms *mockPKSLookup) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(ms.code)
 	if ms.code == http.StatusOK {
 		w.Header().Set("Content-Type", "application/pgp-keys")
@@ -132,7 +132,7 @@ func TestFetchPubkey(t *testing.T) {
 				client.OptHTTPClient(srv.Client()),
 			}
 
-			el, err := FetchPubkey(context.Background(), tt.fingerprint, false, opts...)
+			el, err := FetchPubkey(context.Background(), tt.fingerprint, opts...)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("unexpected error: %v", err)
 				return

--- a/internal/pkg/util/env/clean_test.go
+++ b/internal/pkg/util/env/clean_test.go
@@ -308,7 +308,7 @@ func TestSetContainerEnv(t *testing.T) {
 			generator := generate.New(&ociConfig.Spec)
 
 			senv := SetContainerEnv(generator, tc.env, tc.cleanEnv, tc.homeDest)
-			if !equal(t, ociConfig.Process.Env, tc.resultEnv) {
+			if !equal(ociConfig.Process.Env, tc.resultEnv) {
 				t.Fatalf("unexpected envs:\n want: %v\ngot: %v", tc.resultEnv, ociConfig.Process.Env)
 			}
 			if tc.singularityEnv != nil && !reflect.DeepEqual(senv, tc.singularityEnv) {
@@ -320,7 +320,7 @@ func TestSetContainerEnv(t *testing.T) {
 
 // equal tells whether a and b contain the same elements in the
 // same order. A nil argument is equivalent to an empty slice.
-func equal(t *testing.T, a, b []string) bool {
+func equal(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -537,9 +537,8 @@ func (p *Points) Import(points map[AuthorizedTag][]Point) error {
 			if flags&syscall.MS_BIND != 0 {
 				if err = p.AddBind(tag, point.Source, point.Destination, flags); err == nil {
 					continue
-				} else {
-					return err
 				}
+				return err
 			}
 
 			for _, option := range point.InternalOptions {

--- a/internal/pkg/util/passwdfile/passwdfile_unix.go
+++ b/internal/pkg/util/passwdfile/passwdfile_unix.go
@@ -79,7 +79,7 @@ func readColonFile(r io.Reader, fn lineFunc, readCols int) (v any, err error) {
 		}
 		v, err = fn(wholeLine)
 		if v != nil || err != nil {
-			return
+			return v, err
 		}
 
 		// If necessary, skip the rest of the line

--- a/mconfig
+++ b/mconfig
@@ -20,7 +20,7 @@ hstld=
 hstranlib=
 hstobjcopy=
 hstgo=
-hstgo_version="1.18"
+hstgo_version="1.20"
 hstgo_opts="go"
 
 tgtcc=

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -432,6 +432,7 @@ func ParseDefinitionFile(r io.Reader) (d types.Definition, err error) {
 	s.Split(scanDefinitionFile)
 
 	// advance scanner until it returns a useful token or errors
+	//nolint:revive
 	for s.Scan() && s.Text() == "" && s.Err() == nil {
 	}
 

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -50,6 +50,7 @@ func TestScanDefinitionFile(t *testing.T) {
 
 			s := bufio.NewScanner(r)
 			s.Split(scanDefinitionFile)
+			//nolint:revive
 			for s.Scan() && s.Text() == "" && s.Err() == nil {
 			}
 
@@ -136,6 +137,7 @@ func TestDoSections(t *testing.T) {
 	s1.Split(scanDefinitionFile)
 
 	// advance scanner until it returns a useful token
+	//nolint:revive
 	for s1.Scan() && s1.Text() == "" {
 		// Nothing to do
 	}
@@ -151,6 +153,7 @@ func TestDoSections(t *testing.T) {
 	s2.Split(scanDefinitionFile)
 
 	// Advance the scanner until it returns a useful token
+	//nolint:revive
 	for s2.Scan() && s2.Text() == "" {
 		// Nothing to do
 	}

--- a/pkg/cmdline/cmd.go
+++ b/pkg/cmdline/cmd.go
@@ -36,7 +36,7 @@ func (c CommandError) Error() string {
 	return string(c)
 }
 
-func onError(cmd *cobra.Command, err error) error {
+func onError(_ *cobra.Command, err error) error {
 	return FlagError(err.Error())
 }
 

--- a/pkg/image/ocisif.go
+++ b/pkg/image/ocisif.go
@@ -53,10 +53,10 @@ func (f *ociSifFormat) initializer(img *Image, fi os.FileInfo) error {
 	return nil
 }
 
-func (f *ociSifFormat) openMode(writable bool) int {
+func (f *ociSifFormat) openMode(bool) int {
 	return os.O_RDONLY
 }
 
-func (f *ociSifFormat) lock(img *Image) error {
+func (f *ociSifFormat) lock(*Image) error {
 	return nil
 }

--- a/pkg/image/sandbox.go
+++ b/pkg/image/sandbox.go
@@ -28,10 +28,10 @@ func (f *sandboxFormat) initializer(img *Image, fi os.FileInfo) error {
 	return nil
 }
 
-func (f *sandboxFormat) openMode(writable bool) int {
+func (f *sandboxFormat) openMode(_ bool) int {
 	return os.O_RDONLY
 }
 
-func (f *sandboxFormat) lock(img *Image) error {
+func (f *sandboxFormat) lock(_ *Image) error {
 	return nil
 }

--- a/pkg/image/squashfs.go
+++ b/pkg/image/squashfs.go
@@ -170,10 +170,10 @@ func (f *squashfsFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	return nil
 }
 
-func (f *squashfsFormat) openMode(writable bool) int {
+func (f *squashfsFormat) openMode(bool) int {
 	return os.O_RDONLY
 }
 
-func (f *squashfsFormat) lock(img *Image) error {
+func (f *squashfsFormat) lock(*Image) error {
 	return nil
 }

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -116,7 +116,9 @@ func New(opts ...Option) (ocibundle.Bundle, error) {
 }
 
 // Delete erases OCI bundle created an OCI image ref
-func (b *Bundle) Delete(ctx context.Context) error {
+//
+// FIXME: use context for cancellation, or remove.
+func (b *Bundle) Delete(_ context.Context) error {
 	if b.rootfsMounted {
 		sylog.Debugf("Unmounting bundle rootfs %q", tools.RootFs(b.bundlePath).Path())
 		if err := syscall.Unmount(tools.RootFs(b.bundlePath).Path(), syscall.MNT_DETACH); err != nil {
@@ -222,7 +224,9 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 }
 
 // Update will update the OCI config for the OCI bundle, so that it is ready for execution.
-func (b *Bundle) Update(ctx context.Context, ociConfig *specs.Spec) error {
+//
+// FIXME: use context for cancellation, or remove.
+func (b *Bundle) Update(_ context.Context, ociConfig *specs.Spec) error {
 	// generate OCI bundle directory and config
 	g, err := tools.GenerateBundleConfig(b.bundlePath, ociConfig)
 	if err != nil {

--- a/pkg/ocibundle/ocisif/bundle_linux.go
+++ b/pkg/ocibundle/ocisif/bundle_linux.go
@@ -174,7 +174,7 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 }
 
 // Update will update the OCI config for the OCI bundle, so that it is ready for execution.
-func (b *Bundle) Update(ctx context.Context, ociConfig *specs.Spec) error {
+func (b *Bundle) Update(_ context.Context, ociConfig *specs.Spec) error {
 	// generate OCI bundle directory and config
 	g, err := tools.GenerateBundleConfig(b.bundlePath, ociConfig)
 	if err != nil {

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -148,7 +148,7 @@ func (s *sifBundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 }
 
 // Update will update the OCI config for the OCI bundle, so that it is ready for execution.
-func (s *sifBundle) Update(ctx context.Context, ociConfig *specs.Spec) error {
+func (s *sifBundle) Update(_ context.Context, ociConfig *specs.Spec) error {
 	// generate OCI bundle directory and config
 	g, err := tools.GenerateBundleConfig(s.bundlePath, ociConfig)
 	if err != nil {

--- a/pkg/util/capabilities/config_test.go
+++ b/pkg/util/capabilities/config_test.go
@@ -46,13 +46,13 @@ func TestReadFromWriteTo(t *testing.T) {
 
 			test.c.WriteTo(&r)
 
-			new, err := ReadFrom(&r)
+			newConfig, err := ReadFrom(&r)
 			if err != nil {
 				t.Errorf("unexpected failure running %s test: %s", test.name, err)
 			}
 
-			if !reflect.DeepEqual(test.c, *new) {
-				t.Errorf("failed to read/write config:\n\thave: %v\n\twant: %v", test.c, *new)
+			if !reflect.DeepEqual(test.c, *newConfig) {
+				t.Errorf("failed to read/write config:\n\thave: %v\n\twant: %v", test.c, *newConfig)
 			}
 		})
 	}

--- a/pkg/util/capabilities/process_linux_test.go
+++ b/pkg/util/capabilities/process_linux_test.go
@@ -43,8 +43,8 @@ func TestGetProcess(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error while getting process %s capabilities: %s", tt.name, err)
 		}
-		cap := Map[tt.cap]
-		if tt.cap != "" && caps&uint64(1<<cap.Value) == 0 {
+		c := Map[tt.cap]
+		if tt.cap != "" && caps&uint64(1<<c.Value) == 0 {
 			t.Fatalf("%s capability %s missing", tt.name, tt.cap)
 		}
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump go version to 1.20 in go.mod

Bump golangci-lint to 1.54.0

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
