### PR TITLE
e2e: fix: use image with no WorkingDir for actionOCIHomeCwdPasswd (4.2)

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -2110,11 +2110,13 @@ func (c actionTests) actionOciNoSetgroups(t *testing.T) {
 }
 
 // Check that by default, the container is entered at the correct $HOME for the
-// user, and $HOME in their passwd entry is correct.
-// https://github.com/sylabs/singularity/issues/1791
+// user when no WorkingDir is set in the image config, and $HOME in their passwd
+// entry is correct. https://github.com/sylabs/singularity/issues/1791
 func (c actionTests) actionOciHomeCwdPasswd(t *testing.T) {
-	e2e.EnsureOCISIF(t, c.env)
-	imageRef := "oci-sif:" + c.env.OCISIFPath
+	e2e.EnsureImage(t, c.env)
+	// Use the non-OCI-SIF test image as from 3.18.9 docker://alpine (used as
+	// OCI-SIF test image source) has WorkingDir="/".
+	imageRef := c.env.ImagePath
 	for _, p := range e2e.OCIProfiles {
 		cu := p.ContainerUser(t)
 		// Ignore shell field as we use preserve container value. Tested previously.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Newest alpine:3.18 image has WorkingDir="/" explicitly set, causing this test to fail.

Use the non-OCI-SIF test image, which results in an unset WorkingDir as before. This will remain the case as non-OCI-SIF Singularity images don't have a way of setting a working dir.


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
