### PR TITLE
lint: enable prealloc + corresponding fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters:
     - maintidx
     - misspell
     - nakedret
+    - prealloc
     - reassign
     - revive
     - staticcheck

--- a/internal/pkg/plugin/binary.go
+++ b/internal/pkg/plugin/binary.go
@@ -88,7 +88,7 @@ func List() ([]*Meta, error) {
 		return nil, fmt.Errorf("cannot list plugins in directory %q", rootDir)
 	}
 
-	var metas []*Meta
+	metas := make([]*Meta, 0, len(entries))
 	for _, entry := range entries {
 		fi, err := os.Stat(entry)
 		if err != nil {

--- a/internal/pkg/runtime/engine/config/oci/generate/generate.go
+++ b/internal/pkg/runtime/engine/config/oci/generate/generate.go
@@ -28,6 +28,7 @@ import (
 	"os"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/samber/lo"
 	"github.com/sylabs/singularity/v4/pkg/util/capabilities"
 	"golang.org/x/sys/unix"
 )
@@ -239,10 +240,7 @@ func (g *Generator) SetupPrivileged(privileged bool) {
 	// Add all capabilities, we don't need to check for the
 	// latest capability available as it's handled automatically
 	// by the starter
-	var allCapability []string
-	for capStr := range capabilities.Map {
-		allCapability = append(allCapability, capStr)
-	}
+	allCapability := lo.Keys(capabilities.Map)
 
 	g.initLinux()
 	g.initProcessCapabilities()

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -454,8 +454,6 @@ func ParseDefinitionFile(r io.Reader) (d types.Definition, err error) {
 // and parses it into a slice of Definition structs or returns error if
 // an error is encounter while parsing
 func All(r io.Reader) ([]types.Definition, error) {
-	var stages []types.Definition
-
 	raw, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("while attempting to read definition file: %v", err)
@@ -483,6 +481,7 @@ func All(r io.Reader) ([]types.Definition, error) {
 		return nil, errEmptyDefinition
 	}
 
+	stages := make([]types.Definition, 0, len(splitBuf))
 	for _, stage := range splitBuf {
 		if len(stage) == 0 {
 			continue

--- a/pkg/image/sif_test.go
+++ b/pkg/image/sif_test.go
@@ -24,8 +24,7 @@ func createSIF(t *testing.T, corrupted bool, fns ...func() (sif.DescriptorInput,
 	}
 	sifFile.Close()
 
-	var opts []sif.CreateOpt
-
+	opts := make([]sif.CreateOpt, 0, len(fns))
 	for _, fn := range fns {
 		di, err := fn()
 		if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Enable the `prealloc` linter in golangci-lint, and perform fixes, as appropriate, in code.

