### PR TITLE
OCI credentials storage: only store "auth" field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Don't bind `/var/tmp` on top of `/tmp` in the container, where `/var/tmp`
   resolves to same location as `/tmp`.
+- Fix problem where credentials locally stored with `registry login` command
+  were not usable in some execution flows. Run `registry login` again with
+  latest version to ensure credentials are stored correctly.
 
 ## 4.0.0 \[2023-09-19\]
 

--- a/e2e/registry/registry.go
+++ b/e2e/registry/registry.go
@@ -7,13 +7,23 @@
 package registry
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/types"
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
+	"github.com/sylabs/singularity/v4/pkg/syfs"
+	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
 )
 
 type ctx struct {
@@ -274,6 +284,130 @@ func (c ctx) registryLoginRepeated(t *testing.T) {
 	}
 }
 
+// JSON files created by our `remote login` flow should be usable in execution
+// flows that use containers/image APIs.
+// See https://github.com/sylabs/singularity/issues/2226
+func (c ctx) registryIssue2226(t *testing.T) {
+	testRegistry := c.env.TestRegistry
+	testRegistryURI := fmt.Sprintf("docker://%s", testRegistry)
+	privRepo := fmt.Sprintf("%s/private/e2eprivrepo", testRegistry)
+	privRepoURI := fmt.Sprintf("docker://%s", privRepo)
+
+	tmpdir, tmpdirCleanup := e2e.MakeTempDir(t, "", "issue2226", "")
+	t.Cleanup(func() {
+		if !t.Failed() {
+			tmpdirCleanup(t)
+		}
+	})
+
+	prevCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("could not get current working directory: %s", err)
+	}
+	defer os.Chdir(prevCwd)
+	if err = os.Chdir(tmpdir); err != nil {
+		t.Fatalf("could not change cwd to %q: %s", tmpdir, err)
+	}
+
+	areWeLoggedIn := false
+
+	privRepoLogin := func() {
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("registry login"),
+			e2e.WithArgs("-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, testRegistryURI),
+			e2e.ExpectExit(0),
+		)
+		areWeLoggedIn = true
+	}
+	privRepoLogout := func() {
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("registry logout"),
+			e2e.WithArgs(testRegistryURI),
+			e2e.ExpectExit(0),
+		)
+		areWeLoggedIn = false
+	}
+
+	privRepoLogin()
+	t.Cleanup(func() {
+		if areWeLoggedIn {
+			privRepoLogout()
+		}
+	})
+
+	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	policyCtx, err := signature.NewPolicyContext(policy)
+	if err != nil {
+		t.Fatalf("failed to create new policy context: %v", err)
+	}
+
+	sourceCtx := &types.SystemContext{
+		OCIInsecureSkipTLSVerify:    false,
+		DockerInsecureSkipTLSVerify: types.NewOptionalBool(false),
+		DockerRegistryUserAgent:     useragent.Value(),
+	}
+	destCtx := &types.SystemContext{
+		OCIInsecureSkipTLSVerify:    true,
+		DockerInsecureSkipTLSVerify: types.NewOptionalBool(true),
+		DockerRegistryUserAgent:     useragent.Value(),
+	}
+
+	u := e2e.CurrentUser(t)
+	configPath := filepath.Join(u.Dir, ".singularity", syfs.DockerConfFile)
+	sourceCtx.AuthFilePath = configPath
+	destCtx.AuthFilePath = configPath
+
+	source := "docker://alpine:latest"
+	dest := fmt.Sprintf("%s/my-alpine:latest", privRepoURI)
+	sourceRef, err := docker.ParseReference(strings.TrimPrefix(source, "docker:"))
+	if err != nil {
+		t.Fatalf("failed to parse %s reference: %s", source, err)
+	}
+	destRef, err := docker.ParseReference(strings.TrimPrefix(dest, "docker:"))
+	if err != nil {
+		t.Fatalf("failed to parse %s reference: %s", dest, err)
+	}
+
+	_, err = copy.Image(context.Background(), policyCtx, destRef, sourceRef, &copy.Options{
+		ReportWriter:   io.Discard,
+		SourceCtx:      sourceCtx,
+		DestinationCtx: destCtx,
+	})
+	if err != nil {
+		var e docker.ErrUnauthorizedForCredentials
+		if errors.As(err, &e) {
+			t.Fatalf("Authentication info written by 'registry login' did not work when trying to copy OCI image to private repo (%v)", e)
+		}
+		t.Fatalf("Failed to copy %s to %s: %s", source, dest, err)
+	}
+
+	privRepoLogout()
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("noauth"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull --no-https"),
+		e2e.WithArgs(dest),
+		e2e.ExpectExit(255),
+	)
+
+	privRepoLogin()
+
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("auth"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull --no-https"),
+		e2e.WithArgs(dest),
+		e2e.ExpectExit(0),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
@@ -288,5 +422,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"registry login push private": np(c.registryLoginPushPrivate),
 		"registry login repeated":     np(c.registryLoginRepeated),
 		"registry list":               np(c.registryList),
+		"registry issue 2226":         np(c.registryIssue2226),
 	}
 }

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -227,7 +227,7 @@ func Run(t *testing.T) {
 	t.Log("Path to test OCI-SIF image:", ociArchivePath)
 	testenv.OCISIFPath = ociSifPath
 
-	// Docker Archive test image path, built on demand by e2e.EnsureDockerArhive
+	// Docker Archive test image path, built on demand by e2e.EnsureDockerArchive
 	dockerArchivePath := path.Join(name, "docker.tar")
 	t.Log("Path to test Docker archive:", dockerArchivePath)
 	testenv.DockerArchivePath = dockerArchivePath

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -9,6 +9,7 @@ package credential
 import (
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -104,8 +105,7 @@ func (h *ociHandler) login(u *url.URL, username, password string, insecure bool)
 	}
 
 	cf.AuthConfigs[regName] = types.AuthConfig{
-		Username: username,
-		Password: pass,
+		Auth: base64.StdEncoding.EncodeToString([]byte(username + ":" + pass)),
 	}
 
 	configData, err := json.Marshal(cf)

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -9,7 +9,6 @@ package credential
 import (
 	"context"
 	"crypto/tls"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -89,7 +88,6 @@ func (h *ociHandler) login(u *url.URL, username, password string, insecure bool)
 	}
 
 	ociConfig := syfs.DockerConf()
-	ociConfigNew := syfs.DockerConf() + ".new"
 
 	cf := configfile.New(syfs.DockerConf())
 	if fs.IsFile(ociConfig) {
@@ -102,21 +100,23 @@ func (h *ociHandler) login(u *url.URL, username, password string, insecure bool)
 		if err != nil {
 			return nil, err
 		}
+		cf.Filename = syfs.DockerConf()
 	}
 
-	cf.AuthConfigs[regName] = types.AuthConfig{
-		Auth: base64.StdEncoding.EncodeToString([]byte(username + ":" + pass)),
+	creds := cf.GetCredentialsStore(regName)
+
+	// DockerHub requires special logic for historical reasons.
+	serverAddress := regName
+	if serverAddress == name.DefaultRegistry {
+		serverAddress = authn.DefaultAuthKey
 	}
 
-	configData, err := json.Marshal(cf)
-	if err != nil {
-		return nil, err
-	}
-	if err := os.WriteFile(ociConfigNew, configData, 0o600); err != nil {
-		return nil, err
-	}
-	if err := os.Rename(ociConfigNew, ociConfig); err != nil {
-		return nil, err
+	if err := creds.Store(types.AuthConfig{
+		Username:      username,
+		Password:      pass,
+		ServerAddress: serverAddress,
+	}); err != nil {
+		return nil, fmt.Errorf("while trying to store new credentials: %w", err)
 	}
 
 	return &Config{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Changes creation of JSON-encoded OCI credential files so that they encode the `"auth"` field, rather than `"username"`/`"password"`.

### This fixes or addresses the following GitHub issues:

 - Fixes #2226 

