### PR TITLE
improve help string for --build-arg

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -297,7 +297,7 @@ var buildVarArgsFlag = cmdline.Flag{
 	Value:        &buildArgs.buildVarArgs,
 	DefaultValue: []string{},
 	Name:         "build-arg",
-	Usage:        "defines variable=value to replace {{ variable }} entries in build definition file",
+	Usage:        "provide value to replace {{ variable }} entries in build definition file, in variable=value format",
 }
 
 // --build-arg-file


### PR DESCRIPTION
## Description of the Pull Request (PR):

Rephrases the help string for the `--build-arg` flag (to the `build` command) to make the part about _variable=value_ format more salient.

