### PR TITLE
chore: ci: bump Go, CircleCI machine, linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.21.10'
+    default: '1.22.4'
 
 executors:
   node:
@@ -38,13 +38,13 @@ executors:
       - image: ubuntu:24.04
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.57.1
+      - image: golangci/golangci-lint:v1.59.0
   ubuntu-machine:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:2024.04.4
   ubuntu-machine-large:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:2024.04.4
     resource_class: large
 
 commands:

--- a/internal/pkg/build/buildkit/client/client.go
+++ b/internal/pkg/build/buildkit/client/client.go
@@ -302,7 +302,7 @@ func buildImage(ctx context.Context, opts *Opts, tarFile *os.File, listenSocket,
 			}
 			logrus.SetLevel(logrus.ErrorLevel)
 		}
-		_, err = d.UpdateFrom(context.TODO(), ch)
+		_, err = d.UpdateFrom(ctx, ch)
 		if err != nil {
 			pipeR.Close()
 		}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump Go version to latest, CircleCI Ubuntu 22.04 machine image, golangci-lint version.


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
