### PR TITLE
bump Go version in CircleCI config to 1.21.1 (release-3.11)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.20.5'
+    default: '1.21.1'
 
 executors:
   node:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump Go version in CircleCI config to 1.21.1 (done ahead of release 3.11.5).

