### PR TITLE
fix: pick apptainer 1848 (fix empty shell field)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Changes Since Last Release
 
+### Bug Fixes
+
+- Fix regression that led to an empty shell field in the `/etc/passwd` file.
+
 ## 4.2.0 \[2024-09-04\]
 
 ### New Features & Functionality

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,6 +38,7 @@ The following have contributed code and/or documentation to this repository.
 - Dave Godlove <d@sylabs.io>, <davidgodlove@gmail.com>
 - Dave Love <d.love@liverpool.ac.uk>
 - David Trudgian <david.trudgian@sylabs.io>, <dave@trudgian.net>
+- Dennis Klein <d.klein@gsi.de>
 - Diana Langenbach <dcl@dcl.sh>
 - Dimitri Papadopoulos <3234522+DimitriPapadopoulos@users.noreply.github.com>
 - Divya Cote <divya.cote@gmail.com>

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -2956,6 +2956,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5690":                   c.issue5690,                      // https://github.com/sylabs/singularity/issues/5690
 		"issue 1950":                   c.issue1950,                      // https://github.com/sylabs/singularity/issues/1950
 		"issue 2690":                   c.issue2690,                      // https://github.com/sylabs/singularity/issues/2690
+		"issue 1848":                   c.issue1848,                      // https://github.com/apptainer/apptainer/issues/1848
 		"network":                      c.actionNetwork,                  // test basic networking
 		"netns-path":                   c.actionNetnsPath,                // test netns joining
 		"binds":                        c.actionBinds,                    // test various binds with --bind and --mount

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -910,5 +912,29 @@ func (c actionTests) issue3129(t *testing.T) {
 		e2e.WithDir(dir),
 		e2e.WithArgs(image, "/bin/true"),
 		e2e.ExpectExit(0),
+	)
+}
+
+// Verify the generated host user data appended to /etc/passwd
+func (c actionTests) issue1848(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+	user := e2e.UserProfile.HostUser(t)
+	expectedPasswdLine := fmt.Sprintf("%s:x:%d:%d:%s:%s:%s",
+		user.Name,
+		user.UID,
+		user.GID,
+		user.Gecos,
+		user.Dir,
+		user.Shell,
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(c.env.ImagePath, "tail", "-1", "/etc/passwd"),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(e2e.ExactMatch, expectedPasswdLine),
+		),
 	)
 }

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -1547,17 +1547,14 @@ func (e *EngineOperations) setUserInfo(useTargetIDs bool) {
 
 	if useTargetIDs {
 		pw, err = user.GetPwUID(uint32(e.EngineConfig.GetTargetUID()))
-		if err == nil {
-			e.EngineConfig.JSON.UserInfo.Username = pw.Name
-			e.EngineConfig.JSON.UserInfo.Gecos = pw.Gecos
-			e.EngineConfig.JSON.UserInfo.UID = int(pw.UID)
-			e.EngineConfig.JSON.UserInfo.GID = int(pw.GID)
-		}
-	} else {
+	}
+
+	if err == nil {
 		e.EngineConfig.JSON.UserInfo.Username = pw.Name
 		e.EngineConfig.JSON.UserInfo.Gecos = pw.Gecos
 		e.EngineConfig.JSON.UserInfo.UID = int(pw.UID)
 		e.EngineConfig.JSON.UserInfo.GID = int(pw.GID)
+		e.EngineConfig.JSON.UserInfo.Shell = pw.Shell
 	}
 
 	e.EngineConfig.JSON.UserInfo.Groups = make(map[int]string)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick https://github.com/apptainer/apptainer/pull/1848

Fixes an empty shell field in the user's `/etc/passwd` entry in native mode.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
