### PR TITLE
feat: basic overlay handling on OCI-SIF push

### DIFF
--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sylabs/singularity/v4/docs"
 	"github.com/sylabs/singularity/v4/internal/pkg/client/library"
 	"github.com/sylabs/singularity/v4/internal/pkg/client/oci"
+	"github.com/sylabs/singularity/v4/internal/pkg/client/ocisif"
 	"github.com/sylabs/singularity/v4/internal/pkg/client/oras"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/v4/internal/pkg/signature"
@@ -72,9 +73,9 @@ var pushDescriptionFlag = cmdline.Flag{
 var pushLayerFormatFlag = cmdline.Flag{
 	ID:           "pushLayerFormatFlag",
 	Value:        &pushLayerFormat,
-	DefaultValue: "",
+	DefaultValue: ocisif.DefaultLayerFormat,
 	Name:         "layer-format",
-	Usage:        "layer format when pushing OCI-SIF images - squashfs (default) or tar",
+	Usage:        "layer format when pushing OCI-SIF images - squashfs or tar",
 	EnvKeys:      []string{"LAYER_FORMAT"},
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

When pushing an OCI-SIF to an OCI registry:

* If the image contains an overlay, and we are pushing without an explicit --layer-format, then synchronize the overlay digest and push it as an ext3 layer.
* If the image contains an overlay, and we are pushing with the explicit 'squashfs' or 'tar' layer format, refuse to push. Instruct the user to seal the overlay before pushing.

### This fixes or addresses the following GitHub issues:

 - Fixes #2871 
 - Fixes #3119


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
