### PR TITLE
e2e: look for mkfs.ext3 using FindBin() (release-4.0)

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
 	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/exec"
 	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/require"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
@@ -784,7 +785,11 @@ func (c actionTests) PersistentOverlay(t *testing.T) {
 		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}
 
-	cmd = exec.Command("mkfs.ext3", "-q", "-F", ext3Img)
+	mkfsExt3Cmd, err := bin.FindBin("mkfs.ext3")
+	if err != nil {
+		t.Fatal("Unable to find 'mkfs.ext3' binary even though require.Command() was called")
+	}
+	cmd = exec.Command(mkfsExt3Cmd, "-q", "-F", ext3Img)
 	if res := cmd.Run(t); res.Error != nil {
 		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}
@@ -1940,7 +1945,11 @@ func (c actionTests) bindImage(t *testing.T) {
 		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}
 
-	cmd = exec.Command("mkfs.ext3", "-q", "-F", ext3Img)
+	mkfsExt3Cmd, err := bin.FindBin("mkfs.ext3")
+	if err != nil {
+		t.Fatal("Unable to find 'mkfs.ext3' binary even though require.Command() was called")
+	}
+	cmd = exec.Command(mkfsExt3Cmd, "-q", "-F", ext3Img)
 	if res := cmd.Run(t); res.Error != nil {
 		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -787,7 +787,7 @@ func (c actionTests) PersistentOverlay(t *testing.T) {
 
 	mkfsExt3Cmd, err := bin.FindBin("mkfs.ext3")
 	if err != nil {
-		t.Fatal("Unable to find 'mkfs.ext3' binary even though require.Command() was called")
+		t.Fatalf("Unable to find 'mkfs.ext3' binary even though require.Command() was called: %v", err)
 	}
 	cmd = exec.Command(mkfsExt3Cmd, "-q", "-F", ext3Img)
 	if res := cmd.Run(t); res.Error != nil {
@@ -1947,7 +1947,7 @@ func (c actionTests) bindImage(t *testing.T) {
 
 	mkfsExt3Cmd, err := bin.FindBin("mkfs.ext3")
 	if err != nil {
-		t.Fatal("Unable to find 'mkfs.ext3' binary even though require.Command() was called")
+		t.Fatalf("Unable to find 'mkfs.ext3' binary even though require.Command() was called: %v", err)
 	}
 	cmd = exec.Command(mkfsExt3Cmd, "-q", "-F", ext3Img)
 	if res := cmd.Run(t); res.Error != nil {

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1615,7 +1615,11 @@ func (c actionTests) actionOciBindImage(t *testing.T) {
 		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}
 
-	cmd = testExec.Command("mkfs.ext3", "-q", "-F", ext3Img)
+	mkfsExt3Cmd, err := bin.FindBin("mkfs.ext3")
+	if err != nil {
+		t.Fatal("Unable to find 'mkfs.ext3' binary even though require.Command() was called")
+	}
+	cmd = testExec.Command(mkfsExt3Cmd, "-q", "-F", ext3Img)
 	if res := cmd.Run(t); res.Error != nil {
 		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1617,7 +1617,7 @@ func (c actionTests) actionOciBindImage(t *testing.T) {
 
 	mkfsExt3Cmd, err := bin.FindBin("mkfs.ext3")
 	if err != nil {
-		t.Fatal("Unable to find 'mkfs.ext3' binary even though require.Command() was called")
+		t.Fatalf("Unable to find 'mkfs.ext3' binary even though require.Command() was called: %v", err)
 	}
 	cmd = testExec.Command(mkfsExt3Cmd, "-q", "-F", ext3Img)
 	if res := cmd.Run(t); res.Error != nil {

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -79,7 +79,7 @@ func (c *configTests) prepImages(t *testing.T) (cleanup func(t *testing.T)) {
 		}
 		mkfsExt3Cmd, err := bin.FindBin("mkfs.ext3")
 		if err != nil {
-			t.Fatal("Unable to find 'mkfs.ext3' binary even though require.Command() was called")
+			t.Fatalf("Unable to find 'mkfs.ext3' binary even though require.Command() was called: %v", err)
 		}
 		cmd = exec.Command(mkfsExt3Cmd, "-d", c.sandboxImage, c.ext3Image)
 		if out, err := cmd.CombinedOutput(); err != nil {

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
 	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/require"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/user"
 )
@@ -76,7 +77,11 @@ func (c *configTests) prepImages(t *testing.T) (cleanup func(t *testing.T)) {
 			defer cleanup(t)
 			t.Fatalf("Error creating blank ext3 image: %v: %s", err, out)
 		}
-		cmd = exec.Command("mkfs.ext3", "-d", c.sandboxImage, c.ext3Image)
+		mkfsExt3Cmd, err := bin.FindBin("mkfs.ext3")
+		if err != nil {
+			t.Fatal("Unable to find 'mkfs.ext3' binary even though require.Command() was called")
+		}
+		cmd = exec.Command(mkfsExt3Cmd, "-d", c.sandboxImage, c.ext3Image)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			defer cleanup(t)
 			t.Fatalf("Error creating populated ext3 image: %v: %s", err, out)

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -76,7 +76,7 @@ func (c ctx) singularityInspect(t *testing.T) {
 	// it can't set system xattrs while rootless.
 	unsquashfsPath, err := bin.FindBin("unsquashfs")
 	if err != nil {
-		t.Fatal("Unable to find 'unsquashfs' binary even though require.Command() was called")
+		t.Fatalf("Unable to find 'unsquashfs' binary even though require.Command() was called: %v", err)
 	}
 
 	cmd := exec.Command(unsquashfsPath, "-user-xattrs", "-d", sandboxImage, squashImage)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2106 

Use bin.FindBin() to locate the `mkfs.ext3` command in e2e tests.

### This fixes or addresses the following GitHub issues:

 - Fixes #2078 

