### PR TITLE
e2e: use alpine:3.18 instead of latest for main e2e images

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -815,7 +815,7 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 			exit: 0,
 			dfd: e2e.DefFileDetails{
 				Bootstrap: "docker",
-				From:      c.env.TestRegistry + "/my-alpine",
+				From:      c.env.TestRegistry + "/my-alpine:3.18",
 			},
 		},
 		{
@@ -823,7 +823,7 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 			exit: 0,
 			dfd: e2e.DefFileDetails{
 				Bootstrap: "docker",
-				From:      "my-alpine",
+				From:      "my-alpine:3.18",
 				Registry:  c.env.TestRegistry,
 			},
 		},
@@ -832,7 +832,7 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 			exit: 255,
 			dfd: e2e.DefFileDetails{
 				Bootstrap: "docker",
-				From:      "my-alpine",
+				From:      "my-alpine:3.18",
 				Registry:  c.env.TestRegistry,
 				Namespace: "not-a-namespace",
 			},

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -83,7 +83,7 @@ func (c ctx) issue5172(t *testing.T) {
 	u := e2e.UserProfile.HostUser(t)
 
 	// create $HOME/.config/containers/registries.conf
-	regImage := "docker://" + c.env.TestRegistry + "/my-alpine"
+	regImage := c.env.TestRegistryImage
 	regDir := filepath.Join(u.Dir, ".config", "containers")
 	regFile := filepath.Join(regDir, "registries.conf")
 	imagePath := filepath.Join(c.env.TestDir, "issue-5172")

--- a/e2e/registry/registry.go
+++ b/e2e/registry/registry.go
@@ -319,8 +319,8 @@ func (c ctx) registryAuthTester(t *testing.T, withCustomAuthFile bool) {
 		e2e.PrivateRepoLogout(t, c.env, e2e.UserProfile, localAuthFileName)
 	})
 
-	orasCustomPushTarget := fmt.Sprintf("oras://%s/authfile-pushtest-oras-alpine:latest", c.env.TestRegistryPrivPath)
-	dockerCustomPushTarget := fmt.Sprintf("docker://%s/authfile-pushtest-ocisif-alpine:latest", c.env.TestRegistryPrivPath)
+	orasCustomPushTarget := fmt.Sprintf("oras://%s/authfile-pushtest-oras-alpine:3.18", c.env.TestRegistryPrivPath)
+	dockerCustomPushTarget := fmt.Sprintf("docker://%s/authfile-pushtest-ocisif-alpine:3.18", c.env.TestRegistryPrivPath)
 
 	tests := []struct {
 		name          string
@@ -362,28 +362,28 @@ func (c ctx) registryAuthTester(t *testing.T, withCustomAuthFile bool) {
 		{
 			name:          "noauth oras push",
 			cmd:           "push",
-			args:          []string{"my-alpine_latest.sif", orasCustomPushTarget},
+			args:          []string{"my-alpine_3.18.sif", orasCustomPushTarget},
 			whileLoggedIn: false,
 			expectExit:    255,
 		},
 		{
 			name:          "oras push",
 			cmd:           "push",
-			args:          []string{"my-alpine_latest.sif", orasCustomPushTarget},
+			args:          []string{"my-alpine_3.18.sif", orasCustomPushTarget},
 			whileLoggedIn: true,
 			expectExit:    0,
 		},
 		{
 			name:          "noauth docker push",
 			cmd:           "push",
-			args:          []string{"my-alpine_latest.oci.sif", dockerCustomPushTarget},
+			args:          []string{"my-alpine_3.18.oci.sif", dockerCustomPushTarget},
 			whileLoggedIn: false,
 			expectExit:    255,
 		},
 		{
 			name:          "docker push",
 			cmd:           "push",
-			args:          []string{"my-alpine_latest.oci.sif", dockerCustomPushTarget},
+			args:          []string{"my-alpine_3.18.oci.sif", dockerCustomPushTarget},
 			whileLoggedIn: true,
 			expectExit:    0,
 		},

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -199,13 +199,13 @@ func Run(t *testing.T) {
 
 	// Provision local registry
 	testenv.TestRegistry = e2e.StartRegistry(t, testenv)
-	testenv.TestRegistryImage = fmt.Sprintf("docker://%s/my-alpine:latest", testenv.TestRegistry)
+	testenv.TestRegistryImage = fmt.Sprintf("docker://%s/my-alpine:3.18", testenv.TestRegistry)
 	testenv.TestRegistryLayeredImage = fmt.Sprintf("docker://%s/aufs-sanity:latest", testenv.TestRegistry)
 	testenv.TestRegistryPrivURI = fmt.Sprintf("docker://%s", testenv.TestRegistry)
 	testenv.TestRegistryPrivPath = fmt.Sprintf("%s/private/e2eprivrepo", testenv.TestRegistry)
-	testenv.TestRegistryPrivImage = fmt.Sprintf("docker://%s/my-alpine:latest", testenv.TestRegistryPrivPath)
+	testenv.TestRegistryPrivImage = fmt.Sprintf("docker://%s/my-alpine:3.18", testenv.TestRegistryPrivPath)
 
-	// Copy small test image (alpine:latest) into local registry from DockerHub
+	// Copy small test image (alpine:3.18) into local registry from DockerHub
 	insecureSource := false
 	insecureValue := os.Getenv("E2E_DOCKER_MIRROR_INSECURE")
 	if insecureValue != "" {
@@ -214,7 +214,7 @@ func Run(t *testing.T) {
 			t.Fatalf("could not convert E2E_DOCKER_MIRROR_INSECURE=%s: %s", insecureValue, err)
 		}
 	}
-	e2e.CopyOCIImage(t, "docker://alpine:latest", testenv.TestRegistryImage, insecureSource, true)
+	e2e.CopyOCIImage(t, "docker://alpine:3.18", testenv.TestRegistryImage, insecureSource, true)
 
 	// This image has many (8) small layers, constructed to test overlay behavior.
 	// https://github.com/sylabs/singularity-test-containers/tree/master/docker-aufs-sanity
@@ -222,7 +222,7 @@ func Run(t *testing.T) {
 
 	// Copy same test image into private location in test registry
 	e2e.PrivateRepoLogin(t, testenv, e2e.UserProfile, "")
-	e2e.CopyOCIImage(t, "docker://alpine:latest", testenv.TestRegistryPrivImage, insecureSource, true)
+	e2e.CopyOCIImage(t, "docker://alpine:3.18", testenv.TestRegistryPrivImage, insecureSource, true)
 	e2e.PrivateRepoLogout(t, testenv, e2e.UserProfile, "")
 
 	// SIF base test path, built on demand by e2e.EnsureImage


### PR DESCRIPTION
## Description of the Pull Request (PR):

Cherry pick #2946 to release-4.1

Using alpine:latest can cause issues when things change in a new alpine release.


### This fixes or addresses the following GitHub issues:

 - Fixes #2944 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
