### PR TITLE
fix: do not copy local OCI images to layout (release-4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Use ABI 3 for Apparmor profile on Ubuntu <23.10.
 
+### Bug Fixes
+
+- Avoid unnecessary copying / extraction of OCI images and Docker tarballs into
+  a layout directory when they are directly accessible as a local file /
+  directory.
+
 ## 4.1.3 \[2024-05-08\]
 
 ### Requirements

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -159,8 +159,9 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		imgCache = cp.b.Opts.ImgCache
 	}
 
-	// Fetch the image into a temporary containers/image oci layout dir.
-	cp.srcImg, err = ociimage.FetchToLayout(ctx, cp.transportOptions, imgCache, ref, b.TmpDir)
+	// If the image is not a local file or OCI layout, fetch into cache or
+	// temporary layout.
+	cp.srcImg, err = ociimage.LocalImage(ctx, cp.transportOptions, imgCache, ref, b.TmpDir)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/client/ocisif/ocisif.go
+++ b/internal/pkg/client/ocisif/ocisif.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sylabs Inc. All rights reserved.
+// Copyright (c) 2023-2024 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -133,7 +133,7 @@ func createOciSif(ctx context.Context, tOpts *ociimage.TransportOptions, imgCach
 		return err
 	}
 
-	img, err := ociimage.FetchToLayout(ctx, tOpts, imgCache, imageSrc, tmpDir)
+	img, err := ociimage.LocalImage(ctx, tOpts, imgCache, imageSrc, tmpDir)
 	if err != nil {
 		return fmt.Errorf("while fetching OCI image: %w", err)
 	}

--- a/internal/pkg/ociimage/digest.go
+++ b/internal/pkg/ociimage/digest.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry-pick #2935

When an OCI image is already available as an OCI layout directory, or a docker tarball, ggcr can read it directly. We can avoid additionally fetching it into the cache or a temporary OCI layout directory. This saves time, disk space, and I/O.

### This fixes or addresses the following GitHub issues:

 - Fixes #2934


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
