### PR TITLE
fix: Execute correct %appscript and add test for instance start --app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
   given the `--app <appname>` flag, and will automatically invoke the relevant
   SCIF command.
 
+### Bug Fixes
+
+- Execute correct `%appstart` script when using `instance start` with `--app`.
+
 ## 4.0.2 \[2023-11-16\]
 
 ### Changed defaults / behaviours

--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -94,10 +94,18 @@ func (c *ctx) expectInstance(t *testing.T, name string, nb int) {
 	)
 }
 
-// Sends a deterministic message to an echo server and expects the same message
-// in response.
-func echo(t *testing.T, port int) {
-	const message = "b40cbeaaea293f7e8bd40fb61f389cfca9823467\n"
+// Sends a deterministic message to an echo server and expects the same, or a
+// reversed, message in response.
+func echo(t *testing.T, port int, reverse bool) {
+	const (
+		message         = "b40cbeaaea293f7e8bd40fb61f389cfca9823467\n"
+		reversedMessage = "7643289acfc983f16bf04db8e7f392aeaaebc04b\n"
+	)
+
+	expectResponse := message
+	if reverse {
+		expectResponse = reversedMessage
+	}
 
 	// give it some time for responding, attempt 10 times by
 	// waiting 100 millisecond between each try
@@ -114,8 +122,9 @@ func echo(t *testing.T, port int) {
 		fmt.Fprint(sock, message)
 
 		response, responseErr := bufio.NewReader(sock).ReadString('\n')
-		if responseErr != nil || response != message {
-			t.Errorf("Bad response: err = %v, response = %v", responseErr, response)
+
+		if responseErr != nil || response != expectResponse {
+			t.Errorf("Bad response: err = %v, response %q != %q", responseErr, response, expectResponse)
 		}
 		break
 	}

--- a/e2e/testdata/Singularity
+++ b/e2e/testdata/Singularity
@@ -59,9 +59,11 @@ export HELLOTHISIS
 
 %appstart foo
     echo "STARTING FOO"
-    exec nc -l -k -p $1 -e /bin/cat
+    # Echo back reverse of strings sent on port $1
+    exec nc -l -k -p $1 -e /bin/rev
 
 %startscript
+    # Echo back strings sent on port $1
     exec nc -l -k -p $1 -e /bin/cat
 
 %runscript

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -203,7 +203,13 @@ test)
     sylog info "No test script found in container, exiting"
     exit 0 ;;
 start)
-    if test -x "/.singularity.d/startscript"; then
+    if test -n "${SINGULARITY_APPNAME:-}"; then
+        if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/startscript"; then
+            exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/startscript" "$@"
+        fi
+        sylog error "No startscript for contained app: ${SINGULARITY_APPNAME:-}"
+        exit 1
+    elif test -x "/.singularity.d/startscript"; then
         exec "/.singularity.d/startscript" "$@"
     fi
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add an e2e test for `instance start --app`. Use the same echo server pattern that's implemented for testing `instance start`, but make `%appstart foo` a string reversing echo server, so we can tell that we started the right thing.

This uncovered issue #2410 - so we also have a fix to run the correct `%appscript` instead of the generic `%startscript` for `instance start --app`.

### This fixes or addresses the following GitHub issues:

 - Fixes #1944
 - Fixes #2410 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
