### PR TITLE
oci: explicitly gate unpacking of OCI image with appropriate options

### DIFF
--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -693,6 +693,13 @@ func (l *Launcher) Exec(ctx context.Context, ep launcher.ExecParams) error {
 		)
 		l.nativeSIF = true
 	default:
+		canUseTmpSandbox := l.singularityConf.TmpSandboxAllowed
+		if l.cfg.NoTmpSandbox {
+			canUseTmpSandbox = false
+		}
+		if !canUseTmpSandbox {
+			return fmt.Errorf("unpacking image to temporary sandbox dir required, but is prohibited by 'tmp sandbox = no' in singularity.conf or --no-tmp-sandbox command-line flag")
+		}
 		b, err = native.New(
 			native.OptBundlePath(bundleDir),
 			native.OptImageRef(image),


### PR DESCRIPTION
## Description of the Pull Request (PR):

Adds explicit code to internal/pkg/runtime/launcher/oci/launcher_linux.go:696 that will block unpacking of image to temporary sandbox dir in OCI mode, based on `tmp sandbox` option in `singularity.conf` as well as `--no-tmp-sandbox` flag (and corresponding `SINGULARITY_NO_TMP_SANDBOX` env var).

This mirrors the native-mode code found at internal/pkg/runtime/launcher/native/launcher_linux.go:996 and internal/pkg/runtime/launcher/native/launcher_linux.go:1072

Currently, this is strictly speaking redundant, as the image-extracting code will only happen in OCI mode if fallback flow is chosen in cmd/internal/cli/actions.go, and that code itself consults the aforementioned option / flag / env var (in the interest of producing more informative warnings/errors). But adding this code here ensures that any future code flow that reaches this point will only allow image extraction under the correct circumstances.

