### PR TITLE
oci: fix: Don't mount /var/tmp pointing to /tmp in container (release-4.0)

### DIFF
--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -47,9 +47,18 @@ func (l *Launcher) getMounts() ([]specs.Mount, error) {
 	if err := l.addDevMounts(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring devpts mount: %w", err)
 	}
+
+	// To facilitate handleVarTmpToTmpSymlink(), store indices of mounts added
+	// by addTmpMounts(), in addition to adding them to spec.
+	mountsCount := len(*mounts)
 	if err := l.addTmpMounts(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring tmp mounts: %w", err)
 	}
+	for mountsCount < len(*mounts) {
+		l.defaultTmpMountIndices = append(l.defaultTmpMountIndices, mountsCount)
+		mountsCount++
+	}
+
 	if err := l.addHomeMount(mounts); err != nil {
 		return nil, fmt.Errorf("while configuring home mount: %w", err)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2221 

This PR is the OCI-mode counterpart of native-mode PR #2213 

It is not uncommon for `/var/tmp` in a container to be a symlink onto `/tmp`. In this case, singularity will currently:

* Mount host `/tmp` onto the container `/tmp`
* Mount host `/var/tmp` onto the container `/tmp` through the symlink.

At the end of finalizeSpec() (internal/pkg/runtime/launcher/oci/launcher_linux.go:406), check if in-container `/tmp` and `/var/tmp` resolve to the same location. If so, remove any default mounts (but _not_ user-generated ones) whose destination is `/var/tmp` from the OCI spec we're constructing.

Also adds e2e tests to ensure parity of behavior across native- and OCI-modes with user-requested bind mounts of /var/tmp, with `(--contain) --workdir`, and with `(--compat)`. (Parentheses in the preceding text indicate independently-necessary differences between native- and OCI-mode command line options to ensure a common baseline for the tests.)