### PR TITLE
e2e: fix profile in issue1950() regression "native binds" subtest

### DIFF
--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -777,7 +777,7 @@ func (c actionTests) issue1950(t *testing.T) {
 		},
 		{
 			name:       "native binds",
-			profile:    e2e.OCIUserProfile,
+			profile:    e2e.UserProfile,
 			extraArgs:  []string{"-B", "/tmp", "-B", "/var/tmp"},
 			canaryFile: vartmpCanary,
 			expectExit: 0,


### PR DESCRIPTION
## Description of the Pull Request (PR):

Corrects the `profile` field of the "native binds" subtest of the issue1950() e2e regression test.