### PR TITLE
lint: enable nolintlint + corresponding fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters:
     - maintidx
     - misspell
     - nakedret
+    - nolintlint
     - reassign
     - revive
     - staticcheck
@@ -51,3 +52,10 @@ linters-settings:
 issues:
   max-per-linter: 0
   max-same-issues: 0
+  exclude:
+    - EXC0004
+  exclude-rules:
+    - linters:
+        - gosec
+      text: "^(G107|G204|G306):"
+

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -587,7 +587,6 @@ func (c ctx) testDockerLabels(t *testing.T) {
 	)
 }
 
-//nolint:dupl
 func (c ctx) testDockerCMD(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
 	t.Cleanup(func() {

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -364,7 +364,6 @@ func (c ctx) ociTestRocm(t *testing.T) {
 	}
 }
 
-//nolint:dupl
 func (c ctx) testBuildNvidiaLegacy(t *testing.T) {
 	require.Nvidia(t)
 
@@ -524,7 +523,6 @@ func (c ctx) testBuildNvCCLI(t *testing.T) {
 	}
 }
 
-//nolint:dupl
 func (c ctx) testBuildRocm(t *testing.T) {
 	require.Rocm(t)
 	require.Command(t, "lsmod")

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1743,7 +1743,6 @@ cat /proc/$$/cmdline`
 	)
 }
 
-//nolint:maintidx
 func (c imgBuildTests) buildDefinitionWithBuildArgs(t *testing.T) {
 	busyboxSIF := e2e.BusyboxSIF(t)
 	fileContent := `HOME=/root

--- a/internal/app/singularity/keyserver_list.go
+++ b/internal/app/singularity/keyserver_list.go
@@ -19,9 +19,6 @@ import (
 )
 
 // KeyserverList prints information about remote configurations
-// FIXME - remoteName is not being honored
-//
-//nolint:revive
 func KeyserverList(remoteName string, usrConfigFile string) (err error) {
 	c := &remote.Config{}
 

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -170,8 +170,6 @@ func (m *Manager) UpdateFromFile(path string) error {
 //
 // Disable context check as it raises a warning throuch lcmanager.New, which is
 // in a dependency we cannot modify to pass a context.
-//
-// nolint:contextcheck
 func (m *Manager) AddProc(pid int) (err error) {
 	if m.group == "" || m.cgroup == nil {
 		return ErrUnitialized
@@ -260,8 +258,6 @@ func checkRootless(group string, systemd bool) (rootless bool, err error) {
 //
 // Disable context check as it raises a warning throuch lcmanager.New, which is
 // in a dependency we cannot modify to pass a context.
-//
-// nolint:contextcheck
 func newManager(resources *specs.LinuxResources, group string, systemd bool) (manager *Manager, err error) {
 	if resources == nil {
 		return nil, fmt.Errorf("non-nil cgroup LinuxResources definition is required")
@@ -389,8 +385,6 @@ func NewManagerWithFile(specPath string, pid int, group string, systemd bool) (m
 //
 // Disable context check as it raises a warning throuch lcmanager.New, which is
 // in a dependency we cannot modify to pass a context.
-//
-// nolint:contextcheck
 func GetManagerForGroup(group string) (manager *Manager, err error) {
 	if group == "" {
 		return nil, fmt.Errorf("cannot load cgroup - no name/path specified")

--- a/internal/pkg/cgroups/manager_linux_v1_test.go
+++ b/internal/pkg/cgroups/manager_linux_v1_test.go
@@ -52,7 +52,6 @@ func TestCgroupsV1(t *testing.T) {
 	runSystemdTests(t, tests)
 }
 
-//nolint:dupl
 func testGetCgroupRootPathV1(t *testing.T, systemd bool) {
 	// This cgroup won't be created in the fs as we don't add a PID through the manager
 	group := filepath.Join("/singularity/rootpathtest")
@@ -85,7 +84,6 @@ func testGetCgroupRootPathV1(t *testing.T, systemd bool) {
 	}
 }
 
-//nolint:dupl
 func testGetCgroupRelPathV1(t *testing.T, systemd bool) {
 	// This cgroup won't be created in the fs as we don't add a PID through the manager
 	group := filepath.Join("/singularity/rootpathtest")
@@ -110,7 +108,6 @@ func testGetCgroupRelPathV1(t *testing.T, systemd bool) {
 	}
 }
 
-//nolint:dupl
 func testNewUpdateV1(t *testing.T, systemd bool) {
 	_, manager, cleanup := testManager(t, systemd)
 	defer cleanup()
@@ -142,7 +139,6 @@ func testNewUpdateV1(t *testing.T, systemd bool) {
 	ensureInt(t, pidsMax, 512)
 }
 
-//nolint:dupl
 func testUpdateUnifiedV1(t *testing.T, systemd bool) {
 	_, manager, cleanup := testManager(t, systemd)
 	defer cleanup()

--- a/internal/pkg/cgroups/manager_linux_v2_test.go
+++ b/internal/pkg/cgroups/manager_linux_v2_test.go
@@ -52,7 +52,6 @@ func TestCgroupsV2(t *testing.T) {
 	runSystemdTests(t, tests)
 }
 
-//nolint:dupl
 func testGetCgroupRootPathV2(t *testing.T, systemd bool) {
 	// This cgroup won't be created in the fs as we don't add a PID through the manager
 	group := filepath.Join("/singularity/rootpathtest")
@@ -99,7 +98,6 @@ func testGetCgroupRelPathV2(t *testing.T, systemd bool) {
 	}
 }
 
-//nolint:dupl
 func testNewUpdateV2(t *testing.T, systemd bool) {
 	_, manager, cleanup := testManager(t, systemd)
 	defer cleanup()
@@ -132,7 +130,6 @@ func testNewUpdateV2(t *testing.T, systemd bool) {
 	ensureInt(t, pidsMax, 512)
 }
 
-//nolint:dupl
 func testUpdateUnifiedV2(t *testing.T, systemd bool) {
 	// Apply a 1024 pids.max limit using the v1 style config that sets [pids] limit
 	_, manager, cleanup := testManager(t, systemd)
@@ -149,7 +146,6 @@ func testUpdateUnifiedV2(t *testing.T, systemd bool) {
 	ensureInt(t, pidsMax, 512)
 }
 
-//nolint:dupl
 func testAddProcV2(t *testing.T, systemd bool) {
 	pid, manager, cleanup := testManager(t, systemd)
 
@@ -173,7 +169,6 @@ func testAddProcV2(t *testing.T, systemd bool) {
 	ensureContainsInt(t, cgroupProcs, int64(newPid))
 }
 
-//nolint:dupl
 func testFreezeThawV2(t *testing.T, systemd bool) {
 	manager := &Manager{}
 	if err := manager.Freeze(); err == nil {

--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -58,7 +58,7 @@ func ProgressBarCallback(ctx context.Context) ProgressCallback {
 	}
 
 	return func(totalSize int64, r io.Reader, w io.Writer) error {
-		p, bar := initProgressBar(totalSize) //nolint:contextcheck
+		p, bar := initProgressBar(totalSize)
 
 		// create proxy reader
 		bodyProgress := bar.ProxyReader(r)

--- a/internal/pkg/remote/endpoint/client_test.go
+++ b/internal/pkg/remote/endpoint/client_test.go
@@ -133,7 +133,6 @@ func TestKeyserverClientOpts(t *testing.T) {
 	}
 }
 
-//nolint:dupl
 func TestLibraryClientConfig(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -203,7 +202,6 @@ func TestLibraryClientConfig(t *testing.T) {
 	}
 }
 
-//nolint:dupl
 func TestBuilderClientConfig(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -183,7 +183,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		return err
 	}
 
-	if sendFd { // nolint:staticcheck
+	if sendFd {
 		fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 		if err != nil {
 			return fmt.Errorf("failed to create socketpair to pass file descriptor: %s", err)

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -122,8 +122,6 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 }
 
 // checkOpts ensures that options set are supported by the oci.Launcher.
-//
-// nolint:maintidx
 func checkOpts(lo launcher.Options) error {
 	badOpt := []string{}
 

--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -28,7 +28,7 @@ func FUSEMount(ctx context.Context, offset uint64, path, mountPath string) error
 	if err != nil {
 		return err
 	}
-	cmd := exec.CommandContext(ctx, squashfuse, args...) //nolint:gosec
+	cmd := exec.CommandContext(ctx, squashfuse, args...)
 
 	sylog.Debugf("Executing %s %s", squashfuse, strings.Join(args, " "))
 
@@ -49,7 +49,7 @@ func FUSEUnmount(ctx context.Context, mountPath string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.CommandContext(ctx, fusermount, args...) //nolint:gosec
+	cmd := exec.CommandContext(ctx, fusermount, args...)
 
 	sylog.Debugf("Executing %s %s", fusermount, strings.Join(args, " "))
 

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -432,7 +432,7 @@ func ParseDefinitionFile(r io.Reader) (d types.Definition, err error) {
 	s.Split(scanDefinitionFile)
 
 	// advance scanner until it returns a useful token or errors
-	//nolint:revive
+	//nolint:revive,nolintlint
 	for s.Scan() && s.Text() == "" && s.Err() == nil {
 	}
 

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -50,7 +50,7 @@ func TestScanDefinitionFile(t *testing.T) {
 
 			s := bufio.NewScanner(r)
 			s.Split(scanDefinitionFile)
-			//nolint:revive
+			//nolint:revive,nolintlint
 			for s.Scan() && s.Text() == "" && s.Err() == nil {
 			}
 
@@ -137,7 +137,7 @@ func TestDoSections(t *testing.T) {
 	s1.Split(scanDefinitionFile)
 
 	// advance scanner until it returns a useful token
-	//nolint:revive
+	//nolint:revive,nolintlint
 	for s1.Scan() && s1.Text() == "" {
 		// Nothing to do
 	}
@@ -153,7 +153,7 @@ func TestDoSections(t *testing.T) {
 	s2.Split(scanDefinitionFile)
 
 	// Advance the scanner until it returns a useful token
-	//nolint:revive
+	//nolint:revive,nolintlint
 	for s2.Scan() && s2.Text() == "" {
 		// Nothing to do
 	}

--- a/pkg/util/archive/copy.go
+++ b/pkg/util/archive/copy.go
@@ -19,8 +19,6 @@ import (
 //
 // Disable context check as it raises a warning through the docker dependency we
 // cannot modify to pass a context.
-//
-// nolint:contextcheck
 func CopyWithTar(src, dst string, disableIDMapping bool) error {
 	ar := da.NewDefaultArchiver()
 

--- a/pkg/util/capabilities/capabilities.go
+++ b/pkg/util/capabilities/capabilities.go
@@ -465,7 +465,7 @@ func Normalize(capabilities []string) ([]string, []string) {
 
 	capabilities = normalize(capabilities)
 
-	// nolint:prealloc
+	//nolint:prealloc
 	var included []string
 	var excluded []string
 	for _, capb := range capabilities {

--- a/pkg/util/unix/socket_test.go
+++ b/pkg/util/unix/socket_test.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	// TODO - go 1.20 initializes seed randomly by default, so can drop this
 	// deprecated call in future.
-	rand.Seed(time.Now().UnixNano()) // nolint:staticcheck
+	rand.Seed(time.Now().UnixNano()) //nolint:staticcheck
 }
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")


### PR DESCRIPTION
## Description of the Pull Request (PR):

Enable the `nolintlint` linter in golangci-lint, and perform fixes, as appropriate, in code.

