### PR TITLE
replace "none" with "bind" in Type field of OCI-mode bind mounts

### DIFF
--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -476,7 +476,7 @@ func (l *Launcher) preparePasswd(bundlePath string, uid uint32) (*specs.Mount, e
 	passwdMount := specs.Mount{
 		Source:      containerPasswd,
 		Destination: "/etc/passwd",
-		Type:        "none",
+		Type:        "bind",
 		Options:     []string{"bind"},
 	}
 	return &passwdMount, nil
@@ -508,7 +508,7 @@ func (l *Launcher) prepareGroup(bundlePath string, uid, gid uint32) (*specs.Moun
 	groupMount := specs.Mount{
 		Source:      containerGroup,
 		Destination: "/etc/group",
-		Type:        "none",
+		Type:        "bind",
 		Options:     []string{"bind"},
 	}
 	return &groupMount, nil
@@ -558,7 +558,7 @@ func (l *Launcher) prepareResolvConf(bundlePath string) (*specs.Mount, error) {
 	resolvMount := specs.Mount{
 		Source:      containerResolvConfPath,
 		Destination: "/etc/resolv.conf",
-		Type:        "none",
+		Type:        "bind",
 		Options:     []string{"bind"},
 	}
 
@@ -619,7 +619,7 @@ fi
 	envMount := specs.Mount{
 		Source:      hostEnvPath,
 		Destination: containerEnvPath,
-		Type:        "none",
+		Type:        "bind",
 		Options:     []string{"bind", "ro", "nosuid", "nodev"},
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

With older versions of `crun` (e.g. 0.12.1, the version currently available on Ubuntu 20.04), specifying `"none"` as the `type` field for a bind mount (even when the `options` field includes `"bind"`) in the config.json of the OCI bundle results in undesired behavior. In particular, bind-mounts of regular files specified in the config.json result in the destinations of those mounts being created as directories (instead of files), and the actual bind-mount then failing (due to a file-vs.-dir mismatch; even though the error msg generated by crun doesn't exactly make it clear that this is the problem...).

This PR replaces `"none"` with `"bind"` in the `type` field of bind-mounts generated in internal/pkg/runtime/launcher/oci/launcher_linux.go

