### PR TITLE
e2e: EL7 / SLES12 assorted fixes

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -774,7 +774,11 @@ func (c actionTests) PersistentOverlay(t *testing.T) {
 	}
 
 	// create the squashfs overlay image
-	cmd := exec.Command("mksquashfs", squashDir, squashfsImage, "-noappend", "-all-root")
+	mksquashfsCmd, err := bin.FindBin("mksquashfs")
+	if err != nil {
+		t.Fatalf("Unable to find 'mksquashfs' binary even though require.Command() was called: %v", err)
+	}
+	cmd := exec.Command(mksquashfsCmd, squashDir, squashfsImage, "-noappend", "-all-root")
 	if res := cmd.Run(t); res.Error != nil {
 		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}
@@ -1934,7 +1938,11 @@ func (c actionTests) bindImage(t *testing.T) {
 	}
 
 	// create the squashfs overlay image
-	cmd := exec.Command("mksquashfs", squashDir, squashfsImage, "-noappend", "-all-root")
+	mksquashfsCmd, err := bin.FindBin("mksquashfs")
+	if err != nil {
+		t.Fatalf("Unable to find 'mksquashfs' binary even though require.Command() was called: %v", err)
+	}
+	cmd := exec.Command(mksquashfsCmd, squashDir, squashfsImage, "-noappend", "-all-root")
 	if res := cmd.Run(t); res.Error != nil {
 		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1900,6 +1900,7 @@ func (c actionTests) fuseMount(t *testing.T) {
 	for _, tt := range basicTests {
 		c.env.RunSingularity(
 			t,
+			e2e.PreRun(tt.requirements),
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(tt.profile),
 			e2e.WithCommand("exec"),

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1766,10 +1766,11 @@ func (c actionTests) fuseMount(t *testing.T) {
 	}
 
 	basicTests := []struct {
-		name    string
-		spec    string
-		key     string
-		profile e2e.Profile
+		name         string
+		spec         string
+		key          string
+		profile      e2e.Profile
+		requirements func(t *testing.T)
 	}{
 		{
 			name:    "HostDaemonAsRoot",
@@ -1824,48 +1825,72 @@ func (c actionTests) fuseMount(t *testing.T) {
 			spec:    "host-daemon",
 			key:     userPrivKey,
 			profile: e2e.UserNamespaceProfile,
+			requirements: func(t *testing.T) {
+				require.Kernel(t, 4, 18)
+			},
 		},
 		{
 			name:    "HostAsUserNamespace",
 			spec:    "host",
 			key:     userPrivKey,
 			profile: e2e.UserNamespaceProfile,
+			requirements: func(t *testing.T) {
+				require.Kernel(t, 4, 18)
+			},
 		},
 		{
 			name:    "ContainerDaemonAsUserNamespace",
 			spec:    "container-daemon",
 			key:     userPrivKey,
 			profile: e2e.UserNamespaceProfile,
+			requirements: func(t *testing.T) {
+				require.Kernel(t, 4, 18)
+			},
 		},
 		{
 			name:    "ContainerAsUserNamespace",
 			spec:    "container",
 			key:     userPrivKey,
 			profile: e2e.UserNamespaceProfile,
+			requirements: func(t *testing.T) {
+				require.Kernel(t, 4, 18)
+			},
 		},
 		{
 			name:    "HostDaemonAsFakeroot",
 			spec:    "host-daemon",
 			key:     userPrivKey,
 			profile: e2e.FakerootProfile,
+			requirements: func(t *testing.T) {
+				require.Kernel(t, 4, 18)
+			},
 		},
 		{
 			name:    "HostAsFakeroot",
 			spec:    "host",
 			key:     userPrivKey,
 			profile: e2e.FakerootProfile,
+			requirements: func(t *testing.T) {
+				require.Kernel(t, 4, 18)
+			},
 		},
 		{
 			name:    "ContainerDaemonAsFakeroot",
 			spec:    "container-daemon",
 			key:     userPrivKey,
 			profile: e2e.FakerootProfile,
+			requirements: func(t *testing.T) {
+				require.Kernel(t, 4, 18)
+			},
 		},
 		{
 			name:    "ContainerAsFakeroot",
 			spec:    "container",
 			key:     userPrivKey,
 			profile: e2e.FakerootProfile,
+			requirements: func(t *testing.T) {
+				require.Kernel(t, 4, 18)
+			},
 		},
 	}
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1612,7 +1612,11 @@ func (c actionTests) actionOciBindImage(t *testing.T) {
 	}
 
 	// create the squashfs overlay image
-	cmd := testExec.Command("mksquashfs", squashDir, squashfsImage, "-noappend", "-all-root")
+	mksquashfsCmd, err := bin.FindBin("mksquashfs")
+	if err != nil {
+		t.Fatalf("Unable to find 'mksquashfs' binary even though require.Command() was called: %v", err)
+	}
+	cmd := testExec.Command(mksquashfsCmd, squashDir, squashfsImage, "-noappend", "-all-root")
 	if res := cmd.Run(t); res.Error != nil {
 		t.Fatalf("Unexpected error while running command.\n%s", res)
 	}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -91,7 +91,11 @@ func (c *configTests) prepImages(t *testing.T) (cleanup func(t *testing.T)) {
 	// A bare squashfs image
 	t.Run("PrepareSquashfs", func(t *testing.T) {
 		c.squashfsImage = filepath.Join(tmpDir, "squashfs.img")
-		cmd := exec.Command("mksquashfs", c.sandboxImage, c.squashfsImage)
+		mksquashfsCmd, err := bin.FindBin("mksquashfs")
+		if err != nil {
+			t.Fatalf("Unable to find 'mksquashfs' binary even though require.Command() was called: %v", err)
+		}
+		cmd := exec.Command(mksquashfsCmd, c.sandboxImage, c.squashfsImage)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			defer cleanup(t)
 			t.Fatalf("Error creating squashfs image: %v: %s", err, out)

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -33,9 +33,10 @@ func (c *ctx) verify(t *testing.T) {
 
 	ocspOk := false
 	t.Run("startOCSPResponder", func(t *testing.T) {
-		// Skip kernel < 3.11, which is a proxy for EL7 (3.10 kernel) where
-		// algorithms in OCSP chain are not all supported.
-		require.Kernel(t, 3, 11)
+		// Skip kernel < 4.18, which is a proxy for EL7 (3.10 kernel) and SLES12
+		// (4.15 kernel) where some algorithms in OCSP chain are not all
+		// supported.
+		require.Kernel(t, 4, 18)
 
 		if err := c.startOCSPResponder(priKeyPath, rootPath); err != nil {
 			t.Errorf("OCSP responder could not start: %s", err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

**e2e: change OCSPResponder gating for SLES12**
    
As well as EL7, SLES12 doesn't support some of the algorithms in the OCSP chain that is tested.

Adjust the kernel requirement, so that it exclude SLES12 as well as EL7.

Using a kernel requirement is an inexact / indirect method of checking for algorithm support, but is simple and works across our target supported distros.

**e2e: gate --fusemount tests with userns on kernel 4.18**

Avoids failures on SLES12 where there is no kernel support for FUSE mounts in conjunction with a userns.

**e2e: fix: use bin.FindBin for path to mksquashfs**

In recent work the require.Command test helper was modified to use `bin.Findbin` ahead of `exec.LookPath`.

Since `mksquashfs` has handling via `singularity.conf` in `bin.FindBin` we need to use this to invoke it to ensure parity with the `require.Command` result.


### This fixes or addresses the following GitHub issues:

Working towards #2473 & #2478 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
