### PR TITLE
ci: Add centos stream 10 RPM builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ executors:
   almalinux9:
     docker:
       - image: almalinux:9
+  centosstream10:
+    docker:
+      - image: quay.io/centos/centos:stream10
   ubuntu2004:
     docker:
       - image: ubuntu:20.04
@@ -410,12 +413,12 @@ workflows:
       - build-rpm:
           matrix:
             parameters:
-              e: ["almalinux8", "almalinux9"]
-          filters:
-            branches:
-              only:
-                - main
-                - /release-.*/
+              e: ["almalinux8", "almalinux9", "centosstream10"]
+#          filters:
+#            branches:
+#              only:
+#                - main
+#                - /release-.*/
 
       - build-deb:
           matrix:
@@ -432,7 +435,7 @@ workflows:
       - build-rpm:
           matrix:
             parameters:
-              e: ["almalinux8", "almalinux9"]
+              e: ["almalinux8", "almalinux9", "centosstream10"]
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Add centos stream 10 to the CI matrix for RPM builds.

This will be replaced with a non-stream EL distribution once RHEL 10 releases.

CI portion of #3432 