### PR TITLE
docs: improve 'remote list' documentation (release-4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Set default `PATH` in container run in OCI-Mode when image does not set `PATH`.
 - Fix storage of credentials for `docker.io` to behave the same as for
   `index.docker.io`.
+- Improve documentation for `remote list` command.
 
 ## 4.1.2 \[2024-03-05\]
 

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -83,7 +83,7 @@ const (
 	RemoteListLong  string = `
   The 'remote list' command lists all remote endpoints configured for use.
 
-  The current remote is indicated by 'YES' in the 'ACTIVE' column and can be changed
+  The current remote is indicated by '✓' in the 'ACTIVE' column and can be changed
   with the 'remote use' command.`
 	RemoteListExample string = `
   $ singularity remote list`


### PR DESCRIPTION
Update online documentation to reflect the fact that '✓' is used instead of 'YES' in 'remote list' output since https://github.com/sylabs/singularity/pull/1919.