### PR TITLE
oci: warning / info for unsupported image-spec features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - In `--oci` mode always set inner ID map based on host user, not `USER` in OCI
   container. Fixes incorrect permissions for files owned by `USER` in the
   container.
+- Provide warning / info message for OCI image-spec features (volumes, exposed
+  ports) that are not supported by singularity.
 
 ## 4.1.1 \[2024-02-01\]
 

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -302,6 +302,14 @@ func (l *Launcher) finalizeSpec(ctx context.Context, b ocibundle.Bundle, spec *s
 		return fmt.Errorf("bundle has no image spec")
 	}
 
+	if len(imgSpec.Config.Volumes) != 0 {
+		sylog.Warningf("Container specifies volume mounts, which are not supported by singularity. It may not operate as expected.")
+	}
+	if len(imgSpec.Config.ExposedPorts) != 0 && !l.cfg.Namespaces.Net {
+		sylog.Infof("Container specifies exposed ports.")
+		sylog.Infof("Unless started with --net, singularity uses the host network namespace and all ports are exposed subject to host firewall rules.")
+	}
+
 	// In the absence of a USER in the OCI image config, we will run the
 	// container process as our own user / group, i.e. the uid / gid outside of
 	// any initial id-mapped user namespace.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Provide warning / info message for OCI image-spec features (volumes, exposed ports) that are not supported by singularity.

### This fixes or addresses the following GitHub issues:

 - Fixes #2665


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
