### PR TITLE
oci: --bind / --mount for data containers

### DIFF
--- a/e2e/data/data.go
+++ b/e2e/data/data.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2024, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package data
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
+	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
+)
+
+type ctx struct {
+	env e2e.TestEnv
+}
+
+// Check that `data package` creates a valid data container, that can be used.
+func (c ctx) testDataPackage(t *testing.T) {
+	e2e.EnsureOCISIF(t, c.env)
+	// <tmpdir>/innner/file
+	outerDir := t.TempDir()
+	innerDir := filepath.Join(outerDir, "inner")
+	innerFile := filepath.Join(innerDir, "file")
+	content := []byte("TEST")
+	if err := os.Mkdir(innerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(innerFile, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Basic test that we can run the bound in `nvidia-smi` which *should* be on the PATH
+	tests := []struct {
+		name            string
+		packageSrc      string // directory / file to package
+		packageExitCode int    // exit code from singularity data package
+		boundFile       string // expected location of file in container with data container --bind
+	}{
+		{
+			name:            "InvalidSource",
+			packageSrc:      filepath.Join(c.env.TestDir, "/this/does/not/exist"),
+			packageExitCode: 255,
+		},
+		{
+			name:            "ValidOuter",
+			packageSrc:      outerDir,
+			packageExitCode: 0,
+			boundFile:       "/data/inner/file",
+		},
+		{
+			name:            "ValidInner",
+			packageSrc:      innerDir,
+			packageExitCode: 0,
+			boundFile:       "/data/file",
+		},
+		{
+			name:            "ValidFile",
+			packageSrc:      innerFile,
+			packageExitCode: 0,
+			boundFile:       "/data/file",
+		},
+	}
+
+	// Create a data container
+	for _, tt := range tests {
+		dcPath := filepath.Join(c.env.TestDir, "testDataPackage-"+tt.name)
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name+"/package"),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("data"),
+			e2e.WithArgs("package", tt.packageSrc, dcPath),
+			e2e.ExpectExit(tt.packageExitCode),
+		)
+
+		if tt.boundFile == "" {
+			continue
+		}
+
+		// Verify that the file is at the expected location, when data container used with `--bind`
+		bindSpec := fmt.Sprintf("%s:/data:image-src=/", dcPath)
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name+"/bind"),
+			e2e.WithProfile(e2e.OCIUserProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs("--bind", bindSpec, c.env.OCISIFPath, "/bin/cat", tt.boundFile),
+			e2e.ExpectExit(0,
+				e2e.ExpectOutput(e2e.ExactMatch, string(content)),
+			),
+			e2e.PostRun(func(t *testing.T) {
+				if err := os.Remove(dcPath); err != nil {
+					t.Error(err)
+				}
+			}),
+		)
+	}
+}
+
+// E2ETests is the main func to trigger the test suite
+func E2ETests(env e2e.TestEnv) testhelper.Tests {
+	c := ctx{
+		env: env,
+	}
+
+	return testhelper.Tests{
+		"package": c.testDataPackage,
+	}
+}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sylabs/singularity/v4/e2e/cgroups"
 	"github.com/sylabs/singularity/v4/e2e/cmdenvvars"
 	"github.com/sylabs/singularity/v4/e2e/config"
+	"github.com/sylabs/singularity/v4/e2e/data"
 	"github.com/sylabs/singularity/v4/e2e/delete"
 	"github.com/sylabs/singularity/v4/e2e/docker"
 	"github.com/sylabs/singularity/v4/e2e/ecl"
@@ -73,6 +74,7 @@ var e2eGroups = map[string]testhelper.Group{
 	"CGROUPS":        cgroups.E2ETests,
 	"CMDENVVARS":     cmdenvvars.E2ETests,
 	"CONFIG":         config.E2ETests,
+	"DATA":           data.E2ETests,
 	"DELETE":         delete.E2ETests,
 	"DOCKER":         docker.E2ETests,
 	"E2EBUILDCFG":    e2ebuildcfg.E2ETests,

--- a/internal/pkg/ocisif/datacontainer.go
+++ b/internal/pkg/ocisif/datacontainer.go
@@ -13,12 +13,14 @@ import (
 	"path/filepath"
 	"sync"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	ocimutate "github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sylabs/oci-tools/pkg/mutate"
+	ocitsif "github.com/sylabs/oci-tools/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 // ConfigMediaType custom media type.
@@ -45,7 +47,7 @@ func WriteDataContainerFromPath(path string, dst string, workDir string) error {
 
 // newDataContainerFromFSPath takes a path to a directory or regular file within fsys, and returns
 // a data container image populated with the directory/file.
-func newDataContainerFromFSPath(fsys fs.FS, path string, cfg DataContainerConfig) (v1.Image, error) {
+func newDataContainerFromFSPath(fsys fs.FS, path string, cfg DataContainerConfig) (ggcrv1.Image, error) {
 	fi, err := fs.Stat(fsys, path)
 	if err != nil {
 		return nil, err
@@ -94,7 +96,7 @@ func tarOpener(fn tarWriterFunc) tarball.Opener {
 }
 
 // createDataContainerFromLayer create OCI datacontainer from the supplied v1.Layer.
-func createDataContainerFromLayer(layer v1.Layer, cfg DataContainerConfig) (v1.Image, error) {
+func createDataContainerFromLayer(layer ggcrv1.Layer, cfg DataContainerConfig) (ggcrv1.Image, error) {
 	img := ocimutate.MediaType(empty.Image, types.OCIManifestSchema1)
 
 	img, err := ocimutate.AppendLayers(img, layer)
@@ -105,4 +107,54 @@ func createDataContainerFromLayer(layer v1.Layer, cfg DataContainerConfig) (v1.I
 	return mutate.Apply(img,
 		mutate.SetConfig(cfg, DataContainerConfigMediaType),
 	)
+}
+
+func DataContainerLayerOffset(f *os.File) (int64, error) {
+	fimg, err := sif.LoadContainer(f,
+		sif.OptLoadWithFlag(os.O_RDONLY),
+		sif.OptLoadWithCloseOnUnload(false),
+	)
+	if err != nil {
+		return 0, err
+	}
+	defer fimg.UnloadContainer()
+
+	ix, err := ocitsif.ImageIndexFromFileImage(fimg)
+	if err != nil {
+		return 0, fmt.Errorf("while obtaining image index: %w", err)
+	}
+	idxManifest, err := ix.IndexManifest()
+	if err != nil {
+		return 0, fmt.Errorf("while obtaining index manifest: %w", err)
+	}
+
+	// One image only.
+	if len(idxManifest.Manifests) != 1 {
+		return 0, fmt.Errorf("only single image data containers are supported, found %d images", len(idxManifest.Manifests))
+	}
+	imageDigest := idxManifest.Manifests[0].Digest
+
+	img, err := ix.Image(imageDigest)
+	if err != nil {
+		return 0, fmt.Errorf("while initializing image: %w", err)
+	}
+
+	// One SquashFS layer only.
+	layers, err := img.Layers()
+	if err != nil {
+		return 0, fmt.Errorf("while getting image layers: %w", err)
+	}
+	if len(layers) != 1 {
+		return 0, fmt.Errorf("only single layer data containers are supported, found %d layers", len(layers))
+	}
+	mt, err := layers[0].MediaType()
+	if err != nil {
+		return 0, fmt.Errorf("while getting layer mediatype: %w", err)
+	}
+	if mt != SquashfsLayerMediaType {
+		return 0, fmt.Errorf("unsupported layer mediaType: %v", mt)
+	}
+
+	offset, err := layers[0].(*ocitsif.Layer).Offset()
+	return offset, err
 }

--- a/internal/pkg/util/fs/fuse/fuse_mount_linux.go
+++ b/internal/pkg/util/fs/fuse/fuse_mount_linux.go
@@ -91,7 +91,7 @@ func (i *ImageMount) Mount(ctx context.Context) (err error) {
 func (i *ImageMount) determineMountCmd() (string, error) {
 	var fuseMountTool string
 	switch i.Type {
-	case image.SQUASHFS:
+	case image.SQUASHFS, image.OCISIF:
 		fuseMountTool = "squashfuse"
 	case image.EXT3:
 		fuseMountTool = "fuse2fs"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow OCI-SIF data container created with `singularity data package` to be mounted using the `--bind` and `--mount` flags.

An `image-source=/` option is required on the bind to mount from the root of the data container layer. A shortcut `--data` flag that does not require this will be added in future.

### This fixes or addresses the following GitHub issues:

 - Fixes #2873


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
