### PR TITLE
Address further FIXMEs

### DIFF
--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -246,7 +246,7 @@ var OciAttachCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := oci.Attach(cmd.Context(), args[0]); err != nil {
+		if err := oci.Attach(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -679,19 +679,14 @@ func (c configTests) configGlobal(t *testing.T) {
 			directiveValue: "yes",
 			exit:           0,
 		},
-		// FIXME
-		// The e2e tests currently run inside a PID namespace.
-		//   (see internal/init/init_linux.go)
-		// We can't instruct systemd to manage our cgroups as the PIDs in our test namespace
-		// won't match what systemd sees.
-		// {
-		// 	name:           "SystemdCgroupsYes",
-		// 	argv:           []string{"--apply-cgroups", "testdata/cgroups/pids_limit.toml", c.sandboxImage, "true"},
-		// 	profile:        e2e.RootProfile,
-		// 	directive:      "systemd cgroups",
-		// 	directiveValue: "yes",
-		// 	exit:           0,
-		// },
+		{
+			name:           "SystemdCgroupsYes",
+			argv:           []string{"--apply-cgroups", "testdata/cgroups/pids_limit.toml", c.sandboxImage, "true"},
+			profile:        e2e.RootProfile,
+			directive:      "systemd cgroups",
+			directiveValue: "yes",
+			exit:           0,
+		},
 		{
 			name:           "SystemdCgroupNo",
 			argv:           []string{"--apply-cgroups", "testdata/cgroups/pids_limit.toml", c.sandboxImage, "true"},

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -453,7 +453,6 @@ func appData(b *types.Bundle, a *App) string {
 	return filepath.Join(b.RootfsPath, "/scif/data/", a.Name)
 }
 
-// FIXME: Replace with Go, or existing util function?
 func copyWithfLr(src, dst string) error {
 	cp, err := bin.FindBin("cp")
 	if err != nil {

--- a/internal/pkg/runtime/launcher/oci/oci_attach_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_attach_linux.go
@@ -10,7 +10,6 @@ package oci
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"io"
 	"net"
@@ -53,9 +52,7 @@ const (
 )
 
 // Attach attaches the console to a running container
-//
-// FIXME: use context for cancellation, or remove.
-func Attach(_ context.Context, containerID string) error {
+func Attach(containerID string) error {
 	streams := attachStreams{
 		OutputStream: os.Stdout,
 		ErrorStream:  os.Stderr,

--- a/internal/pkg/util/crypt/crypt_dev_test.go
+++ b/internal/pkg/util/crypt/crypt_dev_test.go
@@ -80,14 +80,12 @@ func TestEncrypt(t *testing.T) {
 			key:       []byte("dummyKey"),
 			shallPass: false,
 		},
-		/* FIXME: deactivate because it creates too much variability in test results with CI
 		{
 			name:      "empty file",
 			path:      emptyFile.Name(),
 			key:       []byte("dummyKey"),
 			shallPass: false,
 		},
-		*/
 		{
 			name:      "valid file",
 			path:      tempTargetFile.Name(),


### PR DESCRIPTION
## Description of the Pull Request (PR):

**e2e: enable configGlobal SystemdCgroupsYes**
    
This test was disabled as it wasn't possible to run it within a PID namespace. Our e2e tests have not used a PIDn amespace for some time now, so we can enable it again.

**chore: drop FIXME from copyWithflr**

There isn't an easy way to replace `cp -fLr` with go code and be 100% certain that it has the exact same behaviour across all possible source / dest we could encounter when building a SCIF container.

Drop the FIXME. We'll keep using `cp -fLr`.

**crypt: enable emptyFile test**

Not clear exactly why this was disabled / what 'too much variability in test results with CI' means.

Possibly due to an issue on older distros? It is passing for me.

**oci: Drop ctx / FIXME from oci.Attach func**
    
Remove the FIXME note and the ctx parameter from oci.Attach.
    
When we are attached to the container, detaching from it should be controlled by our detachKeys, not the context, so it's not needed here.



### This fixes or addresses the following GitHub issues:

 - Fixes #2027 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
