### PR TITLE
refactor: use ggcr for ociimage.ImageDigest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/gosimple/slug v1.13.1
 	github.com/moby/buildkit v0.12.3
 	github.com/moby/term v0.5.0
-	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/opencontainers/runc v1.1.10
 	github.com/opencontainers/runtime-spec v1.1.0
@@ -175,6 +174,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/networkplumbing/go-nft v0.3.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/proglottis/gpgme v0.1.3 // indirect

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -19,7 +19,6 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
-	"github.com/opencontainers/go-digest"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/syfs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
@@ -114,7 +113,7 @@ func (h *Handle) GetOciCacheDir(cacheType string) (cacheDir string, err error) {
 	return h.getCacheTypeDir(cacheType), nil
 }
 
-func (h *Handle) GetOciCacheBlob(cacheType string, blobDigest digest.Digest) (io.ReadCloser, error) {
+func (h *Handle) GetOciCacheBlob(cacheType string, blobDigest v1.Hash) (io.ReadCloser, error) {
 	if h.disabled {
 		return nil, errCacheDisabled
 	}
@@ -133,7 +132,7 @@ func (h *Handle) GetOciCacheBlob(cacheType string, blobDigest digest.Digest) (io
 	return layout.Blob(hash)
 }
 
-func (h *Handle) PutOciCacheBlob(cacheType string, blobDigest digest.Digest, r io.ReadCloser) (err error) {
+func (h *Handle) PutOciCacheBlob(cacheType string, blobDigest v1.Hash, r io.ReadCloser) (err error) {
 	if h.disabled {
 		return errCacheDisabled
 	}

--- a/internal/pkg/client/oci/nativesif.go
+++ b/internal/pkg/client/oci/nativesif.go
@@ -21,12 +21,7 @@ import (
 func pullNativeSIF(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, opts PullOptions) (imagePath string, err error) {
 	to := transportOptions(opts)
 
-	ref, err := ociimage.URIToImageReference(pullFrom)
-	if err != nil {
-		return "", err
-	}
-
-	hash, err := ociimage.ImageDigest(ctx, to, imgCache, ref)
+	hash, err := ociimage.ImageDigest(ctx, to, imgCache, pullFrom)
 	if err != nil {
 		return "", fmt.Errorf("failed to get checksum for %s: %s", pullFrom, err)
 	}

--- a/internal/pkg/client/ocisif/ocisif.go
+++ b/internal/pkg/client/ocisif/ocisif.go
@@ -70,12 +70,7 @@ func PullOCISIF(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom 
 		Platform:         opts.Platform,
 	}
 
-	ref, err := ociimage.URIToImageReference(pullFrom)
-	if err != nil {
-		return "", err
-	}
-
-	hash, err := ociimage.ImageDigest(ctx, tOpts, imgCache, ref)
+	hash, err := ociimage.ImageDigest(ctx, tOpts, imgCache, pullFrom)
 	if err != nil {
 		return "", fmt.Errorf("failed to get digest for %s: %s", pullFrom, err)
 	}

--- a/internal/pkg/ociimage/digest.go
+++ b/internal/pkg/ociimage/digest.go
@@ -11,118 +11,131 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
-	"github.com/containers/image/v5/docker"
-	"github.com/containers/image/v5/types"
+	"github.com/google/go-containerregistry/pkg/name"
 	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/opencontainers/go-digest"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
-	"github.com/sylabs/singularity/v4/pkg/syfs"
+	"github.com/sylabs/singularity/v4/internal/pkg/remote/credential/ociauth"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
-// ImageDigest obtains the digest of the image manifest for an ImageReference.
-// If the ImageReference points at a multi-arch repository with an image index
-// (manifest list), it will traverse this to retrieve the digest of the image
-// manifest for the requested architecture specified in sysCtx.
-func ImageDigest(ctx context.Context, tOpts *TransportOptions, imgCache *cache.Handle, ref types.ImageReference) (digest.Digest, error) {
+// ImageDigest obtains the digest of the image manifest for a uri-like image
+// reference. If the reference points to a multi-arch repository with an image
+// index (manifest list), it will traverse this to retrieve the digest of the
+// image manifest for the requested architecture specified in tOpts.
+func ImageDigest(ctx context.Context, tOpts *TransportOptions, imgCache *cache.Handle, uri string) (v1.Hash, error) {
+	// oci-archive - Perform a tar extraction first, and handle as an oci layout.
+	if strings.HasPrefix(uri, "oci-archive:") {
+		layoutURI, cleanup, err := extractOCIArchive(uri, tOpts.TmpDir)
+		if err != nil {
+			return v1.Hash{}, err
+		}
+		defer cleanup()
+		uri = layoutURI
+	}
+
+	srcType, srcRef, err := URItoSourceSinkRef(uri)
+	if err != nil {
+		return v1.Hash{}, err
+	}
+
 	// For OCI registries (docker://) attempt to use HEAD operation and cached
 	// image manifest/image index to avoid hitting GET API limits.
-	if ref.Transport().Name() == "docker" {
-		return dockerDigest(ctx, tOpts, imgCache, ref)
+	if srcType == RegistrySourceSink && imgCache != nil && !imgCache.IsDisabled() {
+		return cachedRegistryDigest(ctx, tOpts, *imgCache, srcRef)
 	}
-	return directDigest(ctx, tOpts, imgCache, ref)
+	return directDigest(ctx, tOpts, srcType, srcRef)
 }
 
-// directDigest obtains the image manifest digest for an ImageReference, by
-// retrieving the manifest from the OCI source. If the ImageReference points at
-// a multi-arch repository with an image index (manifest list), it will traverse
-// this to retrieve the digest of the image manifest for the requested
-// architecture specified in sysCtx.
-func directDigest(ctx context.Context, tOpts *TransportOptions, imgCache *cache.Handle, ref types.ImageReference) (digest.Digest, error) {
-	// TODO - replace with ggcr code
-	source, err := ref.NewImageSource(ctx, SystemContextFromTransportOptions(tOpts))
+// directDigest obtains the image manifest digest for srcRef, by retrieving the
+// manifest from the OCI source. If the srcRef points at a multi-arch repository
+// with an image index (manifest list), it will traverse this to retrieve the
+// digest of the image manifest for the requested architecture specified in
+// tOpts.
+func directDigest(ctx context.Context, tOpts *TransportOptions, srcType SourceSink, srcRef string) (v1.Hash, error) {
+	img, err := srcType.Image(ctx, srcRef, tOpts)
 	if err != nil {
-		return "", err
+		return v1.Hash{}, err
 	}
-	defer func() {
-		if closeErr := source.Close(); closeErr != nil {
-			err = fmt.Errorf("%w (src: %v)", err, closeErr)
-		}
-	}()
-
-	mf, _, err := source.GetManifest(ctx, nil)
-	if err != nil {
-		return "", err
-	}
-
-	// Digest of whatever the registry originally returned (index or manifest)
-	origDigest := digest.FromBytes(mf)
-
-	// Cache this index or manifest for future lookups
-	if imgCache != nil && !imgCache.IsDisabled() {
-		sylog.Debugf("Caching image index or manifest %s", origDigest.String())
-		err := imgCache.PutOciCacheBlob(cache.OciBlobCacheType, origDigest, io.NopCloser(bytes.NewBuffer(mf)))
-		if err != nil {
-			sylog.Errorf("While caching image index or manifest: %v", err)
-		}
-	}
-
-	// Actual digest of image (resolved through index if necessary)
-	return digestFromManifestOrIndex(tOpts, mf)
+	return img.Digest()
 }
 
-// dockerDigest obtains the image manifest digest for a registry (docker://)
-// image source, attempting to use a HEAD against the registry, and cached image
-// index / manifest, to avoid unnecessary GET operations that count against
-// Docker Hub API limits.
-func dockerDigest(ctx context.Context, tOpts *TransportOptions, imgCache *cache.Handle, ref types.ImageReference) (digest.Digest, error) {
-	if imgCache == nil || imgCache.IsDisabled() {
-		return directDigest(ctx, tOpts, imgCache, ref)
+// cachedRegistryDigest obtains the image manifest digest for a registry
+// (docker://) image source, attempting to use a HEAD against the registry and a
+// locally cached image index / manifest, to avoid unnecessary GET operations
+// that count against Docker Hub API limits.
+func cachedRegistryDigest(ctx context.Context, tOpts *TransportOptions, imgCache cache.Handle, srcRef string) (v1.Hash, error) {
+	var nameOpts []name.Option
+	if tOpts != nil && tOpts.Insecure {
+		nameOpts = append(nameOpts, name.Insecure)
 	}
-
-	// TODO - replace with ggcr code
-	d, err := docker.GetDigest(ctx, SystemContextFromTransportOptions(tOpts), ref)
+	remoteRef, err := name.ParseReference(srcRef, nameOpts...)
 	if err != nil {
-		// If a custom auth file has been requested (via sysCtx) and is outright
-		// missing, docker.GetDigest still returns a generic "access to the
-		// resource is denied" error. Therefore, check if a non-default auth
-		// file was requested and, if so, generate a more useful error.
-		if tOpts.AuthFilePath != syfs.DockerConf() {
-			return d, fmt.Errorf("could not read necessary credentials from file %q", tOpts.AuthFilePath)
-		}
-
-		// Not all registries send digest in HEAD. Fall back to digest from retrieved manifest.
-		sylog.Debugf("Couldn't get digest from HEAD against registry: %v", err)
-		return directDigest(ctx, tOpts, imgCache, ref)
+		return v1.Hash{}, err
 	}
-	sylog.Debugf("%s has digest %s via HEAD", ref.DockerReference().String(), d.String())
+	remoteOpts := []remote.Option{
+		remote.WithContext(ctx),
+	}
+	if tOpts != nil {
+		remoteOpts = append(remoteOpts,
+			ociauth.AuthOptn(tOpts.AuthConfig, tOpts.AuthFilePath))
+	}
+
+	// remote.HEAD will return a descriptor with the digest indicated by the Docker-Content-Digest header.
+	headDesc, err := remote.Head(remoteRef, remoteOpts...)
+	if err != nil {
+		return registryDigestFallback(ctx, tOpts, srcRef, err)
+	}
+	sylog.Debugf("HEAD returned digest %v, mediaType %v", headDesc.Digest, headDesc.MediaType)
 
 	// Is the corresponding blob present in the cache?
-	r, err := imgCache.GetOciCacheBlob(cache.OciBlobCacheType, d)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			sylog.Warningf("While opening cached image index or manifest: %v", err)
+	r, err := imgCache.GetOciCacheBlob(cache.OciBlobCacheType, headDesc.Digest)
+	// Present in cache but couldn't open - warn and fall back.
+	if err != nil && !os.IsNotExist(err) {
+		return registryDigestFallback(ctx, tOpts, srcRef, err)
+	}
+	// Present in cache, and opened - read and obtain true image digest.
+	if err == nil {
+		sylog.Debugf("Found cached image index or manifest for %s", headDesc.Digest)
+		defer r.Close()
+		mf, err := io.ReadAll(r)
+		if err != nil {
+			return registryDigestFallback(ctx, tOpts, srcRef, err)
 		}
-		sylog.Debugf("No cached image index or manifest")
-		return directDigest(ctx, tOpts, imgCache, ref)
+		return digestFromManifestOrIndex(tOpts, mf)
 	}
-	defer r.Close()
-	sylog.Debugf("Found cached image index or manifest for %s", d)
-
-	mf, err := io.ReadAll(r)
+	// Not in cache - GET the index or manifest from the remote, and cache it.
+	sylog.Debugf("No cached image index or manifest")
+	getDesc, err := remote.Get(remoteRef, remoteOpts...)
 	if err != nil {
-		return "", fmt.Errorf("while reading cached image index or manifest: %w", err)
+		return registryDigestFallback(ctx, tOpts, srcRef, err)
 	}
-	return digestFromManifestOrIndex(tOpts, mf)
+	if getDesc.Digest != headDesc.Digest {
+		return registryDigestFallback(ctx, tOpts, srcRef, fmt.Errorf("digest changed between HEAD and GET requests: %v != %v", getDesc.Digest, headDesc.Digest))
+	}
+
+	sylog.Debugf("Caching image index or manifest %s", getDesc.Digest)
+	if err := imgCache.PutOciCacheBlob(cache.OciBlobCacheType, getDesc.Digest, io.NopCloser(bytes.NewBuffer(getDesc.Manifest))); err != nil {
+		return registryDigestFallback(ctx, tOpts, srcRef, err)
+	}
+	return digestFromManifestOrIndex(tOpts, getDesc.Manifest)
+}
+
+func registryDigestFallback(ctx context.Context, tOpts *TransportOptions, srcRef string, cause error) (v1.Hash, error) {
+	sylog.Warningf("Couldn't use cached digest for registry: %v", cause)
+	sylog.Warningf("Falling back to direct digest.")
+	return directDigest(ctx, tOpts, RegistrySourceSink, srcRef)
 }
 
 // digestFromManifestOrIndex returns the digest of the provided manifest, or the
 // digest of the manifest of an image satisfying sysCtx platform requirements if
 // an image index is supplied.
-func digestFromManifestOrIndex(tOpts *TransportOptions, manifestOrIndex []byte) (digest.Digest, error) {
+func digestFromManifestOrIndex(tOpts *TransportOptions, manifestOrIndex []byte) (v1.Hash, error) {
 	if tOpts == nil {
-		return "", fmt.Errorf("internal error: nil TransportOptions")
+		return v1.Hash{}, fmt.Errorf("internal error: nil TransportOptions")
 	}
 
 	// mediaType is only a SHOULD for manifests and image indexes,so we can't
@@ -134,16 +147,17 @@ func digestFromManifestOrIndex(tOpts *TransportOptions, manifestOrIndex []byte) 
 	mf, err := ggcrv1.ParseManifest(bytes.NewBuffer(manifestOrIndex))
 	if err == nil && mf.Config.Digest.Hex != "" {
 		sylog.Debugf("Content is an image manifest, returning digest.")
-		return digest.FromBytes(manifestOrIndex), nil
+		digest, _, err := v1.SHA256(bytes.NewBuffer(manifestOrIndex))
+		return digest, err
 	}
 
 	// If we don't have a manifest, try to parse as an image index, and check for at least one manifest.
 	ix, err := ggcrv1.ParseIndexManifest(bytes.NewBuffer(manifestOrIndex))
 	if err != nil {
-		return "", fmt.Errorf("error parsing IndexManifest: %w", err)
+		return v1.Hash{}, fmt.Errorf("error parsing IndexManifest: %w", err)
 	}
 	if len(ix.Manifests) == 0 {
-		return "", fmt.Errorf("not a valid image manifest or image index")
+		return v1.Hash{}, fmt.Errorf("not a valid image manifest or image index")
 	}
 
 	requiredPlatform := tOpts.Platform
@@ -154,8 +168,8 @@ func digestFromManifestOrIndex(tOpts *TransportOptions, manifestOrIndex []byte) 
 		}
 		if mf.Platform.Satisfies(requiredPlatform) {
 			sylog.Debugf("%s (%s) satisfies %s", mf.Digest.String(), mf.Platform.String(), requiredPlatform.String())
-			return digest.Digest(mf.Digest.String()), nil
+			return mf.Digest, nil
 		}
 	}
-	return "", fmt.Errorf("no image satisfies requested platform: %s", requiredPlatform.String())
+	return v1.Hash{}, fmt.Errorf("no image satisfies requested platform: %s", requiredPlatform.String())
 }

--- a/internal/pkg/ociimage/digest_test.go
+++ b/internal/pkg/ociimage/digest_test.go
@@ -9,15 +9,15 @@ import (
 	"testing"
 
 	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	ggcrempty "github.com/google/go-containerregistry/pkg/v1/empty"
 	ggcrmutate "github.com/google/go-containerregistry/pkg/v1/mutate"
 	ggcrrandom "github.com/google/go-containerregistry/pkg/v1/random"
-	"github.com/opencontainers/go-digest"
 	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	"gotest.tools/v3/assert"
 )
 
-func imageWithManifest(t *testing.T) (rawManifest []byte, imageDigest digest.Digest) {
+func imageWithManifest(t *testing.T) (rawManifest []byte, imageDigest v1.Hash) {
 	im, err := ggcrrandom.Image(1024, 3)
 	if err != nil {
 		t.Fatal(err)
@@ -30,10 +30,10 @@ func imageWithManifest(t *testing.T) (rawManifest []byte, imageDigest digest.Dig
 	if err != nil {
 		t.Fatal(err)
 	}
-	return rm, digest.Digest(id.String())
+	return rm, id
 }
 
-func imageWithIndex(t *testing.T) (rawIndex []byte, imageDigest digest.Digest) {
+func imageWithIndex(t *testing.T) (rawIndex []byte, imageDigest v1.Hash) {
 	im, err := ggcrrandom.Image(1024, 3)
 	if err != nil {
 		t.Fatal(err)
@@ -56,7 +56,7 @@ func imageWithIndex(t *testing.T) (rawIndex []byte, imageDigest digest.Digest) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return ri, digest.Digest(id.String())
+	return ri, id
 }
 
 func Test_digestFromManifestOrIndex(t *testing.T) {
@@ -67,7 +67,7 @@ func Test_digestFromManifestOrIndex(t *testing.T) {
 		name             string
 		transportOptions *TransportOptions
 		manifestOrIndex  []byte
-		want             digest.Digest
+		want             v1.Hash
 		wantErr          bool
 	}{
 		{
@@ -107,7 +107,7 @@ func Test_digestFromManifestOrIndex(t *testing.T) {
 				},
 			},
 			manifestOrIndex: index,
-			want:            "",
+			want:            v1.Hash{},
 			wantErr:         true,
 		},
 		{
@@ -120,7 +120,7 @@ func Test_digestFromManifestOrIndex(t *testing.T) {
 				},
 			},
 			manifestOrIndex: index,
-			want:            "",
+			want:            v1.Hash{},
 			wantErr:         true,
 		},
 		{
@@ -133,7 +133,7 @@ func Test_digestFromManifestOrIndex(t *testing.T) {
 				},
 			},
 			manifestOrIndex: index,
-			want:            "",
+			want:            v1.Hash{},
 			wantErr:         true,
 		},
 	}

--- a/internal/pkg/ociimage/transport.go
+++ b/internal/pkg/ociimage/transport.go
@@ -10,12 +10,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/containers/image/v5/docker"
-	dockerarchive "github.com/containers/image/v5/docker/archive"
-	dockerdaemon "github.com/containers/image/v5/docker/daemon"
-	ociarchive "github.com/containers/image/v5/oci/archive"
-	ocilayout "github.com/containers/image/v5/oci/layout"
-	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
 	"github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -138,43 +132,6 @@ func SystemContextFromTransportOptions(tOpts *TransportOptions) *types.SystemCon
 	}
 	sc := tOpts.SystemContext()
 	return &sc
-}
-
-// DefaultPolicy is Singularity's default containers/image OCI signature verification policy - accept anything.
-func DefaultPolicy() (*signature.PolicyContext, error) {
-	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
-	return signature.NewPolicyContext(policy)
-}
-
-// URIToImageReference parses a uri-like OCI image reference into a containers/image types.ImageReference.
-func URIToImageReference(imageRef string) (types.ImageReference, error) {
-	parts := strings.SplitN(imageRef, ":", 2)
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("could not parse image ref: %s", imageRef)
-	}
-
-	var srcRef types.ImageReference
-	var err error
-
-	switch parts[0] {
-	case "docker":
-		srcRef, err = docker.ParseReference(parts[1])
-	case "docker-archive":
-		srcRef, err = dockerarchive.ParseReference(parts[1])
-	case "docker-daemon":
-		srcRef, err = dockerdaemon.ParseReference(parts[1])
-	case "oci":
-		srcRef, err = ocilayout.ParseReference(parts[1])
-	case "oci-archive":
-		srcRef, err = ociarchive.ParseReference(parts[1])
-	default:
-		return nil, errUnsupportedTransport
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return srcRef, nil
 }
 
 // URItoSourceSinkRef parses a uri-like OCI image reference into a SourceSink and ref


### PR DESCRIPTION
## Description of the Pull Request (PR):

Re-implement the OCI image digest flows using ggcr instead of containers/image/v5.

When obtaining the ImageDigest for an image in a remote registry we need to try to use a `HEAD` request that doesn't count against Docker Hub API limits.

Unfortunately, the `Docker-Content-Digest` returned by `HEAD` is for the image index when a repository is multi-arch. We have to locally cache the manifest or image index so that we can always resolve the digest we get back from `HEAD` requests to a true image digest.

### This fixes or addresses the following GitHub issues:

 - Fixes #2383 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
