### PR TITLE
oci: correct check for --oci and --no-oci together

### DIFF
--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -400,7 +400,7 @@ func persistentPreRun(*cobra.Command, []string) error {
 	singularityconf.SetCurrentConfig(config)
 
 	// Honor 'oci mode' in singularity.conf, and allow negation with `--no-oci`.
-	if isOCI && !isOCI {
+	if isOCI && noOCI {
 		return fmt.Errorf("--oci and --no-oci cannot be used together")
 	}
 	isOCI = isOCI || config.OCIMode

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -344,6 +344,15 @@ func (c actionTests) actionOciExec(t *testing.T) {
 				e2e.ExpectOutput(e2e.UnwantedExactMatch, "1"),
 			},
 		},
+		// Can't use `--no-oci` with `--oci` (implied by OCI profiles)
+		{
+			name: "no-oci",
+			argv: []string{"--no-oci", c.env.OCISIFPath, "/bin/true"},
+			exit: 255,
+			wantOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectError(e2e.ContainMatch, "--oci and --no-oci cannot be used together"),
+			},
+		},
 	}
 	for _, profile := range e2e.OCIProfiles {
 		t.Run(profile.String(), func(t *testing.T) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

The check for --oci and --no-oci being incorrectly used together was incorrect.

Fix the logic, and add an e2e test that catches this.


### This fixes or addresses the following GitHub issues:

 - Fixes #2133


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
