### PR TITLE
feat: pull OCI-SIF with overlay, without --keep-layers

### DIFF
--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -909,13 +909,11 @@ func (c ctx) testPullOCIOverlay(t *testing.T) {
 		keepLayers bool
 		expectExit int
 	}{
-		// Pull without `--keep-layers`... not implemented
 		{
 			name:       "pull",
 			keepLayers: false,
-			expectExit: 255,
+			expectExit: 0,
 		},
-		// Pull with `--keep-layers`... success
 		{
 			name:       "pull keep-layers",
 			keepLayers: true,


### PR DESCRIPTION
## Description of the Pull Request (PR):

When we are pulling an OCI image to an OCI-SIF then by default we squash the image layers down to a single layer for the OCI-SIF file.

This doesn't make sense when the last layer is an overlay - users will generally expect an image pushed with a writable overlay remains writable when pulled.

When pulling to OCI-SIF without `--keep-layers` squash all the squashfs layers, but preserve a separate final overlay layer.


### This fixes or addresses the following GitHub issues:

 - Fixes #3135


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
