### PR TITLE
add better handling of cmd output in squashfs code (release-4.0)

### DIFF
--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -28,12 +28,14 @@ func FUSEMount(ctx context.Context, offset uint64, path, mountPath string) error
 	if err != nil {
 		return err
 	}
+
 	cmd := exec.CommandContext(ctx, squashfuse, args...)
-
-	sylog.Debugf("Executing %s %s", squashfuse, strings.Join(args, " "))
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to mount: %w", err)
+	if outputBytes, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf(
+			"failed to mount: %w (cmdline: %q; output: %q)", err,
+			strings.Join(append([]string{squashfuse}, args...), " "),
+			string(outputBytes),
+		)
 	}
 
 	return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2105 

This PR improves the way the output of external commands is handled inside internal/pkg/util/fs/squashfs/squashfs.go - in particular, if an external command exits with an error, the error propagated to the caller will include the stdout and stderr output the command.

