### PR TITLE
chore: address context-related FIXMEs

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -29,9 +29,7 @@ type BusyBoxConveyorPacker struct {
 }
 
 // Get just stores the source
-//
-// FIXME: use context for cancellation.
-func (c *BusyBoxConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
+func (c *BusyBoxConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
 	c.b = b
 
 	// get mirrorURL, OSVerison, and Includes components to definition
@@ -55,7 +53,7 @@ func (c *BusyBoxConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
 		return fmt.Errorf("while inserting busybox: %v", err)
 	}
 
-	cmd := exec.Command(busyBoxPath, `--install`, filepath.Join(c.b.RootfsPath, "/bin"))
+	cmd := exec.CommandContext(ctx, busyBoxPath, `--install`, filepath.Join(c.b.RootfsPath, "/bin"))
 
 	sylog.Debugf("\n\tBusyBox Path: %s\n\tMirrorURL: %s\n", busyBoxPath, mirrorurl)
 

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -45,9 +45,7 @@ type YumConveyorPacker struct {
 }
 
 // Get downloads container information from the specified source
-//
-// FIXME: use context for cancellation.
-func (c *YumConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
+func (c *YumConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
 	c.b = b
 
 	// check for dnf or yum on system
@@ -90,7 +88,7 @@ func (c *YumConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
 
 	// Do the install
 	sylog.Debugf("\n\tInstall Command Path: %s\n\tDetected Arch: %s\n\tOSVersion: %s\n\tMirrorURL: %s\n\tUpdateURL: %s\n\tIncludes: %s\n\tSetopt: %s\n", installCommandPath, runtime.GOARCH, c.osversion, c.mirrorurl, c.updateurl, c.include, c.setopt)
-	cmd := exec.Command(installCommandPath, args...)
+	cmd := exec.CommandContext(ctx, installCommandPath, args...)
 	if sylog.GetLevel() >= int(sylog.VerboseLevel) {
 		cmd.Stdout = os.Stdout
 	}

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -52,10 +52,8 @@ func machine() (string, error) {
 
 // Get downloads container information from the specified source
 //
-// FIXME: use context for cancellation.
-//
 //nolint:maintidx
-func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) error {
+func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) error {
 	var suseconnectProduct, suseconnectModver string
 	var suseconnectPath string
 	var pgpfile string
@@ -223,27 +221,27 @@ func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) error {
 
 	// Add mirrorURL/installURL as repo
 	if mirrorurl != "" {
-		cmd := exec.Command(zypperPath, `--root`, cp.b.RootfsPath, `ar`, mirrorurl, `repo`)
+		cmd := exec.CommandContext(ctx, zypperPath, `--root`, cp.b.RootfsPath, `ar`, mirrorurl, `repo`)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err = cmd.Run(); err != nil {
 			return fmt.Errorf("while adding zypper mirror: %v", err)
 		}
 		// Refreshing gpg keys
-		cmd = exec.Command(zypperPath, `--root`, cp.b.RootfsPath, `--gpg-auto-import-keys`, `refresh`)
+		cmd = exec.CommandContext(ctx, zypperPath, `--root`, cp.b.RootfsPath, `--gpg-auto-import-keys`, `refresh`)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err = cmd.Run(); err != nil {
 			return fmt.Errorf("while refreshing gpg keys: %v", err)
 		}
 		if updateurl != "" {
-			cmd := exec.Command(zypperPath, `--root`, cp.b.RootfsPath, `ar`, `-f`, updateurl, `update`)
+			cmd := exec.CommandContext(ctx, zypperPath, `--root`, cp.b.RootfsPath, `ar`, `-f`, updateurl, `update`)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			if err = cmd.Run(); err != nil {
 				return fmt.Errorf("while adding zypper update: %v", err)
 			}
-			cmd = exec.Command(zypperPath, `--root`, cp.b.RootfsPath, `--gpg-auto-import-keys`, `refresh`, `-r`, `update`)
+			cmd = exec.CommandContext(ctx, zypperPath, `--root`, cp.b.RootfsPath, `--gpg-auto-import-keys`, `refresh`, `-r`, `update`)
 			if err = cmd.Run(); err != nil {
 				return fmt.Errorf("while refreshing update %v", err)
 			}
@@ -270,7 +268,7 @@ func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) error {
 		if err = os.Symlink(rpmrel+rpmbase+`/rpm`, cp.b.RootfsPath+rpmsys+`/rpm`); err != nil {
 			return fmt.Errorf("cannot create rpm symlink")
 		}
-		cmd := exec.Command("rpmkeys", `--root`, cp.b.RootfsPath, `--import`, pgpfile)
+		cmd := exec.CommandContext(ctx, "rpmkeys", `--root`, cp.b.RootfsPath, `--import`, pgpfile)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err = cmd.Run(); err != nil {

--- a/internal/pkg/client/ocisif/ocisif.go
+++ b/internal/pkg/client/ocisif/ocisif.go
@@ -304,9 +304,7 @@ func imgLayersToSquashfs(img ggcrv1.Image, digest ggcrv1.Hash, workDir string) (
 }
 
 // PushOCISIF pushes a single image from sourceFile to the OCI registry destRef.
-//
-// FIXME: Use context for cancellation.
-func PushOCISIF(_ context.Context, sourceFile, destRef string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string) error {
+func PushOCISIF(ctx context.Context, sourceFile, destRef string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string) error {
 	destRef = strings.TrimPrefix(destRef, "docker://")
 	destRef = strings.TrimPrefix(destRef, "//")
 	ir, err := name.ParseReference(destRef)
@@ -338,7 +336,11 @@ func PushOCISIF(_ context.Context, sourceFile, destRef string, ociAuth *ocitypes
 		return fmt.Errorf("while obtaining image: %w", err)
 	}
 
-	remoteOpts := []remote.Option{ociauth.AuthOptn(ociAuth, reqAuthFile), remote.WithUserAgent(useragent.Value())}
+	remoteOpts := []remote.Option{
+		ociauth.AuthOptn(ociAuth, reqAuthFile),
+		remote.WithUserAgent(useragent.Value()),
+		remote.WithContext(ctx),
+	}
 	if term.IsTerminal(2) {
 		pb := &progress.DownloadBar{}
 		progChan := make(chan ggcrv1.Update, 1)

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -103,9 +103,7 @@ func DownloadImage(_ context.Context, path, ref string, ociAuth *ocitypes.Docker
 
 // UploadImage uploads the image specified by path and pushes it to the provided oci reference,
 // it will use credentials if supplied
-//
-// FIXME: use context for cancellation.
-func UploadImage(_ context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string) error {
+func UploadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string) error {
 	// ensure that are uploading a SIF
 	if err := ensureSIF(path); err != nil {
 		return err
@@ -128,7 +126,11 @@ func UploadImage(_ context.Context, path, ref string, ociAuth *ocitypes.DockerAu
 		return err
 	}
 
-	remoteOpts := []remote.Option{ociauth.AuthOptn(ociAuth, reqAuthFile), remote.WithUserAgent(useragent.Value())}
+	remoteOpts := []remote.Option{
+		ociauth.AuthOptn(ociAuth, reqAuthFile),
+		remote.WithUserAgent(useragent.Value()),
+		remote.WithContext(ctx),
+	}
 	if term.IsTerminal(2) {
 		pb := &progress.DownloadBar{}
 		progChan := make(chan ggcrv1.Update, 1)

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -30,10 +30,26 @@ import (
 )
 
 // DownloadImage downloads a SIF image specified by an oci reference to a file using the included credentials
-//
-// FIXME: use context for cancellation.
-func DownloadImage(_ context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string, pb *progress.DownloadBar) error {
-	im, err := remoteImage(ref, ociAuth, reqAuthFile, pb)
+func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string, pb *progress.DownloadBar) error {
+	if pb != nil {
+		// Due to the way our progress bar is implemented in remoteImage() -
+		// namely, using a custom http.RoundTripper, whose API does not allow
+		// for explicit passing of a context var - we need to handle context
+		// cancellation ourselves in the case where pb is not nil.
+		doneChan := make(chan struct{})
+		defer close(doneChan)
+		go func() {
+			select {
+			case <-ctx.Done():
+				pb.Abort(true)
+				return
+			case <-doneChan:
+				return
+			}
+		}()
+	}
+
+	im, err := remoteImage(ctx, ref, ociAuth, reqAuthFile, pb)
 	if err != nil {
 		return err
 	}
@@ -179,10 +195,8 @@ func ensureSIF(filepath string) error {
 }
 
 // RefHash returns the digest of the SIF layer of the OCI manifest for supplied ref
-//
-// FIXME: use context for cancellation.
-func RefHash(_ context.Context, ref string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string) (ggcrv1.Hash, error) {
-	im, err := remoteImage(ref, ociAuth, reqAuthFile, nil)
+func RefHash(ctx context.Context, ref string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string) (ggcrv1.Hash, error) {
+	im, err := remoteImage(ctx, ref, ociAuth, reqAuthFile, nil)
 	if err != nil {
 		return ggcrv1.Hash{}, err
 	}
@@ -240,7 +254,7 @@ func sha256sum(r io.Reader) (result string, nBytes int64, err error) {
 }
 
 // remoteImage returns a v1.Image for the provided remote ref.
-func remoteImage(ref string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string, pb *progress.DownloadBar) (ggcrv1.Image, error) {
+func remoteImage(ctx context.Context, ref string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string, pb *progress.DownloadBar) (ggcrv1.Image, error) {
 	ref = strings.TrimPrefix(ref, "oras://")
 	ref = strings.TrimPrefix(ref, "//")
 
@@ -253,7 +267,10 @@ func remoteImage(ref string, ociAuth *ocitypes.DockerAuthConfig, reqAuthFile str
 		return nil, fmt.Errorf("invalid reference %q: %w", ref, err)
 	}
 
-	remoteOpts := []remote.Option{ociauth.AuthOptn(ociAuth, reqAuthFile)}
+	remoteOpts := []remote.Option{
+		ociauth.AuthOptn(ociAuth, reqAuthFile),
+		remote.WithContext(ctx),
+	}
 	if pb != nil {
 		rt := progress.NewRoundTripper(nil, pb)
 		remoteOpts = append(remoteOpts, remote.WithTransport(rt))

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -758,8 +758,10 @@ func (l *Launcher) Exec(ctx context.Context, ep launcher.ExecParams) error {
 	// Execution of runc/crun run, wrapped with overlay prep / cleanup.
 	err = l.RunWrapped(ctx, id.String(), b.Path(), "")
 
-	// Unmounts pristine rootfs from bundle, and removes the bundle.
-	if cleanupErr := b.Delete(ctx); cleanupErr != nil {
+	// Unmounts pristine rootfs from bundle, and removes the bundle. We want to
+	// make a best effort here even if the main context has been canceled, hence
+	// the use of context.Background().
+	if cleanupErr := b.Delete(context.Background()); cleanupErr != nil { //nolint:contextcheck
 		sylog.Errorf("Couldn't cleanup bundle: %v", err)
 	}
 

--- a/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_runc_linux.go
@@ -22,9 +22,7 @@ import (
 )
 
 // Delete deletes container resources
-//
-// FIXME: use context for cancellation, or remove.
-func Delete(_ context.Context, containerID string, systemdCgroups bool) error {
+func Delete(ctx context.Context, containerID string, systemdCgroups bool) error {
 	runtimeBin, err := Runtime()
 	if err != nil {
 		return err
@@ -42,7 +40,7 @@ func Delete(_ context.Context, containerID string, systemdCgroups bool) error {
 	}
 	runtimeArgs = append(runtimeArgs, "delete", containerID)
 
-	cmd := exec.Command(runtimeBin, runtimeArgs...)
+	cmd := exec.CommandContext(ctx, runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdout
@@ -177,9 +175,7 @@ func Resume(containerID string, systemdCgroups bool) error {
 }
 
 // Run runs a container (equivalent to create/start/delete)
-//
-// FIXME: use context for cancellation, or remove.
-func Run(_ context.Context, containerID, bundlePath, pidFile string, systemdCgroups bool) error {
+func Run(ctx context.Context, containerID, bundlePath, pidFile string, systemdCgroups bool) error {
 	runtimeBin, err := Runtime()
 	if err != nil {
 		return err
@@ -215,7 +211,7 @@ func Run(_ context.Context, containerID, bundlePath, pidFile string, systemdCgro
 	go signalProxy(containerID, signals)
 
 	runtimeArgs = append(runtimeArgs, containerID)
-	cmd := exec.Command(runtimeBin, runtimeArgs...)
+	cmd := exec.CommandContext(ctx, runtimeBin, runtimeArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -115,9 +115,10 @@ func New(opts ...Option) (ocibundle.Bundle, error) {
 	return &b, nil
 }
 
-// Delete erases OCI bundle created an OCI image ref
-//
-// FIXME: use context for cancellation, or remove.
+// Delete erases OCI bundle created an OCI image ref.
+// Context argument isn't used here, but is part of the Bundle interface which
+// is defined under pkg/, so changing this API is not possible until next major
+// version.
 func (b *Bundle) Delete(_ context.Context) error {
 	if b.rootfsMounted {
 		sylog.Debugf("Unmounting bundle rootfs %q", tools.RootFs(b.bundlePath).Path())
@@ -223,9 +224,11 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	return b.writeConfig(g)
 }
 
-// Update will update the OCI config for the OCI bundle, so that it is ready for execution.
-//
-// FIXME: use context for cancellation, or remove.
+// Update will update the OCI config for the OCI bundle, so that it is ready for
+// execution.
+// Context argument isn't used here, but is part of the Bundle interface which
+// is defined under pkg/, so changing this API is not possible until next major
+// version.
 func (b *Bundle) Update(_ context.Context, ociConfig *specs.Spec) error {
 	// generate OCI bundle directory and config
 	g, err := tools.GenerateBundleConfig(b.bundlePath, ociConfig)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.

In the process of satisfying the linters in #2026 a number of 'FIXME' items were added. The majority of these deal with contexts that are not being used.

internal/pkg/build/sources/conveyorPacker_arch.go

- [x] 111:// FIXME: use context for cancellation.

internal/pkg/build/sources/conveyorPacker_yum.go

- [x] 48:// FIXME: use context for cancellation.

internal/pkg/build/sources/conveyorPacker_zypper.go

- [x] 53:// FIXME: use context for cancellation.

internal/pkg/build/sources/conveyorPacker_busybox.go

- [x] 33:// FIXME: use context for cancellation.

internal/pkg/runtime/launcher/oci/oci_runc_linux.go

- [x] 26:// FIXME: use context for cancellation, or remove.
- [x] 181:// FIXME: use context for cancellation, or remove

internal/pkg/client/ocisif/ocisif.go

- [x] 257:// FIXME: Use context for cancellation.

internal/pkg/client/oras/oras.go

- [x] 32:// FIXME: use context for cancellation.
- [x] 104:// FIXME: use context for cancellation.
- [x] 149:// FIXME: use context for cancellation.

pkg/ocibundle/native/bundle_linux.go

- [x] 120:// FIXME: use context for cancellation, or remove.
- [x] 228:// FIXME: use context for cancellation, or remove.

