### PR TITLE
increase golangci-lint timeout to avoid sporadic CircleCI failures (release-4.0)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 run:
-  timeout: 3m
+  concurrency: 2
+  timeout: 5m
   build-tags:
     - apparmor
     - containers_image_openpgp


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2320 

Increases the timeout for `golangci-lint` from `3m` to `5m` to avoid sporadic CircleCI failures.

