### PR TITLE
feat: push --with-cosign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   public key with the `--key` flag. Verification passes if at least one
   signature that can be validated with the provided key is present. The JSON
   payloads of all valid signatures are displayed.
+- `singularity push` now supports pushing cosign signatures in an OCI-SIF to
+  an OCI registry, via the `--with-cosign` flag.
 
 ## Requirements / Packaging
 

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -36,6 +36,9 @@ var (
 
 	// pushLayerFormat sets the layer format to be used when pushing OCI images.
 	pushLayerFormat string
+
+	// pushWithCosign sets whether cosign signatures are pushed when pushing OCI images.
+	pushWithCosign bool
 )
 
 // --library
@@ -79,6 +82,16 @@ var pushLayerFormatFlag = cmdline.Flag{
 	EnvKeys:      []string{"LAYER_FORMAT"},
 }
 
+// --with-cosign
+var pushWithCosignFlag = cmdline.Flag{
+	ID:           "pushWithCosignFlag",
+	Value:        &pushWithCosign,
+	DefaultValue: false,
+	Name:         "with-cosign",
+	Usage:        "push cosign signatures from OCI-SIF images",
+	EnvKeys:      []string{"WITH_COSIGN"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(PushCmd)
@@ -95,6 +108,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&commonTmpDirFlag, PushCmd)
 
 		cmdManager.RegisterFlagForCmd(&pushLayerFormatFlag, PushCmd)
+		cmdManager.RegisterFlagForCmd(&pushWithCosignFlag, PushCmd)
 	})
 }
 
@@ -206,6 +220,7 @@ var PushCmd = &cobra.Command{
 				Auth:        ociAuth,
 				AuthFile:    reqAuthFile,
 				LayerFormat: pushLayerFormat,
+				WithCosign:  pushWithCosign,
 			}
 			if err := oci.Push(cmd.Context(), file, ref, opts); err != nil {
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)

--- a/internal/pkg/client/oci/push.go
+++ b/internal/pkg/client/oci/push.go
@@ -28,6 +28,9 @@ type PushOptions struct {
 	// TmpDir is a temporary directory to be used for an temporary files created
 	// during the push.
 	TmpDir string
+	// WithCosign sets whether to push any associated cosign signatures when
+	// pushing an OCI-SIF to a registry.
+	WithCosign bool
 }
 
 // Push pushes an image into an OCI registry, as an OCI image (not an ORAS artifact).
@@ -46,6 +49,7 @@ func Push(ctx context.Context, sourceFile string, destRef string, opts PushOptio
 			AuthFile:    opts.AuthFile,
 			LayerFormat: opts.LayerFormat,
 			TmpDir:      opts.TmpDir,
+			WithCosign:  opts.WithCosign,
 		}
 		return ocisif.PushOCISIF(ctx, sourceFile, destRef, ocisifOpts)
 	case image.SIF:


### PR DESCRIPTION
## Description of the Pull Request (PR):

When the `--with-cosign` flag is specified, `singularity push` will now push cosign signatures from an OCI-SIF to a remote OCI registry.

Signatures cannot be pushed if the push operation would mutate the image.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
