### PR TITLE
chore: replace UnavailableError with wrapping for i/p/client/ocisif

### DIFF
--- a/internal/pkg/client/ocisif/ocisif.go
+++ b/internal/pkg/client/ocisif/ocisif.go
@@ -8,6 +8,7 @@ package ocisif
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,7 +32,6 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/credential/ociauth"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
-	obocisif "github.com/sylabs/singularity/v4/pkg/ocibundle/ocisif"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
 	"golang.org/x/term"
@@ -39,6 +39,8 @@ import (
 
 // TODO - Replace when exported from SIF / oci-tools
 const SquashfsLayerMediaType types.MediaType = "application/vnd.sylabs.image.layer.v1.squashfs"
+
+var ErrFailedSquashfsConversion = errors.New("could not convert layer to squashfs")
 
 type PullOptions struct {
 	TmpDir      string
@@ -231,7 +233,7 @@ func convertLayoutToOciSif(layoutDir string, digest ggcrv1.Hash, imageDest, work
 		workDir,
 		mutate.OptSquashfsSkipWhiteoutConversion(true))
 	if err != nil {
-		return &obocisif.UnavailableError{Underlying: fmt.Errorf("while converting to squashfs format: %w", err)}
+		return fmt.Errorf("%w: %v", ErrFailedSquashfsConversion, err)
 	}
 	img, err = mutate.Apply(img,
 		mutate.ReplaceLayers(squashfsLayer),

--- a/pkg/ocibundle/ocisif/bundle_linux.go
+++ b/pkg/ocibundle/ocisif/bundle_linux.go
@@ -25,6 +25,12 @@ import (
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
+// UnavailableError is used to wrap an Underlying error, while indicating that
+// it is not currently possible to setup an OCI bundle using direct mount(s)
+// from an OCI-SIF. This is intended to permit fall-back paths in the caller
+// when squashfuse is unavailable / failing.
+//
+// TODO - replace with native Go error wrapping at major version increment.
 type UnavailableError struct {
 	Underlying error
 }
@@ -172,7 +178,7 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	sylog.Debugf("Mounting squashfs rootfs from %q to %q", imgFile, tools.RootFs(b.bundlePath).Path())
 	if err := mount(ctx, imgFile, tools.RootFs(b.bundlePath).Path(), rootfsLayer.Digest); err != nil {
 		b.Delete(ctx)
-		return &UnavailableError{Underlying: fmt.Errorf("while mounting squashfs layer: %w", err)}
+		return UnavailableError{Underlying: fmt.Errorf("while mounting squashfs layer: %w", err)}
 	}
 	b.imageMounted = true
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

In pkg/ocibundle/ocisif an UnavailableError type was provided to hold an underlying error, effectively performing error wrapping. The error was used:

* In pkg/ocibundle/ocisif to wrap errors from a failed squashfs mount.
* In internal/pkg/client to wrap errors from a failed tar -> squashfs conversion.

The underlying intent was to use this error type to implement fallback in the actions flows from OCI-SIF create/execution to a directory bundle.

Sharing a generic error across the packages isn't ideal, and we should be able to use Go's native error wrapping.

However, we shouldn't change `pkg/ocibundle/ocisif` until a major version bump, as this modifies a public API.

This PR replaces the UnavailableError type in the client case with a specific error, and the use of error wrapping.

It was also noted that in actions.go error messages / warning were very long and confusing to read. They have been split to multiple errors / warnings.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
