### PR TITLE
fuse: automatically use squashfuse for images, deprecate --sif-fuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changes Since Last Release
 
+### Changed defaults / behaviours
+
+- In native mode, SIF/SquashFS container images will now be mounted with
+  squashfuse when kernel mounts are disabled in `singularity.conf`, or cannot be
+  used (non-setuid / user namespace workflow). If the FUSE mount fails,
+  Singularity will fall back to extracting the container to a temporary sandbox
+  in order to run it.
+
 ### New Features & Functionality
 
 - The `registry login` and `registry logout` commands now support a `--authfile
@@ -27,10 +35,18 @@
   executable, then the `run` / `exec` / `shell` commands in `--oci` mode can be
   given the `--app <appname>` flag, and will automatically invoke the relevant
   SCIF command.
-- SIF/SquashFS container images can now be mounted using FUSE in all native mode
-  flows, including setuid mode. To enable, use the `--sif-fuse` flag, or set
-  `sif fuse = yes` in `singularity.conf`. Overlay partitions and extfs images
-  are not yet supported.
+- A new `--tmp-sandbox` flag has been added to the `run / shell / exec /
+  instance start` commands. This will force Singularity to extract a container
+  to a temporary sandbox before running it, when it would otherwise perform a
+  kernel or FUSE mount.
+
+### Deprecated Functionality
+
+- The experimental `--sif-fuse` flag, and `sif fuse` directive in
+  `singularity.conf` are deprecated. The flag and directive were used to enable
+  experimental mounting of SIF/SquashFS container images with FUSE in prior
+  versions of Singularity. From 4.1, FUSE mounts are used automatically when
+  kernel mounts are disabled / not available.
 
 ### Bug Fixes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -766,6 +766,7 @@ var actionSIFFUSEFlag = cmdline.Flag{
 	Name:         "sif-fuse",
 	Usage:        "attempt FUSE mount of SIF",
 	EnvKeys:      []string{"SIF_FUSE"},
+	Deprecated:   "FUSE mounts are now used automatically when kernel mounts are disabled / unavailable.",
 }
 
 // --proot (hidden)
@@ -891,6 +892,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&commonOCIFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonNoOCIFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonKeepLayersFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionTmpSandbox, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoTmpSandbox, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonAuthFileFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionDevice, actionsCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -387,6 +387,7 @@ func launchContainer(cmd *cobra.Command, ep launcher.ExecParams) error {
 		launcher.OptDevice(device),
 		launcher.OptCdiDirs(cdiDirs),
 		launcher.OptNoCompat(noCompat),
+		launcher.OptTmpSandbox(tmpSandbox),
 		launcher.OptNoTmpSandbox(noTmpSandbox),
 	}
 

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -84,6 +84,7 @@ var (
 
 	// Options controlling the unpacking of images to temporary sandboxes
 	canUseTmpSandbox bool
+	tmpSandbox       bool
 	noTmpSandbox     bool
 
 	// Use OCI runtime and OCI SIF?
@@ -303,6 +304,16 @@ var commonKeepLayersFlag = cmdline.Flag{
 	Name:         "keep-layers",
 	Usage:        "Keep layers when creating an OCI-SIF. Do not squash to a single layer.",
 	EnvKeys:      []string{"KEEP_LAYERS"},
+}
+
+// --tmp-sandbox
+var actionTmpSandbox = cmdline.Flag{
+	ID:           "actionTmpSandbox",
+	Value:        &tmpSandbox,
+	DefaultValue: false,
+	Name:         "tmp-sandbox",
+	Usage:        "Forces unpacking of images into temporary sandbox dirs when a kernel or FUSE mount would otherwise be used.",
+	EnvKeys:      []string{"TMP_SANDBOX"},
 }
 
 // --no-tmp-sandbox

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -533,7 +533,8 @@ func (c configTests) configGlobal(t *testing.T) {
 			profile:        e2e.UserProfile,
 			directive:      "allow kernel squashfs",
 			directiveValue: "no",
-			exit:           255,
+			exit:           0,
+			resultOp:       e2e.ExpectError(e2e.ContainMatch, "Mounting image with FUSE"),
 		},
 		{
 			name:           "AllowKernelSquashfsYes_Container",
@@ -542,6 +543,7 @@ func (c configTests) configGlobal(t *testing.T) {
 			directive:      "allow kernel squashfs",
 			directiveValue: "yes",
 			exit:           0,
+			resultOp:       e2e.ExpectError(e2e.UnwantedContainMatch, "Mounting image with FUSE"),
 		},
 		// Standalone ext3 rootfs
 		{
@@ -635,7 +637,8 @@ func (c configTests) configGlobal(t *testing.T) {
 			profile:        e2e.UserProfile,
 			directive:      "allow kernel squashfs",
 			directiveValue: "no",
-			exit:           255,
+			exit:           0,
+			resultOp:       e2e.ExpectError(e2e.ContainMatch, "Mounting image with FUSE"),
 		},
 		{
 			name:           "AllowKernelSquashfsYes_SIF",
@@ -644,6 +647,7 @@ func (c configTests) configGlobal(t *testing.T) {
 			directive:      "allow kernel squashfs",
 			directiveValue: "yes",
 			exit:           0,
+			resultOp:       e2e.ExpectError(e2e.UnwantedContainMatch, "Mounting image with FUSE"),
 		},
 		// Encrypted squashFS rootfs in SIF
 		{

--- a/internal/app/starter/host.go
+++ b/internal/app/starter/host.go
@@ -9,12 +9,13 @@ import (
 	"context"
 	"net"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/engine"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
-//nolint:dupl
 func PostStartHost(postStartSocket int, e *engine.Engine) {
 	sylog.Debugf("Entering PostStartHost")
 	comm := os.NewFile(uintptr(postStartSocket), "unix")
@@ -30,7 +31,7 @@ func PostStartHost(postStartSocket int, e *engine.Engine) {
 	// Wait for a write into the socket from master to trigger after container process started.
 	data := make([]byte, 1)
 	if _, err := conn.Read(data); err != nil {
-		sylog.Fatalf("While reading from cleanup socket: %s", err)
+		sylog.Fatalf("While reading from post start socket: %s", err)
 	}
 
 	if err := e.PostStartHost(ctx); err != nil {
@@ -47,9 +48,17 @@ func PostStartHost(postStartSocket int, e *engine.Engine) {
 	os.Exit(0)
 }
 
-//nolint:dupl
 func CleanupHost(cleanupSocket int, e *engine.Engine) {
 	sylog.Debugf("Entering CleanupHost")
+
+	// An unclean shutdown, in which the parent of the cleanup process exits,
+	// will result in SIGTERM (as this was set as the parent death signal in the
+	// C starter code).
+	tc := make(chan os.Signal, 1)
+	signal.Notify(tc, syscall.SIGTERM)
+
+	// A clean container shutdown results in the master process sending a
+	// message on the cleanup socket to trigger cleanup. We will use SIGHUP to indicate this.
 	comm := os.NewFile(uintptr(cleanupSocket), "unix")
 	conn, err := net.FileConn(comm)
 	if err != nil {
@@ -58,24 +67,48 @@ func CleanupHost(cleanupSocket int, e *engine.Engine) {
 	comm.Close()
 	defer conn.Close()
 
-	ctx := context.TODO()
-
-	// Wait for a write into the socket from master to trigger cleanup after container exited
-	data := make([]byte, 1)
-	if _, err := conn.Read(data); err != nil {
-		sylog.Fatalf("While reading from cleanup socket: %s", err)
-	}
-
-	if err := e.CleanupHost(ctx); err != nil {
-		if _, err := conn.Write([]byte{'f'}); err != nil {
-			sylog.Fatalf("Could not write to master: %s", err)
+	go func() {
+		data := make([]byte, 1)
+		_, err := conn.Read(data)
+		// Clean shutdown - master should be notified after cleanup.
+		if err == nil {
+			tc <- syscall.SIGHUP
 		}
-		sylog.Fatalf("While running host cleanup tasks: %s", err)
+		// Unclean shutdown - master not available to notify after cleanup.
+		tc <- syscall.SIGTERM
+		sylog.Debugf("While reading from cleanup socket: %s", err)
+	}()
+
+	// Block here until direct SIGTERM, or generated SIGHUP from reading master
+	// socket, is received.
+	sig := <-tc
+	sylog.Debugf("CleanupHost Signaled: %v", sig)
+
+	// Run engine specific cleanup tasks
+	err = e.CleanupHost(context.TODO())
+
+	// If we are in a clean (master initiated) shutdown, notify master of any cleanup failure.
+	if err != nil && sig == syscall.SIGHUP {
+		if _, err := conn.Write([]byte{'f'}); err != nil {
+			sylog.Debugf("Could not write to master: %s", err)
+		}
+	}
+	// Exit on cleanup failure.
+	if err != nil {
+		sylog.Errorf("While running host cleanup tasks: %s", err)
+		sylog.Debugf("Exiting CleanupHost - Cleanup failure")
+		os.Exit(1)
 	}
 
-	if _, err := conn.Write([]byte{'c'}); err != nil {
-		sylog.Fatalf("Could not write to master: %s", err)
+	// If we are in a clean (master initiated) shutdown, notify master of the cleanup success.
+	if sig == syscall.SIGHUP {
+		if _, err := conn.Write([]byte{'c'}); err != nil {
+			sylog.Debugf("Could not write to master: %s", err)
+			sylog.Debugf("Exiting CleanupHost - Master socket write failure")
+			os.Exit(1)
+		}
 	}
-	sylog.Debugf("Exiting CleanupHost")
+
+	sylog.Debugf("Exiting CleanupHost - Success")
 	os.Exit(0)
 }

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -149,6 +149,10 @@ type Options struct {
 	// This will be used by a launcher handling OCI images directly.
 	TransportOptions *ociimage.TransportOptions
 
+	// TmpSandbox forces unpacking of images into temporary sandbox dirs when a
+	// kernel or FUSE mount would otherwise be used.
+	TmpSandbox bool
+
 	// NoTmpSandbox prohibits unpacking of images into temporary sandbox dirs.
 	NoTmpSandbox bool
 
@@ -508,6 +512,15 @@ func OptKeyInfo(ki *cryptkey.KeyInfo) Option {
 func OptSIFFuse(b bool) Option {
 	return func(lo *Options) error {
 		lo.SIFFUSE = b
+		return nil
+	}
+}
+
+// TmpSandbox forces unpacking of images into temporary sandbox dirs when a
+// kernel or FUSE mount would otherwise be used.
+func OptTmpSandbox(b bool) Option {
+	return func(lo *Options) error {
+		lo.TmpSandbox = b
 		return nil
 	}
 }

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -329,7 +329,8 @@ allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }
 # ALLOW KERNEL SQUASHFS: [BOOL]
 # DEFAULT: yes
 # If set to no, Singularity will not perform any kernel mounts of squashfs filesystems.
-# This affects both stand-alone image files and filesystems embedded in a SIF file.
+# Instead, for SIF / SquashFS containers, a squashfuse mount will be attempted, with
+# extraction to a temporary sandbox directory if this fails.
 # Applicable to setuid mode only.
 allow kernel squashfs = {{ if eq .AllowKernelSquashfs true }}yes{{ else }}no{{ end }}
 
@@ -523,7 +524,7 @@ systemd cgroups = {{ if eq .SystemdCgroups true }}yes{{ else }}no{{ end }}
 
 # SIF FUSE: [BOOL]
 # DEFAULT: no
-# EXPERIMENTAL
+# DEPRECATED - FUSE mounts are now used automatically when kernel mounts are disabled / unavailable.
 # Whether to try mounting SIF images with Squashfuse by default.
 # Applies only to unprivileged / user namespace flows. Requires squashfuse and
 # fusermount on PATH. Will fall back to extracting the SIF on failure.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Deprecate the explicit `--sif-fuse` flag and `sif fuse` directive for `singularity.conf`. These were previously used to enable experimental FUSE mount of SIF/SquashFS containers.

Modify image handling so that we now try squashfuse mounts automatically, with fall back to temporary sandbox extraction, when:

* squashfs kernel mounts have been disabled in `singularity.conf` -or-
* we are running in a non-setuid / user namespace flow.

Add a `--tmp-sandbox` flag to allow forcing extraction to a temporary sandbox when a kernel mount or FUSE mount would otherwise be used / attempted.

This change exposed an issue via the e2e tests - where there is a failure after the starter is called, but before the container is entered successfully, the host cleanup may not be called. To address this, added the commit...

[fix: ensure host cleanup runs when parent exits](https://github.com/sylabs/singularity/pull/2451/commits/b21bfd901a6c7bc41e5d4b53de8c718cbe2add94)

When a container doesn't exit cleanly, or fails to start correctly, then the master process won't write into the cleanup socket to initiate cleanup in the host namespaces.

Prior to this commit, this caused the host cleanup to exit with an EOF error, leaving FUSE mounts in place in host namespaces.

The host cleanup process has SIGTERM set as its parent death signal, so we can trap this to ensure that cleanup runs for an 'unclean' exit where the master doesn't initate cleanup via the socket.

### This fixes or addresses the following GitHub issues:

 - Fixes #2216


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
