### PR TITLE
oci: pull and run multi-layer OCI-SIF images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   (`$HOME/.singularity/docker-config.json`). The commands `pull`, `push`, `run`,
   `exec`, `shell`, and `instance start` can now also be passed a `--authfile
   <path>` option, to read OCI registry credentials from this custom file.
+- A new `--keep-layers` flag, for the `pull` and `run/shell/exec/instance start`
+  commands, allows individual layers to be preserved when an OCI-SIF image is
+  created from an OCI source. Multi layer OCI-SIF images can be run with
+  SingularityCE 4.1 and later.
 
 ### Bug Fixes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -890,6 +890,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionProotFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&commonOCIFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonNoOCIFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&commonKeepLayersFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoTmpSandbox, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonAuthFileFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionDevice, actionsCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -104,6 +104,7 @@ func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, 
 		DockerHost:  dockerHost,
 		NoHTTPS:     noHTTPS,
 		OciSif:      isOCI,
+		KeepLayers:  keepLayers,
 		ReqAuthFile: reqAuthFile,
 	}
 
@@ -144,6 +145,7 @@ func handleLibrary(ctx context.Context, imgCache *cache.Handle, pullFrom string)
 		LibraryConfig: c,
 		// false to allow OCI execution of native SIF from library
 		RequireOciSif: false,
+		KeepLayers:    keepLayers,
 		TmpDir:        tmpDir,
 		Platform:      getOCIPlatform(),
 	}
@@ -202,7 +204,6 @@ func replaceURIWithImage(ctx context.Context, cmd *cobra.Command, args []string)
 			sylog.Errorf("%v", err)
 			sylog.Fatalf("OCI-SIF could not be created, and fallback to temporary sandbox dir disallowed")
 		}
-
 		sylog.Warningf("%v", err)
 		sylog.Warningf("OCI-SIF could not be created, falling back to unpacking OCI bundle in temporary sandbox dir")
 		return origImageURI

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -140,6 +140,7 @@ func init() {
 
 		cmdManager.RegisterFlagForCmd(&commonOCIFlag, PullCmd)
 		cmdManager.RegisterFlagForCmd(&commonNoOCIFlag, PullCmd)
+		cmdManager.RegisterFlagForCmd(&commonKeepLayersFlag, PullCmd)
 
 		cmdManager.RegisterFlagForCmd(&commonArchFlag, PullCmd)
 		cmdManager.RegisterFlagForCmd(&commonPlatformFlag, PullCmd)
@@ -239,6 +240,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			KeyClientOpts: co,
 			LibraryConfig: lc,
 			RequireOciSif: isOCI,
+			KeepLayers:    keepLayers,
 			TmpDir:        tmpDir,
 			Platform:      getOCIPlatform(),
 		}
@@ -303,6 +305,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			NoHTTPS:     noHTTPS,
 			NoCleanUp:   buildArgs.noCleanUp,
 			OciSif:      isOCI,
+			KeepLayers:  keepLayers,
 			Platform:    getOCIPlatform(),
 			ReqAuthFile: reqAuthFile,
 		}

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -90,6 +90,9 @@ var (
 	isOCI bool
 	noOCI bool
 
+	// Keep individual layers when creating / pulling an OCI-SIF?
+	keepLayers bool
+
 	// Platform for retrieving images
 	arch     string
 	platform string
@@ -290,6 +293,16 @@ var commonNoOCIFlag = cmdline.Flag{
 	Name:         "no-oci",
 	Usage:        "Launch container with native runtime",
 	EnvKeys:      []string{"NO_OCI"},
+}
+
+// --keep-layers
+var commonKeepLayersFlag = cmdline.Flag{
+	ID:           "keepLayers",
+	Value:        &keepLayers,
+	DefaultValue: false,
+	Name:         "keep-layers",
+	Usage:        "Keep layers when creating an OCI-SIF. Do not squash to a single layer.",
+	EnvKeys:      []string{"KEEP_LAYERS"},
 }
 
 // --no-tmp-sandbox

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -9,24 +9,25 @@ package e2e
 // from specifying which Singularity binary to use to controlling how Singularity
 // environment variables will be set.
 type TestEnv struct {
-	CmdPath               string // Path to the Singularity binary to use for the execution of a Singularity command
-	ImagePath             string // Path to the image that has to be used for the execution of a Singularity command
-	OrasTestImage         string // URI to SIF image pushed into local registry with ORAS
-	OrasTestOCISIF        string // URI to OCI-SIF image pushed into local registry with ORAS
-	OrasTestPrivImage     string // URI to SIF image pushed into local registry with ORAS
-	OCIArchivePath        string // Path to test OCI archive tar file
-	OCISIFPath            string // Path to test OCI-SIF file
-	DockerArchivePath     string // Path to test Docker archive tar file
-	TestDir               string // Path to the directory from which a Singularity command needs to be executed
-	TestRegistry          string // Host:Port of local registry
-	TestRegistryPrivPath  string // Host:Port of local registry + path to private location
-	TestRegistryPrivURI   string // Transport (docker://) + Host:Port of local registry + path to private location
-	TestRegistryImage     string // URI to OCI image pushed into local registry
-	TestRegistryPrivImage string // URI to OCI image pushed into private location in local registry
-	TestRegistryOCISIF    string // URI to OCI SIF pushed into local registry as OCI image (non-oras)
-	KeyringDir            string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using SINGULARITY_SYPGPDIR which should be avoided when running e2e tests)
-	PrivCacheDir          string // PrivCacheDir sets the location of the image cache to be used by the Singularity command to be executed as root (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
-	UnprivCacheDir        string // UnprivCacheDir sets the location of the image cache to be used by the Singularity command to be executed as the unpriv user (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
-	RunDisabled           bool
-	DisableCache          bool // DisableCache can be set to disable the cache during the execution of a e2e command
+	CmdPath                  string // Path to the Singularity binary to use for the execution of a Singularity command
+	ImagePath                string // Path to the image that has to be used for the execution of a Singularity command
+	OrasTestImage            string // URI to SIF image pushed into local registry with ORAS
+	OrasTestOCISIF           string // URI to OCI-SIF image pushed into local registry with ORAS
+	OrasTestPrivImage        string // URI to SIF image pushed into local registry with ORAS
+	OCIArchivePath           string // Path to test OCI archive tar file
+	OCISIFPath               string // Path to test OCI-SIF file
+	DockerArchivePath        string // Path to test Docker archive tar file
+	TestDir                  string // Path to the directory from which a Singularity command needs to be executed
+	TestRegistry             string // Host:Port of local registry
+	TestRegistryPrivPath     string // Host:Port of local registry + path to private location
+	TestRegistryPrivURI      string // Transport (docker://) + Host:Port of local registry + path to private location
+	TestRegistryImage        string // URI to single layer OCI image pushed into local registry
+	TestRegistryLayeredImage string // URI to 7-layer OCI image pushed into local registry
+	TestRegistryPrivImage    string // URI to OCI image pushed into private location in local registry
+	TestRegistryOCISIF       string // URI to OCI SIF pushed into local registry as OCI image (non-oras)
+	KeyringDir               string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using SINGULARITY_SYPGPDIR which should be avoided when running e2e tests)
+	PrivCacheDir             string // PrivCacheDir sets the location of the image cache to be used by the Singularity command to be executed as root (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
+	UnprivCacheDir           string // UnprivCacheDir sets the location of the image cache to be used by the Singularity command to be executed as the unpriv user (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
+	RunDisabled              bool
+	DisableCache             bool // DisableCache can be set to disable the cache during the execution of a e2e command
 }

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -200,6 +200,7 @@ func Run(t *testing.T) {
 	// Provision local registry
 	testenv.TestRegistry = e2e.StartRegistry(t, testenv)
 	testenv.TestRegistryImage = fmt.Sprintf("docker://%s/my-alpine:latest", testenv.TestRegistry)
+	testenv.TestRegistryLayeredImage = fmt.Sprintf("docker://%s/aufs-sanity:latest", testenv.TestRegistry)
 	testenv.TestRegistryPrivURI = fmt.Sprintf("docker://%s", testenv.TestRegistry)
 	testenv.TestRegistryPrivPath = fmt.Sprintf("%s/private/e2eprivrepo", testenv.TestRegistry)
 	testenv.TestRegistryPrivImage = fmt.Sprintf("docker://%s/my-alpine:latest", testenv.TestRegistryPrivPath)
@@ -214,6 +215,10 @@ func Run(t *testing.T) {
 		}
 	}
 	e2e.CopyOCIImage(t, "docker://alpine:latest", testenv.TestRegistryImage, insecureSource, true)
+
+	// This image has many (8) small layers, constructed to test overlay behavior.
+	// https://github.com/sylabs/singularity-test-containers/tree/master/docker-aufs-sanity
+	e2e.CopyOCIImage(t, "docker://sylabsio/aufs-sanity:latest", testenv.TestRegistryLayeredImage, insecureSource, true)
 
 	// Copy same test image into private location in test registry
 	e2e.PrivateRepoLogin(t, testenv, e2e.UserProfile, "")

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -47,6 +47,8 @@ type PullOptions struct {
 	// RequireOciSif should be set true to require that the image pulled is an OCI-SIF.
 	// If false a native SIF pull will be attempted, followed by an OCI(-SIF) pull on failure.
 	RequireOciSif bool
+	// When pulling an OCI-SIF, keep multiple layers if true, squash to single layer otherwise.
+	KeepLayers bool
 	// Platform specifies the platform of the image to retrieve.
 	Platform gccrv1.Platform
 }
@@ -146,9 +148,10 @@ func pullOCI(ctx context.Context, imgCache *cache.Handle, directTo string, pullF
 
 	authConf := lr.authConfig()
 	ocisifOpts := ocisif.PullOptions{
-		TmpDir:   opts.TmpDir,
-		OciAuth:  authConf,
-		Platform: opts.Platform,
+		TmpDir:     opts.TmpDir,
+		OciAuth:    authConf,
+		Platform:   opts.Platform,
+		KeepLayers: opts.KeepLayers,
 	}
 	return ocisif.PullOCISIF(ctx, imgCache, directTo, pullRef, ocisifOpts)
 }

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -28,6 +28,7 @@ type PullOptions struct {
 	NoHTTPS     bool
 	NoCleanUp   bool
 	OciSif      bool
+	KeepLayers  bool
 	Platform    gccrv1.Platform
 	ReqAuthFile string
 }
@@ -78,6 +79,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, opts Pul
 			NoCleanUp:   opts.NoCleanUp,
 			Platform:    opts.Platform,
 			ReqAuthFile: opts.ReqAuthFile,
+			KeepLayers:  opts.KeepLayers,
 		}
 		return ocisif.PullOCISIF(ctx, imgCache, directTo, pullFrom, ocisifOpts)
 	}
@@ -102,6 +104,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom st
 			NoCleanUp:   opts.NoCleanUp,
 			Platform:    opts.Platform,
 			ReqAuthFile: opts.ReqAuthFile,
+			KeepLayers:  opts.KeepLayers,
 		}
 		src, err = ocisif.PullOCISIF(ctx, imgCache, directTo, pullFrom, ocisifOpts)
 	} else {


### PR DESCRIPTION
## Description of the Pull Request (PR):

When an OCI-SIF is created explicitly with `pull`, or implicitly with `run/shell/exec/instance start`, permit the image layers to be kept intact.

The new `--keep-layers` flag for these commands skips squashing images to a single layer when an OCI-SIF is created from an OCI source.

To allow execution of the resulting multi-layer oci-sif files:

* Mount each layer from an oci-sif using squashfuse, onto a `layer/n` directory in the bundle.
* Mount a read-only overlay using all layers onto the `rootfs` directory in the bundle.
* Keep track of the mounts so they can be unmounted on `.Delete()`.

### This fixes or addresses the following GitHub issues:

 - Fixes #2266
 - Fixes #2267

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
