### PR TITLE
fix: use Apparmor ABI 3 on Ubuntu <23.10 (release-4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Use ABI 3 for Apparmor profile on Ubuntu <23.10.
+
 ## 4.1.3 \[2024-05-08\]
 
 ### Requirements

--- a/debian/apparmor-placeholder
+++ b/debian/apparmor-placeholder
@@ -1,4 +1,6 @@
-abi <abi/4.0>,
+# Placeholder unconfined policy for Singularity starter binaries.
+# Uses AppArmor 3 ABI on Ubuntu <23.10
+abi <abi/3.0>,
 include <tunables/global>
  
 profile singularity-ce /usr/lib/@{multiarch}/singularity/bin/starter{,-suid} flags=(unconfined) {

--- a/debian/apparmor-userns
+++ b/debian/apparmor-userns
@@ -1,4 +1,5 @@
-# Permit unprivileged user namespace creation for SingularityCE starter
+# Permit unprivileged user namespace creation for SingularityCE starter.
+# Uses AppArmor 4 ABI on Ubuntu >=23.10
 abi <abi/4.0>,
 include <tunables/global>
 

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,7 @@
 srcver = $(shell scripts/get-version | sed -e 's,\(^[^+]\+\)-,\1~,; s,-,.,g')
 dist   = $(shell lsb_release -s -c)
 
+OS_VERSION := $(shell grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI')
 OS_MAJOR := $(shell grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI' | cut -d'.' -f1)
 
 DH_VERBOSE=1
@@ -75,12 +76,12 @@ override_dh_auto_install:
 # install standard build
 	cd $(SRCDIR)/$(DH_GOPKG) && \
 	make -C builddir install
-# Apparmor userns profile needed on Ubuntu 24.04, or unconfined placeholder for older versions.
-	if [ $(OS_MAJOR) -gt 23 ] ; then \
+# Apparmor userns profile needed on Ubuntu >=23.10, or unconfined placeholder for older versions.
+	if [ $(OS_MAJOR) -gt 23 ] || [ "$(OS_VERSION)" = "23.10" ]; then \
 		echo "Ubuntu 24.04 or newer - installing apparmor userns profile"; \
 		install -D -m 644 debian/apparmor-userns $(DESTDIR)/etc/apparmor.d/singularity-ce; \
 	else \
-		echo "Ubuntu 23.10 or older - installing apparmor placeholder profile"; \
+		echo "Ubuntu 23.04 or older - installing apparmor placeholder profile"; \
 		install -D -m 644 debian/apparmor-placeholder $(DESTDIR)/etc/apparmor.d/singularity-ce; \
 	fi;
 	dh_apparmor --profile-name=singularity-ce


### PR DESCRIPTION
## Description of the Pull Request (PR):

Our placeholder policy for AppArmor must use ABI 3, as ABI 4 isn't available on Ubuntu <23.10.

We can install the actual userns policy with ABI 4 on 23.10 and above.

### This fixes or addresses the following GitHub issues:

 - Fixes #2970


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
