### PR TITLE
chore: Refactor OverlayCreate

### DIFF
--- a/cmd/internal/cli/overlay_create.go
+++ b/cmd/internal/cli/overlay_create.go
@@ -48,7 +48,7 @@ var overlayCreateDirFlag = cmdline.Flag{
 var OverlayCreateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	RunE: func(_ *cobra.Command, args []string) error {
-		if err := singularity.OverlayCreate(overlaySize, args[0], overlaySparse, overlayDirs...); err != nil {
+		if err := singularity.OverlayCreate(args[0], overlaySize, overlaySparse, overlayDirs...); err != nil {
 			sylog.Fatalf(err.Error())
 		}
 		return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Refactor the OverlayCreate routines ahead of work to add overlay creation for OCI-SIF.

* Don't duplicate utility functions from the image package.
* Split up command checks / image checks / ext overlay file create / addition to SIF into separate functions.

Should allow OCI-SIF overlay creation to be added in a neater commit.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
