### PR TITLE
chore: replace UnavailableError with wrapping for i/p/client/ocisif (release4.0)

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -20,13 +20,14 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/client/library"
 	"github.com/sylabs/singularity/v4/internal/pkg/client/net"
 	"github.com/sylabs/singularity/v4/internal/pkg/client/oci"
+	ocisifclient "github.com/sylabs/singularity/v4/internal/pkg/client/ocisif"
 	"github.com/sylabs/singularity/v4/internal/pkg/client/oras"
 	"github.com/sylabs/singularity/v4/internal/pkg/client/shub"
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/launcher"
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/launcher/native"
 	ocilauncher "github.com/sylabs/singularity/v4/internal/pkg/runtime/launcher/oci"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/uri"
-	"github.com/sylabs/singularity/v4/pkg/ocibundle/ocisif"
+	bndocisif "github.com/sylabs/singularity/v4/pkg/ocibundle/ocisif"
 	"github.com/sylabs/singularity/v4/pkg/syfs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
@@ -190,13 +191,18 @@ func replaceURIWithImage(ctx context.Context, cmd *cobra.Command, args []string)
 		sylog.Fatalf("Unsupported transport type: %s", t)
 	}
 
-	var mountErr *ocisif.UnavailableError
-	if errors.As(err, &mountErr) {
+	// If we are in OCI mode, then we can still attempt to run from a directory
+	// bundle if tar->squashfs conversion in OCI-SIF creation fails. This
+	// fallback is important while sqfstar/tar2sqfs are not bundled, and not
+	// available in common distros.
+	if errors.Is(err, ocisifclient.ErrFailedSquashfsConversion) {
 		if !canUseTmpSandbox {
-			sylog.Fatalf("OCI-SIF functionality could not be used, and fallback to unpacking OCI bundle in temporary sandbox dir disallowed (original error msg: %s)", err)
+			sylog.Errorf("%v", err)
+			sylog.Fatalf("OCI-SIF could not be created, and fallback to temporary sandbox dir disallowed")
 		}
 
-		sylog.Warningf("OCI-SIF functionality could not be used, falling back to unpacking OCI bundle in temporary sandbox dir (original error msg: %s)", err)
+		sylog.Warningf("%v", err)
+		sylog.Warningf("OCI-SIF could not be created, falling back to unpacking OCI bundle in temporary sandbox dir")
 		return origImageURI
 	}
 
@@ -416,17 +422,25 @@ func launchContainer(cmd *cobra.Command, ep launcher.ExecParams) error {
 		}
 	}
 
-	err = l.Exec(cmd.Context(), ep)
-	var mountErr *ocisif.UnavailableError
-	if !(errors.As(err, &mountErr) && strings.HasPrefix(ep.Image, "oci-sif:")) {
-		return err
+	execErr := l.Exec(cmd.Context(), ep)
+
+	// Check if we are using an OCI-SIF *and* the exec error indicates that a
+	// direct mount bundle is unavailable (squashfs mount failure etc). If both
+	// are true, we will try a fallback path extracting to a sandbox dir
+	// bundle.
+	var mountErr bndocisif.UnavailableError
+	if !(errors.As(execErr, &mountErr) && strings.HasPrefix(ep.Image, "oci-sif:")) {
+		// Any other situation is a failure
+		return execErr
 	}
 
 	if !canUseTmpSandbox {
-		return fmt.Errorf("OCI-SIF functionality could not be used, and fallback to unpacking OCI bundle in temporary sandbox dir disallowed (original error msg: %w)", err)
+		sylog.Errorf("%v", execErr)
+		return fmt.Errorf("OCI-SIF could not be used, and fallback to temporary sandbox dir disallowed")
 	}
+	sylog.Warningf("%v", execErr)
+	sylog.Warningf("OCI-SIF could not be used, falling back to unpacking OCI bundle in temporary sandbox dir")
 
-	sylog.Warningf("OCI-SIF functionality could not be used, falling back to unpacking OCI bundle in temporary sandbox dir (original error msg: %s)", err)
 	// Create a cache handle only when we know we are using a URI
 	imgCache := getCacheHandle(cache.Config{Disable: disableCache})
 	if imgCache == nil {
@@ -434,12 +448,12 @@ func launchContainer(cmd *cobra.Command, ep launcher.ExecParams) error {
 	}
 	origImageURIPtr := cmd.Context().Value(keyOrigImageURI)
 	if origImageURIPtr == nil {
-		return fmt.Errorf("unable to recover original image URI from context while attempting temp-dir OCI fallback (original OCI-SIF err: %w)", mountErr)
+		return fmt.Errorf("unable to recover original image URI from context")
 	}
 
 	origImageURI, ok := origImageURIPtr.(*string)
 	if !ok {
-		return fmt.Errorf("unable to recover original image URI (expected string, found: %T) from context while attempting temp-dir OCI fallback (original OCI-SIF err: %w)", origImageURIPtr, mountErr)
+		return fmt.Errorf("unable to recover original image URI (expected string, found: %T) from context", origImageURIPtr)
 	}
 	ep.Image = *origImageURI
 

--- a/internal/pkg/client/ocisif/ocisif.go
+++ b/internal/pkg/client/ocisif/ocisif.go
@@ -8,6 +8,7 @@ package ocisif
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,7 +31,6 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/ociimage"
 	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
-	obocisif "github.com/sylabs/singularity/v4/pkg/ocibundle/ocisif"
 	"github.com/sylabs/singularity/v4/pkg/syfs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
@@ -39,6 +39,8 @@ import (
 
 // TODO - Replace when exported from SIF / oci-tools
 const SquashfsLayerMediaType types.MediaType = "application/vnd.sylabs.image.layer.v1.squashfs"
+
+var ErrFailedSquashfsConversion = errors.New("could not convert layer to squashfs")
 
 type PullOptions struct {
 	TmpDir      string
@@ -231,7 +233,7 @@ func convertLayoutToOciSif(layoutDir string, digest ggcrv1.Hash, imageDest, work
 		workDir,
 		mutate.OptSquashfsSkipWhiteoutConversion(true))
 	if err != nil {
-		return &obocisif.UnavailableError{Underlying: fmt.Errorf("while converting to squashfs format: %w", err)}
+		return fmt.Errorf("%w: %v", ErrFailedSquashfsConversion, err)
 	}
 	img, err = mutate.Apply(img,
 		mutate.ReplaceLayers(squashfsLayer),

--- a/pkg/ocibundle/ocisif/bundle_linux.go
+++ b/pkg/ocibundle/ocisif/bundle_linux.go
@@ -25,6 +25,12 @@ import (
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
+// UnavailableError is used to wrap an Underlying error, while indicating that
+// it is not currently possible to setup an OCI bundle using direct mount(s)
+// from an OCI-SIF. This is intended to permit fall-back paths in the caller
+// when squashfuse is unavailable / failing.
+//
+// TODO - replace with native Go error wrapping at major version increment.
 type UnavailableError struct {
 	Underlying error
 }
@@ -172,7 +178,7 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	sylog.Debugf("Mounting squashfs rootfs from %q to %q", imgFile, tools.RootFs(b.bundlePath).Path())
 	if err := mount(ctx, imgFile, tools.RootFs(b.bundlePath).Path(), rootfsLayer.Digest); err != nil {
 		b.Delete(ctx)
-		return &UnavailableError{Underlying: fmt.Errorf("while mounting squashfs layer: %w", err)}
+		return UnavailableError{Underlying: fmt.Errorf("while mounting squashfs layer: %w", err)}
 	}
 	b.imageMounted = true
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

In pkg/ocibundle/ocisif an UnavailableError type was provided to hold an underlying error, effectively performing error wrapping. The error was used:

* In pkg/ocibundle/ocisif to wrap errors from a failed squashfs mount.
* In internal/pkg/client to wrap errors from a failed tar -> squashfs conversion.

The underlying intent was to use this error type to implement fallback in the actions flows from OCI-SIF create/execution to a directory bundle.

Sharing a generic error across the packages isn't ideal, and we should be able to use Go's native error wrapping.

However, we shouldn't change `pkg/ocibundle/ocisif` as this modifies a public API.

This PR replaces the UnavailableError type in the client case with a specific error, and the use of error wrapping.

It was also noted that in actions.go error messages / warning were very long and confusing to read. They have been split to multiple errors / warnings.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
