### PR TITLE
build: split buildkitd code into separate singularity-buildkitd

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -225,7 +225,9 @@ func runBuild(cmd *cobra.Command, args []string) {
 			ContextDir:      wd,
 			DisableCache:    disableCache,
 		}
-		bkclient.Run(cmd.Context(), bkOpts, dest, spec)
+		if err := bkclient.Run(cmd.Context(), bkOpts, dest, spec); err != nil {
+			sylog.Fatalf("%v", err)
+		}
 	} else {
 		runBuildLocal(cmd.Context(), authConf, cmd, dest, spec)
 	}

--- a/cmd/singularity-buildkitd/main.go
+++ b/cmd/singularity-buildkitd/main.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package main
+
+import (
+	"context"
+	"os"
+
+	bkdaemon "github.com/sylabs/singularity/v4/internal/pkg/build/buildkit/daemon"
+	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
+)
+
+func main() {
+	if len(os.Args) < 2 || len(os.Args) > 3 {
+		sylog.Fatalf("%s: usage: %s <socket-uri> [architecture]", bkdaemon.DaemonName, os.Args[0])
+	}
+
+	bkSocket := os.Args[1]
+	bkArch := ""
+	if len(os.Args) == 3 {
+		bkArch = os.Args[2]
+	}
+
+	sylog.Debugf("%s: parsing configuration file %s", bkdaemon.DaemonName, buildcfg.SINGULARITY_CONF_FILE)
+	config, err := singularityconf.Parse(buildcfg.SINGULARITY_CONF_FILE)
+	if err != nil {
+		sylog.Fatalf("%s: couldn't parse configuration file %s: %v", bkdaemon.DaemonName, buildcfg.SINGULARITY_CONF_FILE, err)
+	}
+	singularityconf.SetCurrentConfig(config)
+
+	daemonOpts := &bkdaemon.Opts{
+		ReqArch: bkArch,
+	}
+	if err := bkdaemon.Run(context.Background(), daemonOpts, bkSocket); err != nil {
+		sylog.Fatalf("%s: %v", bkdaemon.DaemonName, err)
+	}
+}

--- a/internal/pkg/build/buildkit/auth/authprovider.go
+++ b/internal/pkg/build/buildkit/auth/authprovider.go
@@ -19,7 +19,7 @@
 // This file contains modified code originally taken from:
 // github.com/moby/buildkit/tree/v0.12.3/session/auth/authprovider
 
-package daemon
+package auth
 
 import (
 	"context"

--- a/internal/pkg/util/bin/bin_singularity.go
+++ b/internal/pkg/util/bin/bin_singularity.go
@@ -121,3 +121,9 @@ func findSquashfuse(name string) (path string, err error) {
 	// squashfuse if found on PATH
 	return findOnPath(name)
 }
+
+// findSingularityBuildkitd returns the bundled singularity-buildkitd.
+func FindSingularityBuildkitd() (path string, err error) {
+	bkd := filepath.Join(buildcfg.LIBEXECDIR, "singularity", "bin", "singularity-buildkitd")
+	return exec.LookPath(bkd)
+}

--- a/mconfig
+++ b/mconfig
@@ -864,6 +864,9 @@ fi
 drawline $makeit_fragsdir/build_scripts.mk
 cat $makeit_fragsdir/build_scripts.mk >> $makeit_makefile
 
+drawline $makeit_fragsdir/build_singularity-buildkitd.mk
+cat $makeit_fragsdir/build_singularity-buildkitd.mk >> $makeit_makefile
+
 drawline $makeit_fragsdir/Makefile.stub
 # here, `depends' need to happen after all other rules; at the very end
 final_all=`cat $makeit_interdir/all.mk | awk 'BEGIN { FS="all: " } { print $2 }'`

--- a/mlocal/frags/build_singularity-buildkitd.mk
+++ b/mlocal/frags/build_singularity-buildkitd.mk
@@ -1,0 +1,27 @@
+# This file contains all of the rules for building the singularity-buildkitd binary
+
+singularity-buildkitd_deps := $(BUILDDIR_ABSPATH)/singularity-buildkitd.d
+
+-include $(singularity-buildkitd_deps)
+
+$(singularity-buildkitd_deps): $(GO_MODFILES)
+	@echo " GEN GO DEP" $@
+	$(V)$(SOURCEDIR)/makeit/gengodep -v3 "$(GO)" "singularity-buildkitd_SOURCE" "$(GO_TAGS)" "$@" "$(SOURCEDIR)/cmd/singularity-buildkitd"
+
+# Look at dependencies file changes via singularity_deps
+# because it means that a module was updated.
+singularity-buildkitd := $(BUILDDIR)/singularity-buildkitd
+$(singularity-buildkitd): $(singularity_build_config) $(singularity-buildkitd_deps) $(singularity-buildkitd_SOURCE)
+	@echo " GO" $@; echo "    [+] GO_TAGS" \"$(GO_TAGS)\"
+	$(V)$(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) -tags "$(GO_TAGS)" $(GO_LDFLAGS) \
+		-o $(BUILDDIR)/singularity-buildkitd $(SOURCEDIR)/cmd/singularity-buildkitd
+
+singularity-buildkitd_INSTALL := $(DESTDIR)$(LIBEXECDIR)/singularity/bin/singularity-buildkitd
+$(singularity-buildkitd_INSTALL): $(singularity-buildkitd)
+	@echo " INSTALL" $@
+	$(V)umask 0022 && mkdir -p $(@D)
+	$(V)install -m 0755 $(singularity-buildkitd) $(singularity-buildkitd_INSTALL)
+
+CLEANFILES += $(singularity-buildkitd)
+INSTALLFILES += $(singularity-buildkitd_INSTALL)
+ALL += $(singularity-buildkitd)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Prior to this PR, the `singularity` binary included a fairly complete `buildkitd` implementation.

This PR splits out the buildkit daemon code so that it is compiled into a separate `singularity-buildkitd` executable, executed as a child process when required.

Having a separate binary is useful as it allows sysadmins to remove the buildkit functionality easily, if they are concerned about increased attack surface / number of dependencies etc.

As part of this change, the locking behaviour and root dir of our singularity-builtkitd have been changed to avoid conflicts.

Boltdb is used by buildkit to track build history, caching, and other things. Boltdb only supports one process accessing a DB file at a time and employs exclusive locking to ensure this.

Previously, our own singularity-buildkitd was using the default buildkitd root, and creating a lock file with a random component. It was possible to start multiple singularity-buildkitd instances that could sometimes deadlock due to Boltdb locking. To fix this, use our own buildkitd root under `~/.singularity.d` so we don't compete with a system buildkit. Use a lock file with a fixed name, and wait for any `singularity-buildkitd` that's already running to complete before starting another.

If users want to make use of a system-wide buildkitd cache etc. then they should run a buildkitd separately and set `BUILDKIT_HOST` so that Singularity will use it.


### This fixes or addresses the following GitHub issues:

 - Fixes #2419 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
