### PR TITLE
e2e: gate OCI-mode / buildkitd on kernel >=4.18

### DIFF
--- a/e2e/build/build.go
+++ b/e2e/build/build.go
@@ -2035,9 +2035,9 @@ func (c imgBuildTests) buildUseExistingBuildkitd(t *testing.T) {
 	t.Setenv("BUILDKIT_HOST", sockAddr)
 	c.env.RunSingularity(
 		t,
-		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithProfile(e2e.OCIUserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs("--oci", outputImgPath, dockerfileSimple),
+		e2e.WithArgs(outputImgPath, dockerfileSimple),
 		e2e.ExpectExit(0, e2e.ExpectError(e2e.RegexMatch, "buildkitd already running.+will use that daemon")),
 	)
 
@@ -2055,7 +2055,7 @@ func (c imgBuildTests) buildDockerfile(t *testing.T) {
 	defer os.Chdir(prevWd)
 
 	imageNoPrefix := strings.TrimPrefix(c.env.TestRegistryImage, "docker://")
-	profiles := []e2e.Profile{e2e.UserProfile, e2e.RootProfile}
+	profiles := []e2e.Profile{e2e.OCIUserProfile, e2e.OCIRootProfile}
 	for _, profile := range profiles {
 		t.Run(profile.String(), func(t *testing.T) {
 			tmpdir, tmpdirCleanup := e2e.MakeTempDir(t, "", "build_dockerfile_e2e_", "dir")
@@ -2257,7 +2257,7 @@ func (c imgBuildTests) buildDockerfile(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
 					if tt.dockerfile != "" {
-						buildArgs := []string{"-F", "--oci"}
+						buildArgs := []string{"-F"}
 						buildArgs = append(buildArgs, tt.buildArgs...)
 						buildArgs = append(buildArgs, tt.imgPath, tt.dockerfile)
 						c.env.RunSingularity(
@@ -2270,7 +2270,7 @@ func (c imgBuildTests) buildDockerfile(t *testing.T) {
 						)
 					}
 					if tt.actCmd != "" {
-						actArgs := append([]string{"--oci", tt.imgPath}, tt.actArgs...)
+						actArgs := append([]string{tt.imgPath}, tt.actArgs...)
 						c.env.RunSingularity(
 							t,
 							e2e.AsSubtest("act"),

--- a/e2e/internal/e2e/profile.go
+++ b/e2e/internal/e2e/profile.go
@@ -136,7 +136,7 @@ var OCIProfiles = map[string]Profile{
 		defaultCwd:        "",
 		requirementsFn:    ociRequirements,
 		singularityOption: "--oci",
-		optionForCommands: []string{"shell", "exec", "run", "test", "instance start", "pull"},
+		optionForCommands: []string{"shell", "exec", "run", "test", "instance start", "pull", "build"},
 		oci:               true,
 	},
 	ociRootProfile: {
@@ -147,7 +147,7 @@ var OCIProfiles = map[string]Profile{
 		defaultCwd:        "",
 		requirementsFn:    ociRequirements,
 		singularityOption: "--oci",
-		optionForCommands: []string{"shell", "exec", "run", "test", "instance start", "pull"},
+		optionForCommands: []string{"shell", "exec", "run", "test", "instance start", "pull", "build"},
 		oci:               true,
 	},
 	ociFakerootProfile: {
@@ -158,7 +158,7 @@ var OCIProfiles = map[string]Profile{
 		defaultCwd:        "",
 		requirementsFn:    ociRequirements,
 		singularityOption: "--oci --fakeroot",
-		optionForCommands: []string{"shell", "exec", "run", "test", "instance start", "pull"},
+		optionForCommands: []string{"shell", "exec", "run", "test", "instance start", "pull", "build"},
 		oci:               true,
 	},
 }
@@ -275,6 +275,7 @@ func fakerootRequirements(t *testing.T) {
 // ociRequirements ensures requirements are satisfied to correctly execute
 // commands with the OCI runtime / profile.
 func ociRequirements(t *testing.T) {
+	require.Kernel(t, 4, 18) // FUSE in userns
 	require.UserNamespace(t)
 	require.Command(t, "runc")
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

We require FUSE in userns for OCI-mode and our singularity-buildkitd (which uses a fuse-overlayfs snapshotter on kernel <5.11). FUSE in userns is supported on kernel >=4.18.

Add the kernel requirement to the OCI profile.

Modify the buildkit / Dockerfile build tests to use the OCI profile instead of specifying the `--oci` flag directly.

### This fixes or addresses the following GitHub issues:

 - Fixes #2494 
 - Fixes #2493 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
