### PR TITLE
e2e: fix: ensure e2e.Privileged funcs are called

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -750,7 +750,7 @@ func (c actionTests) PersistentOverlay(t *testing.T) {
 	// sandbox overlay implies creation of upper/work directories by
 	// Singularity, so we would need privileges to delete the test
 	// directory correctly
-	defer e2e.Privileged(cleanup)
+	defer e2e.Privileged(cleanup)(t)
 
 	squashfsImage := filepath.Join(testdir, "squashfs.simg")
 	ext3Img := filepath.Join(testdir, "ext3_fs.img")
@@ -1165,7 +1165,7 @@ func (c actionTests) actionBinds(t *testing.T) {
 
 	workspace, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "bind-workspace-", "")
 	sandbox, _ := e2e.MakeTempDir(t, workspace, "sandbox-", "")
-	defer e2e.Privileged(cleanup)
+	defer e2e.Privileged(cleanup)(t)
 
 	contCanaryDir := "/canary"
 	hostCanaryDir := filepath.Join(workspace, "canary")
@@ -1693,7 +1693,7 @@ func (c actionTests) fuseMount(t *testing.T) {
 	u := e2e.UserProfile.HostUser(t)
 
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "sshfs-", "")
-	defer e2e.Privileged(cleanup)
+	defer e2e.Privileged(cleanup)(t)
 
 	sshfsWrapper := filepath.Join(imageDir, "sshfs-wrapper")
 	rootPrivKey := filepath.Join(imageDir, "/etc/ssh/ssh_host_rsa_key")
@@ -2639,7 +2639,7 @@ func (c actionTests) relWorkdirScratch(t *testing.T) {
 	testdir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "persistent-overlay-", "")
 	t.Cleanup(func() {
 		if !t.Failed() {
-			e2e.Privileged(cleanup)
+			e2e.Privileged(cleanup)(t)
 		}
 	})
 

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -490,7 +490,7 @@ func (c actionTests) actionOciBinds(t *testing.T) {
 	workspace, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "bind-workspace-", "")
 	t.Cleanup(func() {
 		if !t.Failed() {
-			e2e.Privileged(cleanup)
+			e2e.Privileged(cleanup)(t)
 		}
 	})
 
@@ -809,7 +809,7 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 		mainDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
 		t.Cleanup(func() {
 			if !t.Failed() {
-				e2e.Privileged(cleanup)
+				e2e.Privileged(cleanup)(t)
 			}
 		})
 		stws.mainDir = mainDir
@@ -1840,7 +1840,7 @@ func (c actionTests) actionOciRelWorkdirScratch(t *testing.T) {
 	testdir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "persistent-overlay-", "")
 	t.Cleanup(func() {
 		if !t.Failed() {
-			e2e.Privileged(cleanup)
+			e2e.Privileged(cleanup)(t)
 		}
 	})
 

--- a/e2e/build/build.go
+++ b/e2e/build/build.go
@@ -1125,7 +1125,7 @@ func (c imgBuildTests) buildUpdateSandbox(t *testing.T) {
 	testDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "build-sandbox-", "")
 	t.Cleanup(func() {
 		if !t.Failed() {
-			e2e.Privileged(cleanup)
+			e2e.Privileged(cleanup)(t)
 		}
 	})
 

--- a/e2e/build/regressions.go
+++ b/e2e/build/regressions.go
@@ -542,7 +542,7 @@ from: %s
 				t, c.env.TestDir, fmt.Sprintf("issue1812-sandbox-%s-", testName), "")
 			t.Cleanup(func() {
 				if !t.Failed() {
-					e2e.Privileged(cleanup)
+					e2e.Privileged(cleanup)(t)
 				}
 			})
 
@@ -563,7 +563,7 @@ from: %s
 				t, c.env.TestDir, fmt.Sprintf("issue1812-sandbox-%s-", testName), "")
 			t.Cleanup(func() {
 				if !t.Failed() {
-					e2e.Privileged(cleanup)
+					e2e.Privileged(cleanup)(t)
 				}
 			})
 

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -153,7 +153,7 @@ func Run(t *testing.T) {
 	testenv.PrivCacheDir = privCacheDir
 	defer e2e.Privileged(func(t *testing.T) {
 		cleanPrivCache(t)
-	})
+	})(t)
 
 	unprivCacheDir, cleanUnprivCache := e2e.MakeCacheDir(t, testenv.TestDir)
 	testenv.UnprivCacheDir = unprivCacheDir


### PR DESCRIPTION
## Description of the Pull Request (PR):

e2e.Privileged returns a function that must be called with `(t)`. Some instances were not calling the privileged function. Fix these.

### This fixes or addresses the following GitHub issues:

 - Fixes #3103

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
