### PR TITLE
fix: honor --writable for userns temp sandbox (4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   ports) that are not supported by singularity.
 - Honor `WORKDIR` by default for OCI images in `--oci` mode, as required by OCI
   image-spec.
+- Restore previous `--writable` behaviour when running a container image from
+  SIF/SquashFS in user namepace mode. The image will be extracted to a temporary
+  sandbox, which is writable at runtime. Note that any changes are not made to
+  the original image.
 
 ## 4.1.1 \[2024-02-01\]
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2874,6 +2874,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5631":                   c.issue5631,                      // https://github.com/sylabs/singularity/issues/5631
 		"issue 5690":                   c.issue5690,                      // https://github.com/sylabs/singularity/issues/5690
 		"issue 1950":                   c.issue1950,                      // https://github.com/sylabs/singularity/issues/1950
+		"issue 2690":                   c.issue2690,                      // https://github.com/sylabs/singularity/issues/2690
 		"network":                      c.actionNetwork,                  // test basic networking
 		"binds":                        c.actionBinds,                    // test various binds with --bind and --mount
 		"exit and signals":             c.exitSignals,                    // test exit and signals propagation

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -838,3 +838,24 @@ func (c actionTests) issue1950(t *testing.T) {
 		)
 	}
 }
+
+// Historically, when running an image file in userns mode, singularity creates
+// a temporary sandbox, and --writable can apply to this temporary sandbox.
+// Ensure that from 4.1, where FUSE mount is the default, we fall back to a
+// temporary sandbox to preserve this behavior.
+//
+// We may wish to change this in future as it's somewhat confusing because the
+// image the user specifies is *not* written to. However, that'd be a behavior
+// change that would need to be at a major release.
+// See: https://github.com/sylabs/singularity/issues/2690
+func (c actionTests) issue2690(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserNamespaceProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--writable", c.env.ImagePath, "touch", "/foo"),
+		e2e.ExpectExit(0),
+	)
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2691

Restore the long standing previous behaviour of singularity's native runtime, where `--writable` can be used when running a SIF / SquashFS container image in userns (`-u`) mode.

In this situation:

 - The image is extracted to a temporary sandbox.
 - The resulting container run from the sandbox is writable.

This behaviour has always been a bit confusing / inconsistent, because no writes happen to the actual image that the user specified. Only the temporary sandbox, which is deleted when the container exits, is written to. The PR adds awarning to this effect.

We may want to revisit this behaviour at a future major version, because it is inconsistent with other flows. However, this PR is needed because not honoring `--writable` in this manner was a behaviour change regression within a major version.

PR also adds additional comments around `launcher.prepareImage` to try and clarify what's expected.

### This fixes or addresses the following GitHub issues:

 - Fixes #2690


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
