### PR TITLE
fix: error-handling upon creation of OCI bundledir

### DIFF
--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -650,7 +650,7 @@ func (l *Launcher) Exec(ctx context.Context, ep launcher.ExecParams) error {
 
 	bundleDir, err := os.MkdirTemp(buildcfg.SESSIONDIR, "oci-bundle")
 	if err != nil {
-		return nil
+		return err
 	}
 	defer func() {
 		sylog.Debugf("Removing OCI bundle at: %s", bundleDir)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix propagation of errors encountered when creating the OCI-mode bundleDir in Exec() in internal/pkg/runtime/launcher/oci/launcher_linux.go

