### PR TITLE
fix: Don't mount /var/tmp pointing to /tmp in container (release-4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Don't bind `/var/tmp` on top of `/tmp` in the container, where `/var/tmp`
+  resolves to same location as `/tmp`.
+
 ## 4.0.0 \[2023-09-19\]
 
 ### OCI-mode

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2691,6 +2691,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5599":                   c.issue5599,                      // https://github.com/sylabs/singularity/issues/5599
 		"issue 5631":                   c.issue5631,                      // https://github.com/sylabs/singularity/issues/5631
 		"issue 5690":                   c.issue5690,                      // https://github.com/sylabs/singularity/issues/5690
+		"issue 1950":                   c.issue1950,                      // https://github.com/sylabs/singularity/issues/1950
 		"network":                      c.actionNetwork,                  // test basic networking
 		"binds":                        c.actionBinds,                    // test various binds with --bind and --mount
 		"exit and signals":             c.exitSignals,                    // test exit and signals propagation

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -695,3 +695,49 @@ func (c actionTests) invalidRemote(t *testing.T) {
 		e2e.ExpectExit(255),
 	)
 }
+
+// Don't bind /var/tmp over /tmp where /var/tmp is a symlink to /tmp in the
+// container.
+func (c actionTests) issue1950(t *testing.T) {
+	// If `/var/tmp` on the host is a symlink to `/tmp` then we can't test this
+	// easily.
+	tmpHostResolved, err := filepath.EvalSymlinks("/tmp")
+	if err != nil {
+		t.Error(err)
+	}
+	varTmpHostResolved, err := filepath.EvalSymlinks("/var/tmp")
+	if err != nil {
+		t.Error(err)
+	}
+	if varTmpHostResolved == tmpHostResolved {
+		t.Skipf("/var/tmp links to /tmp on host")
+	}
+
+	// Create a canary file in the host /var/tmp
+	varTmpCanary, err := e2e.WriteTempFile("/var/tmp", "issue-1950", "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(varTmpCanary)
+
+	// Build an image in which /var/tmp is a symlink to /tmp
+	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue1950-", "")
+	defer e2e.Privileged(cleanup)(t)
+	image := filepath.Join(dir, "issue_1950.sif")
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(image, "testdata/regressions/issue_1950.def"),
+		e2e.ExpectExit(0),
+	)
+
+	// If /var/tmp is *not* mounted over /tmp, then our canary file should *not* be accessible.
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(image, "cat", varTmpCanary),
+		e2e.ExpectExit(1),
+	)
+}

--- a/e2e/testdata/regressions/issue_1950.def
+++ b/e2e/testdata/regressions/issue_1950.def
@@ -1,0 +1,6 @@
+Bootstrap: library
+From: alpine:3.11.5
+
+%setup
+mv  "${SINGULARITY_ROOTFS}/var/tmp" "${SINGULARITY_ROOTFS}/var/tmpold"
+ln -s ../tmp "${SINGULARITY_ROOTFS}/var/tmp"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2213 to release-4.0

It is not uncommon for `/var/tmp` in a container to be a symlink onto `/tmp`. In this case, singularity will currently:

* Mount host `/tmp` onto the container `/tmp`
* Mount host `/var/tmp` onto the container `/tmp` through the symlink.

Check whether `/var/tmp` resolves to the same place as `/tmp` in the container, and do not mount it if this is the case.

We have to move `addTmpMount` to run under a `RunBeforeTag` call because we need to have the container rootfs in place to to inspect for symlinks. Because the sources of the mounts may be a tmpfs (--contain), or inside a --workdir, we still have to handle creation of the source dirs earlier.

### This fixes or addresses the following GitHub issues:

 - Fixes #1950
 - Fixes #1331

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
