### PR TITLE
chore: drop containers/image related build tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ run:
   timeout: 5m
   build-tags:
     - apparmor
-    - containers_image_openpgp
     - e2e_test
     - fakeroot_engine
     - seccomp

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
         "--fast"
     ],
     "go.buildFlags": [
-        "-tags=apparmor,containers_image_openpgp,fakeroot_engine,seccomp,selinux,singularity_engine,sylog"
+        "-tags=apparmor,fakeroot_engine,seccomp,selinux,singularity_engine,sylog"
     ],
-    "go.testTags": "apparmor,containers_image_openpgp,fakeroot_engine,seccomp,selinux,singularity_engine,sylog,e2e_test,integration_test"
+    "go.testTags": "apparmor,fakeroot_engine,seccomp,selinux,singularity_engine,sylog,e2e_test,integration_test"
 }

--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -1,7 +1,7 @@
 # go tool default build options
 GO111MODULE := on
-GO_TAGS := containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper sylog singularity_engine fakeroot_engine
-GO_TAGS_SUID := containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper sylog singularity_engine fakeroot_engine
+GO_TAGS := sylog singularity_engine fakeroot_engine
+GO_TAGS_SUID := sylog singularity_engine fakeroot_engine
 GO_LDFLAGS :=
 # Need to use non-pie build on ppc64le
 # https://github.com/hpcng/singularity/issues/5762


### PR DESCRIPTION
## Description of the Pull Request (PR):

Now we don't use containers/image (except for types for backward compatibility through to 5.0), remove the build tags related to containers/image and containers/storage that are no longer required.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
