### PR TITLE
support multilayer Dockerfile build

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -354,6 +354,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&commonNoOCIFlag, buildCmd)
 
 		cmdManager.RegisterFlagForCmd(&commonAuthFileFlag, buildCmd)
+		cmdManager.RegisterFlagForCmd(&commonKeepLayersFlag, buildCmd)
 	})
 }
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -109,6 +109,10 @@ func fakerootExec() {
 }
 
 func runBuild(cmd *cobra.Command, args []string) {
+	if keepLayers && !isOCI {
+		sylog.Fatalf("--keep-layers is only supported when building an OCI-SIF (--oci mode)")
+	}
+
 	if buildArgs.nvidia {
 		if buildArgs.remote {
 			sylog.Fatalf("--nv option is not supported for remote build")

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -216,6 +216,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 			BuildVarArgs:    buildArgs.buildVarArgs,
 			BuildVarArgFile: buildArgs.buildVarArgFile,
 			ReqArch:         reqArch,
+			KeepLayers:      keepLayers,
 		}
 		bkclient.Run(cmd.Context(), bkOpts, dest, spec)
 	} else {

--- a/internal/pkg/build/buildkit/client/client.go
+++ b/internal/pkg/build/buildkit/client/client.go
@@ -68,6 +68,8 @@ type Opts struct {
 	BuildVarArgFile string
 	// Requested build architecture
 	ReqArch string
+	// Keep individual layers when creating OCI-SIF?
+	KeepLayers bool
 }
 
 func Run(ctx context.Context, opts *Opts, dest, spec string) {
@@ -95,7 +97,9 @@ func Run(ctx context.Context, opts *Opts, dest, spec string) {
 	sylog.Debugf("Saved OCI image as tar: %s", tarFile.Name())
 	tarFile.Close()
 
-	pullOpts := ocisif.PullOptions{}
+	pullOpts := ocisif.PullOptions{
+		KeepLayers: opts.KeepLayers,
+	}
 	if opts.ReqArch != "" {
 		platform, err := ociplatform.PlatformFromArch(opts.ReqArch)
 		if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

In Dockerfile build (using `buildkit`), honor `--keep-layers` command-line flag to create multilayer OCI-SIF image if requested.

