### PR TITLE
Adding singularity.conf option "compat mode"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   `exec`, `shell`, and `instance start` can now also be passed a `--authfile
   <path>` option, to read OCI registry credentials from this custom file.
 
-- The `singularity.conf` configuration file now features a toggle to control 
+- The `singularity.conf` configuration file now features a toggle to control
 OCI/Docker compatibility mode, `compat mode <no/yes>`.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   `exec`, `shell`, and `instance start` can now also be passed a `--authfile
   <path>` option, to read OCI registry credentials from this custom file.
 
+- The `singularity.conf` configuration file now features a toggle to control 
+OCI/Docker compatibility mode, `compat mode <no/yes>`.
+
 ### Bug Fixes
 
 - Support parentheses in `test` / `[` commands in container startup scripts,

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -71,6 +71,7 @@ The following have contributed code and/or documentation to this repository.
 - Lars Quentin <lars@lquenti.de>
 - Maciej Sieczka <msieczka@sieczka.org>
 - Marcelo Magallon <marcelo@sylabs.io>
+- Marco Claudio De La Pierre <marco.delapierre@gmail.com>
 - Marco Rubin <marco.rubin@protonmail.com>
 - Mark Egan-Fuller <markeganfuller@googlemail.com>
 - Matt Wiens <mwiens91@gmail.com>

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -43,8 +43,6 @@ var (
 	isFakeroot      bool
 	noSetgroups     bool
 	isCleanEnv      bool
-	isCompat        bool
-	noCompat        bool
 	isContained     bool
 	isContainAll    bool
 	isWritable      bool
@@ -350,26 +348,6 @@ var actionCleanEnvFlag = cmdline.Flag{
 	ShortHand:    "e",
 	Usage:        "clean environment before running container",
 	EnvKeys:      []string{"CLEANENV"},
-}
-
-// --compat
-var actionCompatFlag = cmdline.Flag{
-	ID:           "actionCompatFlag",
-	Value:        &isCompat,
-	DefaultValue: false,
-	Name:         "compat",
-	Usage:        "apply settings for increased OCI/Docker compatibility. Infers --containall, --no-init, --no-umask, --no-eval, --writable-tmpfs.",
-	EnvKeys:      []string{"COMPAT"},
-}
-
-// --no-compat
-var actionNoCompatFlag = cmdline.Flag{
-	ID:           "actionNoCompatFlag",
-	Value:        &noCompat,
-	DefaultValue: false,
-	Name:         "no-compat",
-	Usage:        "(--oci mode) do not apply settings for increased OCI/Docker compatibility. Emulate native runtime defaults without --contain etc.",
-	EnvKeys:      []string{"NO_COMPAT"},
 }
 
 // -c|--contain
@@ -821,8 +799,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionApplyCgroupsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionBindFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionCleanEnvFlag, actionsInstanceCmd...)
-		cmdManager.RegisterFlagForCmd(&actionCompatFlag, actionsInstanceCmd...)
-		cmdManager.RegisterFlagForCmd(&actionNoCompatFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionContainAllFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionContainFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionContainLibsFlag, actionsInstanceCmd...)
@@ -890,6 +866,8 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionProotFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&commonOCIFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonNoOCIFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&commonCompatFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&commonNoCompatFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoTmpSandbox, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonAuthFileFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionDevice, actionsCmd...)

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -727,33 +727,6 @@ func (c configTests) configGlobal(t *testing.T) {
 			exit:           0,
 			resultOp:       e2e.ExpectError(e2e.UnwantedContainMatch, "Running a non-OCI SIF in OCI mode."),
 		},
-		{
-			name:           "CompatModeNo",
-			argv:           []string{c.sifImage, "true"},
-			profile:        e2e.UserProfile,
-			directive:      "compat mode",
-			directiveValue: "no",
-			exit:           0,
-			resultOp:       e2e.ExpectError(e2e.ContainMatch, "Disabling OCI/Docker compatibility applies to --oci mode only, ignoring"),
-		},
-		{
-			name:           "CompatModeNo_IsCompat",
-			argv:           []string{"--compat", c.sifImage, "true"},
-			profile:        e2e.UserProfile,
-			directive:      "compat mode",
-			directiveValue: "no",
-			exit:           0,
-			resultOp:       e2e.ExpectError(e2e.UnwantedContainMatch, "Disabling OCI/Docker compatibility applies to --oci mode only, ignoring"),
-		},
-		{
-			name:           "CompatModeYes",
-			argv:           []string{c.sifImage, "true"},
-			profile:        e2e.UserProfile,
-			directive:      "compat mode",
-			directiveValue: "yes",
-			exit:           0,
-			resultOp:       e2e.ExpectError(e2e.UnwantedContainMatch, "Disabling OCI/Docker compatibility applies to --oci mode only, ignoring"),
-		},
 	}
 
 	for _, tt := range tests {

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -727,6 +727,33 @@ func (c configTests) configGlobal(t *testing.T) {
 			exit:           0,
 			resultOp:       e2e.ExpectError(e2e.UnwantedContainMatch, "Running a non-OCI SIF in OCI mode."),
 		},
+		{
+			name:           "CompatModeNo",
+			argv:           []string{c.sifImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "compat mode",
+			directiveValue: "no",
+			exit:           0,
+			resultOp:       e2e.ExpectError(e2e.ContainMatch, "Disabling OCI/Docker compatibility applies to --oci mode only, ignoring"),
+		},
+		{
+			name:           "CompatModeNo_IsCompat",
+			argv:           []string{"--compat", c.sifImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "compat mode",
+			directiveValue: "no",
+			exit:           0,
+			resultOp:       e2e.ExpectError(e2e.UnwantedContainMatch, "Disabling OCI/Docker compatibility applies to --oci mode only, ignoring"),
+		},
+		{
+			name:           "CompatModeYes",
+			argv:           []string{c.sifImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "compat mode",
+			directiveValue: "yes",
+			exit:           0,
+			resultOp:       e2e.ExpectError(e2e.UnwantedContainMatch, "Disabling OCI/Docker compatibility applies to --oci mode only, ignoring"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -79,7 +79,7 @@ func NewLauncher(opts ...launcher.Option) (*Launcher, error) {
 	}
 
 	if lo.NoCompat {
-		sylog.Warningf("--no-compat applies to --oci mode only, ignoring")
+		sylog.Warningf("Disabling OCI/Docker compatibility applies to --oci mode only, ignoring")
 	}
 
 	// Initialize empty default Singularity Engine and OCI configuration

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -77,6 +77,7 @@ type File struct {
 	SystemdCgroups          bool     `default:"yes" authorized:"yes,no" directive:"systemd cgroups"`
 	SIFFUSE                 bool     `default:"no" authorized:"yes,no" directive:"sif fuse"`
 	OCIMode                 bool     `default:"no" authorized:"yes,no" directive:"oci mode"`
+	CompatMode              bool     `default:"no" authorized:"yes,no" directive:"compat mode"`
 	TmpSandboxAllowed       bool     `default:"yes" authorized:"yes,no" directive:"tmp sandbox"`
 }
 
@@ -105,6 +106,15 @@ allow setuid = {{ if eq .AllowSetuid true }}yes{{ else }}no{{ end }}
 # Note that OCI mode requires unprivileged user namespace creation and
 # subuid / subgid mappings.
 oci mode = {{ if eq .OCIMode true }}yes{{ else }}no{{ end }}
+
+# COMPAT MODE: [BOOL]
+# DEFAULT: no
+# Should we apply settings for increased OCI/Docker compatibility by default?
+# Mimics always specifying --compat on the command line.
+# Can be reversed by specifying --no-compat on the command line.
+# Note that default for OCI/Docker Compatibility should be set with 
+# keeping in mind the chosen default for OCI mode above. See documentation.
+compat mode = {{ if eq .CompatMode true }}yes{{ else }}no{{ end }}
 
 # MAX LOOP DEVICES: [INT]
 # DEFAULT: 256


### PR DESCRIPTION
## Description of the Pull Request (PR):

Hey team, I have been deploying Singularity as the HPC container runtime as staff at the Pawsey national centre (AUS) for 4+ years. Now I am maintaining its interface with it within the workflow engine Nextflow as part of my new role at Seqera.
I have started to test the new OCI functionalities in V4.
I am a bit concerned about `--oci` implying `--compat`, as it may disrupt user experience quite a bit. This is particularly true if a system admins decide to enable it by default in `singularity.conf`.

NOT done yet:
- Update User and Admin Docs
- [edit] Add unit tests (made an attempt in `config.go` but with no success) - help appreciated


### This fixes or addresses the following GitHub issues:

 - Partially addresses https://github.com/sylabs/singularity/issues/2305

