### PR TITLE
Fix SquashFS extraction when it contains directory symlinks (release 4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   (`docker://`) etc.
 - Fix confusing error messages / incorrect fall-back attempt when explicit
   execution of an OCI-SIF fails.
+- Fix failing builds from local images that have symbolic links for paths that
+  are part of the base container environment (e.g. /var/tmp -> /tmp).
 
 ## 4.1.4 \[2024-06-28\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ The following have contributed code and/or documentation to this repository.
 - Adam Hughes <adam@sylabs.io>, <stickmanica@gmail.com>
 - Adam Simpson <asimpson@nvidia.com>, <adambsimpson@gmail.com>
 - Afif Elghraoui <afif.elghraoui@nih.gov>
+- Alexander Grund <alexander.grund@tu-dresden.de>
 - Amanda Duffy <aduffy@lenovo.com>
 - Ana Guerrero Lopez <aguerrero@suse.com>
 - Ángel Bejarano <abejarano@ontropos.com>

--- a/e2e/build/build.go
+++ b/e2e/build/build.go
@@ -2455,5 +2455,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 1273":                      c.issue1273,                     // https://github.com/sylabs/singularity/issues/1273
 		"issue 1812":                      c.issue1812,                     // https://github.com/sylabs/singularity/issues/1812
 		"issue 2607":                      c.issue2607,                     // https://github.com/sylabs/singularity/issues/2607
+		"issue 3084":                      c.issue3084,                     // https://github.com/sylabs/singularity/issues/3084
 	}
 }

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -16,11 +16,6 @@ import (
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
-// LocalConveyor only needs to hold the conveyor to have the needed data to pack
-type LocalConveyor struct {
-	src string
-}
-
 // LocalPacker ...
 type LocalPacker interface {
 	Pack(context.Context) (*types.Bundle, error)
@@ -28,8 +23,7 @@ type LocalPacker interface {
 
 // LocalConveyorPacker only needs to hold the conveyor to have the needed data to pack
 type LocalConveyorPacker struct {
-	LocalConveyor
-	LocalPacker
+	localPacker LocalPacker
 }
 
 // GetLocalPacker ...
@@ -104,13 +98,29 @@ func GetLocalPacker(ctx context.Context, src string, b *types.Bundle) (LocalPack
 
 // Get just stores the source.
 func (cp *LocalConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err error) {
-	// insert base metadata before unpacking fs
-	if err = makeBaseEnv(b.RootfsPath); err != nil {
-		return fmt.Errorf("while inserting base environment: %v", err)
+	src := filepath.Clean(b.Recipe.Header["from"])
+
+	cp.localPacker, err = GetLocalPacker(ctx, src, b)
+	return err
+}
+
+// Delegate to local packer then insert base env
+func (cp *LocalConveyorPacker) Pack(ctx context.Context) (*types.Bundle, error) {
+	sylog.Infof("Extracting local image...")
+	b, err := cp.localPacker.Pack(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("while unpacking local image: %v", err)
 	}
 
-	cp.src = filepath.Clean(b.Recipe.Header["from"])
+	// insert base metadata AFTER unpacking fs to avoid conflicts with contained files/symlinks
+	if err = makeBaseEnv(b.RootfsPath); err != nil {
+		return nil, fmt.Errorf("while inserting base environment: %v", err)
+	}
 
-	cp.LocalPacker, err = GetLocalPacker(ctx, cp.src, b)
-	return err
+	sylog.Infof("Inserting Singularity configuration...")
+	if err = makeBaseEnv(b.RootfsPath); err != nil {
+		return nil, fmt.Errorf("while inserting base environment: %v", err)
+	}
+
+	return b, nil
 }

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -113,10 +113,6 @@ func (cp *LocalConveyorPacker) Pack(ctx context.Context) (*types.Bundle, error) 
 	}
 
 	// insert base metadata AFTER unpacking fs to avoid conflicts with contained files/symlinks
-	if err = makeBaseEnv(b.RootfsPath); err != nil {
-		return nil, fmt.Errorf("while inserting base environment: %v", err)
-	}
-
 	sylog.Infof("Inserting Singularity configuration...")
 	if err = makeBaseEnv(b.RootfsPath); err != nil {
 		return nil, fmt.Errorf("while inserting base environment: %v", err)

--- a/internal/pkg/build/sources/conveyorPacker_local_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_local_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package sources_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sylabs/singularity/v4/internal/pkg/build/sources"
+	"github.com/sylabs/singularity/v4/internal/pkg/image/packer"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/v4/pkg/build/types"
+)
+
+func createArchiveFromDir(dir string, t *testing.T) *os.File {
+	mk, err := exec.LookPath("mksquashfs")
+	if err != nil {
+		t.SkipNow()
+	}
+	f, err := os.CreateTemp("", "archive-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(mk, dir, f.Name(), "-noappend", "-no-progress")
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func makeDir(path string, t *testing.T) {
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("while creating directory %s: %v", path, err)
+	}
+}
+
+func isExist(path string) bool {
+	result, _ := fs.PathExists(path)
+	return result
+}
+
+func TestSquashfsInput(t *testing.T) {
+	if s := packer.NewSquashfs(); !s.HasMksquashfs() {
+		t.Skip("mksquashfs not found, skipping")
+	}
+
+	dir, err := os.MkdirTemp(os.TempDir(), "test-localpacker-squashfs-")
+	if err != nil {
+		t.Fatalf("while creating tmpdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Check that folder symlinks in the image to common folders (in base env) work
+	inputDir := filepath.Join(dir, "input")
+
+	makeDir(filepath.Join(dir, "var", "tmp"), t)
+	// Symlink /var/tmp -> /tmp in image
+	makeDir(filepath.Join(inputDir, "tmp"), t)
+	makeDir(filepath.Join(inputDir, "var"), t)
+	if err := os.Symlink("../tmp", filepath.Join(inputDir, "var", "tmp")); err != nil {
+		t.Fatalf("while creating symlink: %v", err)
+	}
+	// And a file we can check for
+	testfile := "conveyorPacker_local_test.go"
+	data, err := os.ReadFile(testfile)
+	if err != nil {
+		t.Fatalf("while reading test file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inputDir, testfile), data, 0o644); err != nil {
+		t.Fatalf("while writing test file: %v", err)
+	}
+	archive := createArchiveFromDir(inputDir, t)
+	defer os.Remove(archive.Name())
+
+	bundleTmp, _ := os.MkdirTemp(os.TempDir(), "bundle-tmp-")
+	b, err := types.NewBundle(dir, bundleTmp)
+	if err != nil {
+		t.Fatalf("while creating bundle: %v", err)
+	}
+	b.Recipe, _ = types.NewDefinitionFromURI("localimage://" + archive.Name())
+
+	lcp := &sources.LocalConveyorPacker{}
+	if err := lcp.Get(context.Background(), b); err != nil {
+		t.Fatalf("while getting local packer: %v", err)
+	}
+
+	_, err = lcp.Pack(context.Background())
+	if err != nil {
+		t.Fatalf("failed to Pack from %s: %v\n", archive.Name(), err)
+	}
+	rootfs := b.RootfsPath
+
+	// check if testfile was extracted
+	path := filepath.Join(rootfs, testfile)
+	if !isExist(path) {
+		t.Errorf("extraction failed, %s is missing", path)
+	}
+	// Check folders and symlinks
+	path = filepath.Join(rootfs, "tmp")
+	if !fs.IsDir(path) {
+		t.Errorf("extraction failed, %s is missing", path)
+	}
+	path = filepath.Join(rootfs, "var")
+	if !fs.IsDir(path) {
+		t.Errorf("extraction failed, %s is missing", path)
+	}
+	path = filepath.Join(rootfs, "var", "tmp")
+	if !isExist(path) {
+		t.Errorf("extraction failed, %s is missing", path)
+	} else if !fs.IsLink(path) {
+		t.Errorf("extraction failed, %s is not a symlink", path)
+	} else {
+		tgt, _ := os.Readlink(path)
+		if tgt != "../tmp" {
+			t.Errorf("extraction failed, %s wrongly points to %s", path, tgt)
+		}
+	}
+}

--- a/internal/pkg/build/sources/conveyorPacker_local_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_local_test.go
@@ -41,11 +41,11 @@ func TestLocalPackerSquashfs(t *testing.T) {
 		t.Fatalf("while creating directory: %v", err)
 	}
 
-	// Create symlinks: /var/tmp -> /tmp , /var/log -> /tmp
-	if err := os.Symlink(filepath.Join(rootfs, "tmp"), filepath.Join(rootfs, "var", "tmp")); err != nil {
+	// Create symlinks: $rootfs/var/tmp -> /tmp , $rootfs/var/log -> /tmp
+	if err := os.Symlink("/tmp", filepath.Join(rootfs, "var", "tmp")); err != nil {
 		t.Fatalf("while creating symlink: %v", err)
 	}
-	if err := os.Symlink(filepath.Join(rootfs, "tmp"), filepath.Join(rootfs, "var", "log")); err != nil {
+	if err := os.Symlink("/tmp", filepath.Join(rootfs, "var", "log")); err != nil {
 		t.Fatalf("while creating symlink: %v", err)
 	}
 
@@ -65,7 +65,7 @@ func TestLocalPackerSquashfs(t *testing.T) {
 	defer os.Remove(image)
 
 	// Creates bundle
-	bundleTmp, _ := os.MkdirTemp(os.TempDir(), "bundle-tmp-")
+	bundleTmp, _ := os.MkdirTemp("", "bundle-temp-*")
 	defer os.RemoveAll(bundleTmp)
 
 	b, err := types.NewBundle(tempDirPath, bundleTmp)
@@ -101,7 +101,7 @@ func TestLocalPackerSquashfs(t *testing.T) {
 	}
 
 	// Check symlinks
-	// /var/tmp -> /tmp
+	// $rootfsPath/var/tmp -> /tmp
 	path = filepath.Join(rootfsPath, "var", "tmp")
 	if exist, _ := fs.PathExists(path); !exist {
 		t.Errorf("extraction failed, %s is missing", path)
@@ -109,11 +109,11 @@ func TestLocalPackerSquashfs(t *testing.T) {
 		t.Errorf("extraction failed, %s is not a symlink", path)
 	} else {
 		tgt, _ := os.Readlink(path)
-		if tgt != filepath.Join(rootfs, "tmp") {
+		if tgt != "/tmp" {
 			t.Errorf("extraction failed, %s wrongly points to %s", path, tgt)
 		}
 	}
-	// /var/log -> /tmp
+	// $rootfsPath/var/log -> /tmp
 	path = filepath.Join(rootfsPath, "var", "log")
 	if exist, _ := fs.PathExists(path); !exist {
 		t.Errorf("extraction failed, %s is missing", path)
@@ -121,7 +121,7 @@ func TestLocalPackerSquashfs(t *testing.T) {
 		t.Errorf("extraction failed, %s is not a symlink", path)
 	} else {
 		tgt, _ := os.Readlink(path)
-		if tgt != filepath.Join(rootfs, "tmp") {
+		if tgt != "/tmp" {
 			t.Errorf("extraction failed, %s wrongly points to %s", path, tgt)
 		}
 	}


### PR DESCRIPTION
Backport #3151 

## Description of the Pull Request (PR):

A SquashFS image might contain directory symlinks such as `/var/tmp -> /tmp`. Before extraction a base environment is created (`makeBaseEnv`) by pre-creating some directories. Among them `/var/tmp`. Although unsquashfs is called with `-force` it fails to replace that by the symlink in the image as it removes only directories.

As per suggestion from @dtrudg the base environment causing the trouble is created after the extraction as done for e.g. OCI images.
