### PR TITLE
fix: oci: always use rootless uid for inner uid map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Set OCI runtime-spec annotations that are required by the documented
   image-spec conversion process.
+- In `--oci` mode always set inner ID map based on host user, not `USER` in OCI
+  container. Fixes incorrect permissions for files owned by `USER` in the
+  container.
 
 ## 4.1.1 \[2024-02-01\]
 

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -1348,6 +1348,37 @@ func (c ctx) testDockerUSERWorker(t *testing.T, container string) {
 			},
 			expectExit: 0,
 		},
+		// `--oci` modes: check correct ownership of the USER home
+		{
+			name:    "HomeOwnershipOCIUser",
+			cmd:     "exec",
+			profile: e2e.OCIUserProfile,
+			args:    []string{container, "stat", "-c", "%U(%u):%G(%g)", "/home/testuser"},
+			expectOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ExactMatch, "testuser(2000):testgroup(2000)"),
+			},
+			expectExit: 0,
+		},
+		{
+			name:    "HomeOwnershipOCIFakeroot",
+			cmd:     "exec",
+			profile: e2e.OCIFakerootProfile,
+			args:    []string{container, "stat", "-c", "%U(%u):%G(%g)", "/home/testuser"},
+			expectOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ExactMatch, "testuser(2000):testgroup(2000)"),
+			},
+			expectExit: 0,
+		},
+		{
+			name:    "HomeOwnershipOCIRoot",
+			cmd:     "exec",
+			profile: e2e.OCIRootProfile,
+			args:    []string{container, "stat", "-c", "%U(%u):%G(%g)", "/home/testuser"},
+			expectOutputs: []e2e.SingularityCmdResultOp{
+				e2e.ExpectOutput(e2e.ExactMatch, "testuser(2000):testgroup(2000)"),
+			},
+			expectExit: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -320,7 +320,7 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 	containerUser := false
 
 	// If the OCI image config specifies a USER we will:
-	//  * When unprivileged - run as that user, via nested subuid/gid mappings (host user -> userns root -> OCI USER)
+	//  * When unprivileged - run as that user, via nested subuid/gid mappings.
 	//  * When privileged - directly run as that user, as a host uid/gid.
 	if imgSpec.Config.User != "" {
 		imgUser, err := tools.BundleUser(b.Path(), imgSpec.Config.User)
@@ -348,7 +348,7 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 	}
 
 	if targetUID != 0 && currentUID != 0 {
-		uidMap, gidMap, err := getReverseUserMaps(currentUID, targetUID, targetGID)
+		uidMap, gidMap, err := getReverseUserMaps(currentUID, uint32(rootlessUID), uint32(rootlessGID))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In OCI mode, as an unprivileged user, we have an outer UID/GID mapping from the host UID/GID to 0:0 and an inner UID/GID mapping back to the host UID/GID.

The code was erroneously using the targetUID/GID for the container process rather than the host UID/GID for the inner mapping. This meant that when a container specifying an Dockerfile `USER` was run the mapping and file owneship in the container was incorrect.

Fix the mapping and add e2e-tests that verify correct file ownership for a container with a `USER`.

### This fixes or addresses the following GitHub issues:

 - Fixes #2623


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
