### PR TITLE
engine: cleanup host directly on StageOne failure (release-4.1)

### DIFF
--- a/internal/app/starter/stage_linux.go
+++ b/internal/app/starter/stage_linux.go
@@ -6,6 +6,7 @@
 package starter
 
 import (
+	"context"
 	"net"
 	"os"
 
@@ -25,10 +26,16 @@ func StageOne(sconfig *starterConfig.Config, e *engine.Engine) {
 	sylog.Debugf("Entering stage 1\n")
 
 	if err := e.PrepareConfig(sconfig); err != nil {
+		if cleanErr := e.CleanupHost(context.TODO()); cleanErr != nil {
+			sylog.Errorf("While running host cleanup tasks: %s", cleanErr)
+		}
 		sylog.Fatalf("%s\n", err)
 	}
 
 	if err := sconfig.Write(e.Common); err != nil {
+		if cleanErr := e.CleanupHost(context.TODO()); cleanErr != nil {
+			sylog.Errorf("While running host cleanup tasks: %s", cleanErr)
+		}
 		sylog.Fatalf("%s", err)
 	}
 

--- a/internal/pkg/runtime/engine/engine_linux.go
+++ b/internal/pkg/runtime/engine/engine_linux.go
@@ -88,20 +88,24 @@ type Operations interface {
 	// a hybrid workflow (e.g. fakeroot), then there is no privileged saved uid
 	// and thus no additional privileges can be gained.
 	CleanupContainer(context.Context, error, syscall.WaitStatus) error
-	// PostStartHost is called after the container process has been executed. It is
-	// run in the process forked from starter before namespace setup etc. and
-	// will perform any cleanup in the host mount namespace at time of CLI
-	// execution.
+	// PostStartHost is called after the container process has been executed. It
+	// is run in the POST_START_HOST process forked from starter before
+	// namespace setup etc. and will perform any cleanup in the host mount
+	// namespace at time of CLI execution.
 	//
-	// No additional privileges can be gained during this call, as privileges
-	// are dropped permanently after forking in starter.
+	// No additional privileges can be gained during this call in the setuid
+	// flow as privileges are dropped permanently after forking in starter.
 	PostStartHost(context.Context) error
-	// CleanupHost is called after CleanupContainer, before master exits.
-	// It is run in the process forked from starter before namespace setup etc. and
-	// will perform any cleanup in the host mount namespace at time of CLI execution.
+	// CleanupHost is called on container exit or startup failure to perform any
+	// required cleanup in the host mount namespace at time of CLI execution.
 	//
-	// No additional privileges can be gained during this call, as privileges are
-	// dropped permanently after forking in starter.
+	// If container creation fails early, in STAGE 1, it will be called directly
+	// from STAGE 1. Otherwise it is run in the CLEANUP_HOST PROCESS, triggered
+	// by master, or the SIGKILL parent death signal.
+	//
+	// No additional privileges can be gained during this call in the setuid
+	// flow, as privileges are dropped permanently in both STAGE1 and
+	// CLEANUP_HOST after forking in starter.
 	CleanupHost(context.Context) error
 }
 

--- a/internal/pkg/runtime/engine/singularity/host_linux.go
+++ b/internal/pkg/runtime/engine/singularity/host_linux.go
@@ -26,8 +26,9 @@ func (e *EngineOperations) PostStartHost(ctx context.Context) (err error) {
 }
 
 // CleanupHost cleans up a SIF FUSE image mount and the temporary directory that
-// holds it, if it exists after container exit. It is called from a HOST_CLEANUP process that exists
-// in the original host namespaces.
+// holds it. If container creation fails early, in STAGE 1, it will be called
+// directly from STAGE 1. Otherwise, it will be called from a CLEANUP_HOST
+// process, when the container cleanly exits, or is killed.
 func (e *EngineOperations) CleanupHost(ctx context.Context) (err error) {
 	tmpDir := e.EngineConfig.GetDeleteTempDir()
 	if e.EngineConfig.GetImageFuse() && tmpDir != "" {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2573

If container creation fails early, while preparing configuration in `StageOne`, our `CLEANUP_HOST` process forked from starter may not have started yet, and won't be trapping `SIGTERM`... in which case any required host cleanup of FUSE mounts etc. will not happen.

Call the host cleanup directly from `StageOne`, on error, to avoid this issue.

While we are in this code...

* Change `SIGHUP` -> `SIGUSR1` for our own signal in the CleanupHost code, so it's obviously our own signal and not from the system.
* Add a return to the go routine receiving `SIGUSR1` to avoid a spurious log message.
* Clarify some comments that discuss the flow of execution

Fixes #2520

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
