### PR TITLE
fix: don't flatten layers with ggcr before extracting (4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   SIF/SquashFS in user namepace mode. The image will be extracted to a temporary
   sandbox, which is writable at runtime. Note that any changes are not made to
   the original image.
+- Fix `target: no such file or directory` error in native mode when extracting
+  layers from certain OCI images that manipulate hard links across layers.
 
 ## 4.1.1 \[2024-02-01\]
 

--- a/internal/pkg/ociimage/unpack.go
+++ b/internal/pkg/ociimage/unpack.go
@@ -13,7 +13,6 @@ import (
 
 	apexlog "github.com/apex/log"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	umocilayer "github.com/opencontainers/umoci/oci/layer"
 	"github.com/opencontainers/umoci/pkg/idtools"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
@@ -21,13 +20,9 @@ import (
 )
 
 // isExtractable checks if we have extractable layers in the image. Shouldn't be
-// an ORAS artifact or similar. If we don't check, ggcr mutate.Extract will
-// happily create an empty rootfs, leading to odd error messages elsewhere.
-func isExtractable(img v1.Image) (bool, error) {
-	layers, err := img.Layers()
-	if err != nil {
-		return false, err
-	}
+// an ORAS artifact or similar. Avoids creating an empty rootfs from 0 layers,
+// leading to odd error messages elsewhere.
+func isExtractable(layers []v1.Layer) (bool, error) {
 	for _, l := range layers {
 		mt, err := l.MediaType()
 		if err != nil {
@@ -42,15 +37,17 @@ func isExtractable(img v1.Image) (bool, error) {
 
 // UnpackRootfs extracts all of the layers of the given srcImage into destDir.
 func UnpackRootfs(_ context.Context, srcImage v1.Image, destDir string) (err error) {
-	extractable, err := isExtractable(srcImage)
+	layers, err := srcImage.Layers()
+	if err != nil {
+		return fmt.Errorf("while getting layers from image: %w", err)
+	}
+	extractable, err := isExtractable(layers)
 	if err != nil {
 		return err
 	}
 	if !extractable {
 		return fmt.Errorf("no extractable OCI/Docker tar layers found in this image")
 	}
-
-	flatTar := mutate.Extract(srcImage)
 
 	var mapOptions umocilayer.MapOptions
 
@@ -88,15 +85,40 @@ func UnpackRootfs(_ context.Context, srcImage v1.Image, destDir string) (err err
 		mapOptions.GIDMappings = append(mapOptions.GIDMappings, gidMap)
 	}
 
-	// Unpack root filesystem
-	unpackOptions := umocilayer.UnpackOptions{MapOptions: mapOptions}
-	err = umocilayer.UnpackLayer(destDir, flatTar, &unpackOptions)
-	if err != nil {
-		return fmt.Errorf("error unpacking rootfs: %s", err)
+	for _, l := range layers {
+		if err := extractLayer(l, mapOptions, destDir); err != nil {
+			return err
+		}
 	}
+	return nil
+}
 
-	// No `--fix-perms` and no sandbox... we are fine
-	return err
+func extractLayer(l v1.Layer, mapOptions umocilayer.MapOptions, destDir string) error {
+	layerDigest, err := l.Digest()
+	if err != nil {
+		return fmt.Errorf("while getting digest: %w", err)
+	}
+	sylog.Debugf("Extracting layer %s", layerDigest)
+	layerReader, err := l.Uncompressed()
+	if err != nil {
+		return fmt.Errorf("while reading layer: %s: %w", layerDigest, err)
+	}
+	defer func() {
+		if closeErr := layerReader.Close(); closeErr != nil {
+			if err == nil {
+				err = fmt.Errorf("while closing layer %s: %w", layerDigest, err)
+			} else {
+				sylog.Errorf("while closing layer %s: %v", layerDigest, err)
+			}
+		}
+	}()
+
+	unpackOptions := umocilayer.UnpackOptions{MapOptions: mapOptions}
+	err = umocilayer.UnpackLayer(destDir, layerReader, &unpackOptions)
+	if err != nil {
+		return fmt.Errorf("while unpacking layer %s: %w", layerDigest, err)
+	}
+	return nil
 }
 
 // FixPerms will work through the rootfs of this bundle, making sure that all


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2685

The ggcr module has a bug in its `mutate.Extract` function, due to optimisations that do not correctly track hard links that are manipulated in specific ways across layers:

https://github.com/google/go-containerregistry/issues/977

Prior to this PR, we were using `mutate.Extract` to flatten an image so that we were only extracting a single tar into a rootfs with umoci. This meant that the bug above could cause umoci to fail, as the flattened tar is invalid in certain circumstances.

Fix the issue by avoiding `mutate.Extract`. Instead extract each layer, in order, using umoci.


### This fixes or addresses the following GitHub issues:

 - Fixes #2684 (native mode)


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
