### PR TITLE
fix: use kernel overlayfs as root, regardless of unpriv support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
 ### Bug Fixes
 
 - Execute correct `%appstart` script when using `instance start` with `--app`.
+- Use kernel overlayfs instead of `fuse-overlayfs` when running as root user,
+  regardless of unprivileged kernel overlay support.
 
 ## 4.0.2 \[2023-11-16\]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

When running as host root, we can use kernel overlayfs instead of fuse-overlayfs without kernel unprivileged overlay support.

This commit fixes the regression from 3.x -> 4.0 on systems without unprivileged kernel overlay support, which is caught by existing OCI e2e tests on these systems.

### This fixes or addresses the following GitHub issues:

 - Fixes #2512


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
