### PR TITLE
feat: singularity overlay create for OCI-SIF

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/sylabs/json-resp v0.9.3
-	github.com/sylabs/oci-tools v0.10.0
+	github.com/sylabs/oci-tools v0.11.0
 	github.com/sylabs/scs-build-client v0.9.6
 	github.com/sylabs/scs-key-client v0.7.6
 	github.com/sylabs/scs-library-client v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/sylabs/json-resp v0.9.3 h1:9GuEmBb1ZHNhVlUEI1wzQSE4ol5avakmRnmeyXfmIk0=
 github.com/sylabs/json-resp v0.9.3/go.mod h1:Q9X4wRlZNPv3x76KaL8vTCBO4aC/DP2gh13xdtEqd1g=
-github.com/sylabs/oci-tools v0.10.0 h1:af2NUFdGoQnjd9U9fCRmWO65QOrVDsosttIj6mrjAP0=
-github.com/sylabs/oci-tools v0.10.0/go.mod h1:cZPg0FwNmUkrMUVDI7KMaociyDwR/pYyEqKb1PJlEk4=
+github.com/sylabs/oci-tools v0.11.0 h1:MAF+wdgsSIsC9Oti6Q6mlhXSCsHpEYxZFh5wKXVpLus=
+github.com/sylabs/oci-tools v0.11.0/go.mod h1:VsfSXGYzoRlZrhDh4jUNdtU/BNK5SaAiHeg9WiQh4nA=
 github.com/sylabs/scs-build-client v0.9.6 h1:aUZtiixIjsfv0KvctbgV5uEP2ZwdrYCjt3tFx1nm/Zo=
 github.com/sylabs/scs-build-client v0.9.6/go.mod h1:l75uhZgPAWdwrUTAbhaEcKKF3AM9D15pbRk0u1I4fwE=
 github.com/sylabs/scs-key-client v0.7.6 h1:4PbySN/0UQpMVoXbhQjcxgZqdFZ6pRbMnCAB35u8ekk=

--- a/internal/pkg/ocisif/overlay.go
+++ b/internal/pkg/ocisif/overlay.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2024, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package ocisif
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	ocitsif "github.com/sylabs/oci-tools/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
+	"github.com/sylabs/singularity/v4/pkg/image"
+)
+
+var Ext3LayerMediaType types.MediaType = "application/vnd.sylabs.image.layer.v1.ext3"
+
+// HasOverlay returns whether the OCI-SIF at imgPath has an ext3 writable final
+// layer - an 'overlay'.
+func HasOverlay(imagePath string) (bool, error) {
+	fi, err := sif.LoadContainerFromPath(imagePath,
+		sif.OptLoadWithFlag(os.O_RDONLY),
+		sif.OptLoadWithCloseOnUnload(false),
+	)
+	if err != nil {
+		return false, err
+	}
+	defer fi.UnloadContainer()
+
+	ii, err := ocitsif.ImageIndexFromFileImage(fi)
+	if err != nil {
+		return false, fmt.Errorf("while obtaining image index: %w", err)
+	}
+	ix, err := ii.IndexManifest()
+	if err != nil {
+		return false, fmt.Errorf("while obtaining index manifest: %w", err)
+	}
+
+	// One image only.
+	if len(ix.Manifests) != 1 {
+		return false, fmt.Errorf("only single image data containers are supported, found %d images", len(ix.Manifests))
+	}
+	imageDigest := ix.Manifests[0].Digest
+	img, err := ii.Image(imageDigest)
+	if err != nil {
+		return false, fmt.Errorf("while initializing image: %w", err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return false, fmt.Errorf("while getting image layers: %w", err)
+	}
+	mt, err := layers[len(layers)-1].MediaType()
+	if err != nil {
+		return false, fmt.Errorf("while getting layer mediatype: %w", err)
+	}
+	return mt == Ext3LayerMediaType, nil
+}
+
+// AddOverlay adds the provided ext3 overlay file at overlayPath to the OCI-SIF
+// at imagePath, as a new image layer.
+func AddOverlay(imagePath string, overlayPath string) error {
+	fi, err := sif.LoadContainerFromPath(imagePath)
+	if err != nil {
+		return err
+	}
+	defer fi.UnloadContainer()
+
+	ii, err := ocitsif.ImageIndexFromFileImage(fi)
+	if err != nil {
+		return fmt.Errorf("while obtaining image index: %w", err)
+	}
+	ix, err := ii.IndexManifest()
+	if err != nil {
+		return fmt.Errorf("while obtaining index manifest: %w", err)
+	}
+	if len(ix.Manifests) != 1 {
+		return fmt.Errorf("only single image OCI-SIF files are supported - found %d images", len(ix.Manifests))
+	}
+	imageDigest := ix.Manifests[0].Digest
+	img, err := ii.Image(imageDigest)
+	if err != nil {
+		return fmt.Errorf("while initializing image: %w", err)
+	}
+
+	ol, err := ext3LayerFromFile(overlayPath)
+	if err != nil {
+		return err
+	}
+
+	img, err = mutate.AppendLayers(img, ol)
+	if err != nil {
+		return err
+	}
+
+	ii = mutate.AppendManifests(empty.Index, mutate.IndexAddendum{Add: img})
+
+	return ocitsif.Update(fi, ii)
+}
+
+// ext3ImageOpener opens a source ext3 overlay image file to be added as a layer.
+type ext3ImageOpener func() (io.ReadSeekCloser, error)
+
+type ext3ImageLayer struct {
+	opener ext3ImageOpener
+	digest v1.Hash
+	diffID v1.Hash
+	size   int64
+}
+
+var _ v1.Layer = (*ext3ImageLayer)(nil)
+
+// Descriptor returns the original descriptor from an image manifest. See partial.Descriptor.
+func (l *ext3ImageLayer) Descriptor() (*v1.Descriptor, error) {
+	return &v1.Descriptor{
+		Size:      l.size,
+		Digest:    l.digest,
+		MediaType: Ext3LayerMediaType,
+	}, nil
+}
+
+// Digest implements v1.Layer
+func (l *ext3ImageLayer) Digest() (v1.Hash, error) {
+	return l.digest, nil
+}
+
+// DiffID returns the Hash of the uncompressed layer.
+func (l *ext3ImageLayer) DiffID() (v1.Hash, error) {
+	return l.diffID, nil
+}
+
+// Compressed returns an io.ReadCloser for the compressed layer contents.
+func (l *ext3ImageLayer) Compressed() (io.ReadCloser, error) {
+	return l.opener()
+}
+
+// Uncompressed returns an io.ReadCloser for the uncompressed layer contents.
+func (l *ext3ImageLayer) Uncompressed() (io.ReadCloser, error) {
+	return l.opener()
+}
+
+// Size returns the compressed size of the Layer.
+func (l *ext3ImageLayer) Size() (int64, error) {
+	return l.size, nil
+}
+
+// MediaType returns the media type of the Layer.
+func (l *ext3ImageLayer) MediaType() (types.MediaType, error) {
+	return Ext3LayerMediaType, nil
+}
+
+func ext3LayerFromFile(path string) (v1.Layer, error) {
+	opener := func() (io.ReadSeekCloser, error) {
+		return os.Open(path)
+	}
+	return ext3LayerFromOpener(opener)
+}
+
+const hdrBuffSize = 2048
+
+func ext3LayerFromOpener(opener ext3ImageOpener) (v1.Layer, error) {
+	rc, err := opener()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	// Ensure our source is really an ext3 image
+	b := make([]byte, hdrBuffSize)
+	if n, err := rc.Read(b); err != nil || n != hdrBuffSize {
+		return nil, fmt.Errorf("while reading overlay file header: %w", err)
+	}
+	_, err = image.CheckExt3Header(b)
+	if err != nil {
+		return nil, fmt.Errorf("while checking overlay file header: %w", err)
+	}
+
+	_, err = rc.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+	digest, size, err := v1.SHA256(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	l := &ext3ImageLayer{
+		opener: opener,
+		digest: digest,
+		diffID: digest, // no compression - diffID = digest
+		size:   size,
+	}
+	return l, nil
+}

--- a/internal/pkg/ocisif/overlay.go
+++ b/internal/pkg/ocisif/overlay.go
@@ -26,7 +26,6 @@ var Ext3LayerMediaType types.MediaType = "application/vnd.sylabs.image.layer.v1.
 func HasOverlay(imagePath string) (bool, error) {
 	fi, err := sif.LoadContainerFromPath(imagePath,
 		sif.OptLoadWithFlag(os.O_RDONLY),
-		sif.OptLoadWithCloseOnUnload(false),
 	)
 	if err != nil {
 		return false, err
@@ -55,6 +54,9 @@ func HasOverlay(imagePath string) (bool, error) {
 	layers, err := img.Layers()
 	if err != nil {
 		return false, fmt.Errorf("while getting image layers: %w", err)
+	}
+	if len(layers) < 1 {
+		return false, fmt.Errorf("image has no layers")
 	}
 	mt, err := layers[len(layers)-1].MediaType()
 	if err != nil {

--- a/internal/pkg/ocisif/overlay_test.go
+++ b/internal/pkg/ocisif/overlay_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2024 Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+package ocisif
+
+import (
+	"path/filepath"
+	"testing"
+
+	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+func TestHasOverlay(t *testing.T) {
+	tests := []struct {
+		name     string
+		genImage func(t *testing.T) ggcrv1.Image
+		want     bool
+		wantErr  bool
+	}{
+		{
+			name: "NoOverlay",
+			genImage: func(t *testing.T) ggcrv1.Image {
+				im, err := random.Image(1024, 3)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return im
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "HasOverlay",
+			genImage: func(t *testing.T) ggcrv1.Image {
+				im, err := random.Image(1024, 3)
+				if err != nil {
+					t.Fatal(err)
+				}
+				l, err := random.Layer(1024, Ext3LayerMediaType)
+				if err != nil {
+					t.Fatal(err)
+				}
+				im, err = mutate.AppendLayers(im, l)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return im
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imgFile := filepath.Join(t.TempDir(), "image.sif")
+			iw, err := NewImageWriter(tt.genImage(t), imgFile, t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := iw.Write(); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := HasOverlay(imgFile)
+
+			if got != tt.want {
+				t.Errorf("Expected %v, got %v", tt.want, got)
+			}
+
+			if err != nil && !tt.wantErr {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if err == nil && tt.wantErr {
+				t.Error("Expected error, but no error returned.")
+			}
+		})
+	}
+}
+
+func TestAddOverlay(t *testing.T) {
+	tests := []struct {
+		name        string
+		overlayPath string
+		wantErr     bool
+		wantOverlay bool
+	}{
+		{
+			name:        "OverlayNotExist",
+			overlayPath: "does/not/exist",
+			wantErr:     true,
+		},
+		{
+			name:        "OverlayWrongFS",
+			overlayPath: "../../../test/images/squashfs-for-overlay.img",
+			wantErr:     true,
+			wantOverlay: false,
+		},
+		{
+			name:        "OverlayOK",
+			overlayPath: "../../../test/images/extfs-for-overlay.img",
+			wantErr:     false,
+			wantOverlay: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imgFile := filepath.Join(t.TempDir(), "image.sif")
+			im, err := random.Image(1024, 3)
+			if err != nil {
+				t.Fatal(err)
+			}
+			iw, err := NewImageWriter(im, imgFile, t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := iw.Write(); err != nil {
+				t.Fatal(err)
+			}
+
+			err = AddOverlay(imgFile, tt.overlayPath)
+			if err != nil && !tt.wantErr {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if err == nil && tt.wantErr {
+				t.Error("Expected error, but no error returned.")
+			}
+
+			hasOverlay, err := HasOverlay(imgFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hasOverlay != tt.wantOverlay {
+				t.Errorf("Image has overlay: %v, want overlay: %v", hasOverlay, tt.wantOverlay)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Support `singularity overlay create` for OCI-SIF images.

An extfs overlay file is created, and then appended to the image encapsulated in the OCI-SIF, as an additional layer.


### This fixes or addresses the following GitHub issues:

 - Fixes #2867 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
