### PR TITLE
fix: oci: fallback to tmp-sandbox issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   (default) or `tar` format. Images pushed with `--layer-format tar` can be
   pulled and run by other OCI runtimes.
 
+### Bug Fixes
+
+- Fix fall-back to temporary sandbox rootfs bundle in OCI-Mode for OCI URIs
+  (`docker://`) etc.
+
 ### Requirements
 
 - Requires a minimum of Go 1.21.5 to build due to dependency updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 - Fix fall-back to temporary sandbox rootfs bundle in OCI-Mode for OCI URIs
   (`docker://`) etc.
+- Fix confusing error messages / incorrect fall-back attempt when explicit
+  execution of an OCI-SIF fails.
 
 ### Requirements
 

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/launcher/native"
 	ocilauncher "github.com/sylabs/singularity/v4/internal/pkg/runtime/launcher/oci"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/uri"
-	"github.com/sylabs/singularity/v4/pkg/image"
 	bndocisif "github.com/sylabs/singularity/v4/pkg/ocibundle/ocisif"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
@@ -428,41 +427,52 @@ func launchContainer(cmd *cobra.Command, ep launcher.ExecParams) error {
 
 	execErr := l.Exec(cmd.Context(), ep)
 
-	// Check if we are using an OCI-SIF *and* the exec error indicates that a
-	// direct mount bundle is unavailable (squashfs mount failure etc). If both
-	// are true, we will try a fallback path extracting to a sandbox dir
-	// bundle.
-	isOCISIF, ocisifCheckErr := image.IsOCISIF(ep.Image)
-	if ocisifCheckErr != nil {
-		return ocisifCheckErr
-	}
+	// When the image is an OCI-SIF, the initial l.Exec above could fail in
+	// OCI-Mode if required FUSE tools are not available. This is indicated by
+	// execErr being an ocisif.UnavailableError.
+	//
+	// If the OCI-SIF image was created by replaceURIWithImage - i.e. the user
+	// asked to run a docker:// or other URI, not an OCI-SIF file - then we can
+	// try to exec again from the original URI. In this case, the OCI launcher
+	// will construct a bundle based on a temporary sandbox rootfs, rather than
+	// an OCI-SIF.
+
+	// Fail if the execError wasn't a result of being unable to create a FUSE
+	// mount bundle from an OCI-SIF.
 	var mountErr bndocisif.UnavailableError
-	if !(errors.As(execErr, &mountErr) && isOCISIF) {
-		// Any other situation is a failure
+	if !(errors.As(execErr, &mountErr)) {
 		return execErr
 	}
 
-	if !canUseTmpSandbox {
-		sylog.Errorf("%v", execErr)
-		return fmt.Errorf("OCI-SIF could not be used, and fallback to temporary sandbox dir disallowed")
-	}
-	sylog.Warningf("%v", execErr)
-	sylog.Warningf("OCI-SIF could not be used, falling back to unpacking OCI bundle in temporary sandbox dir")
-
+	// Fail if the ImageURI is the same as the origImageURI ... i.e. if the
+	// image was directly specified by the user, and is not a reult of
+	// replaceURIWIthImage.
 	origImageURIPtr := cmd.Context().Value(keyOrigImageURI)
 	if origImageURIPtr == nil {
 		return fmt.Errorf("unable to recover original image URI from context")
 	}
-
 	origImageURI, ok := origImageURIPtr.(*string)
 	if !ok {
 		return fmt.Errorf("unable to recover original image URI (expected string, found: %T) from context", origImageURIPtr)
 	}
-	ep.Image = *origImageURI
+	if ep.Image == *origImageURI {
+		return execErr
+	}
 
+	// Fail if we are not permitted to try using a temporary sandbox.
+	if !canUseTmpSandbox {
+		sylog.Warningf("OCI-SIF could not be used, and fallback to temporary sandbox dir disallowed")
+		return execErr
+	}
+
+	// Try to launch the original user-specified URI directly - which will use a
+	// tmp sandbox rootfs bundle, rather than OCI-SIF.
+	sylog.Warningf("%v", execErr)
+	sylog.Warningf("OCI-SIF could not be used, falling back to unpacking OCI bundle in temporary sandbox dir")
 	l, err = ocilauncher.NewLauncher(opts...)
 	if err != nil {
 		return fmt.Errorf("while configuring container: %s", err)
 	}
+	ep.Image = *origImageURI
 	return l.Exec(cmd.Context(), ep)
 }

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -410,6 +410,7 @@ func launchContainer(cmd *cobra.Command, ep launcher.ExecParams) error {
 			DockerDaemonHost: dockerHost,
 			AuthFilePath:     ociauth.ChooseAuthFile(reqAuthFile),
 			UserAgent:        useragent.Value(),
+			Platform:         getOCIPlatform(),
 		}
 		opts = append(opts, launcher.OptTransportOptions(tOpts))
 
@@ -448,11 +449,6 @@ func launchContainer(cmd *cobra.Command, ep launcher.ExecParams) error {
 	sylog.Warningf("%v", execErr)
 	sylog.Warningf("OCI-SIF could not be used, falling back to unpacking OCI bundle in temporary sandbox dir")
 
-	// Create a cache handle only when we know we are using a URI
-	imgCache := getCacheHandle(cache.Config{Disable: disableCache})
-	if imgCache == nil {
-		sylog.Fatalf("failed to create a new image cache handle")
-	}
 	origImageURIPtr := cmd.Context().Value(keyOrigImageURI)
 	if origImageURIPtr == nil {
 		return fmt.Errorf("unable to recover original image URI from context")
@@ -464,5 +460,9 @@ func launchContainer(cmd *cobra.Command, ep launcher.ExecParams) error {
 	}
 	ep.Image = *origImageURI
 
+	l, err = ocilauncher.NewLauncher(opts...)
+	if err != nil {
+		return fmt.Errorf("while configuring container: %s", err)
+	}
 	return l.Exec(cmd.Context(), ep)
 }

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2913,5 +2913,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociHomeCwdPasswd":     c.actionOciHomeCwdPasswd,       // $HOME is correct in /etc/passwd, and is default cwd
 		"ociAllowSetuid":       c.actionOciAllowSetuid,         // --allow-setuid / check for nosuid mount options
 		"ociExitSignals":       c.ociExitSignals,               // test exit and signals propagation
+		"issue 3100":           np(c.issue3100),                // https://github.com/sylabs/singularity/issues/3100
+
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -773,7 +773,7 @@ func (l *Launcher) Exec(ctx context.Context, ep launcher.ExecParams) error {
 	// make a best effort here even if the main context has been canceled, hence
 	// the use of context.Background().
 	if cleanupErr := b.Delete(context.Background()); cleanupErr != nil { //nolint:contextcheck
-		sylog.Errorf("Couldn't cleanup bundle: %v", err)
+		sylog.Errorf("Couldn't cleanup bundle: %v", cleanupErr)
 	}
 
 	if err := l.unmountSessionTmpfs(); err != nil {

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -174,21 +174,12 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 		return err
 	}
 
-	manifestData, err := localImg.RawManifest()
-	if err != nil {
-		return fmt.Errorf("error obtaining manifest source: %s", err)
-	}
-	var manifest imgspecv1.Manifest
-	if err := json.Unmarshal(manifestData, &manifest); err != nil {
-		return fmt.Errorf("error parsing manifest: %w", err)
-	}
-
 	configData, err := localImg.RawConfigFile()
 	if err != nil {
 		return fmt.Errorf("error obtaining image config source: %s", err)
 	}
 	b.imageSpec = &imgspecv1.Image{}
-	if err := json.Unmarshal(configData, &manifest); err != nil {
+	if err := json.Unmarshal(configData, b.imageSpec); err != nil {
 		return fmt.Errorf("error parsing image config: %w", err)
 	}
 

--- a/pkg/ocibundle/native/bundle_linux_test.go
+++ b/pkg/ocibundle/native/bundle_linux_test.go
@@ -9,8 +9,10 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"reflect"
 	"testing"
 
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 	ocitest "github.com/sylabs/singularity/v4/internal/pkg/test/tool/oci"
@@ -100,6 +102,10 @@ func TestFromImageRef(t *testing.T) {
 
 			if err := b.Create(context.Background(), nil); err != nil {
 				t.Errorf("While creating bundle: %s", err)
+			}
+
+			if b.ImageSpec() == nil || reflect.DeepEqual(b.ImageSpec(), imgspecv1.Image{}) {
+				t.Errorf("ImageSpec is nil / empty.")
 			}
 
 			ocitest.ValidateBundle(t, bundleDir)

--- a/pkg/ocibundle/tools/oci.go
+++ b/pkg/ocibundle/tools/oci.go
@@ -112,16 +112,16 @@ func SaveBundleConfig(bundlePath string, g *generate.Generator) error {
 
 // DeleteBundle deletes bundle directory
 func DeleteBundle(bundlePath string) error {
-	if err := os.RemoveAll(Layers(bundlePath).Path()); err != nil {
+	if err := os.RemoveAll(Layers(bundlePath).Path()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete layers directory: %s", err)
 	}
-	if err := os.RemoveAll(Volumes(bundlePath).Path()); err != nil {
+	if err := os.RemoveAll(Volumes(bundlePath).Path()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete volumes directory: %s", err)
 	}
-	if err := os.Remove(RootFs(bundlePath).Path()); err != nil {
+	if err := os.Remove(RootFs(bundlePath).Path()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete rootfs directory: %s", err)
 	}
-	if err := os.Remove(Config(bundlePath).Path()); err != nil {
+	if err := os.Remove(Config(bundlePath).Path()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete config.json file: %s", err)
 	}
 	if err := os.Remove(bundlePath); err != nil && !os.IsExist(err) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

1 - When FUSE mount fails, ensure fallback to a temporary sandbox bundle (using pkg/ocibundle/native) is successful for OCI URI image sources (e.g. docker://...)

A selection of small fixes accomplishes this...

* Ensure platform is set in the transport options used during fallback.
* Use a new launcher instance for fallback Exec, as launcher has some state.
* Correctly set the image config for native bundles.

Also:

* Remove unused imgcache handle in actions code.
* Remove unused manifest obtained in native bundle code.

2- If a user asked to run an OCI-SIF file directly, do not fall-back. We don't currently have any code to create a tmp-sandbox rootfs out of an OCI-SIF file.
    
Additionally, fix the `ocibundle.Delete` function so that it will delete a partial bundle (that has not been fully assembled), rather than raising a confusing error and leaving remnants on the disk.
    

### This fixes or addresses the following GitHub issues:

 - Fixes #3100
 - Fixes #3099


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
