### PR TITLE
oci: fall back to minimal /dev with --no-compat & runc

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -2236,6 +2236,7 @@ func (c actionTests) actionOciNoCompat(t *testing.T) {
 		args     []string
 		exitCode int
 		expect   []e2e.SingularityCmdResultOp
+		requires func(t *testing.T)
 	}
 
 	tests := []test{
@@ -2255,6 +2256,9 @@ func (c actionTests) actionOciNoCompat(t *testing.T) {
 			name:     "fullDev",
 			args:     []string{"--no-compat", imageRef, "sh", "-c", "ls /dev/block"},
 			exitCode: 0,
+			requires: func(t *testing.T) {
+				require.Command(t, "crun")
+			},
 		},
 		// Default bind path /etc/localtime in singularity.conf is bound in
 		{
@@ -2312,6 +2316,7 @@ func (c actionTests) actionOciNoCompat(t *testing.T) {
 	for _, tt := range tests {
 		c.env.RunSingularity(
 			t,
+			e2e.PreRun(tt.requires),
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(e2e.OCIUserProfile),
 			e2e.WithDir(workDir),


### PR DESCRIPTION
## Description of the Pull Request (PR):

runc will fail when run unprivileged, with `/dev` is specified as a bind mount in the `config.json`.

At this point I don't see an easy route to making the `/dev` bind mount work.

Fall back to a minimal dev with `--no-compat` and runc to avoid the issue.

### This fixes or addresses the following GitHub issues:

 - Fixes #2058


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
