### PR TITLE
e2e: fix OCI profile requirements

### DIFF
--- a/e2e/internal/e2e/profile.go
+++ b/e2e/internal/e2e/profile.go
@@ -277,7 +277,7 @@ func fakerootRequirements(t *testing.T) {
 func ociRequirements(t *testing.T) {
 	require.Kernel(t, 4, 18) // FUSE in userns
 	require.UserNamespace(t)
-	require.Command(t, "runc")
+	require.OneCommand(t, []string{"runc", "crun"})
 	require.OneCommand(t, []string{"sqfstar", "tar2sqfs"})
 
 	uid := uint32(origUID)

--- a/e2e/internal/e2e/profile.go
+++ b/e2e/internal/e2e/profile.go
@@ -278,6 +278,7 @@ func ociRequirements(t *testing.T) {
 	require.Kernel(t, 4, 18) // FUSE in userns
 	require.UserNamespace(t)
 	require.Command(t, "runc")
+	require.OneCommand(t, []string{"sqfstar", "tar2sqfs"})
 
 	uid := uint32(origUID)
 

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -270,6 +270,23 @@ func Command(t *testing.T, command string) {
 	t.Skipf("%s command not found in $PATH", command)
 }
 
+// OneCommand checks if one of the provided commands is available (via
+// Singularity's internal bin.FindBin() facility, or else simply on the PATH).
+// If none are found, the current test is skipped with a message.
+func OneCommand(t *testing.T, commands []string) {
+	for _, c := range commands {
+		if _, err := bin.FindBin(c); err == nil {
+			return
+		}
+
+		if _, err := exec.LookPath(c); err == nil {
+			return
+		}
+	}
+
+	t.Skipf("%v commands not found in $PATH", commands)
+}
+
 // Seccomp checks that seccomp is enabled, if not the
 // current test is skipped with a message.
 func Seccomp(t *testing.T) {

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -53,6 +53,9 @@ func FindBin(name string) (path string, err error) {
 	// unprivileged overlays
 	case "fuse-overlayfs":
 		return findOnPath(name)
+	// tar to squashfs tools for OCI-mode image conversion
+	case "tar2sqfs", "sqfstar":
+		return findOnPath(name)
 	default:
 		return "", fmt.Errorf("executable name %q is not known to FindBin", name)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

OCI-mode profiles require `tar2sqfs` or `sqfstar` to create an OCI-SIF.

OCI-mode can use either `crun` or `runc`.

### This fixes or addresses the following GitHub issues:

 - Fixes #2472

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
