### PR TITLE
remove EnsureORASPrivImage()

### DIFF
--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -200,29 +200,6 @@ func EnsureORASImage(t *testing.T, env TestEnv) {
 	})
 }
 
-var orasPrivImageOnce sync.Once
-
-func EnsureORASPrivImage(t *testing.T, env TestEnv) {
-	EnsureImage(t, env)
-
-	ensureMutex.Lock()
-	defer ensureMutex.Unlock()
-
-	orasPrivImageOnce.Do(func() {
-		t.Logf("Pushing %s to %s", env.ImagePath, env.OrasTestPrivImage)
-		env.RunSingularity(
-			t,
-			WithProfile(UserProfile),
-			WithCommand("push"),
-			WithArgs(env.ImagePath, env.OrasTestPrivImage),
-			ExpectExit(0),
-		)
-		if t.Failed() {
-			t.Fatalf("failed to push ORAS image to local private registry")
-		}
-	})
-}
-
 var orasOCISIFOnce sync.Once
 
 func EnsureORASOCISIF(t *testing.T, env TestEnv) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

As part of #2225, a function `EnsureORASPrivImage()` was added to e2e/internal/e2e/image.go which was never used, and which would not work as intended if used.

The functionality in question - interacting with an image in a private repository via the oras protocol - is already covered by other e2e tests; see, in particular: [here](https://github.com/sylabs/singularity/blob/f061a92402edfee242308b0de66614584f73c795/e2e/registry/registry.go#L389), and [here](https://github.com/sylabs/singularity/blob/f061a92402edfee242308b0de66614584f73c795/e2e/actions/actions.go#L2755).

This PR removes the `EnsureORASPrivImage()` function.