### PR TITLE
detect and advise re:OCI-SIF images on older versions (release-3.11)

### DIFF
--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -486,7 +486,7 @@ func (l *Launcher) checkImage() error {
 	}
 
 	if img.Type == image.OCISIF {
-		return fmt.Errorf("native runtime does not support OCI-SIF images, use --oci mode")
+		return fmt.Errorf("encountered OCI-SIF image, which is only supported on singularity versions 4.0 and above")
 	}
 
 	if err := l.checkEncryptionKey(img); err != nil {
@@ -1050,6 +1050,10 @@ func handleImage(ctx context.Context, filename string, tryFUSE bool) (isFUSE boo
 		return false, "", "", fmt.Errorf("could not open image %s: %s", filename, err)
 	}
 	defer img.File.Close()
+
+	if img.Type == image.OCISIF {
+		return false, "", "", fmt.Errorf("encountered OCI-SIF image, which is only supported on singularity versions 4.0 and above")
+	}
 
 	part, err := img.GetRootFsPartition()
 	if err != nil {

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -37,6 +37,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/shell/interpreter"
 	"github.com/sylabs/singularity/internal/pkg/util/starter"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
+	"github.com/sylabs/singularity/pkg/image"
 	imgutil "github.com/sylabs/singularity/pkg/image"
 	clicallback "github.com/sylabs/singularity/pkg/plugin/callback/cli"
 	singularitycallback "github.com/sylabs/singularity/pkg/plugin/callback/runtime/engine/singularity"
@@ -131,12 +132,12 @@ func (l *Launcher) Exec(ctx context.Context, image string, process string, args 
 	l.engineConfig.SetOverlayImage(l.cfg.OverlayPaths)
 	l.engineConfig.SetWritableImage(l.cfg.Writable)
 
-	// Check key is available for encrypted image, if applicable.
+	// Check image is something we can run, and key is available for encrypted image, if applicable.
 	// If we are joining an instance, then any encrypted image is already mounted.
 	if !l.engineConfig.GetInstanceJoin() {
-		err = l.checkEncryptionKey()
+		err = l.checkImage()
 		if err != nil {
-			sylog.Fatalf("While checking container encryption: %s", err)
+			sylog.Fatalf("While checking image: %s", err)
 		}
 	}
 
@@ -478,14 +479,31 @@ func (l *Launcher) setImageOrInstance(image string, name string) error {
 	return nil
 }
 
-// checkEncryptionKey verifies key material is available if the image is encrypted.
-// Allows us to fail fast if required key material is not available / usable.
-func (l *Launcher) checkEncryptionKey() error {
-	sylog.Debugf("Checking for encrypted system partition")
+func (l *Launcher) checkImage() error {
 	img, err := imgutil.Init(l.engineConfig.GetImage(), false)
 	if err != nil {
 		return fmt.Errorf("could not open image %s: %w", l.engineConfig.GetImage(), err)
 	}
+
+	if img.Type == image.OCISIF {
+		return fmt.Errorf("native runtime does not support OCI-SIF images, use --oci mode")
+	}
+
+	if err := l.checkEncryptionKey(img); err != nil {
+		return err
+	}
+
+	// don't defer this call as in all cases it won't be
+	// called before execing starter, so it would leak the
+	// image file descriptor to the container process
+	img.File.Close()
+	return nil
+}
+
+// checkEncryptionKey verifies key material is available if the image is encrypted.
+// Allows us to fail fast if required key material is not available / usable.
+func (l *Launcher) checkEncryptionKey(img *imgutil.Image) error {
+	sylog.Debugf("Checking for encrypted system partition")
 
 	part, err := img.GetRootFsPartition()
 	if err != nil {
@@ -507,10 +525,6 @@ func (l *Launcher) checkEncryptionKey() error {
 
 		l.engineConfig.SetEncryptionKey(plaintextKey)
 	}
-	// don't defer this call as in all cases it won't be
-	// called before execing starter, so it would leak the
-	// image file descriptor to the container process
-	img.File.Close()
 	return nil
 }
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -26,12 +26,14 @@ const (
 	EXT3
 	// SANDBOX constant for directory format
 	SANDBOX
-	// SIF constant for sif format
+	// SIF constant for sif format (native image, not OCI-SIF)
 	SIF
 	// ENCRYPTSQUASHFS constant for encrypted squashfs format
 	ENCRYPTSQUASHFS
 	// RAW constant for raw format
 	RAW
+	// OCISIF constant for OCI-SIF images
+	OCISIF
 )
 
 type Usage uint8
@@ -99,6 +101,7 @@ var registeredFormats = []struct {
 }{
 	{"sandbox", &sandboxFormat{}},
 	{"sif", &sifFormat{}},
+	{"ocisif", &ociSifFormat{}},
 	{"squashfs", &squashfsFormat{}},
 	{"ext3", &ext3Format{}},
 }

--- a/pkg/image/ocisif.go
+++ b/pkg/image/ocisif.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package image
+
+import (
+	"bytes"
+	"os"
+
+	"github.com/sylabs/sif/v2/pkg/sif"
+)
+
+type ociSifFormat struct{}
+
+// initializer performs minimal detection of oci-sif images only.
+// It does not populate any information except img.Type.
+func (f *ociSifFormat) initializer(img *Image, fi os.FileInfo) error {
+	if fi.IsDir() {
+		return debugError("not an oci-sif file image")
+	}
+	b := make([]byte, bufferSize)
+	if n, err := img.File.Read(b); err != nil || n != bufferSize {
+		return debugErrorf("can't read first %d bytes: %v", bufferSize, err)
+	}
+	if !bytes.Contains(b, []byte("SIF_MAGIC")) {
+		return debugError("SIF magic not found")
+	}
+
+	flag := os.O_RDONLY
+	if img.Writable {
+		flag = os.O_RDWR
+	}
+
+	// Load the SIF file
+	fimg, err := sif.LoadContainer(img.File,
+		sif.OptLoadWithFlag(flag),
+		sif.OptLoadWithCloseOnUnload(false),
+	)
+	if err != nil {
+		return err
+	}
+	defer fimg.UnloadContainer()
+
+	// It's a SIF, but an OCI-SIF.
+	if _, err := fimg.GetDescriptor(sif.WithDataType(sif.DataOCIRootIndex)); err != nil {
+		return debugErrorf("image is not an OCI-SIF")
+	}
+
+	img.Type = OCISIF
+
+	return nil
+}
+
+func (f *ociSifFormat) openMode(writable bool) int {
+	return os.O_RDONLY
+}
+
+func (f *ociSifFormat) lock(img *Image) error {
+	return nil
+}

--- a/pkg/image/ocisif_test.go
+++ b/pkg/image/ocisif_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package image
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/sylabs/sif/v2/pkg/sif"
+)
+
+//nolint:dupl
+func TestOCISIFInitializer(t *testing.T) {
+	ociMinimal := func() (sif.DescriptorInput, error) {
+		return sif.NewDescriptorInput(sif.DataOCIRootIndex, bytes.NewBufferString("{}\n"))
+	}
+
+	tests := []struct {
+		name               string
+		path               string
+		writable           bool
+		expectedSuccess    bool
+		expectedPartitions int
+		expectedSections   int
+	}{
+		{
+			name:               "OCISIF",
+			path:               createSIF(t, false, ociMinimal),
+			writable:           false,
+			expectedSuccess:    true,
+			expectedPartitions: 0,
+			expectedSections:   0,
+		},
+		{
+			name:               "Empty",
+			path:               createSIF(t, false),
+			writable:           false,
+			expectedSuccess:    false,
+			expectedPartitions: 0,
+			expectedSections:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+
+			ociSifFmt := new(ociSifFormat)
+			mode := ociSifFmt.openMode(tt.writable)
+
+			img := &Image{
+				Path: tt.path,
+				Name: tt.path,
+			}
+
+			img.Writable = tt.writable
+			img.File, err = os.OpenFile(tt.path, mode, 0)
+			if err != nil {
+				t.Fatalf("cannot open image's file: %s\n", err)
+			}
+			defer img.File.Close()
+
+			fileinfo, err := img.File.Stat()
+			if err != nil {
+				t.Fatalf("cannot stat the image file: %s\n", err)
+			}
+
+			err = ociSifFmt.initializer(img, fileinfo)
+			os.Remove(tt.path)
+
+			if (err == nil) != tt.expectedSuccess {
+				t.Fatalf("got error %v, expect success %v", err, tt.expectedSuccess)
+			} else if tt.expectedPartitions != len(img.Partitions) {
+				t.Fatalf("unexpected partitions number: %d instead of %d", len(img.Partitions), tt.expectedPartitions)
+			} else if tt.expectedSections != len(img.Sections) {
+				t.Fatalf("unexpected sections number: %d instead of %d", len(img.Sections), tt.expectedSections)
+			}
+		})
+	}
+}
+
+func TestOCISIFOpenMode(t *testing.T) {
+	var ociSifFmt ociSifFormat
+
+	if ociSifFmt.openMode(true) != os.O_RDONLY {
+		t.Fatal("openMode(true) returned the wrong value")
+	}
+	if ociSifFmt.openMode(false) != os.O_RDONLY {
+		t.Fatal("openMode(false) returned the wrong value")
+	}
+}

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -77,6 +77,11 @@ func (f *sifFormat) initializer(img *Image, fi os.FileInfo) error {
 		return err
 	}
 	defer fimg.UnloadContainer()
+
+	// It's a SIF, but an OCI-SIF.
+	if _, err := fimg.GetDescriptor(sif.WithDataType(sif.DataOCIRootIndex)); err == nil {
+		return debugErrorf("image is an OCI-SIF")
+	}
 
 	var groupID uint32
 

--- a/pkg/image/sif_test.go
+++ b/pkg/image/sif_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -60,6 +60,7 @@ func createSIF(t *testing.T, corrupted bool, fns ...func() (sif.DescriptorInput,
 	return sifFile.Name()
 }
 
+//nolint:dupl
 func TestSIFInitializer(t *testing.T) {
 	b, err := os.ReadFile(testSquash)
 	if err != nil {
@@ -92,6 +93,10 @@ func TestSIFInitializer(t *testing.T) {
 		return sif.NewDescriptorInput(sif.DataPartition, bytes.NewReader(b),
 			sif.OptPartitionMetadata(sif.FsSquash, sif.PartOverlay, runtime.GOARCH),
 		)
+	}
+
+	ociMinimal := func() (sif.DescriptorInput, error) {
+		return sif.NewDescriptorInput(sif.DataOCIRootIndex, bytes.NewBufferString("{}\n"))
 	}
 
 	tests := []struct {
@@ -165,6 +170,14 @@ func TestSIFInitializer(t *testing.T) {
 			expectedSuccess:    true,
 			expectedPartitions: 1,
 			expectedSections:   1,
+		},
+		{
+			name:               "OCISIF",
+			path:               createSIF(t, false, ociMinimal),
+			writable:           false,
+			expectedSuccess:    false,
+			expectedPartitions: 0,
+			expectedSections:   0,
 		},
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Detect OCI-SIF images and advise the user that they are only supported on Singularity versions 4.0 and above.

This PR cherry-picks https://github.com/sylabs/singularity/pull/2183/commits/084fed552decb9f92ddaea10892353896aed8aa9 ("pkg/image: Add minimal oci-sif type") from 4.0, and then adds code specific to the `release-3.11` branch in a second commit.

In that second commit, the changes in internal/pkg/runtime/launcher/native/launcher_linux.go are not strictly speaking necessary, as the changes to pkg/ocibundle/native/bundle_linux.go would be sufficient to catch the relevant condition as it stands in the `release-3.11` branch right now. But the changes to internal/pkg/runtime/launcher/native/launcher_linux.go are there to guard against potential future scenarios in which we add new code flows to `release-3.11` that may reach those points in the code without going through the relevant part of pkg/ocibundle/native/bundle_linux.go first.

### This fixes or addresses the following GitHub issues:

 - Fixes #2097 

