### PR TITLE
lint: enable whitespace + corresponding fixes (release-4.0)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
     - staticcheck
     - typecheck
     - unused
+    - whitespace
 
 linters-settings:
   misspell:

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -70,7 +70,6 @@ func fakerootExec() {
 			args[idx] = arg
 			idx++
 		}
-
 	}
 
 	user, err := user.GetPwUID(uint32(os.Getuid()))
@@ -394,7 +393,6 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 	if buildArgs.sandbox {
 		buildFormat = "sandbox"
 		sandboxTarget = true
-
 	}
 
 	dp, err := ociplatform.DefaultPlatform()

--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -177,7 +177,6 @@ func collectInput(cmd *cobra.Command) (*keyNewPairOptions, error) {
 			if a == "n" {
 				return nil, errors.New("empty passphrase")
 			}
-
 		}
 
 		genOpts.Password = p

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2414,7 +2414,6 @@ func (c actionTests) actionNoMount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		if tt.testDefault {
 			c.env.RunSingularity(
 				t,

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -2041,7 +2041,6 @@ func (c actionTests) actionOciNoMount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		expectOp := e2e.ExpectOutput(e2e.UnwantedContainMatch, tt.noMatch)
 		if tt.warnMatch != "" {
 			expectOp = e2e.ExpectError(e2e.ContainMatch, tt.warnMatch)
@@ -2134,7 +2133,6 @@ func (c actionTests) actionOciHomeCwdPasswd(t *testing.T) {
 				e2e.ExpectOutput(e2e.RegexMatch, passwdLine),
 			),
 		)
-
 	}
 }
 

--- a/e2e/help/help.go
+++ b/e2e/help/help.go
@@ -47,7 +47,6 @@ var helpOciContentTests = []struct {
 
 func (c ctx) testHelpOciContent(t *testing.T) {
 	for _, tc := range helpOciContentTests {
-
 		name := fmt.Sprintf("help-%s.txt", strings.Join(tc.cmds, "-"))
 
 		testHelpOciContentFn := func(t *testing.T, r *e2e.SingularityCmdResult) {
@@ -68,7 +67,6 @@ func (c ctx) testHelpOciContent(t *testing.T) {
 				}
 			}),
 			e2e.ExpectExit(0, testHelpOciContentFn))
-
 	}
 }
 
@@ -103,7 +101,6 @@ func (c ctx) testCommands(t *testing.T) {
 	}
 
 	for _, tt := range testCommands {
-
 		testFlags := []struct {
 			name string
 			argv string
@@ -118,7 +115,6 @@ func (c ctx) testCommands(t *testing.T) {
 		}
 
 		for _, tf := range testFlags {
-
 			var cmdRun, argRun string
 
 			if tf.name == "PostCommand" || tf.name == "PreCommand" {
@@ -147,7 +143,6 @@ func (c ctx) testCommands(t *testing.T) {
 				}),
 				e2e.ExpectExit(0))
 		}
-
 	}
 }
 
@@ -233,7 +228,6 @@ func (c ctx) testSingularity(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		printSuccessOrFailureFn := func(t *testing.T, r *e2e.SingularityCmdResult) {
 			if r.Stdout != nil {
 				t.Logf(string(r.Stdout) + "\n")

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -188,7 +188,6 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tc := range tt {
-
 				dn, cleanup := c.tempDir(t, "build-from")
 				t.Cleanup(func() {
 					if !t.Failed() {

--- a/e2e/internal/testhelper/testhelper.go
+++ b/e2e/internal/testhelper/testhelper.go
@@ -106,7 +106,6 @@ func (s *Suite) Run(filter *string) {
 
 			t.Run(name, func(t *testing.T) {
 				for testName, fn := range tests[name] {
-
 					if filterMatch != nil {
 						if !filterMatch.MatchString(testName) {
 							continue

--- a/e2e/pull/concurrency.go
+++ b/e2e/pull/concurrency.go
@@ -157,6 +157,5 @@ func (c ctx) testConcurrentPulls(t *testing.T) {
 			// pull image
 			c.imagePull(t, ts)
 		})
-
 	}
 }

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -511,7 +511,6 @@ func (c ctx) testPullCmd(t *testing.T) {
 				if tt.pullDir != "" {
 					tt.expectedImage = filepath.Join(tt.pullDir, imageName)
 				}
-
 			}
 
 			// In order to actually test force, there must already be a file present in

--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -104,7 +104,6 @@ func (c ctx) testSecurityUnpriv(t *testing.T) {
 			e2e.PreRun(tt.preFn),
 			e2e.ExpectExit(tt.expectExit, tt.expectOp),
 		)
-
 	}
 }
 
@@ -195,7 +194,6 @@ func (c ctx) testSecurityPriv(t *testing.T) {
 			e2e.PreRun(tt.preFn),
 			e2e.ExpectExit(tt.expectExit, tt.expectOp),
 		)
-
 	}
 }
 

--- a/e2e/version/version.go
+++ b/e2e/version/version.go
@@ -30,7 +30,6 @@ var tests = []struct {
 // Test that this version uses the semantic version format
 func (c ctx) testSemanticVersion(t *testing.T) {
 	for _, tt := range tests {
-
 		checkSemanticVersionFn := func(t *testing.T, r *e2e.SingularityCmdResult) {
 			outputVer := strings.TrimPrefix(string(r.Stdout), "singularity-ce version ")
 			outputVer = strings.TrimSpace(outputVer)
@@ -59,7 +58,6 @@ func (c ctx) testSemanticVersion(t *testing.T) {
 func (c ctx) testEqualVersion(t *testing.T) {
 	tmpVersion := ""
 	for _, tt := range tests {
-
 		checkEqualVersionFn := func(t *testing.T, r *e2e.SingularityCmdResult) {
 			outputVer := strings.TrimPrefix(string(r.Stdout), "singularity-ce version ")
 			outputVer = strings.TrimSpace(outputVer)
@@ -95,7 +93,6 @@ func (c ctx) testEqualVersion(t *testing.T) {
 			}),
 			e2e.ExpectExit(0, checkEqualVersionFn),
 		)
-
 	}
 }
 

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -153,7 +153,6 @@ func doTokenCheck(e *endpoint.Config) error {
 	if err := e.VerifyToken(""); err != nil {
 		fmt.Println("\nAuthentication token is invalid (please login again).")
 		return err
-
 	}
 	fmt.Println("\nValid authentication token set (logged in).")
 	return nil

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -375,7 +375,6 @@ func copyFiles(b *types.Bundle, a *App) error {
 
 	appBase := filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)
 	for _, line := range strings.Split(a.Files, "\n") {
-
 		// skip empty or comment lines
 		if line = strings.TrimSpace(line); line == "" || strings.Index(line, "#") == 0 {
 			continue
@@ -412,7 +411,6 @@ func writeLabels(b *types.Bundle, a *App) error {
 	labels["SCIF_APP_NAME"] = a.Name
 
 	for _, line := range lines {
-
 		// skip empty or comment lines
 		if line = strings.TrimSpace(line); line == "" || strings.Index(line, "#") == 0 {
 			continue

--- a/internal/pkg/build/assemblers/sandbox.go
+++ b/internal/pkg/build/assemblers/sandbox.go
@@ -34,7 +34,6 @@ func (a *SandboxAssembler) Assemble(b *types.Bundle, path string) (err error) {
 		if err != nil {
 			return fmt.Errorf("copy Failed: %v", err)
 		}
-
 	} else {
 		sylog.Debugf("Moving sandbox from %v to %v", b.RootfsPath, path)
 

--- a/internal/pkg/build/assemblers/sif.go
+++ b/internal/pkg/build/assemblers/sif.go
@@ -208,7 +208,6 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 			keyInfo:   *b.Opts.EncryptionKeyInfo,
 			plaintext: plaintext,
 		}
-
 	}
 
 	err = createSIF(path, b, fsPath, encOpts, arch)

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -90,7 +90,6 @@ func CopyFromHost(src, dstRel, dstRootfs string) error {
 		if err := copyCmd.Run(); err != nil {
 			return fmt.Errorf("while copying %s to %s: %v: %s", paths, dstResolved, args, stderr.String())
 		}
-
 	}
 	return nil
 }
@@ -165,7 +164,6 @@ func CopyFromStage(src, dst, srcRootfs, dstRootfs string, disableIDMapping bool)
 		if err != nil {
 			return fmt.Errorf("while copying %s to %s: %s", paths, dstResolved, err)
 		}
-
 	}
 	return nil
 }

--- a/internal/pkg/client/library/user_test.go
+++ b/internal/pkg/client/library/user_test.go
@@ -85,7 +85,6 @@ func TestGetOCIToken(t *testing.T) {
 				} else {
 					w.WriteHeader(http.StatusNotFound)
 					fmt.Fprintln(w, "Not found")
-
 				}
 			}))
 			defer srv.Close()

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -143,7 +143,6 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 			return "", fmt.Errorf("unable to Download Image: %v", err)
 		}
 		imagePath = directTo
-
 	} else {
 		cacheEntry, err := imgCache.GetEntry(cache.NetCacheType, hash)
 		if err != nil {
@@ -162,7 +161,6 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 			if err != nil {
 				return "", err
 			}
-
 		} else {
 			sylog.Verbosef("Using image from cache")
 		}

--- a/internal/pkg/client/oci/nativesif.go
+++ b/internal/pkg/client/oci/nativesif.go
@@ -57,7 +57,6 @@ func pullNativeSIF(ctx context.Context, imgCache *cache.Handle, directTo, pullFr
 			if err != nil {
 				return "", err
 			}
-
 		} else {
 			sylog.Infof("Using cached SIF image")
 		}

--- a/internal/pkg/client/ocisif/ocisif.go
+++ b/internal/pkg/client/ocisif/ocisif.go
@@ -108,7 +108,6 @@ func PullOCISIF(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom 
 			if err != nil {
 				return "", err
 			}
-
 		} else {
 			sylog.Infof("Using cached OCI-SIF image")
 		}

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -29,7 +29,6 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 			return "", fmt.Errorf("unable to Download Image: %v", err)
 		}
 		imagePath = directTo
-
 	} else {
 		cacheEntry, err := imgCache.GetEntry(cache.OrasCacheType, hash.String())
 		if err != nil {
@@ -52,7 +51,6 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 			if err != nil {
 				return "", err
 			}
-
 		} else {
 			sylog.Infof("Using cached SIF image")
 		}

--- a/internal/pkg/client/shub/pull.go
+++ b/internal/pkg/client/shub/pull.go
@@ -169,7 +169,6 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 			sylog.Infof("Use cached image")
 			imagePath = cacheEntry.Path
 		}
-
 	}
 
 	return imagePath, nil

--- a/internal/pkg/ociimage/fetch.go
+++ b/internal/pkg/ociimage/fetch.go
@@ -122,9 +122,7 @@ func extractArchive(src string, dst string) error {
 
 	for {
 		header, err := tr.Next()
-
 		switch {
-
 		// if no more files are found return
 		case err == io.EOF:
 			return nil

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1227,7 +1227,6 @@ func (c *container) addDevMount(system *mount.System) error {
 					return fmt.Errorf("problem resolving 'tty' group gid: %s", err)
 				}
 				options = fmt.Sprintf("%s,gid=%d", options, group.GID)
-
 			} else {
 				sylog.Debugf("Not setting /dev/pts filesystem gid: user namespace enabled")
 			}
@@ -1241,7 +1240,6 @@ func (c *container) addDevMount(system *mount.System) error {
 			if err := c.session.AddSymlink("/dev/ptmx", "/dev/pts/ptmx"); err != nil {
 				return fmt.Errorf("failed to create /dev/ptmx symlink: %s", err)
 			}
-
 		}
 		// add /dev/console mount pointing to original tty if there is one
 		for fd := 0; fd <= 2; fd++ {
@@ -1274,7 +1272,6 @@ func (c *container) addDevMount(system *mount.System) error {
 					consinfo.Rdev == fdinfo.Rdev {
 					sylog.Debugf("Fd %d is tty pointing to nonexistent %s but /dev/console is good", fd, ttylink)
 					ttylink = "/dev/console"
-
 				} else {
 					sylog.Debugf("Fd %d is tty but %s doesn't exist, skipping", fd, ttylink)
 					continue

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -678,9 +678,7 @@ func (l *Launcher) Exec(ctx context.Context, ep launcher.ExecParams) error {
 
 	// Create a bundle - obtain and extract the image.
 	var b ocibundle.Bundle
-
 	switch {
-
 	case strings.HasPrefix(image, "oci-sif:"):
 		b, err = ocisif.New(
 			ocisif.OptBundlePath(bundleDir),

--- a/internal/pkg/sypgp/sypgp.go
+++ b/internal/pkg/sypgp/sypgp.go
@@ -700,7 +700,6 @@ func formatMROutput(mrString string, longOutput bool) (int, []byte, error) {
 				}
 
 				fmt.Fprintf(tw, longFmt, keyFingerprint, keyType, keyBits, keyDateCreated, keyDateExpired, keyStatus)
-
 			} else {
 				// Short output
 				// take only last 8 chars of fingerprint
@@ -801,7 +800,6 @@ func getEncryptionAlgorithmName(n string) (string, error) {
 		return "", err
 	}
 	switch code {
-
 	case 1, 2, 3:
 		algorithmName = "RSA"
 	case 16:
@@ -1160,7 +1158,6 @@ func PushPubkey(ctx context.Context, e *openpgp.Entity, opts ...client.Option) e
 			return fmt.Errorf("unauthorized or missing token")
 		}
 		return fmt.Errorf("key server did not accept PGP key: %v", err)
-
 	}
 	return nil
 }

--- a/internal/pkg/util/gpu/nvidia.go
+++ b/internal/pkg/util/gpu/nvidia.go
@@ -195,7 +195,6 @@ func NVCLIEnvToFlags(nvidiaEnv []string) (flags []string, err error) {
 		if pair[0] == "NVIDIA_DISABLE_REQUIRE" {
 			disableRequire = true
 		}
-
 	}
 
 	if defaultDriverCaps {

--- a/internal/pkg/util/gpu/paths.go
+++ b/internal/pkg/util/gpu/paths.go
@@ -191,7 +191,6 @@ func ldCache() (map[string]string, error) {
 			if _, ok := ldCache[libName]; !ok {
 				ldCache[libName] = libPath
 			}
-
 		}
 	}
 	return ldCache, nil

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -209,7 +209,6 @@ func parseTokenSection(tok string, sections map[string]*types.Script, files *[]t
 		if !appKnown {
 			*appOrder = append(*appOrder, appName)
 		}
-
 	} else {
 		// create section script object if its a non-standard section
 		if _, ok := sections[key]; !ok {

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -272,7 +272,6 @@ func (m *flagManager) updateCmdFlagFromEnv(cmd *cobra.Command, prefix string) er
 			// First priority goes to prefixed variable
 			val, set := os.LookupEnv(prefix + key)
 			if !set {
-
 				// Determine if environment keys should be looked for without prefix
 				// This annotation just needs to be present, period
 				_, withoutPrefix := flag.Annotations["withoutPrefix"]

--- a/pkg/util/fs/proc/proc_linux_test.go
+++ b/pkg/util/fs/proc/proc_linux_test.go
@@ -413,7 +413,6 @@ func TestParentMount(t *testing.T) {
 				t.Errorf("mount parent of %s should be %s not %s", l.path, l.parent, parent)
 			}
 		}
-
 	}
 }
 

--- a/pkg/util/loop/loop.go
+++ b/pkg/util/loop/loop.go
@@ -217,9 +217,7 @@ func openLoopDev(device, mode int, create bool) (loopFd int, err error) {
 		if err != nil && err != unix.EEXIST {
 			return -1, err
 		}
-
 	} else {
-
 		// If there's another stat error that's likely fatal.. we're done..
 		if err != nil {
 			return -1, fmt.Errorf("could not stat %s: %w", path, err)
@@ -228,7 +226,6 @@ func openLoopDev(device, mode int, create bool) (loopFd int, err error) {
 		if fi.Mode()&os.ModeDevice == 0 {
 			return -1, fmt.Errorf("%s is not a block device", path)
 		}
-
 	}
 
 	// Now open the loop device


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2092 

Enable the `whitespace` linter in golangci-lint, and perform fixes, as appropriate, in code.

