### PR TITLE
fix: oci: set MUST image-spec -> runtime spec annotations (4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Set OCI runtime-spec annotations that are required by the documented
+  image-spec conversion process.
+
 ## 4.1.1 \[2024-02-01\]
 
 ### Security Related Fixes

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -403,6 +403,10 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 
 	l.handleVarTmpToTmpSymlink(spec)
 
+	if err := addAnnotations(spec, imgSpec); err != nil {
+		return err
+	}
+
 	return b.Update(ctx, spec)
 }
 

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -8,54 +8,56 @@ package oci
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
+	"time"
 
-	"github.com/opencontainers/runtime-spec/specs-go"
-
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/launcher"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/rootless"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
 // defaultNamespaces matching native runtime with --compat / --containall, except PID which can be disabled.
-var defaultNamespaces = []specs.LinuxNamespace{
+var defaultNamespaces = []runtimespec.LinuxNamespace{
 	{
-		Type: specs.IPCNamespace,
+		Type: runtimespec.IPCNamespace,
 	},
 	{
-		Type: specs.MountNamespace,
+		Type: runtimespec.MountNamespace,
 	},
 }
 
 // defaultResources - an empty set, no resource limits
-var defaultResources = specs.LinuxResources{}
+var defaultResources = runtimespec.LinuxResources{}
 
 // minimalSpec returns an OCI runtime spec with a minimal OCI configuration that
 // is a starting point for compatibility with Singularity's native launcher in
 // `--compat` mode.
-func minimalSpec() specs.Spec {
-	config := specs.Spec{
-		Version: specs.Version,
+func minimalSpec() runtimespec.Spec {
+	config := runtimespec.Spec{
+		Version: runtimespec.Version,
 	}
-	config.Root = &specs.Root{
+	config.Root = &runtimespec.Root{
 		Path:     "rootfs",
 		Readonly: false,
 	}
-	config.Process = &specs.Process{
+	config.Process = &runtimespec.Process{
 		Terminal: true,
 		// Default fallback to a shell at / - will generally be overwritten by
 		// the launcher.
 		Args: []string{"sh"},
 		Cwd:  "/",
 	}
-	config.Process.User = specs.User{}
+	config.Process.User = runtimespec.User{}
 	config.Process.Env = []string{
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	}
 
 	// All mounts are added by the launcher, as it must handle flags.
-	config.Mounts = []specs.Mount{}
+	config.Mounts = []runtimespec.Mount{}
 
-	config.Linux = &specs.Linux{
+	config.Linux = &runtimespec.Linux{
 		Namespaces: defaultNamespaces,
 		// Ensure this is not nil to work around crun bug.
 		// https://github.com/containers/crun/issues/1402
@@ -66,7 +68,7 @@ func minimalSpec() specs.Spec {
 
 // addNamespaces adds requested namespace, if appropriate, to an existing spec.
 // It is assumed that spec contains at least the defaultNamespaces.
-func addNamespaces(spec *specs.Spec, ns launcher.Namespaces) error {
+func addNamespaces(spec *runtimespec.Spec, ns launcher.Namespaces) error {
 	if ns.IPC {
 		sylog.Infof("--oci runtime always uses an IPC namespace, ipc flag is redundant.")
 	}
@@ -76,7 +78,7 @@ func addNamespaces(spec *specs.Spec, ns launcher.Namespaces) error {
 	if ns.Net {
 		spec.Linux.Namespaces = append(
 			spec.Linux.Namespaces,
-			specs.LinuxNamespace{Type: specs.NetworkNamespace},
+			runtimespec.LinuxNamespace{Type: runtimespec.NetworkNamespace},
 		)
 	}
 
@@ -87,7 +89,7 @@ func addNamespaces(spec *specs.Spec, ns launcher.Namespaces) error {
 	if !ns.NoPID {
 		spec.Linux.Namespaces = append(
 			spec.Linux.Namespaces,
-			specs.LinuxNamespace{Type: specs.PIDNamespace},
+			runtimespec.LinuxNamespace{Type: runtimespec.PIDNamespace},
 		)
 	}
 
@@ -100,7 +102,7 @@ func addNamespaces(spec *specs.Spec, ns launcher.Namespaces) error {
 		if uid == 0 {
 			spec.Linux.Namespaces = append(
 				spec.Linux.Namespaces,
-				specs.LinuxNamespace{Type: specs.UserNamespace},
+				runtimespec.LinuxNamespace{Type: runtimespec.UserNamespace},
 			)
 		} else {
 			sylog.Infof("The --oci runtime always creates a user namespace when run as non-root, --userns / -u flag is redundant.")
@@ -110,8 +112,55 @@ func addNamespaces(spec *specs.Spec, ns launcher.Namespaces) error {
 	if ns.UTS {
 		spec.Linux.Namespaces = append(
 			spec.Linux.Namespaces,
-			specs.LinuxNamespace{Type: specs.UTSNamespace},
+			runtimespec.LinuxNamespace{Type: runtimespec.UTSNamespace},
 		)
+	}
+
+	return nil
+}
+
+// addAnnotations adds the required annotations to the runtime-spec, based on an image-spec.
+// See https://github.com/opencontainers/image-spec/blob/main/conversion.md
+func addAnnotations(rSpec *runtimespec.Spec, iSpec *imgspecv1.Image) error {
+	if rSpec == nil {
+		return fmt.Errorf("runtime spec is required")
+	}
+	if iSpec == nil {
+		return nil
+	}
+
+	if rSpec.Annotations == nil {
+		rSpec.Annotations = map[string]string{}
+	}
+
+	if iSpec.OS != "" {
+		rSpec.Annotations["org.opencontainers.image.os"] = iSpec.OS
+	}
+	if iSpec.Architecture != "" {
+		rSpec.Annotations["org.opencontainers.image.architecture"] = iSpec.Architecture
+	}
+	if iSpec.Variant != "" {
+		rSpec.Annotations["org.opencontainers.image.variant"] = iSpec.Variant
+	}
+	if iSpec.OSVersion != "" {
+		rSpec.Annotations["org.opencontainers.image.os.version"] = iSpec.OSVersion
+	}
+	if iSpec.OSFeatures != nil {
+		rSpec.Annotations["org.opencontainers.image.os.features"] = strings.Join(iSpec.OSFeatures, ",")
+	}
+	if iSpec.Author != "" {
+		rSpec.Annotations["org.opencontainers.image.author"] = iSpec.Author
+	}
+	if iSpec.Created != nil {
+		rSpec.Annotations["org.opencontainers.image.created"] = iSpec.Created.Format(time.RFC3339)
+	}
+	if iSpec.Config.StopSignal != "" {
+		rSpec.Annotations["org.opencontainers.image.stopSignal"] = iSpec.Config.StopSignal
+	}
+
+	// Note: Explicit Config.Labels take precedence over the above.
+	for k, v := range iSpec.Config.Labels {
+		rSpec.Annotations[k] = v
 	}
 
 	return nil
@@ -119,7 +168,7 @@ func addNamespaces(spec *specs.Spec, ns launcher.Namespaces) error {
 
 // noSetgroupsAnnotation will set the `run.oci.keep_original_groups=1` annotation
 // to disable the setgroups call when entering the container. Supported by crun, but not runc.
-func noSetgroupsAnnotation(spec *specs.Spec) error {
+func noSetgroupsAnnotation(rSpec *runtimespec.Spec) error {
 	runtime, err := Runtime()
 	if err != nil {
 		return err
@@ -128,9 +177,9 @@ func noSetgroupsAnnotation(spec *specs.Spec) error {
 		return fmt.Errorf("runtime '%q' does not support --no-setgroups", runtime)
 	}
 
-	if spec.Annotations == nil {
-		spec.Annotations = map[string]string{}
+	if rSpec.Annotations == nil {
+		rSpec.Annotations = map[string]string{}
 	}
-	spec.Annotations["run.oci.keep_original_groups"] = "1"
+	rSpec.Annotations["run.oci.keep_original_groups"] = "1"
 	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2669

The image-spec conversion document specifies which annotations MUST be set when converting an image-spec into a runtime-spec. Adhere to these.

### This fixes or addresses the following GitHub issues:

 - Fixes #2664 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
