### PR TITLE
fix: improve build --oci error for missing XDG_RUNTIME_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   etc. in build from local image.
 - Fall back to `$TMPDIR` as singularity-buildkitd root directory if
   `~/.singularity` is on a filesystem that does not fully support overlay.
+- Add more intuitive error message for rootless `build --oci` when required
+  `XDG_RUNTIME_DIR` env var is not set.
 
 ### New Features & Functionality
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

The buildkit code that we call as a dependency uses XDG_RUNTIME_DIR in multiple locations, so we cannot handle it being unset.

Add a specific error for rootless build --oci with XDG_RUNTIME_DIR unset, so it is clear that this env var must be set.

I don't think we should be setting XDG_RUNTIME_DIR ourselves, to a tmpdir we create. There is a strong assumption that this value is a genuine session specific directory that is configured by systemd, or by the user manually.


### This fixes or addresses the following GitHub issues:

 - Fixes #3410 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
