### PR TITLE
fix: copy relative symlinks correctly between stages (release-4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@
 ### Bug Fixes
 
 - Use ABI 3 for Apparmor profile on Ubuntu <23.10.
-
-### Bug Fixes
-
 - Avoid unnecessary copying / extraction of OCI images and Docker tarballs into
   a layout directory when they are directly accessible as a local file /
   directory.
 - Avoid unnecessary intermediate temporary image layout when building from
   Dockerfile to OCI-SIF.
+- `%files from` in a definition file will now correctly copy symlinks that point
+  to a target above the destination directory, but inside the destination stage
+  rootfs.
 
 ## 4.1.3 \[2024-05-08\]
 

--- a/LICENSE_THIRD_PARTY.md
+++ b/LICENSE_THIRD_PARTY.md
@@ -504,14 +504,6 @@ Are code from the conmon project, under the Apache License, Version 2.0.
    limitations under the License.
 ```
 
-## github.com/docker/cli
-
-The source files:
-
-* `internal/app/singularity/instance_linux.go`
-
-Contain code from the docker cli project, under the Apache License, Version 2.0.
-
 ## github.com/google/go-containerregistry
 
 The source files:
@@ -606,4 +598,52 @@ Contain code from the docker cli project, under the Apache License, Version 2.0.
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+```
+
+## github.com/docker/cli
+
+The source files:
+
+* `internal/app/singularity/instance_linux.go`
+
+Contain code from the docker cli project, under the Apache License, Version 2.0.
+
+```text
+   Copyright 2013-2017 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```
+
+## github.com/docker/docker
+
+The source files:
+
+* `internal/pkg/archive/archive.go`
+
+Contain code from the docker project, under the Apache License, Version 2.0.
+
+```text
+   Copyright 2013-2018 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 ```

--- a/e2e/build/build.go
+++ b/e2e/build/build.go
@@ -2483,5 +2483,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5690":                      c.issue5690,                     // https://github.com/hpcng/singularity/issues/5690
 		"issue 1273":                      c.issue1273,                     // https://github.com/sylabs/singularity/issues/1273
 		"issue 1812":                      c.issue1812,                     // https://github.com/sylabs/singularity/issues/1812
+		"issue 2607":                      c.issue2607,                     // https://github.com/sylabs/singularity/issues/2607
 	}
 }

--- a/e2e/build/regressions.go
+++ b/e2e/build/regressions.go
@@ -635,3 +635,22 @@ from: %s
 		})
 	}
 }
+
+// When a symlink at /foo/bar targets ../bar then it should copy correctly when
+// /foo is copied between stages.
+func (c *imgBuildTests) issue2607(t *testing.T) {
+	image := filepath.Join(c.env.TestDir, "issue_2607.sif")
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(image, "testdata/regressions/issue_2607.def"),
+		e2e.PostRun(func(_ *testing.T) {
+			os.Remove(image)
+		}),
+		e2e.ExpectExit(
+			0,
+		),
+	)
+}

--- a/e2e/testdata/regressions/issue_2607.def
+++ b/e2e/testdata/regressions/issue_2607.def
@@ -1,0 +1,15 @@
+Bootstrap: library
+From: alpine:3.11.5
+Stage: one
+
+%post
+touch /bar
+mkdir -p /foo
+ln -s ../bar /foo/bar
+
+Bootstrap: library
+From: alpine:3.11.5
+Stage: two
+
+%files from one
+/foo

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.14.0
 	github.com/moby/buildkit v0.14.1
+	github.com/moby/sys/sequential v0.5.0
 	github.com/moby/term v0.5.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/opencontainers/runc v1.1.13
@@ -148,7 +149,6 @@ require (
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/mount v0.3.3 // indirect
 	github.com/moby/sys/mountinfo v0.7.1 // indirect
-	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/sys/signal v0.7.0 // indirect
 	github.com/moby/sys/user v0.1.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -160,9 +160,9 @@ func CopyFromStage(src, dst, srcRootfs, dstRootfs string, disableIDMapping bool)
 			dstResolved = path.Join(dstResolved, srcName)
 		}
 
-		err = archive.CopyWithTar(srcResolved, dstResolved, disableIDMapping)
+		err = archive.CopyWithTarWithRoot(srcResolved, dstResolved, dstRootfs, disableIDMapping)
 		if err != nil {
-			return fmt.Errorf("while copying %s to %s: %s", paths, dstResolved, err)
+			return fmt.Errorf("while copying %s to %s: %s", srcGlobbed, dstResolved, err)
 		}
 	}
 	return nil

--- a/pkg/util/archive/archive.go
+++ b/pkg/util/archive/archive.go
@@ -1,0 +1,370 @@
+/*
+Contains code adapted from:
+
+   https://github.com/moby/moby/tree/master/pkg/archive
+
+Copyright 2013-2018 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/containerd/containerd/pkg/userns"
+	da "github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/pools"
+	"github.com/docker/docker/pkg/system"
+	"github.com/moby/sys/sequential"
+	"github.com/pkg/errors"
+	"github.com/sylabs/singularity/v4/pkg/sylog"
+)
+
+// Unpack unpacks the decompressedArchive to dest with options. The target of
+// any symlinks and hard links must be under destRoot. This differs from the
+// unmodified upstream code, which requires that they are under dest.
+func UnpackWithRoot(decompressedArchive io.Reader, dest, destRoot string, options *da.TarOptions) error {
+	tr := tar.NewReader(decompressedArchive)
+	trBuf := pools.BufioReader32KPool.Get(nil)
+	defer pools.BufioReader32KPool.Put(trBuf)
+
+	var dirs []*tar.Header
+
+	if options.WhiteoutFormat != 0 {
+		return fmt.Errorf("options.WhiteoutFormat is not supported by UnpackWithRoot")
+	}
+
+	// Iterate through the files in the archive.
+loop:
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		// ignore XGlobalHeader early to avoid creating parent directories for them
+		if hdr.Typeflag == tar.TypeXGlobalHeader {
+			sylog.Debugf("PAX Global Extended Headers found for %s and ignored", hdr.Name)
+			continue
+		}
+
+		// Normalize name, for safety and for a simple is-root check
+		// This keeps "../" as-is, but normalizes "/../" to "/". Or Windows:
+		// This keeps "..\" as-is, but normalizes "\..\" to "\".
+		hdr.Name = filepath.Clean(hdr.Name)
+
+		for _, exclude := range options.ExcludePatterns {
+			if strings.HasPrefix(hdr.Name, exclude) {
+				continue loop
+			}
+		}
+
+		// Ensure that the parent directory exists.
+		err = createImpliedDirectories(dest, hdr, options)
+		if err != nil {
+			return err
+		}
+
+		// #nosec G305 -- The joined path is checked for path traversal.
+		path := filepath.Join(dest, hdr.Name)
+		rel, err := filepath.Rel(dest, path)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("%q is outside of %q", hdr.Name, dest)
+		}
+
+		// If path exits we almost always just want to remove and replace it
+		// The only exception is when it is a directory *and* the file from
+		// the layer is also a directory. Then we want to merge them (i.e.
+		// just apply the metadata from the layer).
+		if fi, err := os.Lstat(path); err == nil {
+			if options.NoOverwriteDirNonDir && fi.IsDir() && hdr.Typeflag != tar.TypeDir {
+				// If NoOverwriteDirNonDir is true then we cannot replace
+				// an existing directory with a non-directory from the archive.
+				return fmt.Errorf("cannot overwrite directory %q with non-directory %q", path, dest)
+			}
+
+			if options.NoOverwriteDirNonDir && !fi.IsDir() && hdr.Typeflag == tar.TypeDir {
+				// If NoOverwriteDirNonDir is true then we cannot replace
+				// an existing non-directory with a directory from the archive.
+				return fmt.Errorf("cannot overwrite non-directory %q with directory %q", path, dest)
+			}
+
+			if fi.IsDir() && hdr.Name == "." {
+				continue
+			}
+
+			if !(fi.IsDir() && hdr.Typeflag == tar.TypeDir) {
+				if err := os.RemoveAll(path); err != nil {
+					return err
+				}
+			}
+		}
+		trBuf.Reset(tr)
+
+		if err := remapIDs(options.IDMap, hdr); err != nil {
+			return err
+		}
+
+		if err := createTarFile(path, dest, destRoot, hdr, trBuf, options); err != nil {
+			return err
+		}
+
+		// Directory mtimes must be handled at the end to avoid further
+		// file creation in them to modify the directory mtime
+		if hdr.Typeflag == tar.TypeDir {
+			dirs = append(dirs, hdr)
+		}
+	}
+
+	for _, hdr := range dirs {
+		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
+		path := filepath.Join(dest, hdr.Name)
+
+		if err := system.Chtimes(path, hdr.AccessTime, hdr.ModTime); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// createImpliedDirectories will create all parent directories of the current path with default permissions, if they do
+// not already exist. This is possible as the tar format supports 'implicit' directories, where their existence is
+// defined by the paths of files in the tar, but there are no header entries for the directories themselves, and thus
+// we most both create them and choose metadata like permissions.
+//
+// The caller should have performed filepath.Clean(hdr.Name), so hdr.Name will now be in the filepath format for the OS
+// on which the daemon is running. This precondition is required because this function assumes a OS-specific path
+// separator when checking that a path is not the root.
+func createImpliedDirectories(dest string, hdr *tar.Header, options *da.TarOptions) error {
+	// Not the root directory, ensure that the parent directory exists
+	if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
+		parent := filepath.Dir(hdr.Name)
+		parentPath := filepath.Join(dest, parent)
+		if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
+			// RootPair() is confined inside this loop as most cases will not require a call, so we can spend some
+			// unneeded function calls in the uncommon case to encapsulate logic -- implied directories are a niche
+			// usage that reduces the portability of an image.
+			rootIDs := options.IDMap.RootPair()
+
+			err = idtools.MkdirAllAndChownNew(parentPath, da.ImpliedDirectoryMode, rootIDs)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func remapIDs(idMapping idtools.IdentityMapping, hdr *tar.Header) error {
+	ids, err := idMapping.ToHost(idtools.Identity{UID: hdr.Uid, GID: hdr.Gid})
+	hdr.Uid, hdr.Gid = ids.UID, ids.GID
+	return err
+}
+
+const paxSchilyXattr = "SCHILY.xattr."
+
+// createTarFile creates a file from a tar record. The target of any symlinks
+// and hard links must be under extractRoot. This differs from the unmodified upstream
+// code, which requires that they are under extractDir.
+func createTarFile(path, extractDir, extractRoot string, hdr *tar.Header, reader io.Reader, opts *da.TarOptions) error {
+	var (
+		Lchown           = true
+		bestEffortXattrs bool
+		chownOpts        *idtools.Identity
+	)
+	if opts != nil {
+		Lchown = !opts.NoLchown
+		chownOpts = opts.ChownOpts
+		bestEffortXattrs = opts.BestEffortXattrs
+	}
+
+	// hdr.Mode is in linux format, which we can use for sycalls,
+	// but for os.Foo() calls we need the mode converted to os.FileMode,
+	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
+	hdrInfo := hdr.FileInfo()
+
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		// Create directory unless it exists as a directory already.
+		// In that case we just want to merge the two
+		if fi, err := os.Lstat(path); !(err == nil && fi.IsDir()) {
+			if err := os.Mkdir(path, hdrInfo.Mode()); err != nil {
+				return err
+			}
+		}
+
+	case tar.TypeReg:
+		// Source is regular file. We use sequential file access to avoid depleting
+		// the standby list on Windows. On Linux, this equates to a regular os.OpenFile.
+		file, err := sequential.OpenFile(path, os.O_CREATE|os.O_WRONLY, hdrInfo.Mode())
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(file, reader); err != nil {
+			file.Close()
+			return err
+		}
+		file.Close()
+
+	case tar.TypeBlock, tar.TypeChar:
+		sylog.Warningf("Skipping %s - block / char devices are not copied", path)
+		return nil
+
+	case tar.TypeFifo:
+		// Handle this is an OS-specific way
+		sylog.Warningf("Skipping %s - fifos are not copied", path)
+
+	case tar.TypeLink:
+		// #nosec G305 -- The target path is checked for path traversal.
+		targetPath := filepath.Join(extractDir, hdr.Linkname)
+		// check for hardlink breakout
+		if !strings.HasPrefix(targetPath, extractRoot) {
+			return fmt.Errorf("invalid symlink target: %s, resolves to %s, not in root: %s", hdr.Linkname, targetPath, extractRoot)
+		}
+
+		if err := os.Link(targetPath, path); err != nil {
+			return err
+		}
+
+	case tar.TypeSymlink:
+		// 	path 				-> hdr.Linkname = targetPath
+		// e.g. /extractDir/path/to/symlink 	-> ../2/file	= /extractDir/path/2/file
+		targetPath := filepath.Join(filepath.Dir(path), hdr.Linkname) // #nosec G305 -- The target path is checked for path traversal.
+
+		// the reason we don't need to check symlinks in the path (with FollowSymlinkInScope) is because
+		// that symlink would first have to be created, which would be caught earlier, at this very check:
+		if !strings.HasPrefix(targetPath, extractRoot) {
+			return fmt.Errorf("invalid symlink target: %s, resolves to %s, not in root: %s", hdr.Linkname, targetPath, extractRoot)
+		}
+		if err := os.Symlink(hdr.Linkname, path); err != nil {
+			return err
+		}
+
+	case tar.TypeXGlobalHeader:
+		sylog.Debugf("PAX Global Extended Headers found and ignored")
+		return nil
+
+	default:
+		return fmt.Errorf("unhandled tar header type %d", hdr.Typeflag)
+	}
+
+	// Lchown is not supported on Windows.
+	if Lchown && runtime.GOOS != "windows" {
+		if chownOpts == nil {
+			chownOpts = &idtools.Identity{UID: hdr.Uid, GID: hdr.Gid}
+		}
+		if err := os.Lchown(path, chownOpts.UID, chownOpts.GID); err != nil {
+			msg := "failed to Lchown %q for UID %d, GID %d"
+			if errors.Is(err, syscall.EINVAL) && userns.RunningInUserNS() {
+				msg += " (try increasing the number of subordinate IDs in /etc/subuid and /etc/subgid)"
+			}
+			return errors.Wrapf(err, msg, path, hdr.Uid, hdr.Gid)
+		}
+	}
+
+	var xattrErrs []string
+	for key, value := range hdr.PAXRecords {
+		xattr, ok := strings.CutPrefix(key, paxSchilyXattr)
+		if !ok {
+			continue
+		}
+		if err := system.Lsetxattr(path, xattr, []byte(value), 0); err != nil {
+			if bestEffortXattrs && errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.EPERM) {
+				// EPERM occurs if modifying xattrs is not allowed. This can
+				// happen when running in userns with restrictions (ChromeOS).
+				xattrErrs = append(xattrErrs, err.Error())
+				continue
+			}
+			return err
+		}
+	}
+
+	if len(xattrErrs) > 0 {
+		sylog.Warningf("Ignored xattrs in archive: underlying filesystem doesn't support them: %v", xattrErrs)
+	}
+
+	// There is no LChmod, so ignore mode for symlink. Also, this
+	// must happen after chown, as that can modify the file mode
+	if err := handleLChmod(hdr, path, hdrInfo); err != nil {
+		return err
+	}
+
+	aTime := hdr.AccessTime
+	if aTime.Before(hdr.ModTime) {
+		// Last access time should never be before last modified time.
+		aTime = hdr.ModTime
+	}
+
+	// system.Chtimes doesn't support a NOFOLLOW flag atm
+	if hdr.Typeflag == tar.TypeLink {
+		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+			if err := system.Chtimes(path, aTime, hdr.ModTime); err != nil {
+				return err
+			}
+		}
+	} else if hdr.Typeflag != tar.TypeSymlink {
+		if err := system.Chtimes(path, aTime, hdr.ModTime); err != nil {
+			return err
+		}
+	} else {
+		ts := []syscall.Timespec{timeToTimespec(aTime), timeToTimespec(hdr.ModTime)}
+		if err := system.LUtimesNano(path, ts); err != nil && err != system.ErrNotSupportedPlatform {
+			return err
+		}
+	}
+	return nil
+}
+
+func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+	if hdr.Typeflag == tar.TypeLink {
+		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+			if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+				return err
+			}
+		}
+	} else if hdr.Typeflag != tar.TypeSymlink {
+		if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func timeToTimespec(time time.Time) (ts syscall.Timespec) {
+	if time.IsZero() {
+		// Return UTIME_OMIT special value
+		ts.Sec = 0
+		ts.Nsec = (1 << 30) - 2
+		return
+	}
+	return syscall.NsecToTimespec(time.UnixNano())
+}

--- a/pkg/util/archive/copy.go
+++ b/pkg/util/archive/copy.go
@@ -6,19 +6,20 @@
 package archive
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	da "github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
-// CopyWithTar is a wrapper around the docker pkg/archive/copy CopyWithTar allowing unprivileged use.
-// It forces ownership to the current uid/gid in unprivileged situations.
-//
-// Disable context check as it raises a warning through the docker dependency we
-// cannot modify to pass a context.
+// CopyWithTar is a wrapper around the docker pkg/archive/copy CopyWithTar
+// function allowing unprivileged use. It forces ownership to the current
+// uid/gid in unprivileged situations. No file may be copied into a location
+// above dst, and hard links / symlinks may not target a file above dst.
 func CopyWithTar(src, dst string, disableIDMapping bool) error {
 	ar := da.NewDefaultArchiver()
 
@@ -63,6 +64,82 @@ func CopyWithTar(src, dst string, disableIDMapping bool) error {
 			options.ChownOpts = eIdentity
 			return da.Untar(tarArchive, dest, options)
 		}
+	}
+
+	return ar.CopyWithTar(src, dst)
+}
+
+// CopyWithTarWithRoots copies files as with CopyWithTar, but uses a custom
+// ar.Untar which checks that hard link / symlink targets are under dstRoot,
+// and not dst. This allows copying a directory src to dst, where the directory
+// contains a link to a location above dst, but under dstroot.
+func CopyWithTarWithRoot(src, dst, dstRoot string, disableIDMapping bool) error {
+	ar := da.NewDefaultArchiver()
+
+	// If we are running unprivileged, then squash uid / gid as necessary.
+	// TODO: In future, we want to think about preserving effective ownership
+	// for fakeroot cases where there will be a mapping allowing non-root, non-user
+	// ownership to be preserved.
+	euid := os.Geteuid()
+	egid := os.Getgid()
+	var eIdentity *idtools.Identity
+
+	if (euid != 0 || egid != 0) && !disableIDMapping {
+		sylog.Debugf("Using unprivileged CopyWithTar (uid=%d, gid=%d)", euid, egid)
+		// The docker CopytWithTar function assumes it should create the top-level of dst as the
+		// container root user. If we are unprivileged this means setting up an ID mapping
+		// from UID/GID 0 to our host UID/GID.
+		ar.IDMapping = idtools.IdentityMapping{
+			// Single entry mapping of container root (0) to current uid only
+			UIDMaps: []idtools.IDMap{
+				{
+					ContainerID: 0,
+					HostID:      euid,
+					Size:        1,
+				},
+			},
+			// Single entry mapping of container root (0) to current gid only
+			GIDMaps: []idtools.IDMap{
+				{
+					ContainerID: 0,
+					HostID:      egid,
+					Size:        1,
+				},
+			},
+		}
+		// Actual extraction of files needs to be *always* squashed to our current uid & gid.
+		// This requires clearing the IDMaps, and setting a forced UID/GID with ChownOpts for
+		// the lower level Untar func called by the archiver.
+		eIdentity = &idtools.Identity{
+			UID: euid,
+			GID: egid,
+		}
+	}
+
+	ar.Untar = func(tarArchive io.Reader, dest string, options *da.TarOptions) error {
+		if eIdentity != nil {
+			options.IDMap = idtools.IdentityMapping{}
+			options.ChownOpts = eIdentity
+		}
+
+		if tarArchive == nil {
+			return fmt.Errorf("Empty archive")
+		}
+		dest = filepath.Clean(dest)
+		if options == nil {
+			options = &da.TarOptions{}
+		}
+		if options.ExcludePatterns == nil {
+			options.ExcludePatterns = []string{}
+		}
+
+		decompressedArchive, err := da.DecompressStream(tarArchive)
+		if err != nil {
+			return err
+		}
+		defer decompressedArchive.Close()
+
+		return UnpackWithRoot(decompressedArchive, dest, dstRoot, options)
 	}
 
 	return ar.CopyWithTar(src, dst)

--- a/pkg/util/archive/copy_test.go
+++ b/pkg/util/archive/copy_test.go
@@ -13,22 +13,47 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
 func TestCopyWithTar(t *testing.T) {
+	copyFunc := func(src, dst string) error {
+		return CopyWithTar(src, dst, false)
+	}
+
 	t.Run("privileged", func(t *testing.T) {
 		test.EnsurePrivilege(t)
-		testCopyWithTar(t)
+		testCopy(t, copyFunc)
 	})
 
 	t.Run("unprivileged", func(t *testing.T) {
 		test.DropPrivilege(t)
 		defer test.ResetPrivilege(t)
-		testCopyWithTar(t)
+		testCopy(t, copyFunc)
 	})
 }
 
-func testCopyWithTar(t *testing.T) {
+func TestCopyWithTarRoot(t *testing.T) {
+	copyFunc := func(src, dst string) error {
+		return CopyWithTarWithRoot(src, dst, dst, false)
+	}
+
+	t.Run("privileged", func(t *testing.T) {
+		test.EnsurePrivilege(t)
+		testCopy(t, copyFunc)
+	})
+
+	t.Run("unprivileged", func(t *testing.T) {
+		test.DropPrivilege(t)
+		defer test.ResetPrivilege(t)
+		testCopy(t, copyFunc)
+	})
+
+	test.DropPrivilege(t)
+	t.Run("relLinkTarget", testRelLinkTarget)
+}
+
+func testCopy(t *testing.T, copyFunc func(src, dst string) error) {
 	srcRoot := t.TempDir()
 	t.Logf("srcRoot location: %s\n", srcRoot)
 
@@ -54,7 +79,7 @@ func testCopyWithTar(t *testing.T) {
 	// Perform the actual copy to a subdir of our dst tempdir.
 	// This ensures CopyWithTar has to create the dest directory, which is
 	// where the non-wrapped call would fail for unprivileged users.
-	err := CopyWithTar(srcRoot, path.Join(dstRoot, "dst"), false)
+	err := copyFunc(srcRoot, path.Join(dstRoot, "dst"))
 	if err != nil {
 		t.Fatalf("Error during CopyWithTar: %v", err)
 	}
@@ -110,6 +135,66 @@ func testCopyWithTar(t *testing.T) {
 			}
 			if !tt.expectLink && fs.IsLink(dstFinal) {
 				t.Errorf("destination %s should be a symlink, but is", dstFinal)
+			}
+		})
+	}
+}
+
+// Test that CopyWithTarWithRoot doesn't allow relative symlink targets above
+// the dstRoot, but does allow them within the dstRoot, above dst.
+//
+// See - https://github.com/sylabs/singularity/issues/2607
+func testRelLinkTarget(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	linkTargetFile := filepath.Join(tmpDir, "target")
+	if err := os.WriteFile(linkTargetFile, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		linkPath    string
+		linkTarget  string
+		src         string
+		dst         string
+		dstRoot     string
+		expectError bool
+	}{
+		{
+			name:        "symlinkEscape",
+			linkPath:    filepath.Join(tmpDir, "symlinkEscape", "myLink"),
+			linkTarget:  "../target",
+			src:         filepath.Join(tmpDir, "symlinkEscape"),
+			dst:         filepath.Join(tmpDir, "symlinkEscapeDest"),
+			dstRoot:     filepath.Join(tmpDir, "symlinkEscapeDest"),
+			expectError: true,
+		},
+		{
+			name:        "symLinkWithinRoot",
+			linkPath:    filepath.Join(tmpDir, "symlinkWithinRoot", "myLink"),
+			linkTarget:  "../target",
+			src:         filepath.Join(tmpDir, "symlinkWithinRoot"),
+			dst:         filepath.Join(tmpDir, "symlinkWithinRootDest"),
+			dstRoot:     tmpDir,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.MkdirAll(filepath.Dir(tt.linkPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(tt.linkTarget, tt.linkPath); err != nil {
+				t.Fatal(err)
+			}
+			err := CopyWithTarWithRoot(tt.src, tt.dst, tt.dstRoot, false)
+			if err == nil && tt.expectError {
+				sylog.Errorf("expected error, but none returned")
+			}
+			if err != nil && !tt.expectError {
+				sylog.Errorf("unexpected error %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
cherry pick #2924

In a build stage, a valid relative symlink can be created that points to a location in the rootfs that is above the location of the symlink. E.g.:

  /usr/mydir/mysubdir/true -> ../../../bin/true

This symlink is valid in the rootfs. It resolves to `/bin/true`.

If we attempt to copy `/usr/mydir` into a new build stage, then prior to this PR the symlink would cause the copy to fail.

We have been using `CopyFromTar` to copy from src `<stage1>/usr/mydir`, to `<stage2>/usr/mydir`. The `CopyFromTar` routines enforce that the target of a hard link or symlink must be under dst, or a fatal error is raised to avoid a breakout attack.

When copying between stages our boundary is not dst, but the top level of the destination stage's rootfs. We must allow links to be created that are above dst, but within the stage rootfs.

To resolve the issue, bring over enough code from
`docker/docker/pkg/archive` that we can implement a `CopyFromTarWithRoot`, that performs the same as `CopyFromTar`, except that we can specify a destination root directory. Any hard links and symlink targets under this destination root directory are valid.

Fixes #2607