### PR TITLE
fix: CNI: avoid error with iptables setuid check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   `~/.singularity` is on a filesystem that does not fully support overlay.
 - Add more intuitive error message for rootless `build --oci` when required
   `XDG_RUNTIME_DIR` env var is not set.
+- Avoid error in CNI network setup with newer versions of iptables that include
+  a setuid caller check.
 
 ### New Features & Functionality
 

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -2398,8 +2398,15 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 				}
 			}
 			if euid != 0 {
-				priv.Escalate()
-				defer priv.Drop()
+				dropPrivs, err := priv.EscalateRealEffective()
+				if err != nil {
+					return err
+				}
+				defer func() {
+					if err := dropPrivs(); err != nil {
+						sylog.Fatalf("while dropping privilege: %v", err)
+					}
+				}()
 			}
 		}
 

--- a/internal/pkg/util/priv/priv_linux_test.go
+++ b/internal/pkg/util/priv/priv_linux_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2024, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package priv
+
+import (
+	"testing"
+
+	"github.com/sylabs/singularity/v4/internal/pkg/test"
+	"golang.org/x/sys/unix"
+)
+
+func TestEscalateRealEffective(t *testing.T) {
+	test.EnsurePrivilege(t)
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	r, e, s := unix.Getresuid()
+	if r == 0 || e == 0 {
+		t.Fatalf("real / effective ID must be non-zero before escalation. Got r/e/s %d/%d/%d", r, e, s)
+	}
+	unprivUID := r
+
+	drop, err := EscalateRealEffective()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, e, s = unix.Getresuid()
+	t.Logf("Escalated r/e/s: %d/%d/%d", r, e, s)
+	if r != 0 || e != 0 || s != unprivUID {
+		t.Fatalf("Expected escalated r/e/s %d/%d/%d, Got r/e/s %d/%d/%d", 0, 0, unprivUID, r, e, s)
+	}
+
+	if err := drop(); err != nil {
+		t.Fatal(err)
+	}
+
+	r, e, s = unix.Getresuid()
+	t.Logf("Dropped r/e/s: %d/%d/%d", r, e, s)
+	if r != unprivUID || e != unprivUID || s != 0 {
+		t.Fatalf("Expected dropped r/e/s %d/%d/%d, Got r/e/s %d/%d/%d", unprivUID, unprivUID, 0, r, e, s)
+	}
+}

--- a/pkg/network/network_linux.go
+++ b/pkg/network/network_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -22,6 +22,7 @@ import (
 	cnitypes "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/env"
+	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
 type netError string
@@ -451,12 +452,15 @@ func (m *Setup) DelNetworks(ctx context.Context) error {
 }
 
 func (m *Setup) command(ctx context.Context, command string) error {
-	if m.envPath != "" {
-		backupEnv := os.Environ()
-		os.Clearenv()
-		os.Setenv("PATH", m.envPath)
-		defer env.SetFromList(backupEnv)
+	if m.envPath == "" {
+		sylog.Debugf("Network envPath is unset. Setting PATH to a safe default.")
+		m.envPath = "/bin:/sbin:/usr/bin:/usr/sbin"
 	}
+	sylog.Debugf("Network envPath: %s", m.envPath)
+	backupEnv := os.Environ()
+	os.Clearenv()
+	os.Setenv("PATH", m.envPath)
+	defer env.SetFromList(backupEnv)
 
 	config := &libcni.CNIConfig{Path: []string{m.cniPath.Plugin}}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Newer versions of the `iptables` command use a real vs effective uid check whether they are being called from a setuid script, and exit if that's the case.

This check was added because iptables can call out to binaries / libraries on `PATH` / `LD_LIBRARY_PATH`, and these are generally under control of the user - allowing privilege escalation attackes.

Singularity sanitizes the environment before running CNI plugins, which will call `iptables`, so we can set both real and effective uid to 0 to avoid the error.

While we are here, make `PATH` sanitization the default in the network code, rather than relying on the caller applying it.


### This fixes or addresses the following GitHub issues:

 - Fixes #3318


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
