### PR TITLE
fix: panic in ocibundle TestFromImageRef

### DIFF
--- a/pkg/ocibundle/ocisif/bundle_linux_test.go
+++ b/pkg/ocibundle/ocisif/bundle_linux_test.go
@@ -49,7 +49,7 @@ func TestFromImageRef(t *testing.T) {
 			}
 
 			if err := b.Create(context.Background(), nil); err != nil {
-				t.Errorf("While creating bundle: %s", err)
+				t.Fatalf("While creating bundle: %s", err)
 			}
 
 			ocitest.ValidateBundle(t, bundleDir)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix a potential panic where part of a test fails.

If the bundle cannot be created that's a fatal error. We cannot go on to validate it, as the validator will fail with a panic.

### This fixes or addresses the following GitHub issues:

 - Fixes #2985


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
