### PR TITLE
fix: avoid unneccesary temporary layout during build --oci (release-4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Avoid unnecessary copying / extraction of OCI images and Docker tarballs into
   a layout directory when they are directly accessible as a local file /
   directory.
+- Avoid unnecessary intermediate temporary image layout when building from
+  Dockerfile to OCI-SIF.
 
 ## 4.1.3 \[2024-05-08\]
 

--- a/internal/pkg/build/buildkit/client/client.go
+++ b/internal/pkg/build/buildkit/client/client.go
@@ -123,7 +123,7 @@ func Run(ctx context.Context, opts *Opts, dest, spec string) error {
 		}
 		pullOpts.Platform = *platform
 	}
-	if _, err := ocisif.PullOCISIF(ctx, nil, dest, "oci-archive:"+tarFile.Name(), pullOpts); err != nil {
+	if _, err := ocisif.PullOCISIF(ctx, nil, dest, "docker-archive:"+tarFile.Name(), pullOpts); err != nil {
 		return fmt.Errorf("while converting OCI tar image to OCI-SIF: %w", err)
 	}
 


### PR DESCRIPTION
cherry pick #2936

With #2935 in place we can now translate a Docker archive tarball into an OCI-SIF without creating a redundant copy of the image as a temporary OCI layout.

We've previously been processing the buildkit tarball as an oci-archive, which still requires extraction to a temporary layout, as ggcr's tarball package doesn't accept an archived layout without a manifest.json.

Because the buildkit output tarball includes the Docker specific manifest.json, in addition to the standard OCI layout files, it can be treated as a docker-archive - now avoiding the need for the temporary layout.

Significantly reduces disk space needed by `build --oci`, and the associated I/O.

Fixes #2308