### PR TITLE
fix: use username, not name for conmon/singularity stateDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+### Bug Fixes
+
+- Use correct username (not user's name) when computing `singularity oci` conmon
+  / singularity state dir.
+
 ## 4.2.2 \[2024-12-20\]
 
 ### Bug Fixes

--- a/internal/pkg/runtime/launcher/oci/oci_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_linux.go
@@ -121,7 +121,7 @@ func stateDir(containerID string) (string, error) {
 		return "", err
 	}
 
-	configDir, err := syfs.ConfigDirForUsername(u.Name)
+	configDir, err := syfs.ConfigDirForUsername(u.Username)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

For `singularity oci` commands (not `--oci` mode), a conmon/singularity state dir is required. The path was erroneously being computed based on the user's Name, instead of Username.

This shows as a test failure on EL10 where the Name != Username for `root / Super User`, as opposed to other distributions that use `root / root`.


### This fixes or addresses the following GitHub issues:

 - Fixes #3456 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
