### PR TITLE
deb: update dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Vcs-Browser: https://github.com/sylabs/singularity
 Package: singularity-ce
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends},
-  crun | runc,
+  crun (>= 1.5.0) | runc,
   cryptsetup-bin,
   fuse,
   libglib2.0-0,
@@ -39,6 +39,8 @@ Conflicts:
  singularitypro31,
  singularitypro35,
  singularitypro37,
- singularitypro39
+ singularitypro39,
+ singularitypro311
+Recommends: squashfs-tools-ng
 Description: SingularityCE is the Community Edition of Singularity, an
  open source container platform designed to be simple, fast, and secure. 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Require `crun` only when >=1.5.0 is available. Otherwise use `runc`.

Add `squashfs-tools-ng` as a `Recommends`. It is not a `Requires` in case someone cannot enable the Ubuntu universe repos, and does not want to use `--oci` mode.

Add missing conflicts for singularitypro311 while we are here.

Note - I temporarily enabled the deb build CI on this PR to verify it succeeds:

![image](https://github.com/sylabs/singularity/assets/4522799/43e7a557-e5c8-4bfa-b173-0c0308e49220)

The checks on the commit for review will not show this.

### This fixes or addresses the following GitHub issues:

 - Fixes #1974


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
