### PR TITLE
add --config to `keyserver` cmd, honor optional remoteName arg

### DIFF
--- a/cmd/internal/cli/keyserver.go
+++ b/cmd/internal/cli/keyserver.go
@@ -21,6 +21,16 @@ var (
 	keyserverOrder    uint32
 )
 
+// -c|--config
+var keyserverConfigFlag = cmdline.Flag{
+	ID:           "keyserverConfigFlag",
+	Value:        &remoteConfig,
+	DefaultValue: remoteConfigUser,
+	Name:         "config",
+	ShortHand:    "c",
+	Usage:        "path to the file holding keyserver configurations",
+}
+
 // -i|--insecure
 var keyserverInsecureFlag = cmdline.Flag{
 	ID:           "keyserverInsecureFlag",
@@ -80,6 +90,9 @@ func init() {
 		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverLoginCmd)
 		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverLogoutCmd)
 		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverListCmd)
+
+		// default location of the remote.yaml file is the user directory
+		cmdManager.RegisterFlagForCmd(&keyserverConfigFlag, KeyserverCmd)
 
 		cmdManager.RegisterFlagForCmd(&keyserverOrderFlag, KeyserverAddCmd)
 		cmdManager.RegisterFlagForCmd(&keyserverInsecureFlag, KeyserverAddCmd)

--- a/cmd/internal/cli/registry.go
+++ b/cmd/internal/cli/registry.go
@@ -21,7 +21,7 @@ var registryConfigFlag = cmdline.Flag{
 	DefaultValue: remoteConfigUser,
 	Name:         "config",
 	ShortHand:    "c",
-	Usage:        "path to the file holding remote endpoint configurations",
+	Usage:        "path to the file holding registry configurations",
 }
 
 // -u|--username

--- a/docs/keyserver.go
+++ b/docs/keyserver.go
@@ -77,9 +77,9 @@ const (
 	KeyserverListUse   string = `list [remoteName]`
 	KeyserverListShort string = `List all keyservers that are configured`
 	KeyserverListLong  string = `
-  The 'keyserver list' command lists all keyservers configured for use with a
-  given remote endpoint. If no endpoint is specified, the default
-  remote endpoint (SylabsCloud) will be assumed.`
+  The 'keyserver list' command lists the keyservers configured for use with
+  each remote endpoint. If the optional remoteName argument is provided, the
+  command will only list keyservers for the remote endpoint matching that name.`
 	KeyserverListExample string = `
   $ singularity keyserver list`
 )

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -28,7 +28,11 @@ func (c ctx) remoteAdd(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer os.Remove(config.Name()) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(config.Name()) // clean up
+		}
+	})
 
 	testPass := []struct {
 		name   string
@@ -168,7 +172,11 @@ func (c ctx) remoteRemove(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	defer os.Remove(config.Name()) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(config.Name()) // clean up
+		}
+	})
 
 	// Prep config by adding multiple remotes
 	add := []struct {
@@ -241,7 +249,11 @@ func (c ctx) remoteUse(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	defer os.Remove(config.Name()) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(config.Name()) // clean up
+		}
+	})
 
 	testFail := []struct {
 		name   string
@@ -315,7 +327,11 @@ func (c ctx) remoteStatus(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	defer os.Remove(config.Name()) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(config.Name()) // clean up
+		}
+	})
 
 	// Prep config by adding multiple remotes
 	add := []struct {
@@ -386,7 +402,11 @@ func (c ctx) remoteList(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	defer os.Remove(config.Name()) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(config.Name()) // clean up
+		}
+	})
 
 	testPass := []struct {
 		name string

--- a/internal/app/singularity/keyserver_list.go
+++ b/internal/app/singularity/keyserver_list.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/credential"
+	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
 )
 
 // KeyserverList prints information about remote configurations
@@ -62,7 +63,16 @@ func KeyserverList(remoteName string, usrConfigFile string) (err error) {
 		return fmt.Errorf("error getting default remote-endpoint: %w", err)
 	}
 
-	for epName, ep := range c.Remotes {
+	remotes := c.Remotes
+	if remoteName != "" {
+		ep, ok := c.Remotes[remoteName]
+		if !ok {
+			return fmt.Errorf("no remote-endpoint with the name %q found", remoteName)
+		}
+		remotes = map[string]*endpoint.Config{remoteName: ep}
+	}
+
+	for epName, ep := range remotes {
 		fmt.Println()
 		isSystem := ""
 		if ep.System {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add `--config` option to `keyserver` command. (This was available when keyservers were manipulated using the `remote` command, but not ported over to the `keyserver` command until this PR.) Utilize this flag in e2e testing of `keyserver` command.

Honor optional `remoteName` argument to `keyserver list` subcommand to list only the keyservers configured for a particular remote endpoint. Add e2e tests for this.

### This fixes or addresses the following GitHub issues:

 - Fixes #2034 

