### PR TITLE
fix: Address layer / image extraction issues in user namespaces (4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@
   the original image.
 - Fix `target: no such file or directory` error in native mode when extracting
   layers from certain OCI images that manipulate hard links across layers.
-- Fix extraction of OCI layers when run in a root mapped user namespace 
+- Fix extraction of OCI layers when run in a root mapped user namespace
   (e.g.. `unshare -r`).
+- Use user namespace for wrapping of `unsquashfs` when singularity is run with
+  `--userns / -u` flag. Fixes temporary sandbox extraction of images in non-root
+  mapped user namespace (e.g. `unshare -c`).
 
 ## 4.1.1 \[2024-02-01\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   the original image.
 - Fix `target: no such file or directory` error in native mode when extracting
   layers from certain OCI images that manipulate hard links across layers.
+- Fix extraction of OCI layers when run in a root mapped user namespace 
+  (e.g.. `unshare -r`).
 
 ## 4.1.1 \[2024-02-01\]
 

--- a/internal/pkg/build/sources/packer_sif.go
+++ b/internal/pkg/build/sources/packer_sif.go
@@ -51,7 +51,7 @@ func unpackSIF(b *types.Bundle, img *image.Image) (err error) {
 			return fmt.Errorf("could not extract root filesystem: %s", err)
 		}
 
-		s := unpacker.NewSquashfs()
+		s := unpacker.NewSquashfs(false)
 
 		// extract root filesystem
 		if err := s.ExtractAll(reader, b.RootfsPath); err != nil {

--- a/internal/pkg/build/sources/packer_squashfs.go
+++ b/internal/pkg/build/sources/packer_squashfs.go
@@ -29,7 +29,7 @@ func (p *SquashfsPacker) Pack(context.Context) (*types.Bundle, error) {
 		return nil, fmt.Errorf("could not extract root filesystem: %s", err)
 	}
 
-	s := unpacker.NewSquashfs()
+	s := unpacker.NewSquashfs(false)
 
 	// extract root filesystem
 	if err := s.ExtractAll(reader, p.b.RootfsPath); err != nil {

--- a/internal/pkg/image/unpacker/squashfs.go
+++ b/internal/pkg/image/unpacker/squashfs.go
@@ -26,11 +26,11 @@ const (
 	excludeDevRegex = `^(.{0}[^d]|.{1}[^e]|.{2}[^v]|.{3}[^\x2f]).*$`
 )
 
-var cmdFunc func(unsquashfs string, dest string, filename string, filter string, opts ...string) (*exec.Cmd, error)
+var cmdFunc func(squashfs *Squashfs, dest string, filename string, filter string, opts ...string) (*exec.Cmd, error)
 
 // unsquashfsCmd is the command instance for executing unsquashfs command
 // in a non sandboxed environment when this package is used for unit tests.
-func unsquashfsCmd(unsquashfs string, dest string, filename string, filter string, opts ...string) (*exec.Cmd, error) {
+func unsquashfsCmd(squashfs *Squashfs, dest string, filename string, filter string, opts ...string) (*exec.Cmd, error) {
 	args := []string{}
 	args = append(args, opts...)
 	// remove the destination directory if any, if the directory is
@@ -49,18 +49,23 @@ func unsquashfsCmd(unsquashfs string, dest string, filename string, filter strin
 		args = append(args, filter)
 	}
 
-	sylog.Debugf("Calling %s %v", unsquashfs, args)
-	return exec.Command(unsquashfs, args...), nil
+	sylog.Debugf("Calling %s %v", squashfs.UnsquashfsPath, args)
+	return exec.Command(squashfs.UnsquashfsPath, args...), nil
 }
 
 // Squashfs represents a squashfs unpacker.
 type Squashfs struct {
+	// Path to the unsquashfs executable
 	UnsquashfsPath string
+	// ForceUserns sets --userns when unsquashfs is being run wrapped by singularity.
+	ForceUserns bool
 }
 
 // NewSquashfs initializes and returns a Squahfs unpacker instance
-func NewSquashfs() *Squashfs {
-	s := &Squashfs{}
+func NewSquashfs(userns bool) *Squashfs {
+	s := &Squashfs{
+		ForceUserns: userns,
+	}
 	s.UnsquashfsPath, _ = bin.FindBin("unsquashfs")
 	return s
 }
@@ -112,7 +117,7 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) (err e
 	if err != nil {
 		return fmt.Errorf("could not get host UID: %s", err)
 	}
-	rootless := hostuid != 0
+	rootless := s.ForceUserns || hostuid != 0
 
 	// Does our target filesystem support user xattrs?
 	ok, err := TestUserXattr(filepath.Dir(dest))
@@ -155,7 +160,7 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) (err e
 
 	// Now run unsquashfs with our 'best' options
 	sylog.Debugf("Trying unsquashfs options: %v", opts)
-	cmd, err := cmdFunc(s.UnsquashfsPath, dest, filename, filter, opts...)
+	cmd, err := cmdFunc(s, dest, filename, filter, opts...)
 	if err != nil {
 		return fmt.Errorf("command error: %s", err)
 	}

--- a/internal/pkg/image/unpacker/squashfs_test.go
+++ b/internal/pkg/image/unpacker/squashfs_test.go
@@ -50,7 +50,7 @@ func TestSquashfs(t *testing.T) {
 }
 
 func testSquashfs(t *testing.T, tmpParent string) {
-	s := NewSquashfs()
+	s := NewSquashfs(false)
 
 	if !s.HasUnsquashfs() {
 		t.Skip("unsquashfs not found")

--- a/internal/pkg/ociimage/unpack.go
+++ b/internal/pkg/ociimage/unpack.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opencontainers/umoci/pkg/idtools"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"github.com/sylabs/singularity/v4/pkg/util/namespaces"
 )
 
 // isExtractable checks if we have extractable layers in the image. Shouldn't be
@@ -69,7 +70,8 @@ func UnpackRootfs(_ context.Context, srcImage v1.Image, destDir string) (err err
 	}
 
 	// Allow unpacking as non-root
-	if os.Geteuid() != 0 {
+	insideUserNs, _ := namespaces.IsInsideUserNamespace(os.Getpid())
+	if os.Geteuid() != 0 || insideUserNs {
 		mapOptions.Rootless = true
 
 		uidMap, err := idtools.ParseMapping(fmt.Sprintf("0:%d:1", os.Geteuid()))

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -61,7 +61,7 @@ func checkPartition(t *testing.T, reader io.Reader) error {
 	extracted := "/bin/busybox"
 	dir := t.TempDir()
 
-	s := unpacker.NewSquashfs()
+	s := unpacker.NewSquashfs(false)
 	if s.HasUnsquashfs() {
 		if err := s.ExtractFiles([]string{extracted}, reader, dir); err != nil {
 			return fmt.Errorf("extraction failed: %s", err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #2699 

Note - there are no e2e tests for the nested containers / nested namespaces situations that are fixed by the commits in this PR. However, our e2e tests do confirm the changes don't cause regressions in non-nested cases.

The e2e framework doesn't offer a great way of executing singularity nested, and I've opened an issue (#2700) to address this to verify functionality more generally than a messy one-off for this PR would handle.

**fix: use rootless umoci inside user namespace**

If we are running from within a user namespace, then use rootless OCI layer extrraction with umoci.

This permits the extraction to complete when singularity is run under `unshare -r`.

**fix: honor --userns in unsquashfs wrapping**

If singularity is executed with `--userns/-u` then it should also use a user namespace where it executes `unsquashfs` in a wrapped manner.

Previously the `unsquashfs` wrapping was without `--userns/-u` in a setuid installation. This caused extraction to fail from within a non-root-mapped user namespace (e.g. `unshare -c`).

### This fixes or addresses the following GitHub issues:

 - Fixes #2698


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
