### PR TITLE
fix: set missing platform in TestOCIConveyor/Packer

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/build/sources"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
+	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	testCache "github.com/sylabs/singularity/v4/internal/pkg/test/tool/cache"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
@@ -66,7 +67,11 @@ func TestOCIConveyorDocker(t *testing.T) {
 	}
 
 	b.Opts.ImgCache = imgCache
-
+	p, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		t.Fatalf("failed to get DefaultPlatform: %v", err)
+	}
+	b.Opts.Platform = *p
 	cp := &sources.OCIConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
@@ -264,6 +269,11 @@ func TestOCIPacker(t *testing.T) {
 	imgCache, cleanup := setupCache(t)
 	defer cleanup()
 	b.Opts.ImgCache = imgCache
+	p, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		t.Fatalf("failed to get DefaultPlatform: %v", err)
+	}
+	b.Opts.Platform = *p
 
 	err = ocp.Get(context.Background(), b)
 	// clean up tmpfs since assembler isn't called


### PR DESCRIPTION
## Description of the Pull Request (PR):

We must provide platform when retrieving an OCI image.


### This fixes or addresses the following GitHub issues:

 - Fixes #2987


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
