### PR TITLE
cgroups: rework checks for cgroup support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 - In native mode, bare extfs container images will now be mounted with
   fuse2fs when kernel mounts are disabled in `singularity.conf`, or cannot be
   used (non-setuid / user namespace workflow).
+- `--oci` mode containers and native mode instances can now be successfully
+  started as a non-root user on cgroups v2 systems when both:
+  - The system configuration / environment does not provide the correct
+    information necessary to communicate with systemd via dbus.
+  - Resource limits (e.g. `--cpus`) have not been requested.
+  
+  The container / instance will be started in the current cgroup, and information
+  about the configuration issue displayed to the user as warnings.
 
 ### New Features & Functionality
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -17,7 +17,7 @@ reserved.
 
 Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 
-Copyright (c) 2018-2023, Sylabs, Inc. All rights reserved.
+Copyright (c) 2018-2024, Sylabs, Inc. All rights reserved.
 
 Copyright (c) Contributors to the Apptainer project, established as Apptainer a
 Series of LF Projects LLC.

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -404,6 +404,155 @@ func (c *ctx) actionApplyRootless(t *testing.T) {
 	}
 }
 
+// On cgroups v2 systems, can run rootless without resource limits with bad
+// XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS. Cannot run with resource limits
+// and bad env vars.
+func (c *ctx) actionDbusXDG(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+	require.CgroupsV2Unified(t)
+
+	tests := []struct {
+		name            string
+		args            []string
+		expectErrorCode int
+		expectErrorOut  string
+		xdgVar          string
+		dbusVar         string
+	}{
+		{
+			name:            "bad xdg no limits",
+			args:            []string{c.env.ImagePath, "/bin/true"},
+			expectErrorCode: 0,
+			xdgVar:          "/not/a/dir",
+		},
+		{
+			name:            "bad dbus no limits",
+			args:            []string{c.env.ImagePath, "/bin/true"},
+			expectErrorCode: 0,
+			dbusVar:         "/not/a/dbus/socket",
+		},
+		{
+			name:            "bad xdg limits",
+			args:            []string{"--cpus", "1", c.env.ImagePath, "/bin/true"},
+			expectErrorCode: 255,
+			expectErrorOut:  "XDG_RUNTIME_DIR",
+			xdgVar:          "/not/a/dir",
+		},
+		{
+			name:            "bad dbus limits",
+			args:            []string{"--cpus", "1", c.env.ImagePath, "/bin/true"},
+			expectErrorCode: 255,
+			expectErrorOut:  "DBUS_SESSION_BUS_ADDRESS",
+			dbusVar:         "/not/a/dbus/socket",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, profile := range []e2e.Profile{e2e.UserProfile, e2e.OCIUserProfile} {
+				exitFunc := []e2e.SingularityCmdResultOp{}
+				if tt.expectErrorOut != "" {
+					exitFunc = []e2e.SingularityCmdResultOp{e2e.ExpectError(e2e.ContainMatch, tt.expectErrorOut)}
+				}
+				testEnv := []string{}
+				if tt.xdgVar != "" {
+					testEnv = append(testEnv, "XDG_RUNTIME_DIR="+tt.xdgVar)
+				}
+				if tt.dbusVar != "" {
+					testEnv = append(testEnv, "DBUS_SESSION_BUS_ADDRESS="+tt.dbusVar)
+				}
+				c.env.RunSingularity(
+					t,
+					e2e.AsSubtest(profile.String()),
+					e2e.WithProfile(profile),
+					e2e.WithCommand("exec"),
+					e2e.WithArgs(tt.args...),
+					e2e.WithEnv(testEnv),
+					e2e.ExpectExit(tt.expectErrorCode, exitFunc...),
+				)
+			}
+		})
+	}
+}
+
+// On cgroups v2 systems, can run rootless without resource limits with bad
+// XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS. Cannot run with resource limits
+// and bad env vars.
+func (c *ctx) instanceDbusXdg(t *testing.T) {
+	require.CgroupsV2Unified(t)
+	e2e.EnsureImage(t, c.env)
+
+	// All tests require root
+	tests := []struct {
+		name            string
+		args            []string
+		expectErrorCode int
+		xdgVar          string
+		dbusVar         string
+	}{
+		{
+			name:            "bad xdg no limits",
+			args:            []string{c.env.ImagePath},
+			expectErrorCode: 0,
+			xdgVar:          "/not/a/dir",
+		},
+		{
+			name:            "bad dbus no limits",
+			args:            []string{c.env.ImagePath},
+			expectErrorCode: 0,
+			dbusVar:         "/not/a/dbus/socket",
+		},
+		{
+			name:            "bad xdg limits",
+			args:            []string{"--cpus", "1", c.env.ImagePath},
+			expectErrorCode: 255,
+			xdgVar:          "/not/a/dir",
+		},
+		{
+			name:            "bad dbus limits",
+			args:            []string{"--cpus", "1", c.env.ImagePath},
+			expectErrorCode: 255,
+			dbusVar:         "/not/a/dbus/socket",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instanceName := randomName(t)
+
+			testEnv := []string{}
+			if tt.xdgVar != "" {
+				testEnv = append(testEnv, "XDG_RUNTIME_DIR="+tt.xdgVar)
+			}
+			if tt.dbusVar != "" {
+				testEnv = append(testEnv, "DBUS_SESSION_BUS_ADDRESS="+tt.dbusVar)
+			}
+
+			createArgs := append(tt.args, instanceName)
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest("start"),
+				e2e.WithProfile(e2e.UserProfile),
+				e2e.WithCommand("instance start"),
+				e2e.WithArgs(createArgs...),
+				e2e.WithEnv(testEnv),
+				e2e.ExpectExit(tt.expectErrorCode),
+			)
+
+			if tt.expectErrorCode == 0 {
+				c.env.RunSingularity(
+					t,
+					e2e.AsSubtest("stop"),
+					e2e.WithProfile(e2e.UserProfile),
+					e2e.WithCommand("instance stop"),
+					e2e.WithArgs(instanceName),
+					e2e.ExpectExit(0),
+				)
+			}
+		})
+	}
+}
+
 type resourceFlagTest struct {
 	name            string
 	args            []string
@@ -795,5 +944,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"action rootless cgroups":         np(env.WithRootlessManagers(c.actionApplyRootless)),
 		"action flags root cgroups":       np(env.WithRootManagers(c.actionFlagsRoot)),
 		"action flags rootless cgroups":   np(env.WithRootlessManagers(c.actionFlagsRootless)),
+		"action dbus xdg":                 np(c.actionDbusXDG),
+		"instance dbus xdg":               np(c.instanceDbusXdg),
 	}
 }

--- a/internal/pkg/cgroups/util.go
+++ b/internal/pkg/cgroups/util.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,8 +10,13 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	lccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/rootless"
+	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 const unifiedMountPoint = "/sys/fs/cgroup"
@@ -70,4 +75,101 @@ func DefaultPathForPid(systemd bool, pid int) (group string) {
 		group = filepath.Join("/singularity", strPid)
 	}
 	return group
+}
+
+// HasDbus checks if DBUS_SESSION_BUS_ADDRESS is set, and sane.
+// Logs unset var / non-existent target at DEBUG level.
+func HasDbus() (bool, error) {
+	dbusEnv := os.Getenv("DBUS_SESSION_BUS_ADDRESS")
+	if dbusEnv == "" {
+		return false, fmt.Errorf("DBUS_SESSION_BUS_ADDRESS is not set")
+	}
+
+	if !strings.HasPrefix(dbusEnv, "unix:") {
+		return false, fmt.Errorf("DBUS_SESSION_BUS_ADDRESS %q is not a 'unix:' socket", dbusEnv)
+	}
+
+	return true, nil
+}
+
+// HasXDGRuntimeDir checks if XDG_Runtime_Dir is set, and sane.
+// Logs unset var / non-existent target at DEBUG level.
+func HasXDGRuntimeDir() (bool, error) {
+	xdgRuntimeEnv := os.Getenv("XDG_RUNTIME_DIR")
+	if xdgRuntimeEnv == "" {
+		return false, fmt.Errorf("XDG_RUNTIME_DIR is not set")
+	}
+
+	fi, err := os.Stat(xdgRuntimeEnv)
+	if err != nil {
+		return false, fmt.Errorf("XDG_RUNTIME_DIR %q not accessible: %v", xdgRuntimeEnv, err)
+	}
+
+	if !fi.IsDir() {
+		return false, fmt.Errorf("XDG_RUNTIME_DIR %q is not a directory", xdgRuntimeEnv)
+	}
+
+	if err := unix.Access(xdgRuntimeEnv, unix.W_OK); err != nil {
+		return false, fmt.Errorf("XDG_RUNTIME_DIR %q is not writable", xdgRuntimeEnv)
+	}
+
+	return true, nil
+}
+
+// CanUseCgroups checks whether it's possible to use the cgroups manager.
+// - Host root can always use cgroups.
+// - Rootless needs cgroups v2.
+// - Rootless needs systemd manager.
+// - Rootless needs DBUS_SESSION_BUS_ADDRESS and XDG_RUNTIME_DIR set properly.
+// warn controls whether configuration problems preventing use of cgroups will be logged as warnings, or debug messages.
+func CanUseCgroups(systemd bool, warn bool) bool {
+	uid, err := rootless.Getuid()
+	if err != nil {
+		sylog.Errorf("cannot determine uid: %v", err)
+		return false
+	}
+
+	if uid == 0 {
+		return true
+	}
+
+	rootlessOK := true
+
+	if !cgroups.IsCgroup2UnifiedMode() {
+		rootlessOK = false
+		if warn {
+			sylog.Warningf("Rootless cgroups require the system to be configured for cgroups v2 in unified mode.")
+		} else {
+			sylog.Debugf("Rootless cgroups require 'systemd cgroups' to be enabled in singularity.conf")
+		}
+	}
+
+	if !systemd {
+		rootlessOK = false
+		if warn {
+			sylog.Warningf("Rootless cgroups require 'systemd cgroups' to be enabled in singularity.conf")
+		} else {
+			sylog.Debugf("Rootless cgroups require 'systemd cgroups' to be enabled in singularity.conf")
+		}
+	}
+
+	if ok, err := HasXDGRuntimeDir(); !ok {
+		rootlessOK = false
+		if warn {
+			sylog.Warningf("%s", err)
+		} else {
+			sylog.Debugf("%s", err)
+		}
+	}
+
+	if ok, err := HasDbus(); !ok {
+		rootlessOK = false
+		if warn {
+			sylog.Warningf("%s", err)
+		} else {
+			sylog.Debugf("%s", err)
+		}
+	}
+
+	return rootlessOK
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Rework the location of checks for cgroup management support, and add fall-back logic, so that when all of the following apply:

* A system is using cgroups v2
* Singularity is configured to use systemd for cgroups management
* The system configuration / environment doesn't set usable XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS env vars
* The user has not explicitly requested resource limits (e.g --cpus)

... It is still possible to:

* Start an instance as non-root (without the cgroup needed for instance stats)
* run / shell / exec a container as non-root in OCI-Mode

Fixes #2529
Fixes #2568

### This fixes or addresses the following GitHub issues:

 - Fixes #2529 
 - Fixes #2568 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
