### PR TITLE
fix: accommodate binfmt_misc in pkg/image tests

### DIFF
--- a/pkg/image/sif_test.go
+++ b/pkg/image/sif_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sylabs/sif/v2/pkg/sif"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/machine"
 )
 
 const testSquash = "./testdata/squashfs.v4"
@@ -123,12 +124,17 @@ func TestSIFInitializer(t *testing.T) {
 			expectedSections:   0,
 		},
 		{
-			name:               "PrimaryPartitionOtherArchSIF",
-			path:               createSIF(t, false, primPartOtherArch),
-			writable:           false,
-			expectedSuccess:    false,
-			expectedPartitions: 0,
-			expectedSections:   0,
+			name:            "PrimaryPartitionOtherArchSIF",
+			path:            createSIF(t, false, primPartOtherArch),
+			writable:        false,
+			expectedSuccess: machine.CompatibleWith("s390x"),
+			expectedPartitions: func() int {
+				if machine.CompatibleWith("s390x") {
+					return 1
+				}
+				return 0
+			}(),
+			expectedSections: 0,
 		},
 		{
 			name:               "PrimaryPartitionSIF",


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a host is configured such that there is s390x binfmt_misc emulation support, then the PrimaryPartitionOtherArchSIF test will succeed, rather than fail.

### This fixes or addresses the following GitHub issues:

 - Fixes #2986


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
