### PR TITLE
e2e: set platform for pullDisableCache/library_oci-sif

### DIFF
--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -613,6 +613,7 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 		name      string
 		imagePath string
 		imageSrc  string
+		platform  string
 		oci       bool
 		noHTTPS   bool
 	}{
@@ -625,6 +626,7 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 			name:      "library oci-sif",
 			imagePath: filepath.Join(c.env.TestDir, "nocache-library.oci.sif"),
 			imageSrc:  "library://sylabs/tests/alpine-oci-sif:latest",
+			platform:  "linux/amd64",
 			oci:       true,
 		},
 		{
@@ -648,6 +650,9 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 		}
 		if tt.noHTTPS {
 			cmdArgs = append(cmdArgs, "--no-https")
+		}
+		if tt.platform != "" {
+			cmdArgs = append(cmdArgs, "--platform", tt.platform)
 		}
 		cmdArgs = append(cmdArgs, tt.imagePath, tt.imageSrc)
 		c.env.RunSingularity(


### PR DESCRIPTION
## Description of the Pull Request (PR):

OCI-SIF repository in the library is single arch.

Use `--platform` to ensure we always try to pull the correct arch in the no cache test.


### This fixes or addresses the following GitHub issues:

 - Fixes #2056


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
