### PR TITLE
fix: oci: fallback to tmp-sandbox issues (release-4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix fall-back to temporary sandbox rootfs bundle in OCI-Mode for OCI URIs
   (`docker://`) etc.
+- Fix confusing error messages / incorrect fall-back attempt when explicit
+  execution of an OCI-SIF fails.
 
 ## 4.1.4 \[2024-06-28\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Fix fall-back to temporary sandbox rootfs bundle in OCI-Mode for OCI URIs
+  (`docker://`) etc.
+
 ## 4.1.4 \[2024-06-28\]
 
 ### Bug Fixes

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2913,5 +2913,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociHomeCwdPasswd":     c.actionOciHomeCwdPasswd,       // $HOME is correct in /etc/passwd, and is default cwd
 		"ociAllowSetuid":       c.actionOciAllowSetuid,         // --allow-setuid / check for nosuid mount options
 		"ociExitSignals":       c.ociExitSignals,               // test exit and signals propagation
+		"issue 3100":           np(c.issue3100),                // https://github.com/sylabs/singularity/issues/3100
+
 	}
 }

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -773,7 +773,7 @@ func (l *Launcher) Exec(ctx context.Context, ep launcher.ExecParams) error {
 	// make a best effort here even if the main context has been canceled, hence
 	// the use of context.Background().
 	if cleanupErr := b.Delete(context.Background()); cleanupErr != nil { //nolint:contextcheck
-		sylog.Errorf("Couldn't cleanup bundle: %v", err)
+		sylog.Errorf("Couldn't cleanup bundle: %v", cleanupErr)
 	}
 
 	if err := l.unmountSessionTmpfs(); err != nil {

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -174,21 +174,12 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 		return err
 	}
 
-	manifestData, err := localImg.RawManifest()
-	if err != nil {
-		return fmt.Errorf("error obtaining manifest source: %s", err)
-	}
-	var manifest imgspecv1.Manifest
-	if err := json.Unmarshal(manifestData, &manifest); err != nil {
-		return fmt.Errorf("error parsing manifest: %w", err)
-	}
-
 	configData, err := localImg.RawConfigFile()
 	if err != nil {
 		return fmt.Errorf("error obtaining image config source: %s", err)
 	}
 	b.imageSpec = &imgspecv1.Image{}
-	if err := json.Unmarshal(configData, &manifest); err != nil {
+	if err := json.Unmarshal(configData, b.imageSpec); err != nil {
 		return fmt.Errorf("error parsing image config: %w", err)
 	}
 

--- a/pkg/ocibundle/native/bundle_linux_test.go
+++ b/pkg/ocibundle/native/bundle_linux_test.go
@@ -9,8 +9,10 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"reflect"
 	"testing"
 
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 	ocitest "github.com/sylabs/singularity/v4/internal/pkg/test/tool/oci"
@@ -100,6 +102,10 @@ func TestFromImageRef(t *testing.T) {
 
 			if err := b.Create(context.Background(), nil); err != nil {
 				t.Errorf("While creating bundle: %s", err)
+			}
+
+			if b.ImageSpec() == nil || reflect.DeepEqual(b.ImageSpec(), imgspecv1.Image{}) {
+				t.Errorf("ImageSpec is nil / empty.")
 			}
 
 			ocitest.ValidateBundle(t, bundleDir)

--- a/pkg/ocibundle/tools/oci.go
+++ b/pkg/ocibundle/tools/oci.go
@@ -112,16 +112,16 @@ func SaveBundleConfig(bundlePath string, g *generate.Generator) error {
 
 // DeleteBundle deletes bundle directory
 func DeleteBundle(bundlePath string) error {
-	if err := os.RemoveAll(Layers(bundlePath).Path()); err != nil {
+	if err := os.RemoveAll(Layers(bundlePath).Path()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete layers directory: %s", err)
 	}
-	if err := os.RemoveAll(Volumes(bundlePath).Path()); err != nil {
+	if err := os.RemoveAll(Volumes(bundlePath).Path()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete volumes directory: %s", err)
 	}
-	if err := os.Remove(RootFs(bundlePath).Path()); err != nil {
+	if err := os.Remove(RootFs(bundlePath).Path()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete rootfs directory: %s", err)
 	}
-	if err := os.Remove(Config(bundlePath).Path()); err != nil {
+	if err := os.Remove(Config(bundlePath).Path()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete config.json file: %s", err)
 	}
 	if err := os.Remove(bundlePath); err != nil && !os.IsExist(err) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Cherry pick #3102 

1 - When FUSE mount fails, ensure fallback to a temporary sandbox bundle (using pkg/ocibundle/native) is successful for OCI URI image sources (e.g. docker://...)

A selection of small fixes accomplishes this...

* Ensure platform is set in the transport options used during fallback.
* Use a new launcher instance for fallback Exec, as launcher has some state.
* Correctly set the image config for native bundles.

Also:

* Remove unused imgcache handle in actions code.
* Remove unused manifest obtained in native bundle code.

2- If a user asked to run an OCI-SIF file directly, do not fall-back. We don't currently have any code to create a tmp-sandbox rootfs out of an OCI-SIF file.
    
Additionally, fix the `ocibundle.Delete` function so that it will delete a partial bundle (that has not been fully assembled), rather than raising a confusing error and leaving remnants on the disk.
    

### This fixes or addresses the following GitHub issues:

 - Fixes #3100
 - Fixes #3099

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
