### PR TITLE
Re-implement bars when fetching remote OCI images via ggcr

### DIFF
--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -133,7 +133,7 @@ func CopyOCIImage(t *testing.T, source, dest string, insecureSource, insecureDes
 		srcOpts.AuthFilePath = configPath
 	}
 
-	srcImage, err := srcType.Image(context.Background(), srcRef, &srcOpts)
+	srcImage, err := srcType.Image(context.Background(), srcRef, &srcOpts, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize source: %v", err)
 	}
@@ -144,7 +144,7 @@ func CopyOCIImage(t *testing.T, source, dest string, insecureSource, insecureDes
 	if err := ociimage.OCISourceSink.WriteImage(srcImage, tmpDir, nil); err != nil {
 		t.Fatalf("failed to write temporary layout: %s", err)
 	}
-	tmpImg, err := ociimage.OCISourceSink.Image(context.Background(), tmpDir, nil)
+	tmpImg, err := ociimage.OCISourceSink.Image(context.Background(), tmpDir, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize temporary layout source: %v", err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -118,6 +118,7 @@ type OCIConveyorPacker struct {
 
 // Get downloads container information from the specified source
 func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err error) {
+	sylog.Infof("Fetching OCI image...")
 	cp.b = b
 
 	cp.transportOptions = &ociimage.TransportOptions{
@@ -175,11 +176,13 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 
 // Pack puts relevant objects in a Bundle.
 func (cp *OCIConveyorPacker) Pack(ctx context.Context) (*sytypes.Bundle, error) {
+	sylog.Infof("Extracting OCI image...")
 	err := cp.unpackRootfs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("while unpacking tmpfs: %v", err)
 	}
 
+	sylog.Infof("Inserting Singularity configuration...")
 	err = cp.insertBaseEnv()
 	if err != nil {
 		return nil, fmt.Errorf("while inserting base environment: %v", err)

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -12,10 +12,8 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
-	"github.com/sylabs/singularity/v4/internal/pkg/client/progress"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
-	"golang.org/x/term"
 )
 
 // pull will pull an oras image into the cache if directTo="", or a specific file if directTo is set.
@@ -25,14 +23,9 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 		return "", fmt.Errorf("failed to get checksum for %s: %s", pullFrom, err)
 	}
 
-	var pb *progress.DownloadBar
-	if term.IsTerminal(2) {
-		pb = &progress.DownloadBar{}
-	}
-
 	if directTo != "" {
 		sylog.Infof("Downloading oras image")
-		if err := DownloadImage(ctx, directTo, pullFrom, ociAuth, reqAuthFile, pb); err != nil {
+		if err := DownloadImage(ctx, directTo, pullFrom, ociAuth, reqAuthFile); err != nil {
 			return "", fmt.Errorf("unable to Download Image: %v", err)
 		}
 		imagePath = directTo
@@ -45,7 +38,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading oras image")
 
-			if err := DownloadImage(ctx, cacheEntry.TmpPath, pullFrom, ociAuth, reqAuthFile, pb); err != nil {
+			if err := DownloadImage(ctx, cacheEntry.TmpPath, pullFrom, ociAuth, reqAuthFile); err != nil {
 				return "", fmt.Errorf("unable to Download Image: %v", err)
 			}
 			if cacheFileHash, err := ImageHash(cacheEntry.TmpPath); err != nil {

--- a/internal/pkg/client/progress/progress.go
+++ b/internal/pkg/client/progress/progress.go
@@ -14,29 +14,34 @@ import (
 	"github.com/vbauerster/mpb/v8/decor"
 )
 
+var defaultOption = []mpb.BarOption{
+	mpb.PrependDecorators(
+		decor.Counters(decor.SizeB1024(0), "%.1f / %.1f"),
+	),
+	mpb.AppendDecorators(
+		decor.Percentage(),
+		decor.AverageSpeed(decor.SizeB1024(0), " % .1f "),
+		decor.AverageETA(decor.ET_STYLE_GO),
+	),
+}
+
+var unknownSizeOption = []mpb.BarOption{
+	mpb.PrependDecorators(
+		decor.Current(decor.SizeB1024(0), "%.1f / ???"),
+	),
+	mpb.AppendDecorators(
+		decor.AverageSpeed(decor.SizeB1024(0), " % .1f "),
+	),
+}
+
+// initProgressBar initializes an mpb.Progress with a single bar.
 func initProgressBar(totalSize int64) (*mpb.Progress, *mpb.Bar) {
 	p := mpb.New()
 
 	if totalSize > 0 {
-		return p, p.AddBar(totalSize,
-			mpb.PrependDecorators(
-				decor.Counters(decor.SizeB1024(0), "%.1f / %.1f"),
-			),
-			mpb.AppendDecorators(
-				decor.Percentage(),
-				decor.AverageSpeed(decor.SizeB1024(0), " % .1f "),
-				decor.AverageETA(decor.ET_STYLE_GO),
-			),
-		)
+		return p, p.AddBar(totalSize, defaultOption...)
 	}
-	return p, p.AddBar(totalSize,
-		mpb.PrependDecorators(
-			decor.Current(decor.SizeB1024(0), "%.1f / ???"),
-		),
-		mpb.AppendDecorators(
-			decor.AverageSpeed(decor.SizeB1024(0), " % .1f "),
-		),
-	)
+	return p, p.AddBar(totalSize, unknownSizeOption...)
 }
 
 // See: https://ixday.github.io/post/golang-cancel-copy/

--- a/internal/pkg/ociimage/digest.go
+++ b/internal/pkg/ociimage/digest.go
@@ -56,7 +56,7 @@ func ImageDigest(ctx context.Context, tOpts *TransportOptions, imgCache *cache.H
 // digest of the image manifest for the requested architecture specified in
 // tOpts.
 func directDigest(ctx context.Context, tOpts *TransportOptions, srcType SourceSink, srcRef string) (v1.Hash, error) {
-	img, err := srcType.Image(ctx, srcRef, tOpts)
+	img, err := srcType.Image(ctx, srcRef, tOpts, nil)
 	if err != nil {
 		return v1.Hash{}, err
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add back progress bars when remote OCI images are fetch via the new ggcr code.

Because ggcr doesn't have its own progress functionality for reads from a remote, we implement bars on GET requests through a RoundTripper.

The existing RoundTripper code that was implemented for ORAS fetch only has been revised to accommodate multiple bars for multiple GETs, and ensure a more graceful exit.

![image](https://github.com/sylabs/singularity/assets/4522799/6a398b78-4232-4f5a-bd76-98c2b567c7cf)



### This fixes or addresses the following GitHub issues:

 - Fixes #2385


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
