### PR TITLE
fix: include starter-setuid in apparmor profile

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -284,7 +284,7 @@ sudo tee /etc/apparmor.d/singularity-ce << 'EOF'
 abi <abi/4.0>,
 include <tunables/global>
 
-profile singularity-ce /usr/local/libexec/singularity/bin/starter flags=(unconfined) {
+profile singularity-ce /usr/local/libexec/singularity/bin/starter{,-suid} flags=(unconfined) {
   userns,
 
   # Site-specific additions and overrides. See local/README for details.

--- a/debian/apparmor-placeholder
+++ b/debian/apparmor-placeholder
@@ -1,7 +1,7 @@
 abi <abi/4.0>,
 include <tunables/global>
  
-profile singularity-ce /usr/lib/@{multiarch}/singularity/bin/starter flags=(unconfined) {
+profile singularity-ce /usr/lib/@{multiarch}/singularity/bin/starter{,-suid} flags=(unconfined) {
   # Site-specific additions and overrides. See local/README for details.
   include if exists <local/singularity-ce>
 }

--- a/debian/apparmor-userns
+++ b/debian/apparmor-userns
@@ -2,7 +2,7 @@
 abi <abi/4.0>,
 include <tunables/global>
 
-profile singularity-ce /usr/lib/@{multiarch}/singularity/bin/starter flags=(unconfined) {
+profile singularity-ce /usr/lib/@{multiarch}/singularity/bin/starter{,-suid} flags=(unconfined) {
   userns,
 
   # Site-specific additions and overrides. See local/README for details.


### PR DESCRIPTION
## Description of the Pull Request (PR):

The starter-setuid process doesn't run all of its code privileged. In the fakeroot hybrid workflow we need to allow it to create an unprivileged user namespace.

Modify the apparmor profile to permit this.

### This fixes or addresses the following GitHub issues:

 - Fixes #2861


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
