### PR TITLE
e2e: gate KmsgDevice OCI-CDI test to cgroups v2 only (release-4.0)

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -798,6 +798,7 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 	}
 }
 
+//nolint:maintidx
 func (c actionTests) actionOciCdi(t *testing.T) {
 	// Grab the reference OCI archive we're going to use
 	e2e.EnsureOCISIF(t, c.env)
@@ -862,6 +863,7 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 		DeviceNodes []cdispecs.DeviceNode
 		Mounts      []cdispecs.Mount
 		Env         []string
+		reqCGroups2 bool
 	}{
 		{
 			name: "ValidMounts",
@@ -920,6 +922,7 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 					GID:         &wantGID,
 				},
 			},
+			reqCGroups2: true,
 		},
 	}
 
@@ -927,6 +930,10 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 		t.Run(profile.String(), func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
+					if tt.reqCGroups2 {
+						require.CgroupsV2Unified(t)
+					}
+
 					stws := setupIndivSubtestWorkspace(t, len(tt.Mounts))
 
 					// Populate the HostPath values we're going to feed into the CDI JSON template, based on the subtestWorkspace we just created


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2246 

The `TestE2E/PAR/ACTIONS/ociCdi/OCIUser/KmsgDevice/KmsgDevice` test in e2e/actions/oci.go requires cgroups v2. This PR adds appropriate gating so that this test only runs if cgroups v2 is available.

### This fixes or addresses the following GitHub issues:

 - Fixes #2245 

