### PR TITLE
build: more fixes to Dockerfiles build

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -210,6 +210,11 @@ func runBuild(cmd *cobra.Command, args []string) {
 		if cmd.Flags().Lookup("arch").Changed {
 			reqArch = buildArgs.arch
 		}
+		wd, err := os.Getwd()
+		if err != nil {
+			sylog.Fatalf("While trying to determine current dir: %v", err)
+		}
+
 		bkOpts := &bkclient.Opts{
 			AuthConf:        authConf,
 			ReqAuthFile:     reqAuthFile,
@@ -217,6 +222,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 			BuildVarArgFile: buildArgs.buildVarArgFile,
 			ReqArch:         reqArch,
 			KeepLayers:      keepLayers,
+			ContextDir:      wd,
 		}
 		bkclient.Run(cmd.Context(), bkOpts, dest, spec)
 	} else {

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -223,6 +223,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 			ReqArch:         reqArch,
 			KeepLayers:      keepLayers,
 			ContextDir:      wd,
+			DisableCache:    disableCache,
 		}
 		bkclient.Run(cmd.Context(), bkOpts, dest, spec)
 	} else {

--- a/internal/pkg/build/buildkit/client/client.go
+++ b/internal/pkg/build/buildkit/client/client.go
@@ -72,6 +72,8 @@ type Opts struct {
 	KeepLayers bool
 	// Context dir in which to perform build (relevant for ADD statements, etc.)
 	ContextDir string
+	// Disable buildkitd's internal caching mechanism
+	DisableCache bool
 }
 
 func Run(ctx context.Context, opts *Opts, dest, spec string) {
@@ -266,7 +268,9 @@ func newSolveOpt(_ context.Context, opts *Opts, w io.WriteCloser, buildDir, spec
 		"filename": filepath.Base(spec),
 	}
 
-	frontendAttrs["no-cache"] = ""
+	if opts.DisableCache {
+		frontendAttrs["no-cache"] = ""
+	}
 
 	attachable := []session.Attachable{bkdaemon.NewAuthProvider(opts.AuthConf, ociauth.ChooseAuthFile(opts.ReqAuthFile))}
 

--- a/internal/pkg/build/buildkit/client/client.go
+++ b/internal/pkg/build/buildkit/client/client.go
@@ -70,6 +70,8 @@ type Opts struct {
 	ReqArch string
 	// Keep individual layers when creating OCI-SIF?
 	KeepLayers bool
+	// Context dir in which to perform build (relevant for ADD statements, etc.)
+	ContextDir string
 }
 
 func Run(ctx context.Context, opts *Opts, dest, spec string) {
@@ -251,11 +253,8 @@ func newSolveOpt(_ context.Context, opts *Opts, w io.WriteCloser, buildDir, spec
 		return nil, errors.New("stdin not supported yet")
 	}
 
-	if spec == "" {
-		spec = filepath.Join(buildDir, "Dockerfile")
-	}
 	localDirs := map[string]string{
-		"context":    buildDir,
+		"context":    opts.ContextDir,
 		"dockerfile": filepath.Dir(spec),
 	}
 

--- a/test/defs/Dockerfile.add.tmpl
+++ b/test/defs/Dockerfile.add.tmpl
@@ -1,0 +1,3 @@
+FROM {{ .Source }}
+ADD {{ .AddFile }} /
+CMD /bin/true


### PR DESCRIPTION
## Description of the Pull Request (PR):

Two more fixes to Dockerfile builds (a.k.a. `buildkitd`-based builds):

1. Code in newSolveOpt() in internal/pkg/build/buildkit/client/client.go was not setting the `"context"` key of the `LocalDirs` field of `SolveOpt` correctly, causing `ADD` statements in Dockerfiles to fail. This PR fixes this (setting `LocalDirs["context"]` to the current working dir), and adds e2e code to verify it's working.
2. A leftover piece of debugging code hard-coded in internal/pkg/build/buildkit/client/client.go was disabling all build caching. This PR removes that code, and instead hooks up the toggling of `buildkitd`'s internal caching mechanism to the Singularity `--disable-cache` CLI option.

