### PR TITLE
lint: enable forcetypeassert + corresponding fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - dupl
     - dupword
     - exportloopref
+    - forcetypeassert
     - gofumpt
     - goimports
     - gomodguard

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -471,6 +471,7 @@ func Init(loadPlugins bool) {
 	}
 
 	// load plugins and register commands/flags if any
+	//nolint:forcetypeassert
 	if loadPlugins {
 		callbackType := (clicallback.Command)(nil)
 		callbacks, err := plugin.LoadCallbacks(callbackType)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -87,6 +87,7 @@ func TestMain(m *testing.M) {
 			}
 		default:
 			// forward signals to e2e test command
+			//nolint:forcetypeassert
 			syscall.Kill(cmdPid, s.(syscall.Signal))
 		case syscall.SIGURG:
 			// ignore goroutine preemption

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -187,6 +187,7 @@ func Run(t *testing.T) {
 	}
 
 	for _, cf := range configFiles {
+		//nolint:forcetypeassert
 		if fi, err := os.Stat(cf); err != nil {
 			t.Fatalf("%s is not installed on this system: %v", cf, err)
 		} else if !fi.Mode().IsRegular() {

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -116,6 +116,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	if len(callbacks) > 1 {
 		return fmt.Errorf("multiple plugins have registered hook callback for fakeroot")
 	} else if len(callbacks) == 1 {
+		//nolint:forcetypeassert
 		getIDRange = callbacks[0].(fakerootcallback.UserMapping)
 	}
 
@@ -339,6 +340,7 @@ func (e *EngineOperations) MonitorContainer(pid int, signals chan os.Signal) (sy
 	}()
 
 	for {
+		//nolint:forcetypeassert
 		select {
 		case s := <-signals:
 			// Signal received
@@ -352,6 +354,7 @@ func (e *EngineOperations) MonitorContainer(pid int, signals chan os.Signal) (sy
 				// https://github.com/golang/go/issues/24543.
 				break
 			default:
+				//nolint:forcetypeassert
 				if err := syscall.Kill(pid, s.(syscall.Signal)); err != nil {
 					return status, fmt.Errorf("interrupted by signal %s", s.String())
 				}

--- a/internal/pkg/runtime/engine/singularity/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/singularity/cleanup_linux.go
@@ -144,11 +144,13 @@ func umount(lazy bool) (err error) {
 	retry:
 		err = syscall.Unmount(p, umountFlags)
 		// ignore EINVAL meaning it's not a mount point
+		//nolint:forcetypeassert
 		if err != nil && err.(syscall.Errno) != syscall.EINVAL {
 			// when rootfs mount point is a sandbox, the unmount
 			// fail more often with EBUSY, but it's just a matter of
 			// time before resources are released by the kernel so we
 			// retry until the unmount operation succeed (retries 10 times)
+			//nolint:forcetypeassert
 			if err.(syscall.Errno) == syscall.EBUSY && retries < 10 {
 				retries++
 				goto retry

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	osuser "os/user"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"syscall"
@@ -748,7 +749,10 @@ func (c *container) addRootfsMount(system *mount.System) error {
 }
 
 func (c *container) overlayUpperWork(*mount.System) error {
-	ov := c.session.Layer.(*overlay.Overlay)
+	ov, ok := c.session.Layer.(*overlay.Overlay)
+	if !ok {
+		return fmt.Errorf("expected overlay layer, but found layer of type %v", reflect.TypeOf(c.session.Layer))
+	}
 
 	createUpperWork := func(path, label string) error {
 		fi, err := c.rpcOps.Lstat(path)
@@ -778,7 +782,10 @@ func (c *container) overlayUpperWork(*mount.System) error {
 
 func (c *container) addOverlayMount(system *mount.System) error {
 	nb := 0
-	ov := c.session.Layer.(*overlay.Overlay)
+	ov, ok := c.session.Layer.(*overlay.Overlay)
+	if !ok {
+		return fmt.Errorf("expected overlay layer, but found layer of type %v", reflect.TypeOf(c.session.Layer))
+	}
 	hasUpper := false
 
 	if c.engine.EngineConfig.GetWritableTmpfs() {
@@ -1878,6 +1885,7 @@ func (c *container) addCwdMount(system *mount.System) error {
 		sylog.Verbosef("Not mounting CWD, while getting %s information: %s", cwdContainerResolved, err)
 		return nil
 	}
+	//nolint:forcetypeassert
 	cst := fi.Sys().(*syscall.Stat_t)
 
 	var hst syscall.Stat_t

--- a/internal/pkg/runtime/engine/singularity/monitor_linux.go
+++ b/internal/pkg/runtime/engine/singularity/monitor_linux.go
@@ -35,6 +35,7 @@ func (e *EngineOperations) MonitorContainer(pid int, signals chan os.Signal) (sy
 	if len(callbacks) > 1 {
 		return status, fmt.Errorf("multiple plugins have registered callback for '%T'", callbackType)
 	} else if len(callbacks) == 1 {
+		//nolint:forcetypeassert
 		return callbacks[0].(singularitycallback.MonitorContainer)(e.CommonConfig, pid, signals)
 	}
 
@@ -55,6 +56,7 @@ func (e *EngineOperations) MonitorContainer(pid int, signals chan os.Signal) (sy
 			break
 		default:
 			if e.EngineConfig.GetSignalPropagation() {
+				//nolint:forcetypeassert
 				if err := syscall.Kill(pid, s.(syscall.Signal)); err != nil {
 					return status, fmt.Errorf("interrupted by signal %s", s.String())
 				}

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -579,6 +579,7 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 		if len(callbacks) > 1 {
 			return fmt.Errorf("multiple plugins have registered hook callback for fakeroot")
 		} else if len(callbacks) == 1 {
+			//nolint:forcetypeassert
 			getIDRange = callbacks[0].(fakerootcallback.UserMapping)
 		}
 
@@ -761,6 +762,7 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 		if err != nil {
 			return fmt.Errorf("error while getting information for instance task directory: %s", err)
 		}
+		//nolint:forcetypeassert
 		st := fi.Sys().(*syscall.Stat_t)
 		if st.Uid != uint32(uid) || st.Gid != uint32(gid) {
 			return fmt.Errorf("instance process owned by %d:%d instead of %d:%d", st.Uid, st.Gid, uid, gid)
@@ -803,6 +805,7 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 		if err != nil {
 			return fmt.Errorf("error while getting information for parent task directory: %s", err)
 		}
+		//nolint:forcetypeassert
 		st = fi.Sys().(*syscall.Stat_t)
 		if st.Uid != uint32(uid) || st.Gid != uint32(gid) {
 			return fmt.Errorf("parent instance process owned by %d:%d instead of %d:%d", st.Uid, st.Gid, uid, gid)

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -202,6 +202,7 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 		}
 		if err := cmd.Start(); err != nil {
 			if e, ok := err.(*os.PathError); ok {
+				//nolint:forcetypeassert
 				if e.Err.(syscall.Errno) == syscall.ENOEXEC && args[0] != defaultShell {
 					args = append([]string{defaultShell}, args...)
 					goto cmdexec
@@ -263,6 +264,7 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 				// https://github.com/golang/go/issues/24543.
 				break
 			default:
+				//nolint:forcetypeassert
 				signal := s.(syscall.Signal)
 				// EPERM and EINVAL are deliberately ignored because they can't be
 				// returned in this context, this process is PID 1, so it has the
@@ -291,6 +293,7 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 			} else if e, ok := err.(*os.SyscallError); ok {
 				// handle possible race with Wait4 call above by ignoring ECHILD
 				// error because child process was already caught
+				//nolint:forcetypeassert
 				if e.Err.(syscall.Errno) != syscall.ECHILD {
 					sylog.Fatalf("error while waiting container process: %s", e.Error())
 				}
@@ -330,6 +333,7 @@ func (e *EngineOperations) PostStartProcess(_ context.Context, pid int) error {
 		return fmt.Errorf("while loading plugins callbacks '%T': %s", callbackType, err)
 	}
 	for _, cb := range callbacks {
+		//nolint:forcetypeassert
 		if err := cb.(singularitycallback.PostStartProcess)(e.CommonConfig, pid); err != nil {
 			return err
 		}

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -1264,6 +1264,7 @@ func runPluginCallbacks(cfg *config.Common) error {
 		return fmt.Errorf("while loading plugin callbacks '%T': %w", callbackType, err)
 	}
 	for _, c := range callbacks {
+		//nolint:forcetypeassert
 		c.(clicallback.SingularityEngineConfig)(cfg)
 	}
 	return nil

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -236,6 +236,7 @@ func signalProxy(containerID string, signals chan os.Signal) {
 			break
 		default:
 			sylog.Debugf("Received signal %s", s.String())
+			//nolint:forcetypeassert
 			sysSig := s.(syscall.Signal)
 			sylog.Debugf("Sending signal %s to container %s", sysSig.String(), containerID)
 			if err := Kill(containerID, strconv.Itoa(int(sysSig))); err != nil {

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -94,6 +94,8 @@ func IsOwner(name string, uid uint32) bool {
 	if err != nil {
 		return false
 	}
+
+	//nolint:forcetypeassert
 	return info.Sys().(*syscall.Stat_t).Uid == uid
 }
 
@@ -103,6 +105,8 @@ func IsGroup(name string, gid uint32) bool {
 	if err != nil {
 		return false
 	}
+
+	//nolint:forcetypeassert
 	return info.Sys().(*syscall.Stat_t).Gid == gid
 }
 
@@ -112,6 +116,8 @@ func IsExec(name string) bool {
 	if err != nil {
 		return false
 	}
+
+	//nolint:forcetypeassert
 	return info.Sys().(*syscall.Stat_t).Mode&syscall.S_IXUSR != 0
 }
 
@@ -121,6 +127,8 @@ func IsSuid(name string) bool {
 	if err != nil {
 		return false
 	}
+
+	//nolint:forcetypeassert
 	return info.Sys().(*syscall.Stat_t).Mode&syscall.S_ISUID != 0
 }
 

--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -275,6 +275,7 @@ func (m *Manager) Chmod(path string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
+	//nolint:forcetypeassert
 	switch m.entries[path].(type) {
 	case *file:
 		m.entries[path].(*file).mode = mode
@@ -290,6 +291,7 @@ func (m *Manager) Chown(path string, uid, gid int) error {
 	if err != nil {
 		return err
 	}
+	//nolint:forcetypeassert
 	switch m.entries[path].(type) {
 	case *file:
 		m.entries[path].(*file).uid = uid

--- a/internal/pkg/util/passwdfile/passwdfile_unix.go
+++ b/internal/pkg/util/passwdfile/passwdfile_unix.go
@@ -12,9 +12,11 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/user"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -143,7 +145,11 @@ func findUserID(uid string, r io.Reader) (*user.User, error) {
 	if v, err := readColonFile(r, matchUserIndexValue(uid, 2), 6); err != nil {
 		return nil, err
 	} else if v != nil {
-		return v.(*user.User), nil
+		u, ok := v.(*user.User)
+		if !ok {
+			return nil, fmt.Errorf("expected user info, but found %v", reflect.TypeOf(v))
+		}
+		return u, nil
 	}
 	return nil, user.UnknownUserIdError(i)
 }
@@ -152,7 +158,11 @@ func findUsername(name string, r io.Reader) (*user.User, error) {
 	if v, err := readColonFile(r, matchUserIndexValue(name, 0), 6); err != nil {
 		return nil, err
 	} else if v != nil {
-		return v.(*user.User), nil
+		u, ok := v.(*user.User)
+		if !ok {
+			return nil, fmt.Errorf("expected user info, but found %v", reflect.TypeOf(v))
+		}
+		return u, nil
 	}
 	return nil, user.UnknownUserError(name)
 }

--- a/internal/pkg/util/rootless/rootless.go
+++ b/internal/pkg/util/rootless/rootless.go
@@ -141,6 +141,7 @@ func RunInMountNS(args []string) error {
 				// https://github.com/golang/go/issues/24543.
 				break
 			default:
+				//nolint:forcetypeassert
 				signal := s.(syscall.Signal)
 				if err := syscall.Kill(cmd.Process.Pid, signal); err != nil {
 					return err

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -8,6 +8,7 @@ package cmdline
 import (
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -33,6 +34,16 @@ type Flag struct {
 	// If true, will use pFlag StringArrayVar(P) type, where values are not split on comma.
 	// If false, will use pFlag StringSliceVar(P) type, where a single value is split on commas.
 	StringArray bool
+}
+
+type FlagValTypeErr struct {
+	name     string
+	expected string
+	found    string
+}
+
+func (e FlagValTypeErr) Error() string {
+	return fmt.Sprintf("expected value of flag %q to be of type %s, but encountered %s instead", e.name, e.expected, e.found)
 }
 
 // flagManager manages cobra command flags and store them
@@ -109,11 +120,17 @@ func (m *flagManager) registerFlagForCmd(flag *Flag, cmds ...*cobra.Command) err
 
 func (m *flagManager) registerStringVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		val, ok := flag.Value.(*string)
+		if !ok {
+			return FlagValTypeErr{name: flag.Name, expected: "string", found: reflect.TypeOf(flag.Value).String()}
+		}
+
 		//nolint:forcetypeassert
+		defaultVal := flag.DefaultValue.(string)
 		if flag.ShortHand != "" {
-			c.Flags().StringVarP(flag.Value.(*string), flag.Name, flag.ShortHand, flag.DefaultValue.(string), flag.Usage)
+			c.Flags().StringVarP(val, flag.Name, flag.ShortHand, defaultVal, flag.Usage)
 		} else {
-			c.Flags().StringVar(flag.Value.(*string), flag.Name, flag.DefaultValue.(string), flag.Usage)
+			c.Flags().StringVar(val, flag.Name, defaultVal, flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}
@@ -122,11 +139,17 @@ func (m *flagManager) registerStringVar(flag *Flag, cmds []*cobra.Command) error
 
 func (m *flagManager) registerStringSliceVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		val, ok := flag.Value.(*[]string)
+		if !ok {
+			return FlagValTypeErr{name: flag.Name, expected: "[]string", found: reflect.TypeOf(flag.Value).String()}
+		}
+
 		//nolint:forcetypeassert
+		defaultVal := flag.DefaultValue.([]string)
 		if flag.ShortHand != "" {
-			c.Flags().StringSliceVarP(flag.Value.(*[]string), flag.Name, flag.ShortHand, flag.DefaultValue.([]string), flag.Usage)
+			c.Flags().StringSliceVarP(val, flag.Name, flag.ShortHand, defaultVal, flag.Usage)
 		} else {
-			c.Flags().StringSliceVar(flag.Value.(*[]string), flag.Name, flag.DefaultValue.([]string), flag.Usage)
+			c.Flags().StringSliceVar(val, flag.Name, defaultVal, flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}
@@ -135,11 +158,17 @@ func (m *flagManager) registerStringSliceVar(flag *Flag, cmds []*cobra.Command) 
 
 func (m *flagManager) registerStringArrayVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		val, ok := flag.Value.(*[]string)
+		if !ok {
+			return FlagValTypeErr{name: flag.Name, expected: "[]string", found: reflect.TypeOf(flag.Value).String()}
+		}
+
 		//nolint:forcetypeassert
+		defaultVal := flag.DefaultValue.([]string)
 		if flag.ShortHand != "" {
-			c.Flags().StringArrayVarP(flag.Value.(*[]string), flag.Name, flag.ShortHand, flag.DefaultValue.([]string), flag.Usage)
+			c.Flags().StringArrayVarP(val, flag.Name, flag.ShortHand, defaultVal, flag.Usage)
 		} else {
-			c.Flags().StringArrayVar(flag.Value.(*[]string), flag.Name, flag.DefaultValue.([]string), flag.Usage)
+			c.Flags().StringArrayVar(val, flag.Name, defaultVal, flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}
@@ -149,11 +178,17 @@ func (m *flagManager) registerStringArrayVar(flag *Flag, cmds []*cobra.Command) 
 // registerStringArrayCommas uses StringToStringVarP, a variant to allow commas (and a map of string/string)
 func (m *flagManager) registerStringMapVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		val, ok := flag.Value.(*map[string]string)
+		if !ok {
+			return FlagValTypeErr{name: flag.Name, expected: "map[string]string", found: reflect.TypeOf(flag.Value).String()}
+		}
+
 		//nolint:forcetypeassert
+		defaultVal := flag.DefaultValue.(map[string]string)
 		if flag.ShortHand != "" {
-			c.Flags().StringToStringVarP(flag.Value.(*map[string]string), flag.Name, flag.ShortHand, flag.DefaultValue.(map[string]string), flag.Usage)
+			c.Flags().StringToStringVarP(val, flag.Name, flag.ShortHand, defaultVal, flag.Usage)
 		} else {
-			c.Flags().StringToStringVar(flag.Value.(*map[string]string), flag.Name, flag.DefaultValue.(map[string]string), flag.Usage)
+			c.Flags().StringToStringVar(val, flag.Name, defaultVal, flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}
@@ -162,11 +197,17 @@ func (m *flagManager) registerStringMapVar(flag *Flag, cmds []*cobra.Command) er
 
 func (m *flagManager) registerBoolVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		val, ok := flag.Value.(*bool)
+		if !ok {
+			return FlagValTypeErr{name: flag.Name, expected: "bool", found: reflect.TypeOf(flag.Value).String()}
+		}
+
 		//nolint:forcetypeassert
+		defaultVal := flag.DefaultValue.(bool)
 		if flag.ShortHand != "" {
-			c.Flags().BoolVarP(flag.Value.(*bool), flag.Name, flag.ShortHand, flag.DefaultValue.(bool), flag.Usage)
+			c.Flags().BoolVarP(val, flag.Name, flag.ShortHand, defaultVal, flag.Usage)
 		} else {
-			c.Flags().BoolVar(flag.Value.(*bool), flag.Name, flag.DefaultValue.(bool), flag.Usage)
+			c.Flags().BoolVar(val, flag.Name, defaultVal, flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}
@@ -175,11 +216,17 @@ func (m *flagManager) registerBoolVar(flag *Flag, cmds []*cobra.Command) error {
 
 func (m *flagManager) registerIntVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		val, ok := flag.Value.(*int)
+		if !ok {
+			return FlagValTypeErr{name: flag.Name, expected: "int", found: reflect.TypeOf(flag.Value).String()}
+		}
+
 		//nolint:forcetypeassert
+		defaultVal := flag.DefaultValue.(int)
 		if flag.ShortHand != "" {
-			c.Flags().IntVarP(flag.Value.(*int), flag.Name, flag.ShortHand, flag.DefaultValue.(int), flag.Usage)
+			c.Flags().IntVarP(val, flag.Name, flag.ShortHand, defaultVal, flag.Usage)
 		} else {
-			c.Flags().IntVar(flag.Value.(*int), flag.Name, flag.DefaultValue.(int), flag.Usage)
+			c.Flags().IntVar(val, flag.Name, defaultVal, flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}
@@ -188,11 +235,17 @@ func (m *flagManager) registerIntVar(flag *Flag, cmds []*cobra.Command) error {
 
 func (m *flagManager) registerUint32Var(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		val, ok := flag.Value.(*uint32)
+		if !ok {
+			return FlagValTypeErr{name: flag.Name, expected: "uint32", found: reflect.TypeOf(flag.Value).String()}
+		}
+
 		//nolint:forcetypeassert
+		defaultVal := flag.DefaultValue.(uint32)
 		if flag.ShortHand != "" {
-			c.Flags().Uint32VarP(flag.Value.(*uint32), flag.Name, flag.ShortHand, flag.DefaultValue.(uint32), flag.Usage)
+			c.Flags().Uint32VarP(val, flag.Name, flag.ShortHand, defaultVal, flag.Usage)
 		} else {
-			c.Flags().Uint32Var(flag.Value.(*uint32), flag.Name, flag.DefaultValue.(uint32), flag.Usage)
+			c.Flags().Uint32Var(val, flag.Name, defaultVal, flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -109,6 +109,7 @@ func (m *flagManager) registerFlagForCmd(flag *Flag, cmds ...*cobra.Command) err
 
 func (m *flagManager) registerStringVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		//nolint:forcetypeassert
 		if flag.ShortHand != "" {
 			c.Flags().StringVarP(flag.Value.(*string), flag.Name, flag.ShortHand, flag.DefaultValue.(string), flag.Usage)
 		} else {
@@ -121,6 +122,7 @@ func (m *flagManager) registerStringVar(flag *Flag, cmds []*cobra.Command) error
 
 func (m *flagManager) registerStringSliceVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		//nolint:forcetypeassert
 		if flag.ShortHand != "" {
 			c.Flags().StringSliceVarP(flag.Value.(*[]string), flag.Name, flag.ShortHand, flag.DefaultValue.([]string), flag.Usage)
 		} else {
@@ -133,6 +135,7 @@ func (m *flagManager) registerStringSliceVar(flag *Flag, cmds []*cobra.Command) 
 
 func (m *flagManager) registerStringArrayVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		//nolint:forcetypeassert
 		if flag.ShortHand != "" {
 			c.Flags().StringArrayVarP(flag.Value.(*[]string), flag.Name, flag.ShortHand, flag.DefaultValue.([]string), flag.Usage)
 		} else {
@@ -146,6 +149,7 @@ func (m *flagManager) registerStringArrayVar(flag *Flag, cmds []*cobra.Command) 
 // registerStringArrayCommas uses StringToStringVarP, a variant to allow commas (and a map of string/string)
 func (m *flagManager) registerStringMapVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		//nolint:forcetypeassert
 		if flag.ShortHand != "" {
 			c.Flags().StringToStringVarP(flag.Value.(*map[string]string), flag.Name, flag.ShortHand, flag.DefaultValue.(map[string]string), flag.Usage)
 		} else {
@@ -158,6 +162,7 @@ func (m *flagManager) registerStringMapVar(flag *Flag, cmds []*cobra.Command) er
 
 func (m *flagManager) registerBoolVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		//nolint:forcetypeassert
 		if flag.ShortHand != "" {
 			c.Flags().BoolVarP(flag.Value.(*bool), flag.Name, flag.ShortHand, flag.DefaultValue.(bool), flag.Usage)
 		} else {
@@ -170,6 +175,7 @@ func (m *flagManager) registerBoolVar(flag *Flag, cmds []*cobra.Command) error {
 
 func (m *flagManager) registerIntVar(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		//nolint:forcetypeassert
 		if flag.ShortHand != "" {
 			c.Flags().IntVarP(flag.Value.(*int), flag.Name, flag.ShortHand, flag.DefaultValue.(int), flag.Usage)
 		} else {
@@ -182,6 +188,7 @@ func (m *flagManager) registerIntVar(flag *Flag, cmds []*cobra.Command) error {
 
 func (m *flagManager) registerUint32Var(flag *Flag, cmds []*cobra.Command) error {
 	for _, c := range cmds {
+		//nolint:forcetypeassert
 		if flag.ShortHand != "" {
 			c.Flags().Uint32VarP(flag.Value.(*uint32), flag.Name, flag.ShortHand, flag.DefaultValue.(uint32), flag.Usage)
 		} else {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -175,6 +175,7 @@ func (i *Image) AuthorizedOwner(owners []string) (bool, error) {
 		return false, fmt.Errorf("failed to get stat for %s", i.Path)
 	}
 
+	//nolint:forcetypeassert
 	uid := fileinfo.Sys().(*syscall.Stat_t).Uid
 	for _, owner := range owners {
 		pw, err := user.GetPwNam(owner)
@@ -199,6 +200,7 @@ func (i *Image) AuthorizedGroup(groups []string) (bool, error) {
 		return false, fmt.Errorf("failed to get stat for %s", i.Path)
 	}
 
+	//nolint:forcetypeassert
 	gid := fileinfo.Sys().(*syscall.Stat_t).Gid
 	for _, group := range groups {
 		gr, err := user.GetGrNam(group)

--- a/pkg/network/network_linux.go
+++ b/pkg/network/network_linux.go
@@ -208,6 +208,7 @@ func (m *Setup) SetCapability(network string, capName string, args interface{}) 
 				return fmt.Errorf("%s network doesn't have %s capability", network, capName)
 			}
 
+			//nolint:forcetypeassert
 			switch args := args.(type) {
 			case PortMapEntry:
 				if m.runtimeConf[i].CapabilityArgs[capName] == nil {

--- a/pkg/util/fs/proc/proc.go
+++ b/pkg/util/fs/proc/proc.go
@@ -121,6 +121,7 @@ func parseMountInfoLine(line string) MountInfoEntry {
 	if entry.FSType == "btrfs" || entry.FSType == "overlay" || entry.FSType == "ceph" {
 		fi, err := os.Stat(entry.Point)
 		if err == nil {
+			//nolint:forcetypeassert
 			st := fi.Sys().(*syscall.Stat_t)
 			// cast to uint64 as st.Dev is uint32 on MIPS
 			entry.Dev = fmt.Sprintf("%d:%d", unix.Major(uint64(st.Dev)), unix.Minor(uint64(st.Dev)))
@@ -161,6 +162,7 @@ func FindParentMountEntry(path string, entries []MountInfoEntry) (*MountInfoEntr
 	if err != nil {
 		return nil, fmt.Errorf("while getting stat for %s: %s", path, err)
 	}
+	//nolint:forcetypeassert
 	st := fi.Sys().(*syscall.Stat_t)
 	// cast to uint64 as st.Dev is uint32 on MIPS
 	dev := fmt.Sprintf("%d:%d", unix.Major(uint64(st.Dev)), unix.Minor(uint64(st.Dev)))

--- a/pkg/util/loop/loop.go
+++ b/pkg/util/loop/loop.go
@@ -52,6 +52,8 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 	if err != nil {
 		return err
 	}
+
+	//nolint:forcetypeassert
 	st := fi.Sys().(*syscall.Stat_t)
 	imageIno := st.Ino
 	// cast to uint64 as st.Dev is uint32 on MIPS

--- a/pkg/util/loop/loop_test.go
+++ b/pkg/util/loop/loop_test.go
@@ -82,6 +82,7 @@ func TestLoop(t *testing.T) {
 
 	loopDevTwo.Close()
 
+	//nolint:forcetypeassert
 	st := fi.Sys().(*syscall.Stat_t)
 	// cast to uint64 as st.Dev is uint32 on MIPS
 	if uint64(st.Dev) != i1.Device || st.Ino != i1.Inode {

--- a/test/certs/gen_certs.go
+++ b/test/certs/gen_certs.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"reflect"
 	"time"
 
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
@@ -131,7 +132,11 @@ func createLeaf(start time.Time, parentKey crypto.PrivateKey, parent *x509.Certi
 		OCSPServer:     []string{"http://localhost:9999"},
 	}
 
-	return createCertificate(tmpl, parent, key.(crypto.Signer).Public(), parentKey)
+	signer, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("expected signer but got: %v", reflect.TypeOf(key))
+	}
+	return createCertificate(tmpl, parent, signer.Public(), parentKey)
 }
 
 // writeCerts generates certificates and writes them to disk.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Enable the `forcetypeassert` linter in golangci-lint, and perform fixes / add `nolint:` directives, as appropriate, in code.

