### PR TITLE
e2e: use OCI profile, not `--oci`

### DIFF
--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -348,9 +348,9 @@ func EnsureOCISIF(t *testing.T, env TestEnv) {
 
 	env.RunSingularity(
 		t,
-		WithProfile(UserProfile),
+		WithProfile(OCIUserProfile),
 		WithCommand("pull"),
-		WithArgs("--oci", "--no-https", env.OCISIFPath, env.TestRegistryImage),
+		WithArgs("--no-https", env.OCISIFPath, env.TestRegistryImage),
 		ExpectExit(0),
 	)
 }

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -105,10 +105,6 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 		argv += "--library " + tt.library + " "
 	}
 
-	if tt.oci {
-		argv += "--oci "
-	}
-
 	if tt.keepLayers {
 		argv += "--keep-layers "
 	}
@@ -131,9 +127,14 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 
 	argv += tt.srcURI
 
+	profile := e2e.UserProfile
+	if tt.oci {
+		profile = e2e.OCIUserProfile
+	}
+
 	c.env.RunSingularity(
 		t,
-		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithProfile(profile),
 		e2e.WithEnv(tt.envVars),
 		e2e.WithDir(tt.workDir),
 		e2e.WithCommand("pull"),

--- a/e2e/registry/registry.go
+++ b/e2e/registry/registry.go
@@ -326,6 +326,7 @@ func (c ctx) registryAuthTester(t *testing.T, withCustomAuthFile bool) {
 		name          string
 		cmd           string
 		args          []string
+		oci           bool
 		whileLoggedIn bool
 		expectExit    int
 	}{
@@ -353,7 +354,8 @@ func (c ctx) registryAuthTester(t *testing.T, withCustomAuthFile bool) {
 		{
 			name:          "docker pull ocisif",
 			cmd:           "pull",
-			args:          []string{"-F", "--oci", "--disable-cache", "--no-https", c.env.TestRegistryPrivImage},
+			args:          []string{"-F", "--disable-cache", "--no-https", c.env.TestRegistryPrivImage},
+			oci:           true,
 			whileLoggedIn: true,
 			expectExit:    0,
 		},
@@ -407,10 +409,16 @@ func (c ctx) registryAuthTester(t *testing.T, withCustomAuthFile bool) {
 		} else {
 			e2e.PrivateRepoLogout(t, c.env, e2e.UserProfile, localAuthFileName)
 		}
+
+		profile := e2e.UserProfile
+		if tt.oci {
+			profile = e2e.OCIUserProfile
+		}
+
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithProfile(profile),
 			e2e.WithCommand(tt.cmd),
 			e2e.WithArgs(append(authFileArgs, tt.args...)...),
 			e2e.ExpectExit(tt.expectExit),


### PR DESCRIPTION
## Description of the Pull Request (PR):

In some e2e tests we still had code that was specifying `--oci` explicitly, with `e2e.UserProfile`. This bypasses the requirements checking that is in place for `e2e.OCIUserProfile`.

Use OCIUserProfile instead of `--oci`.

### This fixes or addresses the following GitHub issues:

 - Fixes #2723

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
