### PR TITLE
increase golangci-lint timeout to avoid sporadic CircleCI failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  concurrency: 4
+  concurrency: 2
   timeout: 5m
   build-tags:
     - apparmor

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   concurrency: 4
-  timeout: 3m
+  timeout: 5m
   build-tags:
     - apparmor
     - containers_image_openpgp


### PR DESCRIPTION
## Description of the Pull Request (PR):

Increases the timeout for `golangci-lint` from `3m` to `5m` to avoid sporadic CircleCI failures.

