### PR TITLE
oci: fallback to temp dir if OCI-SIF unsupported (release-4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,16 +24,13 @@ In OCI-mode:
   using an OCI, rather than Singularity specific, structure.
 - The `run / shell / exec` commands use a low-level OCI runtime (crun/runc) for container
   execution.
+- If system does not meet the requirements for using OCI-SIF, OCI mode will fall
+  back to a filesystem-based strategy: the OCI container will be unpacked into a
+  temporary sandbox dir and run from there.
 - Default operation is compatible with other OCI tools, similar to using
   `--compat` in Singularity's non-OCI native mode.
 - OCI-modes support running existing Singularity non-OCI-SIF images, and can be
   made to imitate native mode default behavior by using the `--no-compat` flag.
-- If system does not meet the requirements for using OCI-SIF, OCI mode will fall
-  back to a filesystem-based strategy: the OCI container will be unpacked into a
-  temporary directory and run from there.
-  - This fallback strategy can be disabled by setting "oci fallback = no" in
-    `singularity.conf`, or by passing `--no-oci-fallback` to the relevant `run /
-    shell / exec` command.
 
 OCI-mode changes from 3.11 to 4.0 include:
 
@@ -181,6 +178,9 @@ requirements of OCI-mode and usage information.
   sources the optional variant is ignored.
 - The `--arch` flag can now be used to specify a required architecture when pulling
   images from OCI, as well as library sources.
+- Execution flows that unpack an image into a temporary sandbox dir can now be
+  disabled, by setting "tmp sandbox = no" in `singularity.conf` or by passing
+  `--no-tmp-sandbox` to the relevant `run / shell / exec` command.
 
 ### Developer / API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ In OCI-mode:
   `--compat` in Singularity's non-OCI native mode.
 - OCI-modes support running existing Singularity non-OCI-SIF images, and can be
   made to imitate native mode default behavior by using the `--no-compat` flag.
+- If system does not meet the requirements for using OCI-SIF, OCI mode will fall
+  back to a filesystem-based strategy: the OCI container will be unpacked into a
+  temporary directory and run from there.
+  - This fallback strategy can be disabled by setting "oci fallback = no" in
+    `singularity.conf`, or by passing `--no-oci-fallback` to the relevant `run /
+    shell / exec` command.
 
 OCI-mode changes from 3.11 to 4.0 include:
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -890,6 +890,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionProotFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&commonOCIFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonNoOCIFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoOCIFallbackFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionDevice, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionCdiDirs, actionsCmd...)
 	})

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -890,7 +890,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionProotFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&commonOCIFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonNoOCIFlag, actionsInstanceCmd...)
-		cmdManager.RegisterFlagForCmd(&actionNoOCIFallbackFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoTmpSandbox, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionDevice, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionCdiDirs, actionsCmd...)
 	})

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -82,11 +82,13 @@ var (
 	tmpDir         string
 	forceOverwrite bool
 
+	// Options controlling the unpacking of images to temporary sandboxes
+	canUseTmpSandbox bool
+	noTmpSandbox     bool
+
 	// Use OCI runtime and OCI SIF?
-	isOCI          bool
-	noOCI          bool
-	canOCIFallback bool
-	noOCIFallback  bool
+	isOCI bool
+	noOCI bool
 
 	// Platform for retrieving images
 	arch     string
@@ -287,14 +289,14 @@ var commonNoOCIFlag = cmdline.Flag{
 	EnvKeys:      []string{"NO_OCI"},
 }
 
-// --no-oci-fallback
-var actionNoOCIFallbackFlag = cmdline.Flag{
-	ID:           "actionNoOCIFallback",
-	Value:        &noOCIFallback,
+// --no-tmp-sandbox
+var actionNoTmpSandbox = cmdline.Flag{
+	ID:           "actionNoTmpSandbox",
+	Value:        &noTmpSandbox,
 	DefaultValue: false,
-	Name:         "no-oci-fallback",
-	Usage:        "Require OCI-SIF functionality for OCI mode, disallowing OCI temp dir fallback",
-	EnvKeys:      []string{"NO_OCI_FALLBACK"},
+	Name:         "no-tmp-sandbox",
+	Usage:        "Prohibits unpacking of images into temporary sandbox dirs",
+	EnvKeys:      []string{"NO_TMP_SANDBOX"},
 }
 
 // --arch
@@ -420,11 +422,11 @@ func persistentPreRun(*cobra.Command, []string) error {
 		isOCI = false
 	}
 
-	// Honor 'oci fallback' in singularity.conf, and allow negation with
-	// `--no-oci-fallback`.
-	canOCIFallback = config.OCIFallback
-	if noOCIFallback {
-		canOCIFallback = false
+	// Honor 'tmp sandbox' in singularity.conf, and allow negation with
+	// `--no-tmp-sandbox`.
+	canUseTmpSandbox = config.TmpSandboxAllowed
+	if noTmpSandbox {
+		canUseTmpSandbox = false
 	}
 
 	// If we need to enter a namespace (oci-mode) do the re-exec now, before any

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2557,6 +2557,25 @@ func (c actionTests) actionNoSIFFUSE(t *testing.T) {
 	}
 }
 
+// actionTmpSandboxFlag tests the command-line option prohibiting unpacking of image
+// files into temporary sandbox dirs.
+func (c actionTests) actionTmpSandboxFlag(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	profiles := []e2e.Profile{e2e.UserProfile, e2e.RootProfile, e2e.FakerootProfile, e2e.UserNamespaceProfile}
+
+	for _, p := range profiles {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(p.String()),
+			e2e.WithProfile(p),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs("--sif-fuse=false", "--no-tmp-sandbox", "-u", c.env.ImagePath, "/bin/true"),
+			e2e.ExpectExit(255),
+		)
+	}
+}
+
 // Make sure --workdir and --scratch work together nicely even when workdir is a
 // relative path. Test needs to be run in non-parallel mode, because it changes
 // the current working directory of the host.
@@ -2684,6 +2703,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"invalidRemote":                np(c.invalidRemote),              // GHSA-5mv9-q7fq-9394
 		"SIFFUSE":                      np(c.actionSIFFUSE),              // test --sif-fuse
 		"NoSIFFUSE":                    np(c.actionNoSIFFUSE),            // test absence of squashfs and CleanupHost()
+		"TmpSandboxFlag":               c.actionTmpSandboxFlag,           // test --no-tmp-sandbox flag
 		"relWorkdirScratch":            np(c.relWorkdirScratch),          // test relative --workdir with --scratch
 		"ociRelWorkdirScratch":         np(c.actionOciRelWorkdirScratch), // test relative --workdir with --scratch in OCI mode
 		//

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -149,6 +149,9 @@ type Options struct {
 	// This will be used by a launcher handling OCI images directly.
 	SysContext *types.SystemContext
 
+	// NoTmpSandbox prohibits unpacking of images into temporary sandbox dirs.
+	NoTmpSandbox bool
+
 	// Devices contains the list of device mappings (if any), e.g. CDI mappings.
 	Devices []string
 
@@ -505,6 +508,14 @@ func OptKeyInfo(ki *cryptkey.KeyInfo) Option {
 func OptSIFFuse(b bool) Option {
 	return func(lo *Options) error {
 		lo.SIFFUSE = b
+		return nil
+	}
+}
+
+// OptNoTmpSandbox prohibits unpacking of images into temporary sandbox dirs.
+func OptNoTmpSandbox(b bool) Option {
+	return func(lo *Options) error {
+		lo.NoTmpSandbox = b
 		return nil
 	}
 }

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -683,7 +683,7 @@ func (e *EngineConfig) SetImageFuse(fuse bool) {
 	e.JSON.ImageFuse = fuse
 }
 
-// GetFakeroot returns if the ImageDir is a FUSE mount or not.
+// GetImageFuse returns if the ImageDir is a FUSE mount or not.
 func (e *EngineConfig) GetImageFuse() bool {
 	return e.JSON.ImageFuse
 }

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -77,6 +77,7 @@ type File struct {
 	SystemdCgroups          bool     `default:"yes" authorized:"yes,no" directive:"systemd cgroups"`
 	SIFFUSE                 bool     `default:"no" authorized:"yes,no" directive:"sif fuse"`
 	OCIMode                 bool     `default:"no" authorized:"yes,no" directive:"oci mode"`
+	OCIFallback             bool     `default:"yes" authorized:"yes,no" directive:"oci fallback"`
 }
 
 const TemplateAsset = `# SINGULARITY.CONF

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -77,7 +77,7 @@ type File struct {
 	SystemdCgroups          bool     `default:"yes" authorized:"yes,no" directive:"systemd cgroups"`
 	SIFFUSE                 bool     `default:"no" authorized:"yes,no" directive:"sif fuse"`
 	OCIMode                 bool     `default:"no" authorized:"yes,no" directive:"oci mode"`
-	OCIFallback             bool     `default:"yes" authorized:"yes,no" directive:"oci fallback"`
+	TmpSandboxAllowed       bool     `default:"yes" authorized:"yes,no" directive:"tmp sandbox"`
 }
 
 const TemplateAsset = `# SINGULARITY.CONF


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2130 

In OCI-mode, if using OCI-SIF fails (e.g. `squashfuse`/`squashfuse_ll` missing or don't work, `sqfstar`/`tar2sqfs` missing, etc.), fall back to a filesystem-based strategy: unpack the OCI container into a temporary directory, and run it from there.

Add an `tmp sandbox` configuration option to `singularity.conf` (default: `yes`) to control whether unpacking containers to temporary sandbox dirs is allowed, as well as a `--no-tmp-sandbox` flag to disable this behavior via the command-line. NOTE: This configuration option & flag also control whether unpacking the container to a temporary sandbox dir is allowed in the native user-namespace flow.

### This fixes or addresses the following GitHub issues:

 - Fixes #2095 

