### PR TITLE
fix: overlay seal upper dir and fuse-overlayfs .wh..opq issue

### DIFF
--- a/internal/pkg/ocisif/overlay.go
+++ b/internal/pkg/ocisif/overlay.go
@@ -250,9 +250,10 @@ func SealOverlay(imagePath, tmpDir string) error {
 	if err := im.Mount(context.TODO()); err != nil {
 		return err
 	}
-	// Create squashfs from mounted extfs dir.
+	// Create squashfs from upper directory inside mounted extfs dir.
+	upperDir := filepath.Join(mntDir, "upper")
 	sqfs := filepath.Join(tmpDir, "overlay.sqfs")
-	if err := squashfs.Mksquashfs([]string{mntDir}, sqfs); err != nil {
+	if err := squashfs.Mksquashfs([]string{upperDir}, sqfs); err != nil {
 		return err
 	}
 	// Unmount the extfs.

--- a/internal/pkg/ocisif/overlay.go
+++ b/internal/pkg/ocisif/overlay.go
@@ -253,7 +253,18 @@ func SealOverlay(imagePath, tmpDir string) error {
 	// Create squashfs from upper directory inside mounted extfs dir.
 	upperDir := filepath.Join(mntDir, "upper")
 	sqfs := filepath.Join(tmpDir, "overlay.sqfs")
-	if err := squashfs.Mksquashfs([]string{upperDir}, sqfs); err != nil {
+
+	// Exclude the dangling `.wh..opq` 0:0 char device whiteout marker created
+	// by fuse-overlayfs inside opaque directories. This is neither a valid AUFS
+	// or native OverlayFS whiteout.
+	// See: https://github.com/sylabs/singularity/issues/3176
+	sqfsOpts := []squashfs.MksquashfsOpt{
+		squashfs.OptWildcards(true),
+		// '...' indicates an non-rooted match, i.e. match .wh..opq in any directory.
+		squashfs.OptExcludes([]string{"... .wh..opq"}),
+	}
+
+	if err := squashfs.Mksquashfs([]string{upperDir}, sqfs, sqfsOpts...); err != nil {
 		return err
 	}
 	// Unmount the extfs.


### PR DESCRIPTION
## Description of the Pull Request (PR):

**fix: seal overlay from upper/ dir in extfs**

The `overlay seal` command was incorrectly taking the whole of the extfs filesystem embedded in an OCI-SIF, and  converting it into a squashfs layer.

The changes made to the image are inside an `upper/` directory. Create the squashfs layer from this. Do not include the `work/` directory.

**fix: remove fuse-overlayfs .wh..opq in overlay seal**

fuse-overlayfs creates a dangling whiteout file within opaque directories. This takes the form of a `.wh..opq` 0:0 character device.

A `.wh..opq` file is not a valid AUFS whiteout / opaque marker. The real AUFS opaque marker is `.wh..wh..opq`.

A 0:0 character device is an OverlayFS whiteout indication, in this case that a file called `.wh..opq` should be white-outed. However, that file does not really exist, and the directory is opaque (via xattr), so shouldn't contain any individual whiteouts.

The `.wh..opq` 0:0 char device causes particular issues in any later squashfs->tar conversion, where we convert from OverlayFS to AUFS whiteouts. With `--layer-format` tar, the AUFS form is `.wh..wh..opq` - the same as a true AUFS opaque directory marker, with which it will clash.

Exclude `.wh..opq` files in squashfs creation in `overlay seal`. This avoids duplicate `.wh..wh..opq` entries in later `--layer-format=tar` conversion.

### This fixes or addresses the following GitHub issues:

 - Fixes #3175
 - Fixes #3176 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
