### PR TITLE
fix: rpm: use semver version-release for mconfig -V

### DIFF
--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -108,7 +108,7 @@ container platform designed to be simple, fast, and secure.
 %autosetup -n %{name}-@PACKAGE_VERSION@
 
 %build
-./mconfig -V %{version}-%{release} \
+./mconfig -V @PACKAGE_VERSION@-@PACKAGE_RELEASE@ \
         --prefix=%{_prefix} \
         --exec-prefix=%{_exec_prefix} \
         --bindir=%{_bindir} \


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use `@PACKAGE_VERSION@-@PACKAGE_RELEASE@` as the version specifier in the call to `mconfig -V` in our rpm spec.

The RPM spec's own `%{release}`, which will still be used for the name of the RPM package itself, includes `%{?dist}` which may not be semver compliant.

Additionally, using `@PACKAGE_VERSION@` instead of `%{version}` preseves semver style `-` for pre-releases instead of rpm style `~` for pre-releases in the `singularity --version / version`.

We are aiming for semver compliance - our reported version number should be semver compliant.


### This fixes or addresses the following GitHub issues:

 - Fixes #2073


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
