### PR TITLE
docs: install squashfs-tools-ng from EPEL, not COPR

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,26 +125,29 @@ necessary.
 
 ### RHEL / Alma Linux / Rocky Linux / CentOS
 
-On RHEL and derivatives a COPR is available at:
+On RHEL and derivatives, the `squashfs-tools-ng` package is now
+available in the EPEL repositories.
 
-<https://copr.fedorainfracloud.org/coprs/dctrud/squashfs-tools-ng/>
+If you previously used the `dctrud/squashfs-tools-ng` COPR, you should
+disable it:
 
-This provides `squashfs-tools-ng`, which will not replace any standard EL or
-EPEL packages. To use it:
+```sh
+sudo dnf copr remove dctrud/squashfs-tools-ng
+```
+
+Follow the [EPEL Quickstart](https://docs.fedoraproject.org/en-US/epel/#_quickstart)
+for you distribution to enable the EPEL repository. Install `squashfs-tools-ng` with
+`dnf` or `yum`.
 
 #### EL 8 / 9
 
 ```sh
-sudo dnf install dnf-plugins-core
-sudo dnf copr enable dctrud/squashfs-tools-ng 
 sudo dnf install squashfs-tools-ng
 ```
 
 #### EL 7
 
 ```sh
-sudo yum install yum-plugin-copr 
-sudo yum copr enable dctrud/squashfs-tools-ng 
 sudo yum install squashfs-tools-ng
 ```
 

--- a/examples/lima/singularity-ce.yml
+++ b/examples/lima/singularity-ce.yml
@@ -24,10 +24,7 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
-    dnf -y install --enablerepo=epel singularity-ce
-    dnf -y install dnf-plugins-core
-    dnf -y copr enable dctrud/squashfs-tools-ng
-    dnf -y install squashfs-tools-ng 
+    dnf -y install --enablerepo=epel singularity-ce squashfs-tools-ng
 
 probes:
 - script: |


### PR DESCRIPTION
## Description of the Pull Request (PR):

squashfs-tools-ng is now available in EPEL. We should direct people to that, and not the COPR - which will not be maintained in future.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
