### PR TITLE
gpu: Add libnvidia-nvvm.so to nvliblist.conf (release-4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Changed defaults / behaviours
+
+- Added `libnvidia-nvvm` to `nvliblist.conf`. Newer NVIDIA Drivers (known with
+  >= 525.85.05) require this lib to compile OpenCL programs against NVIDIA GPUs,
+  i.e. `libnvidia-opencl` depends on `libnvidia-nvvm`.
+
 ## 4.0.1 \[2023-10-13\]
 
 ### New Features & Functionality

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -114,4 +114,6 @@ The following have contributed code and/or documentation to this repository.
 - Pranathi Locula <locula@deshaw.com>
 - Filip Gorczyca <filip.gorczyca141@gmail.com>
 - Carmelo Piccione <carmelo.piccione@gmail.com>
+- Nicholas Yue <yue.nicholas@gmail.com>
+- Benedikt Riedel <benedikt.riedel@gmail.com>
 ```

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -45,6 +45,7 @@ libnvidia-gtk2.so
 libnvidia-gtk3.so
 libnvidia-ifr.so
 libnvidia-ml.so
+libnvidia-nvvm.so
 libnvidia-opencl.so
 libnvidia-opticalflow.so
 libnvidia-ptxjitcompiler.so


### PR DESCRIPTION
Cherry pick https://github.com/apptainer/apptainer/pull/1753

Original commit message:

Adding libnvidia-nvvm.so to nvliblist.conf to accomodate changes in CUDA12 and NVIDIA Drivers > 530
