### PR TITLE
fix: make: change cond for setting GO_RACE to handle i386 & i686

### DIFF
--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -8,7 +8,7 @@ GO_LDFLAGS :=
 # Need to disable race detector on ppc64le
 # https://github.com/hpcng/singularity/issues/5914
 uname_m := $(shell uname -m)
-ifeq ($(uname_m),ppc64le)
+ifeq ($(uname_m),$(filter $(uname_m),ppc64le i386 i686))
 GO_BUILDMODE := -buildmode=default
 GO_RACE :=
 else


### PR DESCRIPTION
## Description of the Pull Request (PR):

The `-race` to `go test` is not supported on `i686` (on platforms like Raspberry Pi OS).

This PR changes the test that suppresses `-race` in mlocal/frags/go_common_opts.mk so it includes not only `ppc64le` but also, disjunctively, `i386' and `i686` as well.

