### PR TITLE
lint: enable tenv + corresponding fixes (release-4.0)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ linters:
     - reassign
     - revive
     - staticcheck
+    - tenv
     - typecheck
     - unused
 

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -244,6 +244,11 @@ func (c ctx) issue1286(t *testing.T) {
 
 // https://github.com/sylabs/singularity/issues/1528
 // Check that host's TERM value gets passed to OCI container.
+// This test uses fairly fine-grained env vars manipulation which, at the
+// present, is beyond what an API like testing.T.Setenv() enables, and so
+// the tenv linter is turned off here.
+//
+//nolint:tenv
 func (c ctx) issue1528(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.env)
 

--- a/internal/pkg/test/privilege_linux.go
+++ b/internal/pkg/test/privilege_linux.go
@@ -64,9 +64,11 @@ func ResetPrivilege(t *testing.T) {
 	if err := unix.Setresgid(origGID, origGID, unprivGID); err != nil {
 		t.Fatalf("failed to reset group identity: %v", err)
 	}
-	if err := os.Setenv("HOME", origHome); err != nil {
-		t.Fatalf("failed to reset HOME environment variable: %v", err)
-	}
+
+	// We might want restoration of HOME env var to persist past this individual
+	// test, so use os.Setenv() rather than t.Setenv()
+	//nolint:tenv
+	os.Setenv("HOME", origHome)
 
 	runtime.UnlockOSThread()
 }

--- a/internal/pkg/util/bin/bin_test.go
+++ b/internal/pkg/util/bin/bin_test.go
@@ -26,9 +26,7 @@ func TestFindOnPath(t *testing.T) {
 	// Find the true path of 'cp' under a sensible PATH=env.DefaultPath
 	// Forcing this avoid issues with PATH across sudo calls for the tests,
 	// differing orders, /usr/bin -> /bin symlinks etc.
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", env.DefaultPath)
-	defer os.Setenv("PATH", oldPath)
+	t.Setenv("PATH", env.DefaultPath)
 	truePath, err := exec.LookPath("cp")
 	if err != nil {
 		t.Fatalf("exec.LookPath failed to find cp: %v", err)
@@ -46,7 +44,7 @@ func TestFindOnPath(t *testing.T) {
 
 	t.Run("bad path", func(t *testing.T) {
 		// Force a PATH that doesn't contain cp
-		os.Setenv("PATH", "/invalid/dir:/another/invalid/dir")
+		t.Setenv("PATH", "/invalid/dir:/another/invalid/dir")
 
 		gotPath, err := findOnPath("cp")
 		if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2088 

Enable the `tenv` linter in golangci-lint, and perform fixes / add `nolint:` directives, as appropriate, in code.

