### PR TITLE
Remove unused linter directive

### DIFF
--- a/internal/pkg/build/buildkit/auth/authprovider.go
+++ b/internal/pkg/build/buildkit/auth/authprovider.go
@@ -226,7 +226,6 @@ func (ap *authProvider) VerifyTokenAuthority(_ context.Context, req *auth.Verify
 	return &auth.VerifyTokenAuthorityResponse{Signed: sign.Sign(nil, req.Payload, priv)}, nil
 }
 
-//nolint:unparam
 func (ap *authProvider) getAuthConfig(host string) (*authn.AuthConfig, error) {
 	ap.mu.Lock()
 	defer ap.mu.Unlock()


### PR DESCRIPTION
## Description of the Pull Request (PR):

`make check` currently fails with

> internal/pkg/build/buildkit/auth/authprovider.go:229:1: directive `//nolint:unparam` is unused for linter "unparam" (nolintlint)
//nolint:unparam
^

Checking the code the linter looks right, `host` is used