### PR TITLE
feat: accommodate missing /run/user dir in OCI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 - Fix regression from 4.1.5 that overwrites source image runscript, environment
   etc. in build from local image.
 
+### New Features & Functionality
+
+- In OCI-Mode, accommodate systems configured so that they do not create a
+  `/run/user` session directory. OCI-Mode will now attempt to use
+  `$TMPDIR/singularity-oci-<uid>` for runtime state on systems where
+  `$XDG_RUNTIME_DIR` is not set and the default user session path of
+  `/run/user/<uid>` does not exist. Note that the `$TMPDIR/singularity-oci-<uid>`
+  directory is shared between concurrent `--oci` mode invocations, and will not
+  be removed on exit - an empty directory will remain.
+
 ## 4.2.1 \[2024-09-13\]
 
 ### Bug Fixes


### PR DESCRIPTION
## Description of the Pull Request (PR):

On systems where `pam-systemd` is disabled, or there is other configuration preventing the creation of a /run/user/<uid> directory, we need to use a different location for the OCI runtime state.

Change the runtimeStateDir handling to:

* Use XDG_RUNTIME_DIR if set.
* Otherwise, try to use /run/user/<uid>.
* Otherwise, use a location under $TMPDIR.


### This fixes or addresses the following GitHub issues:

 - Fixes #3393


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
