### PR TITLE
feat: push --layer-format tar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   - `allow uts ns` : invalidate the use of the `--uts` and `--hostname` flags.
 - A new `singularity data package` command allows files and directories to
   be packaged into an OCI-SIF data container.
+- A new `--layer-format` flag for `singularity push` allows layers in an OCI-SIF
+  image to be pushed to `library://` and `docker://` registries in `squashfs`
+  (default) or `tar` format. Images pushed with `--layer-format tar` can be
+  pulled and run by other OCI runtimes.
 
 ### Bug Fixes
 

--- a/internal/pkg/ocisif/imagewriter.go
+++ b/internal/pkg/ocisif/imagewriter.go
@@ -121,7 +121,6 @@ func (w *ImageWriter) Write() error {
 	}
 
 	if w.squashFSLayers {
-		sylog.Infof("Converting layers to SquashFS")
 		img, err = imgLayersToSquashfs(img, w.srcDigest, w.workDir)
 		if err != nil {
 			return fmt.Errorf("while converting layers: %w", err)
@@ -158,6 +157,7 @@ func imgLayersToSquashfs(img ggcrv1.Image, digest ggcrv1.Hash, workDir string) (
 		return img, err
 	}
 
+	sylog.Infof("Converting layers to SquashFS")
 	var sqOpts []mutate.SquashfsConverterOpt
 	if len(layers) == 1 {
 		sqOpts = []mutate.SquashfsConverterOpt{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add a `--layer-format` flag for the `singularity push` command. This applies only to pushes of OCI-SIF images (including data containers).

When `--layer-format` is not set, or is set to `squashfs` then the OCI-SIF image is pushed with layers in squashfs format. These can only be used by Singularity.

When `--layer-format` is set to `tar` then the OCI-SIF image is pushed with its layers converted on-the-fly to TAR format. The resulting pushed image can be used by other OCI runtimes.

### This fixes or addresses the following GitHub issues:

 - Fixes #2848


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
