### PR TITLE
fix: set missing platform in TestSIFAssembler

### DIFF
--- a/internal/pkg/build/assemblers/sif_test.go
+++ b/internal/pkg/build/assemblers/sif_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/build/assemblers"
 	"github.com/sylabs/singularity/v4/internal/pkg/build/sources"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
+	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	testCache "github.com/sylabs/singularity/v4/internal/pkg/test/tool/cache"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
@@ -63,6 +64,11 @@ func TestSIFAssemblerDocker(t *testing.T) {
 		t.Fatalf("failed to create an image cache handle: %s", err)
 	}
 	b.Opts.ImgCache = imgCache
+	p, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		t.Fatalf("failed to get DefaultPlatform: %v", err)
+	}
+	b.Opts.Platform = *p
 
 	ocp := &sources.OCIConveyorPacker{}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

We must provide platform when retrieving an OCI image.

### This fixes or addresses the following GitHub issues:

 - Fixes #2989


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
