### PR TITLE
fuse: look for "fusermount3" first, w/"fusermount" as fallback

### DIFF
--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -41,8 +41,8 @@ func FindBin(name string) (path string, err error) {
 		return findFromConfigOnly(name)
 	// distro provided squashfuse and fusermount for unpriv SIF mount and
 	// OCI-mode bare-image overlay
-	case "fusermount":
-		return findOnPath(name)
+	case "fusermount", "fusermount3":
+		return findFusermount()
 	case "squashfuse":
 		// Behavior depends on buildcfg - whether to use bundled squashfuse_ll or external squashfuse_ll/squashfuse
 		return findSquashfuse(name)
@@ -56,4 +56,16 @@ func FindBin(name string) (path string, err error) {
 	default:
 		return "", fmt.Errorf("executable name %q is not known to FindBin", name)
 	}
+}
+
+// findFusermount looks for fusermount3 or, if that's not found, fusermount, on
+// PATH.
+func findFusermount() (string, error) {
+	// fusermount3 if found on PATH
+	path, err := findOnPath("fusermount3")
+	if err == nil {
+		return path, nil
+	}
+	// squashfuse if found on PATH
+	return findOnPath("fusermount")
 }

--- a/internal/pkg/util/fs/overlay/overlay_set_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_set_linux_test.go
@@ -37,15 +37,20 @@ func wrapOverlayTest(f func(t *testing.T)) func(t *testing.T) {
 			t.Fatalf("while checking for unprivileged overlay support in kernel: %s", unprivOlsErr)
 		}
 
+		if unprivOls {
+			kernelOverlayFunc := func(t *testing.T) {
+				require.Command(t, "fusermount")
+				f(t)
+			}
+
+			t.Run("kerneloverlay", kernelOverlayFunc)
+			unprivOverlays.kernelSupport = false
+		}
+
 		fuseOverlayFunc := func(t *testing.T) {
 			require.Command(t, "fuse-overlayfs")
 			require.Command(t, "fusermount")
 			f(t)
-		}
-
-		if unprivOls {
-			t.Run("kerneloverlay", f)
-			unprivOverlays.kernelSupport = false
 		}
 
 		t.Run("fuseoverlayfs", fuseOverlayFunc)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Change how we search for the external tool `fusermount` so that we first look for `fusermount3` and then search for `fusermount` as a fallback.

Also updates the require.Command() function in internal/pkg/test/tool/require/require.go so that it first tries to find the command using the bin.FindBin() function, and only if that fails, tries exec.LookPath(). This allows us to implicitly incorporate the fallback logic of bin.FindBin() when gating tests using require.Command() (so, for example, after this PR, `require.Command("fusermount")` will allow the test to run even if only `fusermount3` is installed, and vice versa).

### This fixes or addresses the following GitHub issues:

 - Fixes #2047 

