### PR TITLE
feat: OCI-SIF overlay seal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
   appended to the encapsulated OCI image. After the overlay has been modified,
   use the `singularity overlay sync` command to synchronize the OCI digests with
   the overlay content.
+- A new `singularity overlay seal` command converts a writable overlay inside
+  an OCI-SIF image into a read-only squashfs layer. This seals changes made to
+  the image via the overlay, so that they are permanent.
 - Added a new `instance run` command that will execute the runscript when an
   instance is initiated instead of executing the startscript.
 

--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -18,6 +18,8 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&overlaySparseFlag, OverlayCreateCmd)
 
 		cmdManager.RegisterSubCmd(OverlayCmd, OverlaySyncCmd)
+
+		cmdManager.RegisterSubCmd(OverlayCmd, OverlaySealCmd)
 	})
 }
 

--- a/cmd/internal/cli/overlay_seal.go
+++ b/cmd/internal/cli/overlay_seal.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2024, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+package cli
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/v4/docs"
+	"github.com/sylabs/singularity/v4/internal/pkg/ocisif"
+	"github.com/sylabs/singularity/v4/pkg/sylog"
+)
+
+// OverlaySyncCmd is the 'overlay sync' command that updates the digest of
+// an overlay in an OCI-SIF image, as recorded in the OCI manifest / config.
+var OverlaySealCmd = &cobra.Command{
+	Args: cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		tmpEnv := os.Getenv("SINGULARITY_TMPDIR")
+		if err := ocisif.SealOverlay(args[0], tmpEnv); err != nil {
+			sylog.Fatalf(err.Error())
+		}
+		return nil
+	},
+	DisableFlagsInUseLine: true,
+
+	Use:     docs.OverlaySealUse,
+	Short:   docs.OverlaySealShort,
+	Long:    docs.OverlaySealLong,
+	Example: docs.OverlaySealExample,
+}

--- a/docs/content.go
+++ b/docs/content.go
@@ -1152,6 +1152,16 @@ Enterprise Performance Computing (EPC)`
   To synchronize an OCI-SIF image containing an overlay:
   $ singularity overlay sync /tmp/overlay.oci.sif`
 
+	OverlaySealUse   string = `seal oci-sif`
+	OverlaySealShort string = `Seal a writable overlay, into a read-only layer.`
+	OverlaySealLong  string = `
+  The overlay seal command converts a writable overlay in an OCI-SIF image into
+  a read-only image layer. This makes changes in the overlay permanent, and allows
+  the image to be pushed with '--layer-format tar'.`
+	OverlaySealExample string = `
+  To seal an OCI-SIF image containing an overlay:
+  $ singularity overlay seal /tmp/overlay.oci.sif`
+
 	DataUse   string = `data`
 	DataShort string = `Manage an OCI-SIF data container`
 	DataLong  string = `

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -347,6 +347,14 @@ func (c ctx) testOverlayOCI(t *testing.T) {
 			args:    []string{ocisif, "ls", "/in-overlay"},
 			exit:    1,
 		},
+		// Seal the overlay
+		{
+			name:    "seal",
+			profile: e2e.OCIUserProfile,
+			command: "overlay",
+			args:    []string{"seal", ocisif},
+			exit:    0,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add a `singularity overlay seal` command, which will convert an ext3 writable overlay into a read-only squashfs layer, 'sealing' the image and making changes stored in the overlay permanent.

### This fixes or addresses the following GitHub issues:

 - Fixes #2870

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
