### PR TITLE
fix: oci: use correct bind options for user /dev[/xxx] binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 - Support parentheses in `test` / `[` commands in container startup scripts,
   via dependency update of mvdan.cc/sh.
+- When user requests a bind of `/dev:/dev` or `/dev/xxx:/dev/xxx` in OCI-mode,
+  ensure that it is bind mounted with appropriate flags so that it is usable in
+  the container.
 
 ## 4.0.1 \[2023-10-13\]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a user requests a bind of all of `/dev`, or a single `/dev/xxx` device, into the container it is because they wish to use a device.

Prior to this PR, OCI-mode was binding `/dev` sources into the container with `nodev` set as a flag. Therefore e.g. `-B /dev/fuse` did not result in a usable FUSE device in the container.

Modify the code so it behaves like native mode. A user request to bind all of `/dev` is treated in the same way as the full `/dev` mount with `--no-compat`. A user request to bind a single `/dev/xxx` entry is performed with logic and flags for dev entries specifically.

This allows FUSE mounts inside OCI-Mode containers to work:

```
$ singularity run --keep-privs --oci -B .:/root -B /dev/fuse --fakeroot  docker://ubuntu
INFO:    Using cached OCI-SIF image
root@mini:~# ./gocryptfs cipher_oci plain_oci/
Password: 
Decrypting master key
DetectQuirks: Btrfs detected, forcing -noprealloc. See https://github.com/rfjakob/gocryptfs/issues/395 for why.
Filesystem mounted and ready.
```

### This fixes or addresses the following GitHub issues:

 - Fixes #2326


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
