### PR TITLE
fix: correct Test_sysCtxToPlatform for non-AMD64

### DIFF
--- a/internal/pkg/ociplatform/ociplatform_test.go
+++ b/internal/pkg/ociplatform/ociplatform_test.go
@@ -15,6 +15,9 @@ import (
 )
 
 func Test_sysCtxToPlatform(t *testing.T) {
+	defaultOS := runtime.GOOS
+	defaultArch, defaultVariant := normalizeArch(runtime.GOARCH, CPUVariant())
+
 	tests := []struct {
 		name   string
 		sysCtx *types.SystemContext
@@ -24,20 +27,20 @@ func Test_sysCtxToPlatform(t *testing.T) {
 			name:   "Default",
 			sysCtx: &types.SystemContext{},
 			want: ggcrv1.Platform{
-				OS:           runtime.GOOS,
-				Architecture: runtime.GOARCH,
-				Variant:      CPUVariant(),
+				OS:           defaultOS,
+				Architecture: defaultArch,
+				Variant:      defaultVariant,
 			},
 		},
 		{
 			name: "OverrideOS",
 			sysCtx: &types.SystemContext{
-				OSChoice: "myOS",
+				OSChoice: "myos",
 			},
 			want: ggcrv1.Platform{
-				OS:           "myOS",
-				Architecture: runtime.GOARCH,
-				Variant:      CPUVariant(),
+				OS:           "myos",
+				Architecture: defaultArch,
+				Variant:      defaultVariant,
 			},
 		},
 		{
@@ -46,9 +49,9 @@ func Test_sysCtxToPlatform(t *testing.T) {
 				ArchitectureChoice: "myarch",
 			},
 			want: ggcrv1.Platform{
-				OS:           runtime.GOOS,
+				OS:           defaultOS,
 				Architecture: "myarch",
-				Variant:      CPUVariant(),
+				Variant:      defaultVariant,
 			},
 		},
 		{
@@ -57,8 +60,8 @@ func Test_sysCtxToPlatform(t *testing.T) {
 				VariantChoice: "myvariant",
 			},
 			want: ggcrv1.Platform{
-				OS:           runtime.GOOS,
-				Architecture: runtime.GOARCH,
+				OS:           defaultOS,
+				Architecture: defaultArch,
 				Variant:      "myvariant",
 			},
 		},


### PR DESCRIPTION
## Description of the Pull Request (PR):

On non-AMD64 for arch/variant normalization occurs, Test_sysCtxToPlatform was checking for incorrect default values.

Fix the test to look for normalized values.

### This fixes or addresses the following GitHub issues:

 - Fixes #2043


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
