### PR TITLE
chore: bump golang-ci-lint to 1.57.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ executors:
       - image: ubuntu:22.04
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.55.1
+      - image: golangci/golangci-lint:v1.57.1
   ubuntu-machine:
     machine:
       image: ubuntu-2204:2022.10.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,6 @@ run:
     - selinux
     - singularity_engine
     - sylog
-  skip-files:
-    - "internal/pkg/util/user/cgo_lookup_unix.go"
 
 linters:
   disable-all: true
@@ -71,4 +69,6 @@ issues:
       # G204 disallows exec.Command() with a command/args stored in variables
       # G306 disallows creation of files with permissions greater than 0600
       text: "^(G107|G204|G306):"
+  exclude-files:
+    - "internal/pkg/util/user/cgo_lookup_unix.go"
 

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -46,7 +46,7 @@ func manDocs(rootCmd *cobra.Command, outDir string) {
 func rstDocs(rootCmd *cobra.Command, outDir string) {
 	assertAccess(outDir)
 	sylog.Infof("Creating Singularity RST docs at %s\n", outDir)
-	if err := doc.GenReSTTreeCustom(rootCmd, outDir, func(a string) string {
+	if err := doc.GenReSTTreeCustom(rootCmd, outDir, func(_ string) string {
 		return ""
 	}, func(name, ref string) string {
 		return fmt.Sprintf(":ref:`%s <%s>`", name, ref)
@@ -62,7 +62,7 @@ func main() {
 		Args:      cobra.ExactArgs(1),
 		Use:       "makeDocs {markdown | man | rst}",
 		Short:     "Generates Singularity documentation",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			// We must Init() as loading commands etc. is deferred until this is called.
 			// Using true here will result in local docs including any content for installed
 			// plugins.

--- a/cmd/internal/cli/buildconfig.go
+++ b/cmd/internal/cli/buildconfig.go
@@ -22,7 +22,7 @@ func init() {
 // BuildConfigCmd outputs a list of the compile-time parameters with which
 // singularity was compiled
 var BuildConfigCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		name := ""
 		if len(args) > 0 {
 			name = args[0]

--- a/cmd/internal/cli/cache_clean_linux.go
+++ b/cmd/internal/cli/cache_clean_linux.go
@@ -77,7 +77,7 @@ var (
 	// cacheCleanCmd is 'singularity cache clean' and will clear your local singularity cache
 	cacheCleanCmd = &cobra.Command{
 		DisableFlagsInUseLine: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			if err := cleanCache(); err != nil {
 				sylog.Fatalf("Handle clean failed: %v", err)
 			}

--- a/cmd/internal/cli/cache_linux.go
+++ b/cmd/internal/cli/cache_linux.go
@@ -23,7 +23,7 @@ func init() {
 
 // CacheCmd : aka, `singularity cache`
 var CacheCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/cache_list_linux.go
+++ b/cmd/internal/cli/cache_list_linux.go
@@ -52,7 +52,7 @@ func init() {
 // CacheListCmd is 'singularity cache list' and will list your local singularity cache
 var CacheListCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if err := cacheListCmd(); err != nil {
 			os.Exit(2)
 		}

--- a/cmd/internal/cli/capability_linux.go
+++ b/cmd/internal/cli/capability_linux.go
@@ -50,7 +50,7 @@ var capGroupFlag = cmdline.Flag{
 var CapabilityAvailCmd = &cobra.Command{
 	Args:                  cobra.RangeArgs(0, 1),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		caps := ""
 		if len(args) > 0 {
 			caps = args[0]
@@ -74,7 +74,7 @@ var CapabilityAvailCmd = &cobra.Command{
 var CapabilityAddCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		c := singularity.CapManageConfig{
 			Caps:  args[0],
 			User:  capConfig.CapUser,
@@ -96,7 +96,7 @@ var CapabilityAddCmd = &cobra.Command{
 var CapabilityDropCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		c := singularity.CapManageConfig{
 			Caps:  args[0],
 			User:  capConfig.CapUser,
@@ -118,7 +118,7 @@ var CapabilityDropCmd = &cobra.Command{
 var CapabilityListCmd = &cobra.Command{
 	Args:                  cobra.RangeArgs(0, 1),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		userGroup := ""
 		if len(args) == 1 {
 			userGroup = args[0]
@@ -142,7 +142,7 @@ var CapabilityListCmd = &cobra.Command{
 
 // CapabilityCmd is the capability command
 var CapabilityCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("Invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/config_fakeroot_linux.go
+++ b/cmd/internal/cli/config_fakeroot_linux.go
@@ -68,7 +68,7 @@ var configFakerootCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		username := args[0]
 		var op singularity.FakerootConfigOp
 

--- a/cmd/internal/cli/config_global_linux.go
+++ b/cmd/internal/cli/config_global_linux.go
@@ -80,7 +80,7 @@ var configGlobalCmd = &cobra.Command{
 	Args:                  cobra.RangeArgs(1, 2),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRootOrUnpriv,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		var op singularity.GlobalConfigOp
 
 		if globalConfigSet {

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -638,7 +638,7 @@ var InspectCmd = &cobra.Command{
 	Long:    docs.InspectLong,
 	Example: docs.InspectExample,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		img, err := image.Init(args[0], false)
 		if err != nil {
 			sylog.Fatalf("Failed to open image %s: %s", args[0], err)

--- a/cmd/internal/cli/instance_linux.go
+++ b/cmd/internal/cli/instance_linux.go
@@ -25,7 +25,7 @@ func init() {
 
 // singularity instance
 var instanceCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/instance_list_linux.go
+++ b/cmd/internal/cli/instance_list_linux.go
@@ -66,7 +66,7 @@ var instanceListLogsFlag = cmdline.Flag{
 // singularity instance list
 var instanceListCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if isOCI {
 			sylog.Warningf("Instances are not supported in OCI mode. Showing non-OCI Singularity container instances.")
 		}

--- a/cmd/internal/cli/instance_stop_linux.go
+++ b/cmd/internal/cli/instance_stop_linux.go
@@ -99,7 +99,7 @@ var instanceStopTimeoutFlag = cmdline.Flag{
 var instanceStopCmd = &cobra.Command{
 	Args:                  cobra.RangeArgs(0, 1),
 	DisableFlagsInUseLine: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		if isOCI {
 			sylog.Fatalf("Instances are not yet supported in OCI-mode. Omit --oci, or use --no-oci, to manage a non-OCI Singularity instance.")
 		}

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -107,7 +107,7 @@ func checkGlobal(cmd *cobra.Command, _ []string) {
 
 // KeyCmd is the 'key' command that allows management of keyrings
 var KeyCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("Invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/key_list.go
+++ b/cmd/internal/cli/key_list.go
@@ -51,7 +51,7 @@ func init() {
 var KeyListCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(0),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if err := doKeyListCmd(secret); err != nil {
 			sylog.Fatalf("While listing keys: %s", err)
 		}

--- a/cmd/internal/cli/key_remove.go
+++ b/cmd/internal/cli/key_remove.go
@@ -48,7 +48,7 @@ var KeyRemoveCmd = &cobra.Command{
 	PreRun:                checkGlobal,
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		var opts []sypgp.HandleOpt
 		path := ""
 

--- a/cmd/internal/cli/keyserver.go
+++ b/cmd/internal/cli/keyserver.go
@@ -148,7 +148,7 @@ var KeyserverAddCmd = &cobra.Command{
 var KeyserverRemoveCmd = &cobra.Command{
 	Args:   cobra.RangeArgs(1, 2),
 	PreRun: setKeyserver,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		uri := args[0]
 		name := ""
 		if len(args) > 1 {
@@ -178,7 +178,7 @@ func setKeyserver(_ *cobra.Command, _ []string) {
 // KeyserverLoginCmd singularity registry login [option] <registry_url>
 var KeyserverLoginCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := singularity.KeyserverLogin(remoteConfig, ObtainLoginArgs(args[0])); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -195,7 +195,7 @@ var KeyserverLoginCmd = &cobra.Command{
 // KeyserverLogoutCmd singularity remote logout [remoteName|serviceURI]
 var KeyserverLogoutCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// default to empty string to signal to KeyserverLogin to use default remote
 		name := ""
 		if len(args) > 0 {
@@ -219,7 +219,7 @@ var KeyserverLogoutCmd = &cobra.Command{
 // KeyserverListCmd singularity remote list
 var KeyserverListCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		remoteName := ""
 		if len(args) > 0 {
 			remoteName = args[0]

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -136,7 +136,7 @@ var OciCreateCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := singularity.OciCreate(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -172,7 +172,7 @@ var OciStartCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := singularity.OciStart(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -204,7 +204,7 @@ var OciKillCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		killSignal := ""
 		if len(args) > 1 && args[1] != "" {
 			killSignal = args[1]
@@ -229,7 +229,7 @@ var OciStateCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := singularity.OciState(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -245,7 +245,7 @@ var OciAttachCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := oci.Attach(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -261,7 +261,7 @@ var OciExecCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := singularity.OciExec(args[0], args[1:]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -277,7 +277,7 @@ var OciUpdateCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := singularity.OciUpdate(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -293,7 +293,7 @@ var OciPauseCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := singularity.OciPause(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -309,7 +309,7 @@ var OciResumeCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := singularity.OciResume(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}

--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -21,7 +21,7 @@ func init() {
 
 // OverlayCmd is the 'overlay' command that allows to manage writable overlay.
 var OverlayCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("Invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/overlay_create.go
+++ b/cmd/internal/cli/overlay_create.go
@@ -47,7 +47,7 @@ var overlayCreateDirFlag = cmdline.Flag{
 // OverlayCreateCmd is the 'overlay create' command that allows to create writable overlay.
 var OverlayCreateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		if err := singularity.OverlayCreate(overlaySize, args[0], overlaySparse, overlayDirs...); err != nil {
 			sylog.Fatalf(err.Error())
 		}

--- a/cmd/internal/cli/plugin_compile_linux.go
+++ b/cmd/internal/cli/plugin_compile_linux.go
@@ -39,7 +39,7 @@ func init() {
 //
 // singularity plugin compile <path> [-o name]
 var PluginCompileCmd = &cobra.Command{
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		sourceDir, err := filepath.Abs(args[0])
 		if err != nil {
 			sylog.Fatalf("While sanitizing input path: %s", err)

--- a/cmd/internal/cli/plugin_create_linux.go
+++ b/cmd/internal/cli/plugin_create_linux.go
@@ -17,7 +17,7 @@ import (
 //
 // singularity plugin create <directory> <name>
 var PluginCreateCmd = &cobra.Command{
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[1]
 		dir := args[0]
 

--- a/cmd/internal/cli/plugin_disable_linux.go
+++ b/cmd/internal/cli/plugin_disable_linux.go
@@ -20,7 +20,7 @@ import (
 // singularity plugin disable <name>
 var PluginDisableCmd = &cobra.Command{
 	PreRun: CheckRootOrUnpriv,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		err := singularity.DisablePlugin(args[0], buildcfg.LIBEXECDIR)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/cmd/internal/cli/plugin_enable_linux.go
+++ b/cmd/internal/cli/plugin_enable_linux.go
@@ -19,7 +19,7 @@ import (
 // singularity plugin enable <name>
 var PluginEnableCmd = &cobra.Command{
 	PreRun: CheckRootOrUnpriv,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		err := singularity.EnablePlugin(args[0])
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/cmd/internal/cli/plugin_inspect_linux.go
+++ b/cmd/internal/cli/plugin_inspect_linux.go
@@ -16,7 +16,7 @@ import (
 
 // PluginInspectCmd displays information about a plugin.
 var PluginInspectCmd = &cobra.Command{
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		err := singularity.InspectPlugin(args[0])
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/cmd/internal/cli/plugin_install_linux.go
+++ b/cmd/internal/cli/plugin_install_linux.go
@@ -18,7 +18,7 @@ import (
 // singularity plugin install <path>
 var PluginInstallCmd = &cobra.Command{
 	PreRun: CheckRootOrUnpriv,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		err := singularity.InstallPlugin(args[0])
 		if err != nil {
 			sylog.Fatalf("Failed to install plugin %q: %s.", args[0], err)

--- a/cmd/internal/cli/plugin_linux.go
+++ b/cmd/internal/cli/plugin_linux.go
@@ -32,7 +32,7 @@ func init() {
 //
 // singularity plugin [...]
 var PluginCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/plugin_list_linux.go
+++ b/cmd/internal/cli/plugin_list_linux.go
@@ -14,7 +14,7 @@ import (
 
 // PluginListCmd lists the plugins installed in the system.
 var PluginListCmd = &cobra.Command{
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		err := singularity.ListPlugins()
 		if err != nil {
 			sylog.Fatalf("Failed to get a list of installed plugins: %s.", err)

--- a/cmd/internal/cli/plugin_uninstall_linux.go
+++ b/cmd/internal/cli/plugin_uninstall_linux.go
@@ -20,7 +20,7 @@ import (
 // singularity plugin uninstall <name>
 var PluginUninstallCmd = &cobra.Command{
 	PreRun: CheckRootOrUnpriv,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 		err := singularity.UninstallPlugin(name)
 		if err != nil {

--- a/cmd/internal/cli/registry.go
+++ b/cmd/internal/cli/registry.go
@@ -89,7 +89,7 @@ var RegistryCmd = &cobra.Command{
 // RegistryLoginCmd singularity registry login [option] <registry_url>
 var RegistryLoginCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := singularity.RegistryLogin(remoteConfig, ObtainLoginArgs(args[0]), reqAuthFile); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -106,7 +106,7 @@ var RegistryLoginCmd = &cobra.Command{
 // RegistryLogoutCmd singularity remote logout [remoteName|serviceURI]
 var RegistryLogoutCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// default to empty string to signal to registryLogin to use default remote
 		name := ""
 		if len(args) > 0 {
@@ -130,7 +130,7 @@ var RegistryLogoutCmd = &cobra.Command{
 // RegistryListCmd singularity remote list
 var RegistryListCmd = &cobra.Command{
 	Args: cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if err := singularity.RegistryList(remoteConfig); err != nil {
 			sylog.Fatalf("%s", err)
 		}

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -221,7 +221,7 @@ var RemoteGetLoginPasswordCmd = &cobra.Command{
 	Long:    docs.RemoteGetLoginPasswordLong,
 	Example: docs.RemoteGetLoginPasswordExample,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		defaultConfig := ""
 
 		config, err := getLibraryClientConfig(defaultConfig)
@@ -243,7 +243,7 @@ var RemoteGetLoginPasswordCmd = &cobra.Command{
 var RemoteAddCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(2),
 	PreRun: setGlobalRemoteConfig,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 		uri := args[1]
 		makeDefault := !remoteAddNotDefault
@@ -279,7 +279,7 @@ var RemoteAddCmd = &cobra.Command{
 var RemoteRemoveCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(1),
 	PreRun: setGlobalRemoteConfig,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 		if err := singularity.RemoteRemove(remoteConfig, name); err != nil {
 			sylog.Fatalf("%s", err)
@@ -299,7 +299,7 @@ var RemoteRemoveCmd = &cobra.Command{
 var RemoteUseCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(1),
 	PreRun: setGlobalRemoteConfig,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 		if err := singularity.RemoteUse(remoteConfig, name, global, remoteUseExclusive); err != nil {
 			sylog.Fatalf("%s", err)
@@ -318,7 +318,7 @@ var RemoteUseCmd = &cobra.Command{
 // RemoteListCmd singularity remote list
 var RemoteListCmd = &cobra.Command{
 	Args: cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if err := singularity.RemoteList(remoteConfig); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -335,7 +335,7 @@ var RemoteListCmd = &cobra.Command{
 // RemoteLoginCmd singularity remote login [remoteName]
 var RemoteLoginCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		loginArgs := new(singularity.LoginArgs)
 
 		// default to empty string to signal to RemoteLogin to use default remote
@@ -373,7 +373,7 @@ var RemoteLoginCmd = &cobra.Command{
 // RemoteLogoutCmd singularity remote logout [remoteName|serviceURI]
 var RemoteLogoutCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// default to empty string to signal to RemoteLogin to use default remote
 		name := ""
 		if len(args) > 0 {
@@ -397,7 +397,7 @@ var RemoteLogoutCmd = &cobra.Command{
 // RemoteStatusCmd singularity remote status [remoteName]
 var RemoteStatusCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// default to empty string to signal to RemoteStatus to use default remote
 		name := ""
 		if len(args) > 0 {

--- a/cmd/internal/cli/run_help_linux.go
+++ b/cmd/internal/cli/run_help_linux.go
@@ -40,7 +40,7 @@ func init() {
 var RunHelpCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// Sanity check
 		if _, err := os.Stat(args[0]); err != nil {
 			sylog.Fatalf("container not found: %s", err)

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -561,7 +561,7 @@ func Init(loadPlugins bool) {
 var singularityCmd = &cobra.Command{
 	TraverseChildren:      true,
 	DisableFlagsInUseLine: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return cmdline.CommandError("invalid command")
 	},
 
@@ -658,7 +658,7 @@ func TraverseParentsUses(cmd *cobra.Command) string {
 // VersionCmd displays installed singularity version
 var VersionCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		fmt.Println(buildcfg.PACKAGE_VERSION)
 	},
 

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -40,10 +40,10 @@ const (
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote get-login-password
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	RemoteGetLoginPasswordUse     string = `get-login-password`
+	RemoteGetLoginPasswordUse     string = `get-login-password` //nolint:gosec
 	RemoteGetLoginPasswordShort   string = `Retrieves the cli secret for the currently logged in user`
 	RemoteGetLoginPasswordLong    string = `The 'remote get-login-password' command allows you to retrieve the cli secret for the currently user.`
-	RemoteGetLoginPasswordExample string = `$ singularity remote get-login-password | docker login -u user --password-stdin https://harbor.sylabs.io`
+	RemoteGetLoginPasswordExample string = `$ singularity remote get-login-password | docker login -u user --password-stdin https://harbor.sylabs.io` //nolint:gosec
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote add command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -493,7 +493,7 @@ func (c actionTests) STDPipe(t *testing.T) {
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.argv...),
 			e2e.WithStdin(&input),
-			e2e.PreRun(func(t *testing.T) {
+			e2e.PreRun(func(_ *testing.T) {
 				input.WriteString(tt.input)
 			}),
 			e2e.ExpectExit(tt.exit),
@@ -1736,7 +1736,7 @@ func (c actionTests) fuseMount(t *testing.T) {
 			e2e.WithStdin(stdinReader),
 			e2e.WithCommand("run"),
 			e2e.WithArgs("--writable", "--no-home", imageDir),
-			e2e.PostRun(func(t *testing.T) {
+			e2e.PostRun(func(_ *testing.T) {
 				stdinReader.Close()
 				stdinWriter.Close()
 			}),

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1911,7 +1911,7 @@ func (c actionTests) ociSTDPipe(t *testing.T) {
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.argv...),
 			e2e.WithStdin(&input),
-			e2e.PreRun(func(t *testing.T) {
+			e2e.PreRun(func(_ *testing.T) {
 				input.WriteString(tt.input)
 			}),
 			e2e.ExpectExit(tt.exit),

--- a/e2e/build/build.go
+++ b/e2e/build/build.go
@@ -1548,7 +1548,7 @@ func (c imgBuildTests) buildBindMount(t *testing.T) {
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
 			e2e.WithArgs(args...),
-			e2e.PostRun(func(t *testing.T) {
+			e2e.PostRun(func(_ *testing.T) {
 				os.Remove(defFile)
 			}),
 			e2e.ExpectExit(tt.exit),
@@ -1578,7 +1578,7 @@ func (c imgBuildTests) testWritableTmpfs(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("-F", "--writable-tmpfs", imagePath, defFile),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(defFile)
 		}),
 		e2e.ExpectExit(0),
@@ -1606,7 +1606,7 @@ func (c imgBuildTests) buildLibraryHost(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("-F", imagePath, defFile),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(defFile)
 		}),
 		e2e.ExpectExit(255,
@@ -1719,7 +1719,7 @@ cat /proc/$$/cmdline`
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("-F", imagePath, defFile),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(defFile)
 		}),
 		e2e.ExpectExit(0,
@@ -2428,7 +2428,7 @@ From: %s
 		e2e.WithProfile(e2e.FakerootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--no-setgroups", "-F", imagePath, defFile),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(defFile)
 			os.Remove(imagePath)
 		}),

--- a/e2e/build/regressions.go
+++ b/e2e/build/regressions.go
@@ -180,7 +180,7 @@ func (c *imgBuildTests) issue4967(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_4967.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(
@@ -200,7 +200,7 @@ func (c *imgBuildTests) issue4969(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_4969.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(
@@ -270,7 +270,7 @@ func (c *imgBuildTests) issue4820(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_4820.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(
@@ -289,7 +289,7 @@ func (c *imgBuildTests) issue5315(t *testing.T) {
 		e2e.WithProfile(e2e.FakerootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_5315.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(
@@ -346,7 +346,7 @@ func (c *imgBuildTests) issue5250(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_5250.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(
@@ -468,7 +468,7 @@ From: {{ .From }}
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, f.Name()),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(0),
@@ -484,7 +484,7 @@ func (c *imgBuildTests) issue1273(t *testing.T) {
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--remote", image, "testdata/proot_alpine.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(

--- a/e2e/pull/regressions.go
+++ b/e2e/pull/regressions.go
@@ -85,7 +85,7 @@ func (c ctx) issue1087(t *testing.T) {
 
 	// Start an http server that serves some output without a content-length
 	data := "DATADATADATADATA"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, data)
 	}))
 	defer srv.Close()

--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -113,7 +113,7 @@ func (c ctx) testSecurityPriv(t *testing.T) {
 	var err error
 	// Get the capability set for root on this system
 	// e.g. "CapEff:	000001ffffffffff"
-	e2e.Privileged(func(t *testing.T) {
+	e2e.Privileged(func(_ *testing.T) {
 		caps, err = capabilities.GetProcessEffective()
 	})(t)
 	if err != nil {

--- a/internal/pkg/build/buildkit/daemon/executor.go
+++ b/internal/pkg/build/buildkit/daemon/executor.go
@@ -489,7 +489,7 @@ func (w *buildExecutor) Run(ctx context.Context, id string, root executor.Mount,
 
 	err = w.run(ctx, id, bundle, process, nil)
 
-	releaseContainer := func(ctx context.Context) error {
+	releaseContainer := func(_ context.Context) error {
 		if w.processMode == bkoci.NoProcessSandbox {
 			return nil
 		}
@@ -806,7 +806,7 @@ func updateRuncFieldsForHostOS(runtime *runc.Runc) {
 
 func (w *buildExecutor) run(ctx context.Context, id, bundle string, process executor.ProcessInfo, started func()) error {
 	killer := newRunProcKiller(w.runc, id)
-	return w.callWithIO(ctx, id, bundle, process, started, killer, func(ctx context.Context, started chan<- int, io runc.IO, pidfile string) error {
+	return w.callWithIO(ctx, id, bundle, process, started, killer, func(ctx context.Context, started chan<- int, io runc.IO, _ string) error {
 		_, err := w.runc.Run(ctx, id, bundle, &runc.CreateOpts{
 			NoPivot: w.noPivot,
 			Started: started,

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -273,7 +273,6 @@ func TestOCIPacker(t *testing.T) {
 	}
 
 	_, err = ocp.Pack(context.Background())
-
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", dockerURI, err)
 	}

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -90,7 +90,6 @@ func DownloadImage(ctx context.Context, filePath string, netURL string) error {
 	pb := progress.BarCallback(ctx)
 
 	err = pb(res.ContentLength, res.Body, out)
-
 	if err != nil {
 		// Delete incomplete image file in the event of failure
 		// we get here e.g. if the context is canceled by Ctrl-C

--- a/internal/pkg/client/progress/progress.go
+++ b/internal/pkg/client/progress/progress.go
@@ -56,7 +56,7 @@ type Callback func(int64, io.Reader, io.Writer) error
 func BarCallback(ctx context.Context) Callback {
 	if sylog.GetLevel() <= -1 {
 		// If we don't need a bar visible, we just copy data through the callback func
-		return func(totalSize int64, r io.Reader, w io.Writer) error {
+		return func(_ int64, r io.Reader, w io.Writer) error {
 			_, err := CopyWithContext(ctx, w, r)
 			return err
 		}

--- a/internal/pkg/ociimage/fetch.go
+++ b/internal/pkg/ociimage/fetch.go
@@ -202,8 +202,7 @@ func extractTarNaive(src string, dst string) error {
 			defer f.Close()
 
 			// copy over contents
-			//#nosec G110
-			if _, err := io.Copy(f, tr); err != nil {
+			if _, err := io.Copy(f, tr); err != nil { //nolint:gosec
 				return err
 			}
 		}

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -131,9 +131,8 @@ func (h *keyserverHandler) login(u *url.URL, username, password string, insecure
 
 	if insecure {
 		client.Transport = &http.Transport{
-			//#nosec G402
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: true, //nolint:gosec
 			},
 		}
 	}

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -671,7 +671,6 @@ func (c *container) mountImage(mnt *mount.Point) error {
 		}
 
 		cryptDev, err = c.rpcOps.Decrypt(offset, path, key, masterPid)
-
 		if err != nil {
 			return fmt.Errorf("unable to decrypt the file system: %s", err)
 		}

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -678,7 +678,7 @@ func injectEnvHandler(senv map[string]string, noEval bool) interpreter.OpenHandl
 func runtimeVarsHandler() interpreter.OpenHandler {
 	var once sync.Once
 
-	return func(path string, _ int, _ os.FileMode) (io.ReadWriteCloser, error) {
+	return func(_ string, _ int, _ os.FileMode) (io.ReadWriteCloser, error) {
 		b := new(bufferCloser)
 
 		once.Do(func() {
@@ -711,7 +711,7 @@ func sylogBuiltin(_ context.Context, argv []string) error {
 
 // getAllEnvBuiltin display all exported variables in the form KEY=VALUE.
 func getAllEnvBuiltin() interpreter.ShellBuiltin {
-	return func(ctx context.Context, argv []string) error {
+	return func(ctx context.Context, _ []string) error {
 		hc := interp.HandlerCtx(ctx)
 
 		keyRe := regexp.MustCompile(`^[a-zA-Z_]+[a-zA-Z0-9_]*$`)

--- a/internal/pkg/signature/verify_test.go
+++ b/internal/pkg/signature/verify_test.go
@@ -548,7 +548,7 @@ func TestVerify(t *testing.T) { //nolint:maintidx
 		t.Run(tt.name, func(t *testing.T) {
 			i := 0
 
-			cb := func(f *sif.FileImage, r integrity.VerifyResult) bool {
+			cb := func(_ *sif.FileImage, r integrity.VerifyResult) bool {
 				defer func() { i++ }()
 
 				if i >= len(tt.wantVerified) {
@@ -748,7 +748,7 @@ func TestVerifyFingerPrint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			i := 0
 
-			cb := func(f *sif.FileImage, r integrity.VerifyResult) bool {
+			cb := func(_ *sif.FileImage, r integrity.VerifyResult) bool {
 				defer func() { i++ }()
 
 				if i >= len(tt.wantVerified) {

--- a/internal/pkg/util/auth/auth_test.go
+++ b/internal/pkg/util/auth/auth_test.go
@@ -11,9 +11,8 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 )
 
-// #nosec G101
 const (
-	testToken     = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"
+	testToken     = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM" // #nosec G101
 	testTokenPath = "test_data/test_token"
 )
 

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -479,7 +479,6 @@ func ForceRemoveAll(path string) error {
 		}
 		return nil
 	})
-
 	// Catastrophic error during the permission walk
 	if err != nil {
 		sylog.Errorf("Unable to set permissions to remove %q: %s", path, err)

--- a/internal/pkg/util/fs/mount/system_linux_test.go
+++ b/internal/pkg/util/fs/mount/system_linux_test.go
@@ -29,7 +29,7 @@ func TestSystem(t *testing.T) {
 	after := false
 	mnt := false
 
-	//nolint:unparam
+	//nolint:unparam,revive
 	mountFn := func(point *Point, system *System) error {
 		mnt = true
 		return nil

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -176,7 +176,7 @@ func TestCheckLowerUpper(t *testing.T) {
 
 		// mock statfs
 		if tt.fsType > 0 {
-			statfs = func(path string, st *unix.Statfs_t) error {
+			statfs = func(_ string, st *unix.Statfs_t) error {
 				st.Type = tt.fsType
 				return nil
 			}

--- a/internal/pkg/util/passwdfile/passwdfile_unix.go
+++ b/internal/pkg/util/passwdfile/passwdfile_unix.go
@@ -46,7 +46,6 @@ func readColonFile(r io.Reader, fn lineFunc, readCols int) (v any, err error) {
 		for {
 			var line []byte
 			line, isPrefix, err = rd.ReadLine()
-
 			if err != nil {
 				// We should return (nil, nil) if EOF is reached
 				// without a match.

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -133,7 +133,6 @@ func New(r io.Reader, name string, args []string, envs []string, runnerOptions .
 	}
 	opts = append(opts, runnerOptions...)
 	s.runner, err = interp.New(opts...)
-
 	if err != nil {
 		return nil, fmt.Errorf("while creating shell interpreter: %s", err)
 	}

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -297,7 +297,7 @@ func EvaluateEnv(ctx context.Context, script []byte, args []string, envs []strin
 		c := strings.Join(args, " ")
 		return fmt.Errorf("could not execute %q: execution is disabled", c)
 	}
-	openHandler := func(ctx context.Context, path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
+	openHandler := func(_ context.Context, path string, _ int, _ os.FileMode) (io.ReadWriteCloser, error) {
 		return nil, fmt.Errorf("could not open/create/modify %q: file feature is disabled", path)
 	}
 

--- a/internal/pkg/util/shell/interpreter/interpreter_test.go
+++ b/internal/pkg/util/shell/interpreter/interpreter_test.go
@@ -130,7 +130,7 @@ func TestInterpreter(t *testing.T) {
 			expectOut: "argument",
 			shellBuiltin: &testShellBuiltin{
 				builtin: "testing",
-				fn: func(shell *Shell) ShellBuiltin {
+				fn: func(_ *Shell) ShellBuiltin {
 					return func(ctx context.Context, args []string) error {
 						hc := interp.HandlerCtx(ctx)
 						fmt.Fprintf(hc.Stdout, "%s\n", args[0])
@@ -144,8 +144,8 @@ func TestInterpreter(t *testing.T) {
 			script: "export FOO=bar && exec /bin/true",
 			shellBuiltin: &testShellBuiltin{
 				builtin: "exec",
-				fn: func(shell *Shell) ShellBuiltin {
-					return func(ctx context.Context, args []string) error {
+				fn: func(_ *Shell) ShellBuiltin {
+					return func(ctx context.Context, _ []string) error {
 						hc := interp.HandlerCtx(ctx)
 						for _, env := range GetEnv(hc) {
 							if env == "FOO=bar" {
@@ -163,8 +163,8 @@ func TestInterpreter(t *testing.T) {
 			expectOut: "a virtual file",
 			openHandler: &testOpenHandler{
 				path: "/virtual/file",
-				fn: func(shell *Shell) OpenHandler {
-					return func(path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
+				fn: func(_ *Shell) OpenHandler {
+					return func(_ string, _ int, _ os.FileMode) (io.ReadWriteCloser, error) {
 						bc := new(bufferCloser)
 						bc.WriteString("echo 'a virtual file'\n")
 						return bc, nil

--- a/pkg/image/squashfs.go
+++ b/pkg/image/squashfs.go
@@ -37,7 +37,7 @@ type squashfsInfo struct {
 	Compression uint16
 	BlockLog    uint16
 	Flags       uint16
-	NoIds       uint16
+	NoIDs       uint16
 	Major       uint16
 	Minor       uint16
 }

--- a/pkg/util/slice/slice_test.go
+++ b/pkg/util/slice/slice_test.go
@@ -261,7 +261,7 @@ func TestSubtract(t *testing.T) {
 		},
 	}
 
-	convertor := func(x int, index int) string {
+	convertor := func(x int, _ int) string {
 		return fmt.Sprintf("Have an int whose value is %#v, why don't you", x)
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix associated new gofumpt lint. Fix gosec false positives. Fix new revive lint (unused-param now applies to anonymous functions).


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
