### PR TITLE
docs: Fix zenodo link (release-3.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,15 @@ fixes and security patches are available for all supported language versions.
 
 ## Citing Singularity
 
-The SingularityCE software may be cited using our Zenodo DOI `10.5281/zenodo.5564905`:
+The SingularityCE software may be cited using our Zenodo DOI `10.5281/zenodo.5570766`:
 
-> SingularityCE Developers (2021) SingularityCE. 10.5281/zenodo.5564905
-> <https://doi.org/10.5281/zenodo.5564905>
+> SingularityCE Developers (2021) SingularityCE. 10.5281/zenodo.5570766
+> <https://doi.org/10.5281/zenodo.5570766>
 
 This is an 'all versions' DOI for referencing SingularityCE in a manner that is
 not version-specific. You may wish to reference the particular version of
 SingularityCE used in your work. Zenodo creates a unique DOI for each release,
-and these can be found in the 'Versions' sidebar on the [Zenodo record page](https://doi.org/10.5281/zenodo.5564905).
+and these can be found in the 'Versions' sidebar on the [Zenodo record page](https://doi.org/10.5281/zenodo.5570766).
 
 Please also consider citing the original publication describing Singularity:
 


### PR DESCRIPTION
At some point, our zenodo all versions DOI changed, so that 3.9.0 and above are not at the DOI for older versions.

Update to the newer all-versions DOI.

Fixes #2119
