### PR TITLE
lint: enable dupword + corresponding fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - decorder
     - dogsled
     - dupl
+    - dupword
     - gofumpt
     - goimports
     - gomodguard

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -157,7 +157,7 @@ func replaceURIWithImage(ctx context.Context, cmd *cobra.Command, args []string)
 	var image string
 	var err error
 
-	// Create a cache handle only when we know we are are using a URI
+	// Create a cache handle only when we know we are using a URI
 	imgCache := getCacheHandle(cache.Config{Disable: disableCache})
 	if imgCache == nil {
 		sylog.Fatalf("failed to create a new image cache handle")

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -458,7 +458,7 @@ func checkBuildTarget(path string) error {
 }
 
 // definitionFromSpec is specifically for parsing specs for the remote builder
-// it uses a different version the the definition struct and parser
+// it uses a different version the definition struct and parser
 func definitionFromSpec(spec string) (types.Definition, error) {
 	// Try spec as URI first
 	def, err := types.NewDefinitionFromURI(spec)

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -187,6 +187,7 @@ type command struct {
 	img         *image.Image
 }
 
+//nolint:dupword
 func newCommand(allData bool, appName string, img *image.Image) *command {
 	command := new(command)
 	command.img = img

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -50,7 +50,7 @@ const (
 	RemoteAddShort string = `Add a new singularity remote endpoint`
 	RemoteAddLong  string = `
   The 'remote add' command allows you to add a new remote endpoint to be
-  be used for singularity remote services. Authentication with a newly created
+  used for singularity remote services. Authentication with a newly created
   endpoint will occur automatically.`
 	RemoteAddExample string = `
   $ singularity remote add SylabsCloud cloud.sylabs.io`

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -455,7 +455,7 @@ var resourceFlagTests = []resourceFlagTest{
 		controllerV1:    "cpu",
 		resourceV1:      "cpu.shares",
 		expectV1:        "123",
-		// Cgroups v2 has a conversion from shares to weight
+		// Cgroups v2 has a conversion from shares to weight:
 		// weight = (1 + ((cpuShares-2)*9999)/262142)
 		delegationV2: "cpu",
 		resourceV2:   "cpu.weight",

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -383,6 +383,7 @@ func (c configTests) configGlobal(t *testing.T) {
 			exit:           0,
 		},
 		// overlay may or not be available, just test with no
+		//nolint:dupword
 		{
 			name:           "EnableOverlayNo",
 			argv:           []string{c.env.ImagePath, "grep", "\\- overlay overlay", "/proc/self/mountinfo"},

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -79,7 +79,8 @@ func (env TestEnv) ImageVerify(t *testing.T, imagePath string) {
 	)
 }
 
-// DefinitionImageVerify checks for image correctness based off off supplied DefFileDetail
+// DefinitionImageVerify checks for image correctness based off of supplied
+// DefFileDetail
 func DefinitionImageVerify(t *testing.T, cmdPath, imagePath string, dfd DefFileDetails) {
 	if dfd.Help != nil {
 		helpPath := filepath.Join(imagePath, `/.singularity.d/runscript.help`)

--- a/internal/app/singularity/plugin_list_linux.go
+++ b/internal/app/singularity/plugin_list_linux.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ListPlugins lists the singularity plugins installed in the plugin
-// plugin installation directory.
+// installation directory.
 func ListPlugins() error {
 	plugins, err := plugin.List()
 	if err != nil {

--- a/internal/app/starter/master_linux_test.go
+++ b/internal/app/starter/master_linux_test.go
@@ -17,7 +17,7 @@ import (
 // part of the main function, as it exits, it would require mock at
 // some point and that would make code more complex than necessary.
 // createContainer and startContainer are quickly tested and only
-// cover case with bad socket file descriptors or non socket file
+// cover case with bad socket file descriptors or non socket
 // file descriptor (stderr).
 
 //nolint:dupl

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -33,6 +33,7 @@ type ociRunscriptData struct {
 	PrependEntrypoint string
 }
 
+//nolint:dupword
 const ociRunscript = `
 # When SINGULARITY_NO_EVAL set, use OCI compatible behavior that does
 # not evaluate resolved CMD / ENTRYPOINT / ARGS through the shell, and

--- a/internal/pkg/plugin/meta.go
+++ b/internal/pkg/plugin/meta.go
@@ -79,8 +79,8 @@ func loadMetaByFilename(filename string) (*Meta, error) {
 	return loadFromJSON(fh)
 }
 
-// metaPath returns the path to the meta file based on the
-// the name of the corresponding plugin.
+// metaPath returns the path to the meta file based on the name of the
+// corresponding plugin.
 func metaPath(name string) string {
 	return filepath.Join(rootDir, pluginIDFromName(name)+".meta")
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -601,7 +601,8 @@ func (l *Launcher) prepareNativeEnv(bundlePath string, userEnv map[string]string
 		b.WriteString(fmt.Sprintf("%s=%s\n", key, value))
 	}
 
-	// Second, we conditionally restore host env vars, if we are are --no-compat and if they are not set already.
+	// Second, we conditionally restore host env vars, if we are --no-compat and
+	// if they are not set already.
 	hostEnvSnippet := `
 if [ ! "${%[1]s+1}" ]; then
 	export %[1]s=%[2]s

--- a/internal/pkg/signature/verify_ocsp.go
+++ b/internal/pkg/signature/verify_ocsp.go
@@ -22,7 +22,7 @@ import (
 )
 
 /*
-Online Certificate Status Protocol - OCSP
+Online Certificate Status Protocol (OCSP)
 
 OCSP responder is used to provide real-time verification of the revocation status of an X.509 certificate.
 RFC: https://www.rfc-editor.org/rfc/rfc6960

--- a/internal/pkg/test/tool/doc.go
+++ b/internal/pkg/test/tool/doc.go
@@ -7,7 +7,7 @@ package tool
 
 /*
 Package tool provides all related test helpers/tools which can be used by
-by unit/e2e/integration tests.
+unit/e2e/integration tests.
 
 All helpers functions here should take as first argument *testing.T, if a function
 doesn't require or use *testing.T, this function should go into another package

--- a/internal/pkg/util/crypt/crypt_dev.go
+++ b/internal/pkg/util/crypt/crypt_dev.go
@@ -236,7 +236,7 @@ func copyDeviceContents(source, dest string, size int64) error {
 		buffer = buffer[:cap(buffer)]
 		numRead, err := syscall.Read(sourceFd, buffer)
 		if err != nil {
-			return fmt.Errorf("unable to read the the file %s", source)
+			return fmt.Errorf("unable to read the file %s", source)
 		}
 		buffer = buffer[:numRead]
 		for n := 0; n < numRead; {

--- a/internal/pkg/util/interactive/interactive_test.go
+++ b/internal/pkg/util/interactive/interactive_test.go
@@ -172,6 +172,7 @@ func TestAskNumberInRange(t *testing.T) {
 	}
 }
 
+//nolint:dupword
 func TestAskQuestion(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
@@ -233,6 +234,7 @@ func TestAskQuestion(t *testing.T) {
 	}
 }
 
+//nolint:dupword
 func TestAskQuestionNoEcho(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/pkg/util/capabilities/process_linux.go
+++ b/pkg/util/capabilities/process_linux.go
@@ -66,8 +66,8 @@ func GetProcessBounding() (uint64, error) {
 	return uint64(data[0].Inheritable) | uint64(data[1].Inheritable)<<32, nil
 }
 
-// SetProcessEffective set effective capabilities for the
-// the current process and returns previous effective set.
+// SetProcessEffective set effective capabilities for the current process and
+// returns previous effective set.
 func SetProcessEffective(caps uint64) (uint64, error) {
 	var data [2]unix.CapUserData
 	var header unix.CapUserHeader

--- a/pkg/util/fs/proc/proc_linux_test.go
+++ b/pkg/util/fs/proc/proc_linux_test.go
@@ -35,6 +35,7 @@ func TestHasFilesystem(t *testing.T) {
 	}
 }
 
+//nolint:dupword
 var mountInfoData = `22 28 0:21 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw
 23 28 0:4 / /proc rw,nosuid,nodev,noexec,relatime shared:13 - proc proc rw
 24 28 0:6 / /dev rw,nosuid,relatime shared:2 - devtmpfs udev rw,size=8110616k,nr_inodes=2027654,mode=755
@@ -368,6 +369,7 @@ func TestReadIDMap(t *testing.T) {
 		}
 	}
 
+	//nolint:dupword
 	for _, e := range []string{"a a a", "0 a a"} {
 		f, err := os.CreateTemp("", "uid_map-")
 		if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Enable the `dupword` linter in golangci-lint, and perform fixes / add `nolint:` directives, as appropriate, in code.

