### PR TITLE
e2e: drop test depending on CentOS 7

### DIFF
--- a/e2e/build/build.go
+++ b/e2e/build/build.go
@@ -2448,7 +2448,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4967":                      c.issue4967,                     // https://github.com/sylabs/singularity/issues/4967
 		"issue 4969":                      c.issue4969,                     // https://github.com/sylabs/singularity/issues/4969
 		"issue 5166":                      c.issue5166,                     // https://github.com/sylabs/singularity/issues/5166
-		"issue 5250":                      c.issue5250,                     // https://github.com/sylabs/singularity/issues/5250
 		"issue 5315":                      c.issue5315,                     // https://github.com/sylabs/singularity/issues/5315
 		"issue 5435":                      c.issue5435,                     // https://github.com/hpcng/singularity/issues/5435
 		"issue 5668":                      c.issue5668,                     // https://github.com/hpcng/singularity/issues/5435

--- a/e2e/build/regressions.go
+++ b/e2e/build/regressions.go
@@ -334,27 +334,6 @@ func (c *imgBuildTests) issue5435(t *testing.T) {
 	)
 }
 
-// This test will yum reinstall the 'setup' package in a centos 7 container during %post.
-// On a CentOS/RHEL/Fedora host this yum reinstall errors unless the bound in /etc/hosts in the build is modified from
-// the package default, so that yum does not attempt to remove->replace it (which is not possible as it is bound in).
-// See the workaround in build.createStageFile
-func (c *imgBuildTests) issue5250(t *testing.T) {
-	image := filepath.Join(c.env.TestDir, "issue_5250.sif")
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.RootProfile),
-		e2e.WithCommand("build"),
-		e2e.WithArgs(image, "testdata/regressions/issue_5250.def"),
-		e2e.PostRun(func(_ *testing.T) {
-			os.Remove(image)
-		}),
-		e2e.ExpectExit(
-			0,
-		),
-	)
-}
-
 // Check that unsquashfs (SIF -> sandbox) works on a tmpfs, that will not support
 // user xattrs. Our home dir in the e2e test is a tmpfs bound over our real home dir
 // so we can use that.

--- a/e2e/testdata/regressions/issue_5250.def
+++ b/e2e/testdata/regressions/issue_5250.def
@@ -1,5 +1,0 @@
-BootStrap: library
-From: centos:7
-
-%post
-    yum -y reinstall setup


### PR DESCRIPTION
## Description of the Pull Request (PR):

CentOS 7 has gone end of life. Various infrastructure like the mirrorlist is no longer available:

https://lists.centos.org/hyperkitty/list/devel@lists.centos.org/thread/EGOA27SGN7W7ASFFFBNUZJ5BXSFT4NKX/

Drop the regression test for 5250, which depends on CentOS7 and is failing due to the retirement of the mirrorlist.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
