### PR TITLE
feat: pull -oci --with-cosign support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@
   payloads of all valid signatures are displayed.
 - `singularity push` now supports pushing cosign signatures in an OCI-SIF to
   an OCI registry, via the `--with-cosign` flag.
+- `singularity pull` now supports pulling cosign signatures from a registry
+  to an OCI-SIF, via the `--with-cosign` flag when `--oci` is also specified.
+  Signatures can only be pulled when the image in the registry is in SquashFS
+  format. Converting layer formats, or squashing to a single layer, modifies
+  the image manifest, and would invalidate any signatures.
 
 ## Requirements / Packaging
 

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -51,6 +51,8 @@ var (
 	unauthenticatedPull bool
 	// pullDir is the path that the containers will be pulled to, if set.
 	pullDir string
+	// pullWithCosign sets whether cosign signatures are pushed when pushing OCI images.
+	pullWithCosign bool
 )
 
 // --library
@@ -118,6 +120,16 @@ var pullAllowUnauthenticatedFlag = cmdline.Flag{
 	Hidden:       true,
 }
 
+// --with-cosign
+var pullWithCosignFlag = cmdline.Flag{
+	ID:           "pullWithCosignFlag",
+	Value:        &pullWithCosign,
+	DefaultValue: false,
+	Name:         "with-cosign",
+	Usage:        "pull associated cosign signatures into an OCI-SIF image",
+	EnvKeys:      []string{"WITH_COSIGN"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(PullCmd)
@@ -147,6 +159,8 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&commonPlatformFlag, PullCmd)
 
 		cmdManager.RegisterFlagForCmd(&commonAuthFileFlag, PullCmd)
+
+		cmdManager.RegisterFlagForCmd(&pullWithCosignFlag, PullCmd)
 	})
 }
 
@@ -244,6 +258,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			KeepLayers:    keepLayers,
 			TmpDir:        tmpDir,
 			Platform:      getOCIPlatform(),
+			WithCosign:    pullWithCosign,
 		}
 		_, err = library.PullToFile(ctx, imgCache, pullTo, ref, pullOpts)
 		if err != nil && err != library.ErrLibraryPullUnsigned {
@@ -309,6 +324,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			KeepLayers:  keepLayers,
 			Platform:    getOCIPlatform(),
 			ReqAuthFile: reqAuthFile,
+			WithCosign:  pullWithCosign,
 		}
 
 		_, err = oci.PullToFile(ctx, imgCache, pullTo, pullFrom, pullOpts)

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -49,6 +49,8 @@ type PullOptions struct {
 	RequireOciSif bool
 	// When pulling an OCI-SIF, keep multiple layers if true, squash to single layer otherwise.
 	KeepLayers bool
+	// When pulling an OCI-SIF, pull cosign signatures associated with the image if true.
+	WithCosign bool
 	// Platform specifies the platform of the image to retrieve.
 	Platform gccrv1.Platform
 }
@@ -152,6 +154,7 @@ func pullOCI(ctx context.Context, imgCache *cache.Handle, directTo string, pullF
 		OciAuth:    authConf,
 		Platform:   opts.Platform,
 		KeepLayers: opts.KeepLayers,
+		WithCosign: opts.WithCosign,
 	}
 	return ocisif.PullOCISIF(ctx, imgCache, directTo, pullRef, ocisifOpts)
 }
@@ -182,6 +185,10 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo string, pull
 	if imgCache.IsDisabled() {
 		directTo = pullTo
 		sylog.Debugf("Cache disabled, pulling directly to: %s", directTo)
+	}
+	if opts.WithCosign {
+		directTo = pullTo
+		sylog.Infof("cosign signature functionality does not support SIF caching, pulling directly to: %s", directTo)
 	}
 
 	src := ""

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -30,6 +30,7 @@ type PullOptions struct {
 	NoCleanUp   bool
 	OciSif      bool
 	KeepLayers  bool
+	WithCosign  bool
 	Platform    gccrv1.Platform
 	ReqAuthFile string
 }
@@ -56,7 +57,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, opts Pul
 			return "", fmt.Errorf("unable to create tmp file: %v", err)
 		}
 		directTo = file.Name()
-		sylog.Infof("Downloading library image to tmp cache: %s", directTo)
+		sylog.Infof("Downloading image to tmp cache: %s", directTo)
 	}
 	if opts.OciSif {
 		ocisifOpts := ocisif.PullOptions{
@@ -68,6 +69,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, opts Pul
 			Platform:    opts.Platform,
 			ReqAuthFile: opts.ReqAuthFile,
 			KeepLayers:  opts.KeepLayers,
+			WithCosign:  opts.WithCosign,
 		}
 		return ocisif.PullOCISIF(ctx, imgCache, directTo, pullFrom, ocisifOpts)
 	}
@@ -82,6 +84,10 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom st
 		directTo = pullTo
 		sylog.Debugf("Cache disabled, pulling directly to: %s", directTo)
 	}
+	if opts.WithCosign {
+		directTo = pullTo
+		sylog.Infof("cosign signature functionality does not support SIF caching, pulling directly to: %s", directTo)
+	}
 	src := ""
 	if opts.OciSif {
 		ocisifOpts := ocisif.PullOptions{
@@ -93,6 +99,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom st
 			Platform:    opts.Platform,
 			ReqAuthFile: opts.ReqAuthFile,
 			KeepLayers:  opts.KeepLayers,
+			WithCosign:  opts.WithCosign,
 		}
 		src, err = ocisif.PullOCISIF(ctx, imgCache, directTo, pullFrom, ocisifOpts)
 	} else {


### PR DESCRIPTION
## Description of the Pull Request (PR):

When using `singularity pull --oci` to pull an image from an OCI registry (or registry backed library) into an OCI-SIF it is now possible to pull any cosign signatures associated with the image using a new `--with-cosign` flag.

Pulling cosign signatures requires that the image in the registry is in a format where it will not be mutated as it is pulled into the OCI-SIF. Any mutations change the image manifest, which would invalidate the signatures. Therefore:

* The image must have SquashFS layers - i.e. it was created and signed with Singularity, and is not a standard tar layer Docker / OCI image.
* The '--keep-layers' flag must be used if the image has more than one layer.

There are important limitations to signature pulling:

* If an image & signatures are updated at the registry during a pull `--with-cosign` by tag, it is possible that a mistmatched signature is retrieved. Pulling by digest avoids this issue.
* Pulling signatures disables OCI-SIF caching.

The caching issue is difficult to overcome, as Singularity's caching of OCI -> SIF pulls is based around the assumption that a SIF contains a single OCI image and the image manifest digest can be used as the cache key. An OCI-SIF containing cosign signatures now holds multiple (container and signature) images. We cannot cache based on the container manifest digest alone. We cannot add a simple `-signed` suffix to the cache key, as the signatures associated with an image at the registry can change independently of the container image itself.

In the mid to long-term it would be beneficial to rewrite the OCI pull / push handling to use the SourceSink interfaces and implementations in sylabs/oci-tools, which accommodate multi-image SIFs more directly. This would require a complete re-think of caching in Singularity - which is overdue but dependent on a major version bump.

### This fixes or addresses the following GitHub issues:

 - Fixes #3511 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
