### PR TITLE
fix: ensure OCI-SIF image can be executed from rel path

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2914,6 +2914,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ociAllowSetuid":       c.actionOciAllowSetuid,         // --allow-setuid / check for nosuid mount options
 		"ociExitSignals":       c.ociExitSignals,               // test exit and signals propagation
 		"issue 3100":           np(c.issue3100),                // https://github.com/sylabs/singularity/issues/3100
+		"issue 3129":           np(c.issue3129),                // https://github.com/sylabs/singularity/issues/3129
 
 	}
 }

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -898,3 +898,17 @@ func (c actionTests) issue3100(t *testing.T) {
 			e2e.ExpectError(e2e.ContainMatch, "falling back to unpacking OCI bundle in temporary sandbox dir")),
 	)
 }
+
+// Check that execution of an image from a relative path succeeds
+func (c actionTests) issue3129(t *testing.T) {
+	e2e.EnsureOCISIF(t, c.env)
+	dir, image := filepath.Split(c.env.OCISIFPath)
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.OCIUserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithDir(dir),
+		e2e.WithArgs(image, "/bin/true"),
+		e2e.ExpectExit(0),
+	)
+}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -800,11 +800,11 @@ func (l *Launcher) RunWrapped(ctx context.Context, containerID, bundlePath, pidF
 		return fmt.Errorf("failed to determine bundle absolute path: %s", err)
 	}
 
-	if err := os.Chdir(absBundle); err != nil {
-		return fmt.Errorf("failed to change directory to %s: %s", absBundle, err)
-	}
-
 	runFunc := func() error {
+		if err := os.Chdir(absBundle); err != nil {
+			return fmt.Errorf("failed to change directory to %s: %s", absBundle, err)
+		}
+
 		for _, im := range l.imageMountsByMountpoint {
 			if err := os.MkdirAll(im.GetMountPoint(), 0o755); err != nil {
 				return err

--- a/internal/pkg/runtime/launcher/oci/oci_overlay.go
+++ b/internal/pkg/runtime/launcher/oci/oci_overlay.go
@@ -8,6 +8,7 @@ package oci
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/ocisif"
@@ -62,7 +63,12 @@ func (l *Launcher) imageOverlaySet(bundleDir string) (*overlay.Set, error) {
 		return nil, nil
 	}
 
-	sifOverlay, sifOffset, err := ocisif.HasOverlay(strings.TrimPrefix(l.image, "oci-sif:"))
+	imgAbs, err := filepath.Abs(strings.TrimPrefix(l.image, "oci-sif:"))
+	if err != nil {
+		return nil, err
+	}
+
+	sifOverlay, sifOffset, err := ocisif.HasOverlay(imgAbs)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +80,7 @@ func (l *Launcher) imageOverlaySet(bundleDir string) (*overlay.Set, error) {
 	item := &overlay.Item{
 		Type:         image.EXT3,
 		Readonly:     !l.cfg.Writable,
-		SourcePath:   strings.TrimPrefix(l.image, "oci-sif:"),
+		SourcePath:   imgAbs,
 		SourceOffset: sifOffset,
 	}
 	item.SetParentDir(bundleDir)


### PR DESCRIPTION
## Description of the Pull Request (PR):

After #3092 OCI-SIF images cannot be executed from a relative path.

Correctly use an absolute path in `imageOverlaySet()`, and add an e2e test.


### This fixes or addresses the following GitHub issues:

 - Fixes #3129


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
