### PR TITLE
fuse: Add fuse2fs mount for  bare extfs images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ commands:
               automake \
               build-essential \
               cryptsetup \
+              fuse2fs \
               git \
               libfuse-dev \
               libglib2.0-dev \
@@ -272,7 +273,7 @@ jobs:
             systemctl --user daemon-reload
             systemctl --user start dbus
             export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$UID/bus
-            
+
             # CircleCI agent starts our command in a cgroup with resource files
             # owned by root. For rootless cgroup tests, we must be in a cgroup
             # owned by ourselves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   used (non-setuid / user namespace workflow). If the FUSE mount fails,
   Singularity will fall back to extracting the container to a temporary sandbox
   in order to run it.
+- In native mode, bare extfs container images will now be mounted with
+  fuse2fs when kernel mounts are disabled in `singularity.conf`, or cannot be
+  used (non-setuid / user namespace workflow).
 
 ### New Features & Functionality
 

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -552,7 +552,8 @@ func (c configTests) configGlobal(t *testing.T) {
 			profile:        e2e.UserProfile,
 			directive:      "allow kernel extfs",
 			directiveValue: "no",
-			exit:           255,
+			exit:           0,
+			resultOp:       e2e.ExpectError(e2e.ContainMatch, "Mounting image with FUSE"),
 		},
 		{
 			name:           "AllowKernelExtfsYes_Container",
@@ -561,6 +562,7 @@ func (c configTests) configGlobal(t *testing.T) {
 			directive:      "allow kernel extfs",
 			directiveValue: "yes",
 			exit:           0,
+			resultOp:       e2e.ExpectError(e2e.UnwantedContainMatch, "Mounting image with FUSE"),
 		},
 		// Standalone squashfs as an overlay
 		{

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/security"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/env"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/fuse"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/squashfs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/gpu"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/starter"
@@ -1015,8 +1016,8 @@ func (l *Launcher) prepareImage(c context.Context, image string) error {
 		// setuid, kernel squashfs permitted, fuse not requested - no action needed
 		return nil
 	case imgutil.EXT3:
-		if isUserNs || l.cfg.SIFFUSE {
-			return l.prepareExtfs(c, img)
+		if !l.engineConfig.File.AllowKernelExtfs || noKernelMount {
+			return l.prepareExtfs(c, img, tryFuse)
 		}
 		// setuid, kernel extfs permitted, fuse not requested - no action needed
 		return nil
@@ -1070,9 +1071,46 @@ func (l *Launcher) prepareSquashfs(ctx context.Context, img *imgutil.Image, tryF
 	return fmt.Errorf("extraction failed: %v", err)
 }
 
-func (l *Launcher) prepareExtfs(_ context.Context, _ *imgutil.Image) error {
-	// TODO - Enable fuse2fs handling
-	return fmt.Errorf("extfs images can only be run in setuid mode with kernel extfs mounts enabled")
+func (l *Launcher) prepareExtfs(ctx context.Context, img *imgutil.Image, tryFuse bool) error {
+	if !tryFuse {
+		return fmt.Errorf("extfs images must be kernel or FUSE mounted, extraction to a temporary sandbox is not supported")
+	}
+
+	allowOther := false
+	// In fakeroot mode, the users is able to assume a subuid/subgid, so allow
+	// others to access the FUSE mount.
+	if l.cfg.Fakeroot {
+		allowOther = true
+	}
+
+	tempDir, imageDir, err := mkContainerDirs()
+	if err != nil {
+		return err
+	}
+
+	im := fuse.ImageMount{
+		Type:       image.EXT3,
+		UID:        os.Getuid(),
+		GID:        os.Getgid(),
+		Readonly:   l.cfg.Writable,
+		SourcePath: filepath.Clean(img.Path),
+		AllowOther: allowOther,
+	}
+	im.SetMountPoint(filepath.Clean(imageDir))
+
+	sylog.Infof("Mounting image with FUSE.")
+	if err := im.Mount(ctx); err != nil {
+		if err2 := os.RemoveAll(tempDir); err2 != nil {
+			sylog.Errorf("Couldn't remove temporary directory %s: %s", tempDir, err2)
+		}
+		return err
+	}
+
+	l.engineConfig.SetImage(imageDir)
+	l.engineConfig.SetImageFuse(true)
+	l.engineConfig.SetDeleteTempDir(tempDir)
+	l.generator.AddProcessEnv("SINGULARITY_CONTAINER", imageDir)
+	return nil
 }
 
 // mkContainerDirs creates a tempDir, with a nested 'root' imageDir that an image can be placed into.


### PR DESCRIPTION
## Description of the Pull Request (PR):

If the container image is a bare extfs image, and extfs kernel mounts have been disabled, use fuse2fs to mount the image.


### This fixes or addresses the following GitHub issues:

 - Fixes #2217 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
