### PR TITLE
ci: split stream 10 rpm build to a 'preview' workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,12 +413,12 @@ workflows:
       - build-rpm:
           matrix:
             parameters:
-              e: ["almalinux8", "almalinux9", "centosstream10"]
-#          filters:
-#            branches:
-#              only:
-#                - main
-#                - /release-.*/
+              e: ["almalinux8", "almalinux9"]
+          filters:
+            branches:
+              only:
+                - main
+                - /release-.*/
 
       - build-deb:
           matrix:
@@ -430,12 +430,24 @@ workflows:
                 - main
                 - /release-.*/
 
+  preview:
+    jobs:
+       - build-rpm:
+          matrix:
+            parameters:
+              e: ["centosstream10"]
+          filters:
+            branches:
+              only:
+                - main
+                - /release-.*/
+
   tagged-release:
     jobs:
       - build-rpm:
           matrix:
             parameters:
-              e: ["almalinux8", "almalinux9", "centosstream10"]
+              e: ["almalinux8", "almalinux9"]
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
There seem to be some issues with rpmbuild failures on some stream 10 docker hub updates, suggesting stream 10 (or at least the Docker image) isn't yet stable enough.

Move the stream 10 rpmbuild to a separate workflow named `preview` that can be excluded from branch protection rules so it doesn't block PR merge.