### PR TITLE
fix: workaround for crun 1.11+ segv with no Linux.Resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Workaround segfault in `crun` v1.11+ when no resource limits are specified.
+  <https://github.com/containers/crun/issues/1402>
+
 ## 4.1.0 \[2024-01-25\]
 
 ### Changed defaults / behaviours

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -26,6 +26,9 @@ var defaultNamespaces = []specs.LinuxNamespace{
 	},
 }
 
+// defaultResources - an empty set, no resource limits
+var defaultResources = specs.LinuxResources{}
+
 // minimalSpec returns an OCI runtime spec with a minimal OCI configuration that
 // is a starting point for compatibility with Singularity's native launcher in
 // `--compat` mode.
@@ -52,7 +55,12 @@ func minimalSpec() specs.Spec {
 	// All mounts are added by the launcher, as it must handle flags.
 	config.Mounts = []specs.Mount{}
 
-	config.Linux = &specs.Linux{Namespaces: defaultNamespaces}
+	config.Linux = &specs.Linux{
+		Namespaces: defaultNamespaces,
+		// Ensure this is not nil to work around crun bug.
+		// https://github.com/containers/crun/issues/1402
+		Resources: &defaultResources,
+	}
 	return config
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

See: https://github.com/containers/crun/issues/1402

When there is no `Linux.Resources` in `config.json`, `crun` v1.11 and above segfault.

To work around this, ensure that `Linux.Resources` is present but empty when no resource limits have been requested.

### This fixes or addresses the following GitHub issues:

 - Fixes #2596


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
