### PR TITLE
Cherry-pick and adapt Apptainer PR: https://github.com/apptainer/apptainer/pull/1401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   overlay create` command. The overlay will be applied read-only, by default,
   when executing the OCI-SIF. To write changes to the container into the overlay,
   use the `--writable` flag.
+- Added a new `instance run` command that will execute the runscript when an
+  instance is initiated instead of executing the startscript.
 
 ### Bug Fixes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -820,8 +820,8 @@ func init() {
 		actionsCmd := cmdManager.GetCmdGroup("actions")
 
 		if instanceStartCmd != nil {
-			cmdManager.SetCmdGroup("actions_instance", ExecCmd, ShellCmd, RunCmd, TestCmd, instanceStartCmd)
-			cmdManager.RegisterFlagForCmd(&actionBootFlag, instanceStartCmd)
+			cmdManager.SetCmdGroup("actions_instance", ExecCmd, ShellCmd, RunCmd, TestCmd, instanceStartCmd, instanceRunCmd)
+			cmdManager.RegisterFlagForCmd(&actionBootFlag, instanceStartCmd, instanceRunCmd)
 		} else {
 			cmdManager.SetCmdGroup("actions_instance", actionsCmd...)
 		}

--- a/cmd/internal/cli/instance_linux.go
+++ b/cmd/internal/cli/instance_linux.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,6 +19,7 @@ func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(instanceCmd)
 		cmdManager.RegisterSubCmd(instanceCmd, instanceStartCmd)
+		cmdManager.RegisterSubCmd(instanceCmd, instanceRunCmd)
 		cmdManager.RegisterSubCmd(instanceCmd, instanceStopCmd)
 		cmdManager.RegisterSubCmd(instanceCmd, instanceListCmd)
 		cmdManager.RegisterSubCmd(instanceCmd, instanceStatsCmd)

--- a/docs/content.go
+++ b/docs/content.go
@@ -537,11 +537,44 @@ Enterprise Performance Computing (EPC)`
   existing container image that will begin running in the background. If a
   startscript is defined in the container metadata the commands in that script
   will be executed with the instance start command as well. You can optionally
-  pass arguments to startscript
+  pass arguments to startscript.
 
   singularity instance start accepts the following container formats` + formats
 	InstanceStartExample string = `
   $ singularity instance start /tmp/my-sql.sif mysql
+
+  $ singularity shell instance://mysql
+  Singularity my-sql.sif> pwd
+  /home/mibauer/mysql
+  Singularity my-sql.sif> ps
+  PID TTY          TIME CMD
+    1 pts/0    00:00:00 sinit
+    2 pts/0    00:00:00 bash
+    3 pts/0    00:00:00 ps
+  Singularity my-sql.sif>
+
+  $ singularity instance stop /tmp/my-sql.sif mysql
+  Stopping /tmp/my-sql.sif mysql`
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// instance run
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	InstanceRunUse   string = `run [start options...] <container path> <instance name> [runscript args...]`
+	InstanceRunShort string = `Run a named instance of the given container image`
+	InstanceRunLong  string = `
+  The instance run command allows you to create a new named instance from an
+  existing container image that will begin running in the background. If a
+  runscript is defined in the container metadata the commands in that script
+  will be executed with the instance run command as well. You can optionally
+  pass arguments to runscript.
+
+  NOTE: This command was added to Singularity significantly later than the other 
+  action commands and will not work with older containers. In that case, you may
+  need to rebuild the container. 
+
+  singularity instance run accepts the following container formats` + formats
+	InstanceRunExample string = `
+  $ singularity instance run /tmp/my-sql.sif mysql
 
   $ singularity shell instance://mysql
   Singularity my-sql.sif> pwd

--- a/internal/pkg/runtime/launcher/launcher.go
+++ b/internal/pkg/runtime/launcher/launcher.go
@@ -59,12 +59,17 @@ func (ep ExecParams) ActionScriptArgs() (args []string, err error) {
 		}
 		args = append(args, ep.Process)
 		args = append(args, ep.Args...)
-	case "run", "shell", "test":
+	case "shell", "test":
 		if ep.Process != "" {
 			return []string{}, fmt.Errorf("%s action doesn't support specifying a process", ep.Action)
 		}
 		if ep.Instance != "" {
 			return []string{}, fmt.Errorf("%s action doesn't support specifying an instance", ep.Action)
+		}
+		args = append(args, ep.Args...)
+	case "run":
+		if ep.Process != "" {
+			return []string{}, fmt.Errorf("%s action doesn't support specifying a process", ep.Action)
 		}
 		args = append(args, ep.Args...)
 	case "start":

--- a/internal/pkg/runtime/launcher/launcher_test.go
+++ b/internal/pkg/runtime/launcher/launcher_test.go
@@ -91,8 +91,8 @@ func TestExecParams_ActionArgs(t *testing.T) {
 			Image:    "image.sif",
 			Action:   "run",
 			Instance: "myinstance",
-			wantArgs: []string{},
-			wantErr:  true,
+			wantArgs: []string{"/.singularity.d/actions/run"},
+			wantErr:  false,
 		},
 		// shell
 		{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Cherry-pick and adapt Apptainer PR: https://github.com/apptainer/apptainer/pull/1401

Added a new subcommand called `run` to the `instance` command group. This command will behave in the same manner as the `start` command, but it will run the runscript instead of the startscript. This will help with OCI container compatability since OCI containers have no concept of a startscript.


### This fixes or addresses the following GitHub issues:

 - Fixes #3083