### PR TITLE
fix: normalize OCI platform arch & variant

### DIFF
--- a/LICENSE_THIRD_PARTY.md
+++ b/LICENSE_THIRD_PARTY.md
@@ -586,6 +586,7 @@ The source files:
 * `internal/pkg/ociplatform/cpuinfo.go`
 * `internal/pkg/ociplatform/cpuinfo_linux.go`
 * `internal/pkg/ociplatform/cpuinfo_linux_test.go`
+* `internal/pkg/ociplatform/database.go`
 
 Contain code from the docker cli project, under the Apache License, Version 2.0.
 

--- a/internal/pkg/ociplatform/cpuinfo.go
+++ b/internal/pkg/ociplatform/cpuinfo.go
@@ -41,14 +41,3 @@ func CPUVariant() string {
 	})
 	return cpuVariantValue
 }
-
-// isArmArch returns true if the architecture is ARM.
-//
-// The arch value should be normalized before being passed to this function.
-func isArmArch(arch string) bool {
-	switch arch {
-	case "arm", "arm64":
-		return true
-	}
-	return false
-}

--- a/internal/pkg/ociplatform/database.go
+++ b/internal/pkg/ociplatform/database.go
@@ -1,0 +1,66 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ociplatform
+
+import (
+	"strings"
+)
+
+// isArmArch returns true if the architecture is ARM.
+//
+// The arch value should be normalized before being passed to this function.
+func isArmArch(arch string) bool {
+	switch arch {
+	case "arm", "arm64":
+		return true
+	}
+	return false
+}
+
+// normalizeArch normalizes the architecture.
+func normalizeArch(arch, variant string) (string, string) {
+	arch, variant = strings.ToLower(arch), strings.ToLower(variant)
+	switch arch {
+	case "i386":
+		arch = "386"
+		variant = ""
+	case "x86_64", "x86-64":
+		arch = "amd64"
+		variant = ""
+	case "aarch64", "arm64":
+		arch = "arm64"
+		switch variant {
+		case "8", "v8":
+			variant = ""
+		}
+	case "armhf":
+		arch = "arm"
+		variant = "v7"
+	case "armel":
+		arch = "arm"
+		variant = "v6"
+	case "arm":
+		switch variant {
+		case "", "7":
+			variant = "v7"
+		case "5", "6", "8":
+			variant = "v" + variant
+		}
+	}
+
+	return arch, variant
+}

--- a/internal/pkg/ociplatform/ociplatform.go
+++ b/internal/pkg/ociplatform/ociplatform.go
@@ -32,6 +32,7 @@ func SysCtxToPlatform(sysCtx *types.SystemContext) ggcrv1.Platform {
 	if variant == "" {
 		variant = CPUVariant()
 	}
+	arch, variant = normalizeArch(arch, variant)
 	return ggcrv1.Platform{
 		Architecture: arch,
 		Variant:      variant,
@@ -73,13 +74,20 @@ func CheckImageRefPlatform(ctx context.Context, sysCtx *types.SystemContext, ima
 }
 
 func DefaultPlatform() (*ggcrv1.Platform, error) {
-	if runtime.GOOS != "linux" {
+	os := runtime.GOOS
+	arch := runtime.GOARCH
+	variant := CPUVariant()
+
+	if os != "linux" {
 		return nil, fmt.Errorf("%q is not a valid platform OS for singularity", runtime.GOOS)
 	}
+
+	arch, variant = normalizeArch(arch, variant)
+
 	return &ggcrv1.Platform{
-		OS:           runtime.GOOS,
-		Architecture: runtime.GOARCH,
-		Variant:      CPUVariant(),
+		OS:           os,
+		Architecture: arch,
+		Variant:      variant,
 	}, nil
 }
 
@@ -91,6 +99,9 @@ func PlatformFromString(p string) (*ggcrv1.Platform, error) {
 	if plat.OS != "linux" {
 		return nil, fmt.Errorf("%q is not a valid platform OS for singularity", plat.OS)
 	}
+
+	plat.Architecture, plat.Variant = normalizeArch(plat.Architecture, plat.Variant)
+
 	return plat, nil
 }
 
@@ -98,9 +109,12 @@ func PlatformFromArch(a string) (*ggcrv1.Platform, error) {
 	if runtime.GOOS != "linux" {
 		return nil, fmt.Errorf("%q is not a valid platform OS for singularity", runtime.GOOS)
 	}
+
+	arch, variant := normalizeArch(a, "")
+
 	return &ggcrv1.Platform{
 		OS:           runtime.GOOS,
-		Architecture: a,
-		Variant:      "",
+		Architecture: arch,
+		Variant:      variant,
 	}, nil
 }

--- a/internal/pkg/ociplatform/ociplatform_test.go
+++ b/internal/pkg/ociplatform/ociplatform_test.go
@@ -43,36 +43,75 @@ func Test_sysCtxToPlatform(t *testing.T) {
 		{
 			name: "OverrideArchitecture",
 			sysCtx: &types.SystemContext{
-				ArchitectureChoice: "myArch",
+				ArchitectureChoice: "myarch",
 			},
 			want: ggcrv1.Platform{
 				OS:           runtime.GOOS,
-				Architecture: "myArch",
+				Architecture: "myarch",
 				Variant:      CPUVariant(),
 			},
 		},
 		{
 			name: "OverrideVariant",
 			sysCtx: &types.SystemContext{
-				VariantChoice: "myVariant",
+				VariantChoice: "myvariant",
 			},
 			want: ggcrv1.Platform{
 				OS:           runtime.GOOS,
 				Architecture: runtime.GOARCH,
-				Variant:      "myVariant",
+				Variant:      "myvariant",
 			},
 		},
 		{
 			name: "OverrideAll",
 			sysCtx: &types.SystemContext{
-				OSChoice:           "myOS",
-				ArchitectureChoice: "myArch",
-				VariantChoice:      "myVariant",
+				OSChoice:           "myos",
+				ArchitectureChoice: "myarch",
+				VariantChoice:      "myvariant",
 			},
 			want: ggcrv1.Platform{
-				OS:           "myOS",
-				Architecture: "myArch",
-				Variant:      "myVariant",
+				OS:           "myos",
+				Architecture: "myarch",
+				Variant:      "myvariant",
+			},
+		},
+		{
+			name: "Normalize linux/arm64/v8",
+			sysCtx: &types.SystemContext{
+				OSChoice:           "linux",
+				ArchitectureChoice: "arm64",
+				VariantChoice:      "v8",
+			},
+			want: ggcrv1.Platform{
+				OS:           "linux",
+				Architecture: "arm64",
+				Variant:      "",
+			},
+		},
+		{
+			name: "Normalize linux/aarch64",
+			sysCtx: &types.SystemContext{
+				OSChoice:           "linux",
+				ArchitectureChoice: "aarch64",
+				VariantChoice:      "",
+			},
+			want: ggcrv1.Platform{
+				OS:           "linux",
+				Architecture: "arm64",
+				Variant:      "",
+			},
+		},
+		{
+			name: "Normalize linux/arm32",
+			sysCtx: &types.SystemContext{
+				OSChoice:           "linux",
+				ArchitectureChoice: "arm",
+				VariantChoice:      "",
+			},
+			want: ggcrv1.Platform{
+				OS:           "linux",
+				Architecture: "arm",
+				Variant:      "v7",
 			},
 		},
 	}
@@ -80,6 +119,64 @@ func Test_sysCtxToPlatform(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := SysCtxToPlatform(tt.sysCtx); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("sysCtxToPlatform() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlatformFromString(t *testing.T) {
+	tests := []struct {
+		name    string
+		plat    string
+		want    *ggcrv1.Platform
+		wantErr bool
+	}{
+		{
+			name:    "BadString",
+			plat:    "os/arch/variant/extra",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "UnsupportedWindows",
+			plat:    "windows/amd64",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "GoodAMD64",
+			plat:    "linux/amd64",
+			want:    &ggcrv1.Platform{OS: "linux", Architecture: "amd64", Variant: ""},
+			wantErr: false,
+		},
+		{
+			name:    "NormalizeARM",
+			plat:    "linux/arm",
+			want:    &ggcrv1.Platform{OS: "linux", Architecture: "arm", Variant: "v7"},
+			wantErr: false,
+		},
+		{
+			name:    "NormalizeARM64/v8",
+			plat:    "linux/arm64/v8",
+			want:    &ggcrv1.Platform{OS: "linux", Architecture: "arm64", Variant: ""},
+			wantErr: false,
+		},
+		{
+			name:    "NormalizeAARCH64",
+			plat:    "linux/aarch64",
+			want:    &ggcrv1.Platform{OS: "linux", Architecture: "arm64", Variant: ""},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PlatformFromString(tt.plat)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PlatformFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PlatformFromString() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In order to ensure that we can pull the correct image on ARM systems:

* `linux/arm64/v8` needs to be normalized to `linux/arm64`
* `linux/arm` needs to be normalized to `linux/arm/v7`

Bring across a small amount of additional code from containerd/containerd (under a compatible license) to perform the normalization.

### This fixes or addresses the following GitHub issues:

 - Fixes #2039 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
