### PR TITLE
chore: 4.2.0-rc.1 docs / CI changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.22.4'
+    default: '1.22.6'
 
 executors:
   node:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,9 @@ updates:
     schedule:
       interval: "daily"
     target-branch: release-4.1
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: release-4.2
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SingularityCE Changelog
 
-## Changes Since Last Release
+## 4.2.0-rc.1 \[2024-08-13\]
+
+This is the first release candidate for the upcoming 4.2 series of
+SingularityCE. We welcome all feedback and testing. Please continue to use the
+latest 4.1 release for production systems.
 
 ### New Features & Functionality
 
@@ -54,6 +58,7 @@
 ### Requirements
 
 - Requires a minimum of Go 1.21.5 to build due to dependency updates.
+- OCI-SIF embedded writable overlay functionality requires `fuse2fs` >= 1.46.6.
 
 ## 4.1.4 \[2024-06-28\]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -201,11 +201,11 @@ cd singularity
 By default your clone will be on the `main` branch which is where development
 of SingularityCE happens. To build a specific version of SingularityCE, check
 out a [release tag](https://github.com/sylabs/singularity/tags) before
-compiling. E.g. to build the 4.1.4 release, checkout the
-`v4.1.4` tag:
+compiling. E.g. to build the 4.2.0-rc.1 release candidate, checkout the
+`v4.2.0-rc.1` tag:
 
 ```sh
-git checkout --recurse-submodules v4.1.4
+git checkout --recurse-submodules v4.2.0-rc.1
 ```
 
 ## Compiling SingularityCE
@@ -295,7 +295,7 @@ build and install the RPM like this:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-export VERSION=4.1.4  # this is the singularity version, change as you need
+export VERSION=4.2.0-rc.1  # this is the singularity version, change as you need
 
 # Fetch the source
 wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-ce-${VERSION}.tar.gz


### PR DESCRIPTION
Follow release procedure for 4.2.0-rc.1

* Bump Go version in CI to latest.
* Add branch to dependabot config.
* Update .MD files.