### PR TITLE
lint: enable exportloopref + corresponding fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - dogsled
     - dupl
     - dupword
+    - exportloopref
     - gofumpt
     - goimports
     - gomodguard

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1054,7 +1054,8 @@ func getFirstPartition(partitions []image.Section) *image.Section {
 }
 
 func getPartitionByID(partitions []image.Section, partID uint32) *image.Section {
-	for _, part := range partitions {
+	var part image.Section
+	for _, part = range partitions {
 		if part.ID == partID {
 			return &part
 		}

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -976,22 +976,14 @@ func (c *container) addImageBindMount(system *mount.System) error {
 				if err != nil {
 					return fmt.Errorf("while getting partitions for %s: %s", img.Path, err)
 				}
-				for _, part := range partitions {
-					if part.ID == partID {
-						data = &part
-						break
-					}
-				}
+				data = getPartitionByID(partitions, partID)
 			} else {
 				// take the first data partition found
 				partitions, err := img.GetDataPartitions()
 				if err != nil {
 					return fmt.Errorf("while getting data partition for %s: %s", img.Path, err)
 				}
-				for _, part := range partitions {
-					data = &part
-					break
-				}
+				data = getFirstPartition(partitions)
 			}
 
 			if data == nil {
@@ -1047,6 +1039,24 @@ func (c *container) addImageBindMount(system *mount.System) error {
 			// to honor bind ordering specified by the users
 			// we add bind mount later in addUserbindsMount
 			c.imageBind[destination] = src
+		}
+	}
+
+	return nil
+}
+
+func getFirstPartition(partitions []image.Section) *image.Section {
+	if len(partitions) > 0 {
+		return &partitions[0]
+	}
+
+	return nil
+}
+
+func getPartitionByID(partitions []image.Section, partID uint32) *image.Section {
+	for _, part := range partitions {
+		if part.ID == partID {
+			return &part
 		}
 	}
 

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -239,15 +239,16 @@ func shouldRun(ctx context.Context, ecl *EclConfig, fp *os.File, kr openpgp.KeyR
 }
 
 func getExecGroup(ecl *EclConfig, fp *os.File) *Execgroup {
+	var v Execgroup
 	// look what execgroup a container is part of
-	for _, v := range ecl.ExecGroups {
+	for _, v = range ecl.ExecGroups {
 		if filepath.Dir(fp.Name()) == v.DirPath {
 			return &v
 		}
 	}
 
 	// go back at it and this time look for an empty dirpath execgroup to fallback into
-	for _, v := range ecl.ExecGroups {
+	for _, v = range ecl.ExecGroups {
 		if v.DirPath == "" {
 			return &v
 		}

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -188,25 +188,7 @@ func checkBlackList(v *integrity.Verifier, egroup *Execgroup) (ok bool, err erro
 }
 
 func shouldRun(ctx context.Context, ecl *EclConfig, fp *os.File, kr openpgp.KeyRing) (ok bool, err error) {
-	var egroup *Execgroup
-
-	// look what execgroup a container is part of
-	for _, v := range ecl.ExecGroups {
-		if filepath.Dir(fp.Name()) == v.DirPath {
-			egroup = &v
-			break
-		}
-	}
-	// go back at it and this time look for an empty dirpath execgroup to fallback into
-	if egroup == nil {
-		for _, v := range ecl.ExecGroups {
-			if v.DirPath == "" {
-				egroup = &v
-				break
-			}
-		}
-	}
-
+	egroup := getExecGroup(ecl, fp)
 	if egroup == nil {
 		return false, fmt.Errorf("%s not part of any execgroup", fp.Name())
 	}
@@ -254,6 +236,24 @@ func shouldRun(ctx context.Context, ecl *EclConfig, fp *os.File, kr openpgp.KeyR
 	}
 
 	return false, fmt.Errorf("ecl config file invalid")
+}
+
+func getExecGroup(ecl *EclConfig, fp *os.File) *Execgroup {
+	// look what execgroup a container is part of
+	for _, v := range ecl.ExecGroups {
+		if filepath.Dir(fp.Name()) == v.DirPath {
+			return &v
+		}
+	}
+
+	// go back at it and this time look for an empty dirpath execgroup to fallback into
+	for _, v := range ecl.ExecGroups {
+		if v.DirPath == "" {
+			return &v
+		}
+	}
+
+	return nil
 }
 
 // ShouldRun determines if a container should run according to its execgroup rules


### PR DESCRIPTION
## Description of the Pull Request (PR):

Enable the `exportloopref` linter in golangci-lint, and perform fixes, as appropriate, in code.

