### PR TITLE
fix: check for --oci with --keep-layers on all commands

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -109,10 +109,6 @@ func fakerootExec() {
 }
 
 func runBuild(cmd *cobra.Command, args []string) {
-	if keepLayers && !isOCI {
-		sylog.Fatalf("--keep-layers is only supported when building an OCI-SIF (--oci mode)")
-	}
-
 	if buildArgs.nvidia {
 		if buildArgs.remote {
 			sylog.Fatalf("--nv option is not supported for remote build")

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -448,6 +448,11 @@ func persistentPreRun(*cobra.Command, []string) error {
 		isOCI = false
 	}
 
+	// --keep-layers is only valid in OCI mode, as native SIFs do not hold layers.
+	if keepLayers && !isOCI {
+		sylog.Fatalf("--keep-layers is only supported when creating OCI-SIF images (--oci mode)")
+	}
+
 	// Honor 'tmp sandbox' in singularity.conf, and allow negation with
 	// `--no-tmp-sandbox`.
 	canUseTmpSandbox = config.TmpSandboxAllowed


### PR DESCRIPTION
## Description of the Pull Request (PR):

Move the check for OCI-mode if `--keep-layers` is set to the root command `persistentPreRun`. This ensures it applies to `pull` `actions` as well as to `build`.


### This fixes or addresses the following GitHub issues:

 - Fixes #2327 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
