### PR TITLE
fix: enforce --platform on pull for all OCI images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
   execution of an OCI-SIF fails.
 - Fix failing builds from local images that have symbolic links for paths that
   are part of the base container environment (e.g. /var/tmp -> /tmp).
+- Fix issue where `--platform` / `--arch` did not apply when pulling an OCI
+  image to native SIF via image manifest, rather than image index.
 
 ### Requirements
 

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -1411,7 +1411,7 @@ func (c ctx) testDockerPlatform(t *testing.T) {
 			exit:     0,
 		},
 		{
-			name:     "MultiArchBadPlatform",
+			name:     "MultiArchInvalidPlatform",
 			platform: "windows/m68k",
 			uri:      "docker://alpine:latest",
 			exit:     255,
@@ -1429,8 +1429,14 @@ func (c ctx) testDockerPlatform(t *testing.T) {
 			exit:     0,
 		},
 		{
-			name:     "SingleArchBadPlatform",
+			name:     "SingleArchInvalidPlatform",
 			platform: "windows/m68k",
+			uri:      "docker://ppc64le/alpine:latest",
+			exit:     255,
+		},
+		{
+			name:     "SingleArchMissingPlatform",
+			platform: "linux/arm64",
 			uri:      "docker://ppc64le/alpine:latest",
 			exit:     255,
 		},

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -196,7 +196,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom st
 
 	src, err := pull(ctx, imgCache, directTo, pullFrom)
 	if err != nil {
-		return "", fmt.Errorf("error fetching image to cache: %v", err)
+		return "", fmt.Errorf("error fetching image: %v", err)
 	}
 
 	if directTo == "" {

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -99,7 +99,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom st
 		src, err = pullNativeSIF(ctx, imgCache, directTo, pullFrom, opts)
 	}
 	if err != nil {
-		return "", fmt.Errorf("error fetching image to cache: %v", err)
+		return "", fmt.Errorf("error fetching image: %v", err)
 	}
 
 	if directTo == "" {

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -86,7 +86,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom st
 
 	src, err := pull(ctx, imgCache, directTo, pullFrom, ociAuth, reqAuthFile)
 	if err != nil {
-		return "", fmt.Errorf("error fetching image to cache: %v", err)
+		return "", fmt.Errorf("error fetching image: %v", err)
 	}
 
 	if directTo == "" {

--- a/internal/pkg/client/shub/pull.go
+++ b/internal/pkg/client/shub/pull.go
@@ -199,7 +199,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom st
 
 	src, err := pull(ctx, imgCache, directTo, pullFrom, noHTTPS)
 	if err != nil {
-		return "", fmt.Errorf("error fetching image to cache: %v", err)
+		return "", fmt.Errorf("error fetching image: %v", err)
 	}
 
 	if directTo == "" {

--- a/internal/pkg/ocisif/overlay.go
+++ b/internal/pkg/ocisif/overlay.go
@@ -27,24 +27,6 @@ import (
 
 var Ext3LayerMediaType types.MediaType = "application/vnd.sylabs.image.layer.v1.ext3"
 
-func getSingleImage(fi *sif.FileImage) (v1.Image, error) {
-	ii, err := ocitsif.ImageIndexFromFileImage(fi)
-	if err != nil {
-		return nil, fmt.Errorf("while obtaining image index: %w", err)
-	}
-	ix, err := ii.IndexManifest()
-	if err != nil {
-		return nil, fmt.Errorf("while obtaining index manifest: %w", err)
-	}
-
-	// One image only.
-	if len(ix.Manifests) != 1 {
-		return nil, fmt.Errorf("only single image data containers are supported, found %d images", len(ix.Manifests))
-	}
-	imageDigest := ix.Manifests[0].Digest
-	return ii.Image(imageDigest)
-}
-
 // HasOverlay returns whether the OCI-SIF at imgPath has an ext3 writable final
 // layer - an 'overlay'. If present, the offset of the overlay data in the
 // OCI-SIF file is also returned.
@@ -57,7 +39,7 @@ func HasOverlay(imagePath string) (bool, int64, error) {
 	}
 	defer fi.UnloadContainer()
 
-	img, err := getSingleImage(fi)
+	img, err := GetSingleImage(fi)
 	if err != nil {
 		return false, 0, fmt.Errorf("while getting image: %w", err)
 	}
@@ -98,7 +80,7 @@ func AddOverlay(imagePath string, overlayPath string) error {
 	}
 	defer fi.UnloadContainer()
 
-	img, err := getSingleImage(fi)
+	img, err := GetSingleImage(fi)
 	if err != nil {
 		return fmt.Errorf("while getting image: %w", err)
 	}
@@ -127,7 +109,7 @@ func SyncOverlay(imagePath string) error {
 	}
 	defer fi.UnloadContainer()
 
-	img, err := getSingleImage(fi)
+	img, err := GetSingleImage(fi)
 	if err != nil {
 		return fmt.Errorf("while getting image: %w", err)
 	}
@@ -200,7 +182,7 @@ func SealOverlay(imagePath, tmpDir string) error {
 	}
 	defer fi.UnloadContainer()
 
-	img, err := getSingleImage(fi)
+	img, err := GetSingleImage(fi)
 	if err != nil {
 		return fmt.Errorf("while getting image: %w", err)
 	}

--- a/internal/pkg/ocisif/overlay_test.go
+++ b/internal/pkg/ocisif/overlay_test.go
@@ -246,7 +246,7 @@ func TestSyncOverlay(t *testing.T) {
 			}
 
 			// Final overlay layer must have the expected digest.
-			img, err := getSingleImage(fi)
+			img, err := GetSingleImage(fi)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -300,7 +300,7 @@ func TestSealOverlay(t *testing.T) {
 		t.Error(err)
 	}
 	defer fi.UnloadContainer()
-	img, err := getSingleImage(fi)
+	img, err := GetSingleImage(fi)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/pkg/ocisif/util.go
+++ b/internal/pkg/ocisif/util.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2024, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package ocisif
+
+import (
+	"fmt"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	ocitsif "github.com/sylabs/oci-tools/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
+)
+
+// GetSingleImage returns a v1.Image from an OCI-SIF, that must contain a single
+// image.
+func GetSingleImage(fi *sif.FileImage) (v1.Image, error) {
+	ii, err := ocitsif.ImageIndexFromFileImage(fi)
+	if err != nil {
+		return nil, fmt.Errorf("while obtaining image index: %w", err)
+	}
+	ix, err := ii.IndexManifest()
+	if err != nil {
+		return nil, fmt.Errorf("while obtaining index manifest: %w", err)
+	}
+
+	// One image only.
+	if len(ix.Manifests) != 1 {
+		return nil, fmt.Errorf("only single image data containers are supported, found %d images", len(ix.Manifests))
+	}
+	imageDigest := ix.Manifests[0].Digest
+	return ii.Image(imageDigest)
+}

--- a/internal/pkg/util/machine/machine.go
+++ b/internal/pkg/util/machine/machine.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/sylabs/sif/v2/pkg/sif"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
@@ -303,4 +304,19 @@ func CompatibleWith(arch string) bool {
 	}
 
 	return canEmulate(arch)
+}
+
+// SifArch returns the architecture of the primary partition in a SIF file.
+func SifArch(filename string) (string, error) {
+	f, err := sif.LoadContainerFromPath(filename, sif.OptLoadWithFlag(os.O_RDONLY))
+	if err != nil {
+		return "", fmt.Errorf("unable to open: %v: %w", filename, err)
+	}
+	defer f.UnloadContainer()
+
+	arch := f.PrimaryArch()
+	if arch == "unknown" {
+		return arch, fmt.Errorf("unknown architecture in SIF file")
+	}
+	return arch, nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Since 4.x we have had `--platform` / `--arch` support on pull from OCI sources. The `--platform` defaults to the host native platform.

In native mode, we were entirely relying on ggcr code to apply filtering / limits by platform. ggcr only does this when handling an image via an image index, not a manifest directly. Therefore, it was possible to pull images (that do not have an image index), with an architecture not expected.

In OCI-Mode a platform check prevented this, but occured very late... after layers were copied.

Move the main platform checks in to the `ociimage.LocalImage` / `ociimage.LocalImageLayout` functions, so that they are as early as possible (before layers are retrieved), and function the same in native and OCI mode.

When an image is retrieved from the cache - because the manifest/index digest in the registry matches a cache entry - check the architecture / platform.

Adjust some error messages, while we are here, that refer to fetching into the cache even when we aren't.

Ensure there is an e2e test that tries to pull from a single-arch repository with a valid, but non-matching platform... rather than just an invalid platform. The e2e test ordering ensures both the cached and non-cached flows are tested.

### This fixes or addresses the following GitHub issues:

 - Fixes #3158


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
