### PR TITLE
e2e: gate TestEncrypt/empty_file on kernel 4.18 (4.1)

### DIFF
--- a/internal/pkg/util/crypt/crypt_dev_test.go
+++ b/internal/pkg/util/crypt/crypt_dev_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
+	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/require"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
@@ -68,11 +69,12 @@ func TestEncrypt(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		path        string
-		key         []byte
-		skipCleanup bool
-		shallPass   bool
+		name         string
+		path         string
+		key          []byte
+		skipCleanup  bool
+		shallPass    bool
+		requirements func(t *testing.T)
 	}{
 		{
 			name:      "empty path",
@@ -85,6 +87,9 @@ func TestEncrypt(t *testing.T) {
 			path:      emptyFile.Name(),
 			key:       []byte("dummyKey"),
 			shallPass: false,
+			requirements: func(t *testing.T) {
+				require.Kernel(t, 4, 18)
+			},
 		},
 		{
 			name:      "valid file",
@@ -96,6 +101,10 @@ func TestEncrypt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.requirements != nil {
+				tt.requirements(t)
+			}
+
 			devPath, err := dev.EncryptFilesystem(tt.path, tt.key)
 			if tt.shallPass && err != nil {
 				if err == ErrUnsupportedCryptsetupVersion {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2696

On RHEL7 & SLES12 the cryptsetup call succeeds, which the test does not expect. On kernel >=4.18 the test will pass.


### This fixes or addresses the following GitHub issues:

 - Fixes #2695


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
