### PR TITLE
Add libnvidia-gpucomp to the list of NVIDIA driver libraries (release-4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Changes Since Last Release
 
+### New Features & Functionality
+
+- Added the upcoming NVIDIA driver library `libnvidia-gpucomp.so` to the
+  list of libraries to add to NVIDIA GPU-enabled containers.
+
 ### Bug Fixes
 
 - Don't bind `/var/tmp` on top of `/tmp` in the container, where `/var/tmp`

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,6 +31,7 @@ The following have contributed code and/or documentation to this repository.
 - Chris Burr <christopher.burr@cern.ch>
 - Chris Hollowell <hollowec@bnl.gov>
 - Christian Neyers <foss@neyers.org>
+- Daniel Dadap <ddadap@nvidia.com>
 - Daniele Tamino <daniele.tamino@gmail.com>
 - Dave Dykstra <dwd@fnal.gov>
 - Dave Godlove <d@sylabs.io>, <davidgodlove@gmail.com>

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -40,6 +40,7 @@ libnvidia-fbc.so
 libnvidia-glcore.so
 libnvidia-glsi.so
 libnvidia-glvkspirv.so
+libnvidia-gpucomp.so
 libnvidia-gtk2.so
 libnvidia-gtk3.so
 libnvidia-ifr.so


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick of #2258

Upcoming versions of the NVIDIA driver will include a new component:

https://forums.developer.nvidia.com/t/new-driver-component-libnvidia-gpucomp/267060

Update the list of NVIDIA driver libraries so that it can be included in the runtime environment along with the others.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
