### PR TITLE
fix: oci: set default PATH if image does not (4.1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ commands:
               libtool \
               pkg-config \
               squashfs-tools \
+              squashfs-tools-ng \
               uidmap \
               zlib1g-dev
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SingularityCE Changelog
 
+## Change Since Last Release
+
+### Bug Fixes
+
+- Set default `PATH` in container run in OCI-Mode when image does not set `PATH`.
+
 ## 4.1.2 \[2024-03-05\]
 
 ### Bug Fixes

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -376,6 +376,12 @@ func (l *Launcher) getProcessEnv(imageSpec imgspecv1.Image, hostEnv []string, us
 }
 
 func setOCIPath(g *generate.Generator, prependPath, path, appendPath string) {
+	// If we have no PATH at this point, then the image didn't define one, and
+	// the user didn't specify a full PATH override. We need to use a default,
+	// to find bare `CMD`s e.g. issue #2721.
+	if path == "" {
+		path = env.DefaultPath
+	}
 	// Compute and set optionally APPEND-ed / PREPEND-ed PATH.
 	if appendPath != "" {
 		path = strings.TrimSuffix(path, ":") + ":" + appendPath
@@ -383,9 +389,7 @@ func setOCIPath(g *generate.Generator, prependPath, path, appendPath string) {
 	if prependPath != "" {
 		path = prependPath + ":" + strings.TrimPrefix(path, ":")
 	}
-	if path != "" {
-		g.AddProcessEnv("PATH", path)
-	}
+	g.AddProcessEnv("PATH", path)
 }
 
 func setNativePath(g *generate.Generator, prependPath, path, appendPath string) {

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -141,6 +141,8 @@ func TestGetProcessArgs(t *testing.T) {
 }
 
 func TestGetProcessEnvOCI(t *testing.T) {
+	defaultPathEnv := "PATH=" + env.DefaultPath
+
 	tests := []struct {
 		name     string
 		noCompat bool
@@ -155,7 +157,10 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			imageEnv: []string{},
 			hostEnv:  []string{},
 			userEnv:  map[string]string{},
-			wantEnv:  []string{"LD_LIBRARY_PATH=/.singularity.d/libs"},
+			wantEnv: []string{
+				defaultPathEnv,
+				"LD_LIBRARY_PATH=/.singularity.d/libs",
+			},
 		},
 		{
 			name:     "PassTERM",
@@ -165,6 +170,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			userEnv:  map[string]string{},
 			wantEnv: []string{
 				"TERM=xterm-256color",
+				defaultPathEnv,
 				"LD_LIBRARY_PATH=/.singularity.d/libs",
 			},
 		},
@@ -176,6 +182,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			userEnv:  map[string]string{},
 			wantEnv: []string{
 				"HTTP_PROXY=proxy.example.com:3128",
+				defaultPathEnv,
 				"LD_LIBRARY_PATH=/.singularity.d/libs",
 			},
 		},
@@ -185,7 +192,10 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			imageEnv: []string{},
 			hostEnv:  []string{"NOT_FOR_CONTAINER=true"},
 			userEnv:  map[string]string{},
-			wantEnv:  []string{"LD_LIBRARY_PATH=/.singularity.d/libs"},
+			wantEnv: []string{
+				defaultPathEnv,
+				"LD_LIBRARY_PATH=/.singularity.d/libs",
+			},
 		},
 		{
 			name:     "ImagePath",
@@ -239,6 +249,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			userEnv:  map[string]string{},
 			wantEnv: []string{
 				"LD_LIBRARY_PATH=/foo:/.singularity.d/libs",
+				defaultPathEnv,
 			},
 		},
 		{
@@ -248,6 +259,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			hostEnv:  []string{},
 			userEnv:  map[string]string{"LD_LIBRARY_PATH": "/foo"},
 			wantEnv: []string{
+				defaultPathEnv,
 				"LD_LIBRARY_PATH=/foo:/.singularity.d/libs",
 			},
 		},
@@ -259,6 +271,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			userEnv:  map[string]string{"LD_LIBRARY_PATH": "/bar"},
 			wantEnv: []string{
 				"LD_LIBRARY_PATH=/bar:/.singularity.d/libs",
+				defaultPathEnv,
 			},
 		},
 		{
@@ -269,6 +282,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			userEnv:  map[string]string{},
 			wantEnv: []string{
 				"FOO=bar",
+				defaultPathEnv,
 				"LD_LIBRARY_PATH=/.singularity.d/libs",
 			},
 		},
@@ -280,6 +294,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			userEnv:  map[string]string{"FOO": "baz"},
 			wantEnv: []string{
 				"FOO=baz",
+				defaultPathEnv,
 				"LD_LIBRARY_PATH=/.singularity.d/libs",
 			},
 		},
@@ -292,6 +307,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			wantEnv: []string{
 				"FOO=bar",
 				"ABC=123",
+				defaultPathEnv,
 				"LD_LIBRARY_PATH=/.singularity.d/libs",
 			},
 		},
@@ -303,6 +319,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			userEnv:  map[string]string{},
 			wantEnv: []string{
 				"FOO=bar",
+				defaultPathEnv,
 				"LD_LIBRARY_PATH=/.singularity.d/libs",
 			},
 		},
@@ -314,6 +331,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			userEnv:  map[string]string{},
 			wantEnv: []string{
 				"FOO=baz",
+				defaultPathEnv,
 				"LD_LIBRARY_PATH=/.singularity.d/libs",
 			},
 		},
@@ -325,6 +343,7 @@ func TestGetProcessEnvOCI(t *testing.T) {
 			userEnv:  map[string]string{"FOO": "baz"},
 			wantEnv: []string{
 				"FOO=baz",
+				defaultPathEnv,
 				"LD_LIBRARY_PATH=/.singularity.d/libs",
 			},
 		},


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick 2722

OCI images almost always set `PATH` in their config. However, some don't. Most recently, `docker://busybox:latest` changed and the new version:

  * Doesn't set `PATH` in its config.
  * Has a CMD of `sh` which has to be found on a `PATH`.

Singularity's OCI mode was failing to find `sh`. Other runtimes set a default `PATH` in the container, so running `busybox:latest` still works.

This PR ensures we set a default `PATH` in the container where the image does not provide one.

In addition - the new docker://busybox:latest image layers have some entries that trigger a bug in `sqfstar`, related to symlink paths being stripped and rejected in error. This bug is present in  >=4.5 <=4.6. Because Ubuntu 22.04 is stuck on 4.5.x, add `squashfs-tools-ng` to the CI environment to use `tar2sqfs`. This is already a recommended dependency by our Debian packaging, and is necessary to fix the #2721 failure on Ubuntu.

### This fixes or addresses the following GitHub issues:

 - Fixes #2721


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
