### PR TITLE
deb: packaging for Ubuntu 24.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ executors:
   ubuntu2204:
     docker:
       - image: ubuntu:22.04
+  ubuntu2404:
+    docker:
+      - image: ubuntu:24.04
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.57.1
@@ -341,6 +344,7 @@ jobs:
               build-essential \
               cryptsetup \
               devscripts \
+              dh-apparmor \
               dh-golang \
               fakeroot \
               git \
@@ -399,7 +403,7 @@ workflows:
       - build-deb:
           matrix:
             parameters:
-              e: ["ubuntu2004", "ubuntu2204"]
+              e: ["ubuntu2004", "ubuntu2204", "ubuntu2404"]
           filters:
             branches:
               only:
@@ -421,7 +425,7 @@ workflows:
       - build-deb:
           matrix:
             parameters:
-              e: ["ubuntu2004", "ubuntu2204"]
+              e: ["ubuntu2004", "ubuntu2204", "ubuntu2404"]
           filters:
             branches:
               ignore: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ pkg/library/client/test[0-9]*
 _build
 debian/.debhelper/
 debian/files
+debian/singularity-ce.postinst.debhelper
+debian/singularity-ce.postrm.debhelper
 debian/singularity-ce*.debhelper.log
 debian/singularity-ce*.substvars
 debian/singularity-ce*/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -266,6 +266,45 @@ install prefix to a different path:
 
 See the output of `./mconfig -h` for available options.
 
+## Apparmor Profile (Ubuntu 24.04+)
+
+Beginning with the 24.04 LTS release, Ubuntu does not permit applications to
+create unprivileged user namespaces by default.
+
+If you install SingularityCE from a GitHub release `.deb` package then an
+apparmor profile will be installed that permits SingularityCE to create
+unprivileged user namespaces.
+
+If you install SingularityCE from source you must configure apparmor.
+Create an apparmor profile file at `/etc/apparmor.d/singularity-ce`:
+
+```sh
+sudo tee /etc/apparmor.d/singularity-ce << 'EOF'
+# Permit unprivileged user namespace creation for SingularityCE starter
+abi <abi/4.0>,
+include <tunables/global>
+
+profile singularity-ce /usr/local/libexec/singularity/bin/starter flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/singularity-ce>
+}
+EOF
+```
+
+Modify the path beginning `/usr/local` if you specified a non-default `--prefix`
+when configuring and installing SingularityCE.
+
+Reload the system apparmor profiles after you have created the file:
+
+```
+sudo systemctl reload apparmor
+```
+
+SingularityCE will now be able to create unprivileged user namespaces on your
+system.
+
 ## Building & Installing from an RPM
 
 On a RHEL / CentOS / Fedora machine you can build a SingularityCE into an RPM

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -298,7 +298,7 @@ when configuring and installing SingularityCE.
 
 Reload the system apparmor profiles after you have created the file:
 
-```
+```sh
 sudo systemctl reload apparmor
 ```
 

--- a/debian/apparmor-placeholder
+++ b/debian/apparmor-placeholder
@@ -1,0 +1,7 @@
+abi <abi/4.0>,
+include <tunables/global>
+ 
+profile singularity-ce /usr/lib/@{multiarch}/singularity/bin/starter flags=(unconfined) {
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/singularity-ce>
+}

--- a/debian/apparmor-userns
+++ b/debian/apparmor-userns
@@ -1,0 +1,10 @@
+# Permit unprivileged user namespace creation for SingularityCE starter
+abi <abi/4.0>,
+include <tunables/global>
+
+profile singularity-ce /usr/lib/@{multiarch}/singularity/bin/starter flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/singularity-ce>
+}

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Uploaders:
 Build-Depends:
  autoconf,
  cryptsetup,
+ dh-apparmor,
  git,
  libfuse-dev,
  libglib2.0-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,8 @@
 srcver = $(shell scripts/get-version | sed -e 's,\(^[^+]\+\)-,\1~,; s,-,.,g')
 dist   = $(shell lsb_release -s -c)
 
+OS_MAJOR := $(shell grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI' | cut -d'.' -f1)
+
 DH_VERBOSE=1
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
@@ -73,6 +75,15 @@ override_dh_auto_install:
 # install standard build
 	cd $(SRCDIR)/$(DH_GOPKG) && \
 	make -C builddir install
+# Apparmor userns profile needed on Ubuntu 24.04, or unconfined placeholder for older versions.
+	if [ $(OS_MAJOR) -gt 23 ] ; then \
+		echo "Ubuntu 24.04 or newer - installing apparmor userns profile"; \
+		install -D -m 644 debian/apparmor-userns $(DESTDIR)/etc/apparmor.d/singularity-ce; \
+	else \
+		echo "Ubuntu 23.10 or older - installing apparmor placeholder profile"; \
+		install -D -m 644 debian/apparmor-placeholder $(DESTDIR)/etc/apparmor.d/singularity-ce; \
+	fi;
+	dh_apparmor --profile-name=singularity-ce
 
 override_dh_fixperms:
 # dh_install copies from debian/tmp into debian/<package name> in the multi-package

--- a/debian/singularity-ce.install
+++ b/debian/singularity-ce.install
@@ -17,3 +17,4 @@ etc/singularity/seccomp-profiles/*
 var/lib/singularity/mnt/session
 usr/share/bash-completion/completions/singularity
 usr/share/man/man1/singularity*
+etc/apparmor.d/singularity-ce

--- a/mlocal/frags/build_squashfuse.mk
+++ b/mlocal/frags/build_squashfuse.mk
@@ -12,13 +12,18 @@ squashfuse_CFLAGS := $(filter-out -Wunused-parameter,$(squashfuse_CFLAGS))
 squashfuse_CFLAGS := $(filter-out -Wunused-variable,$(squashfuse_CFLAGS))
 squashfuse_CFLAGS += -Wno-unused-variable
 
+# Workaround for Ubuntu 24.04... we currently build with -D_FORTIFY_SOURCE=2
+# so filter out the distro -D_FORTIFY_SOURCE=3 from CPPFLAGS to avoid
+# conflict between the two settings.
+squashfuse_CPPFLAGS := $(filter-out -D_FORTIFY_SOURCE=3,$(CPPFLAGS))
+
 $(squashfuse_ll): $(squashfuse_src)
 	@echo " SQUASHFUSE"
 	echo $(squashfuse_CFLAGS)
 	cd $(squashfuse_dir) && ./autogen.sh
-	cd $(squashfuse_dir) && CFLAGS='$(squashfuse_CFLAGS)' ./configure
+	cd $(squashfuse_dir) && CFLAGS='$(squashfuse_CFLAGS)' CPPFLAGS='$(squashfuse_CPPFLAGS)' ./configure
 	$(MAKE) CFLAGS='$(squashfuse_CFLAGS)' -C $(squashfuse_dir) squashfuse_ll
-	
+
 $(squashfuse_INSTALL): $(squashfuse_ll)
 	@echo " INSTALL SQUASHFUSE" $@
 	$(V)umask 0022 && mkdir -p $(@D)


### PR DESCRIPTION
* Document manual apparmor profile install in INSTALL.md for source builds

* Add Ubuntu 24.04 to the CI matrix.

* Add an apparmor profile for Ubuntu >=24 that enables unprivileged user namespace creation in the non-setuid starter.

* Add a placeholder apparmor profile for Ubuntu <24 that just marks the non-setuid starter as unconfined. Avoids version-dependent use of dh_apparmor.

* Strip -D_FORTIFY_SOURCE=3 from CPPFLAGS in squashfuse build, if present (Ubuntu 24.04). This prevents a clash with the -D_FORTIFY_SOURCE=2 that we set explicitly. Squashfuse build already needs some hardening disabled. We should revisit in depth in future.

Closes #2275
