### PR TITLE
mconfig: add custom $builddir include back into CGO_CFLAGS (release-3.11)

### DIFF
--- a/cmd/starter/main_linux.go
+++ b/cmd/starter/main_linux.go
@@ -5,6 +5,11 @@
 
 package main
 
+// Note that the inclusion of builddir here only works when mconfig -b has not
+//  renamed it; that is handled via a setting of CGO_CFLAGS in mconfig. It is
+//  included here also so that Go tools such as code editors and linters can
+//  find config.h when the default builddir is used.
+
 // #cgo CFLAGS: -I${SRCDIR}/../../builddir
 // #include <config.h>
 // #include "c/message.c"

--- a/cmd/starter/main_linux.go
+++ b/cmd/starter/main_linux.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/mconfig
+++ b/mconfig
@@ -60,6 +60,7 @@ with_conmon=1
 with_suid=1
 with_seccomp_check=1
 
+builddir=
 prefix=
 exec_prefix=
 bindir=
@@ -515,7 +516,7 @@ if [ "$builddir" = "" ]; then
 else
 	mkdir -p $builddir
 	if ! builddir=`(cd $builddir 2>/dev/null && pwd -P)`; then
-		echo "error: could not chdir to builddir"
+		echo "error: could not chdir to $builddir"
 		exit 2
 	fi
 fi
@@ -676,7 +677,7 @@ CFLAGS := $cflags
 
 GO := $hstgo
 
-CGO_CFLAGS := $CGO_CFLAGS
+CGO_CFLAGS := -I$builddir $CGO_CFLAGS
 CGO_LDFLAGS := $CGO_LDFLAGS
 CGO_CPPFLAGS := $CGO_CPPFLAGS
 CGO_CXXFLAGS := $CGO_CXXFLAGS

--- a/mconfig
+++ b/mconfig
@@ -1,6 +1,8 @@
 #!/bin/sh -
-# Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+# Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 # Copyright (c) 2015-2018, Yannick Cote <yhcote@gmail.com>. All rights reserved.
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 # Use of this source code is governed by a BSD-style license that can be found
 # in the LICENSE file.
 set -e


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2141 

Pick https://github.com/apptainer/apptainer/pull/719

Building with a custom build dir was broken due to removal of custom $builddir include from CGO_CFLAGS in `mconfig` in PR #100 

This PR adds that custom include back in `mconfig`, while retaining the change to cmd/starter/main_linux.go from PR #100 which facilitates code traversal by linters, IDEs, etc.

### This fixes or addresses the following GitHub issues:

 - Fixes #2012 

