### PR TITLE
fix: run go-licenses correctly with downloaded go

### DIFF
--- a/scripts/update-license-dependencies.sh
+++ b/scripts/update-license-dependencies.sh
@@ -3,8 +3,6 @@
 set -e
 set -u
 
-go install github.com/google/go-licenses@v1.6.0
-
 if [ -d "vendor" ]; then
   echo "Please remove vendor directory before running this script"
   exit 255
@@ -16,4 +14,4 @@ if [ ! -f "go.mod" ]; then
   exit 255
 fi
 
-go-licenses report ./... --ignore github.com/sylabs/singularity/v4 --template scripts/LICENSE_DEPENDENCIES.tpl > LICENSE_DEPENDENCIES.md
+$(go env GOROOT)/bin/go run github.com/google/go-licenses@v1.6.0 report ./... --ignore github.com/sylabs/singularity/v4 --template scripts/LICENSE_DEPENDENCIES.tpl > LICENSE_DEPENDENCIES.md


### PR DESCRIPTION
## Description of the Pull Request (PR):

If the go toolchain is downloaded due to installed version vs go.mod then we need to set GOROOT for go-licenses to run correctly.

See: https://github.com/google/go-licenses/issues/149

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
