### PR TITLE
e2e: fix: relax CustomHomePreservesRootShell regex

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -340,7 +340,7 @@ func (c actionTests) actionExecMultiProfile(t *testing.T) {
 					argv: []string{"--home", "/tmp", c.env.ImagePath, "cat", "/etc/passwd"},
 					exit: 0,
 					wantOutputs: []e2e.SingularityCmdResultOp{
-						e2e.ExpectOutput(e2e.RegexMatch, `^root:x:0:0:root:[^:]*:/bin/ash\n`),
+						e2e.ExpectOutput(e2e.RegexMatch, `^root:x:0:0:\w*:[^:]*:/bin/ash\n`),
 					},
 				},
 			}

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -308,7 +308,7 @@ func (c actionTests) actionOciExec(t *testing.T) {
 			argv: []string{"--home", "/tmp", imageRef, "cat", "/etc/passwd"},
 			exit: 0,
 			wantOutputs: []e2e.SingularityCmdResultOp{
-				e2e.ExpectOutput(e2e.RegexMatch, `^root:x:0:0:root:[^:]*:/bin/ash\n`),
+				e2e.ExpectOutput(e2e.RegexMatch, `^root:x:0:0:\w*:[^:]*:/bin/ash\n`),
 			},
 		},
 		{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow the user fullname to for root to be anything. It is usually `root`, but on EL10 it's now `Super User`.


### This fixes or addresses the following GitHub issues:

 - Fixes #3455


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
