### PR TITLE
fix: flatten overlay mounts in OCI launcher

### DIFF
--- a/internal/pkg/runtime/launcher/oci/oci_overlay.go
+++ b/internal/pkg/runtime/launcher/oci/oci_overlay.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/overlay"
+	"github.com/sylabs/singularity/v4/pkg/image"
 	"github.com/sylabs/singularity/v4/pkg/ocibundle/tools"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
@@ -37,9 +38,26 @@ func WrapWithWritableTmpFs(ctx context.Context, f func() error, bundleDir string
 	return err
 }
 
-// WrapWithOverlays runs a function wrapped with prep / cleanup steps for overlays.
+func prepareWritableTmpfs(ctx context.Context, bundleDir string, allowSetuid bool) (string, error) {
+	sylog.Debugf("Configuring writable tmpfs overlay for %s", bundleDir)
+	c := singularityconf.GetCurrentConfig()
+	if c == nil {
+		return "", fmt.Errorf("singularity configuration is not initialized")
+	}
+	return tools.CreateOverlayTmpfs(ctx, bundleDir, int(c.SessiondirMaxSize), allowSetuid)
+}
+
+func cleanupWritableTmpfs(ctx context.Context, bundleDir, overlayDir string) error {
+	sylog.Debugf("Cleaning up writable tmpfs overlay for %s", bundleDir)
+	return tools.DeleteOverlayTmpfs(ctx, bundleDir, overlayDir)
+}
+
+// WrapWithOverlays runs a function wrapped with prep / cleanup steps for the
+// overlays specified in overlayPaths. If there is no user-provided writable
+// overlay, it adds an ephemeral overlay which is always writable so that the
+// launcher and runtime are able to add content to the container. Whether it is
+// writable from inside the container is controlled by the runtime config.
 func WrapWithOverlays(ctx context.Context, f func() error, bundleDir string, overlayPaths []string, allowSetuid bool) error {
-	writableOverlayFound := false
 	s := overlay.Set{}
 	for _, p := range overlayPaths {
 		item, err := overlay.NewItemFromString(p)
@@ -53,15 +71,24 @@ func WrapWithOverlays(ctx context.Context, f func() error, bundleDir string, ove
 			item.SetAllowSetuid(true)
 		}
 
-		if writableOverlayFound && !item.Readonly {
+		if s.WritableOverlay != nil && !item.Readonly {
 			return fmt.Errorf("you can't specify more than one writable overlay; %#v has already been specified as a writable overlay; use '--overlay %s:ro' instead", s.WritableOverlay, item.SourcePath)
 		}
 		if !item.Readonly {
-			writableOverlayFound = true
 			s.WritableOverlay = item
 		} else {
 			s.ReadonlyOverlays = append(s.ReadonlyOverlays, item)
 		}
+	}
+
+	systemOverlay := ""
+	if s.WritableOverlay == nil {
+		i, err := prepareSystemOverlay(bundleDir, allowSetuid)
+		if err != nil {
+			return err
+		}
+		systemOverlay = i.SourcePath
+		s.WritableOverlay = i
 	}
 
 	rootFsDir := tools.RootFs(bundleDir).Path()
@@ -70,31 +97,45 @@ func WrapWithOverlays(ctx context.Context, f func() error, bundleDir string, ove
 		return err
 	}
 
-	if writableOverlayFound {
-		err = f()
-	} else {
-		err = WrapWithWritableTmpFs(ctx, f, bundleDir, allowSetuid)
-	}
+	err = f()
 
 	// Cleanup actions log errors, but don't return - so we get as much cleanup done as possible.
 	if cleanupErr := s.Unmount(ctx, rootFsDir); cleanupErr != nil {
 		sylog.Errorf("While unmounting rootfs overlay: %v", cleanupErr)
+	}
+	if systemOverlay != "" {
+		if cleanupErr := cleanupSystemOverlay(systemOverlay); cleanupErr != nil {
+			sylog.Errorf("While cleaning up ephemeral writable tmpfs: %v", cleanupErr)
+		}
 	}
 
 	// Return any error from the actual container payload - preserve exit code.
 	return err
 }
 
-func prepareWritableTmpfs(ctx context.Context, bundleDir string, allowSetuid bool) (string, error) {
-	sylog.Debugf("Configuring writable tmpfs overlay for %s", bundleDir)
+func prepareSystemOverlay(bundleDir string, allowSetuid bool) (*overlay.Item, error) {
+	sylog.Debugf("Configuring ephemeral writable tmpfs overlay for %s", bundleDir)
 	c := singularityconf.GetCurrentConfig()
 	if c == nil {
-		return "", fmt.Errorf("singularity configuration is not initialized")
+		return nil, fmt.Errorf("singularity configuration is not initialized")
 	}
-	return tools.CreateOverlayTmpfs(ctx, bundleDir, int(c.SessiondirMaxSize), allowSetuid)
+
+	systemOverlay, err := tools.PrepareOverlayTmpfs(bundleDir, int(c.SessiondirMaxSize), allowSetuid)
+	if err != nil {
+		return nil, err
+	}
+
+	i := overlay.Item{
+		SourcePath: systemOverlay,
+		Type:       image.SANDBOX,
+		Readonly:   false,
+	}
+	i.SetAllowSetuid(allowSetuid)
+
+	return &i, nil
 }
 
-func cleanupWritableTmpfs(ctx context.Context, bundleDir, overlayDir string) error {
-	sylog.Debugf("Cleaning up writable tmpfs overlay for %s", bundleDir)
-	return tools.DeleteOverlayTmpfs(ctx, bundleDir, overlayDir)
+func cleanupSystemOverlay(dir string) error {
+	sylog.Debugf("Cleaning up ephemeral writable tmpfs overlay for %s", dir)
+	return overlay.DetachAndDelete(dir)
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a user specifies a read-only `--overlay` but no writable '--overlay', successful container startup requires that we add an ephemeral writable-tmpfs that runc / crun can write into.

Prior to this PR, '--overlay' overlays were handled and then the ephemeral writable-tmpfs was added in a separate overlayfs mount.

We can avoid 2 stacked overlayfs mounts by adding the ephemeral writable-tmpfs directly within 'WrapWithOverlays'.

This flattening is required so we don't exceed the 2 overlayfs stacking limit with multi-layer OCI-SIF images, which require an overlayfs mount to assemble the initial rootfs.


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
