### PR TITLE
fix: add singularity-buildkitd to packaging

### DIFF
--- a/debian/singularity-ce.install
+++ b/debian/singularity-ce.install
@@ -1,6 +1,7 @@
 usr/bin/singularity
 usr/bin/run-singularity
 usr/lib/*/singularity/bin/conmon
+usr/lib/*/singularity/bin/singularity-buildkitd
 usr/lib/*/singularity/bin/squashfuse_ll
 usr/lib/*/singularity/bin/starter
 usr/lib/*/singularity/bin/starter-suid

--- a/dist/rpm/singularity-ce.spec.in
+++ b/dist/rpm/singularity-ce.spec.in
@@ -135,6 +135,7 @@ make DESTDIR=$RPM_BUILD_ROOT install -C builddir V=
 %dir %{_libexecdir}/singularity
 %dir %{_libexecdir}/singularity/bin
 %{_libexecdir}/singularity/bin/conmon
+%{_libexecdir}/singularity/bin/singularity-buildkitd
 %{_libexecdir}/singularity/bin/squashfuse_ll
 %{_libexecdir}/singularity/bin/starter
 %dir %{_libexecdir}/singularity/cni


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix RPM and Deb by adding singularity-buildkitd binary to installed files.


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
