### PR TITLE
chore: re-enable dependabot on vault/release-3.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     schedule:
       interval: "daily"
     target-branch: release-4.0
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: vault/release-3.11


### PR DESCRIPTION
The 3.11 version of SingularityCE is packaged, by ourselves (Sylabs), in EPEL.

Our intention is to minimally maintain it until a 3.11 version of SingularityCE falls out of current supported Fedora releases in approx. 1 year.

Re-enable dependabot to make it easier to track security related dependency updates.

Note that this branch remains under the `vault/` prefix, because:

* We will not be backporting bugfixes, outside of anything required through Fedora/EPEL.
* We will not be tagging or performing any further releases from GitHub.
* We will only be modifying code to deal with security issues, propagating the changes to EPEL packages.