### PR TITLE
fix: oci: explicit bind options for /sys /proc sources

### DIFF
--- a/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
@@ -57,7 +57,7 @@ func Test_addBindMount(t *testing.T) {
 					Source:      "/tmp",
 					Destination: "/tmp",
 					Type:        "none",
-					Options:     []string{"rbind", "nodev", "ro", "nosuid"},
+					Options:     []string{"rbind", "nodev", "nosuid", "ro"},
 				},
 			},
 		},
@@ -119,6 +119,38 @@ func Test_addBindMount(t *testing.T) {
 			wantMounts: &[]specs.Mount{},
 			// Should fail because bind-mounting SIFs not supported in OCI mode
 			wantErr: true,
+		},
+		{
+			name: "Proc",
+			b: bind.Path{
+				Source:      "/proc",
+				Destination: "/proc",
+			},
+			userbind: true,
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      "/proc",
+					Destination: "/proc",
+					Type:        "none",
+					Options:     []string{"rbind", "nodev", "nosuid", "noexec"},
+				},
+			},
+		},
+		{
+			name: "Sys",
+			b: bind.Path{
+				Source:      "/sys",
+				Destination: "/sys",
+			},
+			userbind: true,
+			wantMounts: &[]specs.Mount{
+				{
+					Source:      "/sys",
+					Destination: "/sys",
+					Type:        "none",
+					Options:     []string{"rbind", "nodev", "nosuid", "noexec"},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -202,7 +234,7 @@ func TestLauncher_addBindMounts(t *testing.T) {
 					Source:      "/tmp",
 					Destination: "/mnt",
 					Type:        "none",
-					Options:     []string{"rbind", "nodev", "ro", "nosuid"},
+					Options:     []string{"rbind", "nodev", "nosuid", "ro"},
 				},
 			},
 			wantErr: false,
@@ -287,7 +319,7 @@ func TestLauncher_addBindMounts(t *testing.T) {
 					Source:      "/tmp",
 					Destination: "/mnt",
 					Type:        "none",
-					Options:     []string{"rbind", "nodev", "ro", "nosuid"},
+					Options:     []string{"rbind", "nodev", "nosuid", "ro"},
 				},
 			},
 			wantErr: false,
@@ -408,7 +440,7 @@ func TestLauncher_addLibrariesMounts(t *testing.T) {
 					Source:      lib1,
 					Destination: "/.singularity.d/libs/lib1.so",
 					Type:        "none",
-					Options:     []string{"rbind", "nodev", "ro", "nosuid"},
+					Options:     []string{"rbind", "nodev", "nosuid", "ro"},
 				},
 			},
 			wantErr: false,
@@ -424,13 +456,13 @@ func TestLauncher_addLibrariesMounts(t *testing.T) {
 					Source:      lib1,
 					Destination: "/.singularity.d/libs/lib1.so",
 					Type:        "none",
-					Options:     []string{"rbind", "nodev", "ro", "nosuid"},
+					Options:     []string{"rbind", "nodev", "nosuid", "ro"},
 				},
 				{
 					Source:      lib2,
 					Destination: "/.singularity.d/libs/lib2.so",
 					Type:        "none",
-					Options:     []string{"rbind", "nodev", "ro", "nosuid"},
+					Options:     []string{"rbind", "nodev", "nosuid", "ro"},
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
## Description of the Pull Request (PR):

When `/sys` or `/proc` are requested to be bind mounted into a container, the bind mount options must be at least as restrictive as on the host.

`/sys` and `/proc` filesystems are generally `nosuid,nodev,noexec`.

`runc` doesn't try more restrictive options on a failed mount, so we have to ensure `nosuid,nodev,noexec` are always set when a bind source is `/sys` or `/proc`.

Tested with `runc` on Fedora - which exhibits the failures shown in the issues.

### This fixes or addresses the following GitHub issues:

 - Fixes #2069 
 - Fixes #2070


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
