### PR TITLE
chore: use latest go1.21 patch release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.21.8'
+    default: '1.21.9'
 
 executors:
   node:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -174,7 +174,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.21.8 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.21.9 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump recommended go version to 1.21.9.