### PR TITLE
rpm: fix rpm build on SLES12

### DIFF
--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -58,7 +58,11 @@ BuildRequires: glib2-devel
 # Required for building bundled squashfuse
 BuildRequires: autoconf
 BuildRequires: automake
+%if "%{_target_vendor}" == "suse" && 0%{?suse_version} < 1500
+BuildRequires: fuse-devel
+%else
 BuildRequires: fuse3-devel
+%endif
 BuildRequires: libtool
 BuildRequires: zlib-devel
 
@@ -75,7 +79,11 @@ Requires: shadow-utils
 Requires: squashfs-tools
 %endif
 Requires: cryptsetup
+%if "%{_target_vendor}" == "suse" && 0%{?suse_version} < 1500
+Requires: fuse
+%else
 Requires: fuse3
+%endif
 
 Provides: %{name}-runtime
 
@@ -115,10 +123,10 @@ container platform designed to be simple, fast, and secure.
         --mandir=%{_mandir} \
         --infodir=%{_infodir}
 
-%make_build -C builddir old_config= V=
+make -C builddir old_config= V=
 
 %install
-%make_install -C builddir V=
+make DESTDIR=$RPM_BUILD_ROOT install -C builddir V=
 
 %files
 %attr(4755, root, root) %{_libexecdir}/singularity/bin/starter-suid


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use fuse instead of fuse3 on SLES12.

Use explicit make instead of macros that do not exist on SLES12.

Was run through CI to check no regression for EL rpm builds:

![image](https://github.com/sylabs/singularity/assets/4522799/c7d16ea3-2cc3-46cb-9d04-87b3e691fb17)

### This fixes or addresses the following GitHub issues:

 - Fixes #2036


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
