### PR TITLE
oci-sif: add `--keep-layers` to preserve layers in OCI-SIF creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   (`$HOME/.singularity/docker-config.json`). The commands `pull`, `push`, `run`,
   `exec`, `shell`, and `instance start` can now also be passed a `--authfile
   <path>` option, to read OCI registry credentials from this custom file.
+- A new `--keep-layers` flag, for the `pull` and `run/shell/exec/instance start`
+  commands, allows individual layers to be preserved when an OCI-SIF image is
+  created from an OCI source.
 
 ## 4.0.1 \[2023-10-13\]
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -890,6 +890,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionProotFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&commonOCIFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonNoOCIFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&commonKeepLayersFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoTmpSandbox, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonAuthFileFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionDevice, actionsCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -103,6 +103,7 @@ func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, 
 		DockerHost:  dockerHost,
 		NoHTTPS:     noHTTPS,
 		OciSif:      isOCI,
+		KeepLayers:  keepLayers,
 		ReqAuthFile: reqAuthFile,
 	}
 
@@ -143,6 +144,7 @@ func handleLibrary(ctx context.Context, imgCache *cache.Handle, pullFrom string)
 		LibraryConfig: c,
 		// false to allow OCI execution of native SIF from library
 		RequireOciSif: false,
+		KeepLayers:    keepLayers,
 		TmpDir:        tmpDir,
 		Platform:      getOCIPlatform(),
 	}

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -140,6 +140,7 @@ func init() {
 
 		cmdManager.RegisterFlagForCmd(&commonOCIFlag, PullCmd)
 		cmdManager.RegisterFlagForCmd(&commonNoOCIFlag, PullCmd)
+		cmdManager.RegisterFlagForCmd(&commonKeepLayersFlag, PullCmd)
 
 		cmdManager.RegisterFlagForCmd(&commonArchFlag, PullCmd)
 		cmdManager.RegisterFlagForCmd(&commonPlatformFlag, PullCmd)
@@ -239,6 +240,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			KeyClientOpts: co,
 			LibraryConfig: lc,
 			RequireOciSif: isOCI,
+			KeepLayers:    keepLayers,
 			TmpDir:        tmpDir,
 			Platform:      getOCIPlatform(),
 		}
@@ -303,6 +305,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			NoHTTPS:     noHTTPS,
 			NoCleanUp:   buildArgs.noCleanUp,
 			OciSif:      isOCI,
+			KeepLayers:  keepLayers,
 			Platform:    getOCIPlatform(),
 			ReqAuthFile: reqAuthFile,
 		}

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -90,6 +90,9 @@ var (
 	isOCI bool
 	noOCI bool
 
+	// Keep individual layers when creating / pulling an OCI-SIF?
+	keepLayers bool
+
 	// Platform for retrieving images
 	arch     string
 	platform string
@@ -290,6 +293,16 @@ var commonNoOCIFlag = cmdline.Flag{
 	Name:         "no-oci",
 	Usage:        "Launch container with native runtime",
 	EnvKeys:      []string{"NO_OCI"},
+}
+
+// --keep-layers
+var commonKeepLayersFlag = cmdline.Flag{
+	ID:           "keepLayers",
+	Value:        &keepLayers,
+	DefaultValue: false,
+	Name:         "keep-layers",
+	Usage:        "Keep layers when creating an OCI-SIF. Do not squash to a single layer.",
+	EnvKeys:      []string{"KEEP_LAYERS"},
 }
 
 // --no-tmp-sandbox

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -47,6 +47,8 @@ type PullOptions struct {
 	// RequireOciSif should be set true to require that the image pulled is an OCI-SIF.
 	// If false a native SIF pull will be attempted, followed by an OCI(-SIF) pull on failure.
 	RequireOciSif bool
+	// When pulling an OCI-SIF, keep multiple layers if true, squash to single layer otherwise.
+	KeepLayers bool
 	// Platform specifies the platform of the image to retrieve.
 	Platform gccrv1.Platform
 }
@@ -146,9 +148,10 @@ func pullOCI(ctx context.Context, imgCache *cache.Handle, directTo string, pullF
 
 	authConf := lr.authConfig()
 	ocisifOpts := ocisif.PullOptions{
-		TmpDir:   opts.TmpDir,
-		OciAuth:  authConf,
-		Platform: opts.Platform,
+		TmpDir:     opts.TmpDir,
+		OciAuth:    authConf,
+		Platform:   opts.Platform,
+		KeepLayers: opts.KeepLayers,
 	}
 	return ocisif.PullOCISIF(ctx, imgCache, directTo, pullRef, ocisifOpts)
 }

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -28,6 +28,7 @@ type PullOptions struct {
 	NoHTTPS     bool
 	NoCleanUp   bool
 	OciSif      bool
+	KeepLayers  bool
 	Platform    gccrv1.Platform
 	ReqAuthFile string
 }
@@ -78,6 +79,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, opts Pul
 			NoCleanUp:   opts.NoCleanUp,
 			Platform:    opts.Platform,
 			ReqAuthFile: opts.ReqAuthFile,
+			KeepLayers:  opts.KeepLayers,
 		}
 		return ocisif.PullOCISIF(ctx, imgCache, directTo, pullFrom, ocisifOpts)
 	}
@@ -102,6 +104,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom st
 			NoCleanUp:   opts.NoCleanUp,
 			Platform:    opts.Platform,
 			ReqAuthFile: opts.ReqAuthFile,
+			KeepLayers:  opts.KeepLayers,
 		}
 		src, err = ocisif.PullOCISIF(ctx, imgCache, directTo, pullFrom, ocisifOpts)
 	} else {


### PR DESCRIPTION
When an OCI-SIF is created explicitly with `pull`, or implicitly with `run/shell/exec/instance start`, permit the image layers to be kept intact.

The new `--keep-layers` flag for these commands skips squashing images to a single layer when an OCI-SIF is created from an OCI source.

This is the initial step for multi-layered OCI-SIF creation. It is not possible to execute the images. Testing will be added as we proceed to refactor a lot of image handling code to allow execution of these multi-layer images.

```
$ singularity pull --oci --keep-layers docker://golang
FATAL:   Image file already exists: "golang_latest.oci.sif" - will not overwrite

$ singularity sif list golang_latest.oci.sif
------------------------------------------------------------------------------
ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
------------------------------------------------------------------------------
1    |1       |NONE    |32176-47541680            |OCI.Blob
2    |1       |NONE    |47541680-66674096         |OCI.Blob
3    |1       |NONE    |66674096-124489136        |OCI.Blob
4    |1       |NONE    |124489136-214961584       |OCI.Blob
5    |1       |NONE    |214961584-281157040       |OCI.Blob
6    |1       |NONE    |281157040-281161136       |OCI.Blob
7    |1       |NONE    |281161136-281162124       |OCI.Blob
8    |1       |NONE    |281162124-281163339       |OCI.Blob
9    |1       |NONE    |281163339-281163580       |OCI.RootIndex
```

Fixes #2266