### PR TITLE
fix: don't fail yum bootstrap when _db_backend rpm macro missing (release-4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Fix problem where credentials locally stored with `registry login` command
   were not usable in some execution flows. Run `registry login` again with
   latest version to ensure credentials are stored correctly.
+- Don't fail in a yum bootstrap on systems where the _db_backend rpm macros is
+  not defined (EL <8).
 
 ## 4.0.0 \[2023-09-19\]
 

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -7,6 +7,7 @@ package sources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -125,11 +126,12 @@ func (c *YumConveyor) getRPMPath() (err error) {
 		return fmt.Errorf("rpm is not in path: %v", err)
 	}
 
+	// The _db_backednd macro is not defined on EL < 8.
 	rpmDBBackend, err := rpm.GetMacro("_db_backend")
-	if err != nil {
+	if err != nil && !errors.Is(err, rpm.ErrMacroUndefined) {
 		return err
 	}
-	if rpmDBBackend != "bdb" {
+	if rpmDBBackend != "" && rpmDBBackend != "bdb" {
 		sylog.Warningf("Your host system is using the %s RPM database backend.", rpmDBBackend)
 		sylog.Warningf("Bootstrapping of older distributions that use the bdb backend will fail.")
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2256 

On EL systems below version 8, the `_db_backend` rpm macro isn't defined. We must accommodate this, and not error out in a yum bootstrap.

### This fixes or addresses the following GitHub issues:

 - Fixes #2237


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
