### PR TITLE
lint: enable unparam + corresponding fixes (release-4.0)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,7 @@ linters:
     - revive
     - staticcheck
     - typecheck
+    - unparam
     - unused
 
 linters-settings:

--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -29,6 +29,7 @@ type instanceList struct {
 	Instances []instance `json:"instances"`
 }
 
+//nolint:unparam
 func (c *ctx) stopInstance(t *testing.T, instance string, stopArgs ...string) (stdout string, stderr string, success bool) {
 	args := stopArgs
 
@@ -52,6 +53,7 @@ func (c *ctx) stopInstance(t *testing.T, instance string, stopArgs ...string) (s
 	return
 }
 
+//nolint:unparam
 func (c *ctx) execInstance(t *testing.T, instance string, execArgs ...string) (stdout string, stderr string, success bool) {
 	args := []string{"instance://" + instance}
 	args = append(args, execArgs...)

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -32,6 +32,8 @@ type PullOptions struct {
 }
 
 // sysCtx provides authentication and tempDir config for containers/image OCI operations
+//
+//nolint:unparam
 func sysCtx(opts PullOptions) (*ocitypes.SystemContext, error) {
 	// DockerInsecureSkipTLSVerify is set only if --no-https is specified to honor
 	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify

--- a/internal/pkg/client/ocisif/ocisif.go
+++ b/internal/pkg/client/ocisif/ocisif.go
@@ -47,6 +47,8 @@ type PullOptions struct {
 }
 
 // sysCtx provides authentication and tempDir config for containers/image OCI operations
+//
+//nolint:unparam
 func sysCtx(opts PullOptions) (*ocitypes.SystemContext, error) {
 	// DockerInsecureSkipTLSVerify is set only if --no-https is specified to honor
 	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
@@ -227,7 +229,7 @@ func convertLayoutToOciSif(layoutDir string, digest v1.Hash, imageDest, workDir 
 	img, err = mutate.Apply(img,
 		mutate.ReplaceLayers(squashfsLayer),
 		mutate.SetHistory(v1.History{
-			Created:    v1.Time{time.Now()}, //nolint:govet
+			Created:    v1.Time{Time: time.Now()},
 			CreatedBy:  useragent.Value(),
 			Comment:    "oci-sif created from " + digest.Hex,
 			EmptyLayer: false,

--- a/internal/pkg/util/fs/mount/system_linux_test.go
+++ b/internal/pkg/util/fs/mount/system_linux_test.go
@@ -29,6 +29,7 @@ func TestSystem(t *testing.T) {
 	after := false
 	mnt := false
 
+	//nolint:unparam
 	mountFn := func(point *Point, system *System) error {
 		mnt = true
 		return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2090 

Enable the `unparam` linter in golangci-lint, and add `nolint:` directives, as appropriate, in code.

