### PR TITLE
fix: ensure network e2e tests run

### DIFF
--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/v4/internal/pkg/security/seccomp"
@@ -98,8 +99,9 @@ func Network(t *testing.T) {
 		cniPath := new(network.CNIPath)
 		cniPath.Conf = filepath.Join(buildcfg.SYSCONFDIR, "singularity", "network")
 		cniPath.Plugin = filepath.Join(buildcfg.LIBEXECDIR, "singularity", "cni")
+		containerID := "singularity-e2e-" + uuid.New().String()
 
-		setup, err := network.NewSetup([]string{"bridge"}, "_test_", nsPath, cniPath)
+		setup, err := network.NewSetup([]string{"bridge"}, containerID, nsPath, cniPath)
 		if err != nil {
 			logFn(err)
 			return

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -349,14 +349,16 @@ func TestNewSetup(t *testing.T) {
 	}
 
 	for _, s := range testSetup {
-		setup, err := NewSetup(s.networks, s.id, s.nspath, s.cniPath)
-		if err != nil && s.success {
-			t.Errorf("unexpected failure for %q test: %s", s.desc, err)
-		} else if err == nil && !s.success {
-			t.Errorf("unexpected success for %q test", s.desc)
-		} else if s.subTest != nil {
-			s.subTest(setup, t)
-		}
+		t.Run(s.desc, func(t *testing.T) {
+			setup, err := NewSetup(s.networks, s.id, s.nspath, s.cniPath)
+			if err != nil && s.success {
+				t.Errorf("unexpected failure for %q test: %s", s.desc, err)
+			} else if err == nil && !s.success {
+				t.Errorf("unexpected success for %q test", s.desc)
+			} else if s.subTest != nil {
+				s.subTest(setup, t)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Network e2e tests were failing to run due to an invalid container name (with newer CNI plugins / distro) in the `require.Network(t)` function.

Fix the container name so that the requirement function passes, and the tests will run properly.

While we are in this code, ensure some other network tests run with named subtests for convenience when reviewing the test logs.



### This fixes or addresses the following GitHub issues:

 - Fixes #3433


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
