### PR TITLE
feat: key generate-cosign-key-pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
   Signatures can only be pulled when the image in the registry is in SquashFS
   format. Converting layer formats, or squashing to a single layer, modifies
   the image manifest, and would invalidate any signatures.
+- The new `singularity key generate-cosign-key-pair` subcommand can be used
+  to generate a password-protected key-pair for signing OCI-SIF images with
+  cosign-compatible signatures.
 
 ## Requirements / Packaging
 

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2017-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2017-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -94,6 +94,9 @@ func init() {
 			&keyGlobalPubKeyFlag,
 			KeyImportCmd, KeyExportCmd, KeyListCmd, KeyPullCmd, KeyPushCmd, KeyRemoveCmd,
 		)
+
+		cmdManager.RegisterSubCmd(KeyCmd, KeyGenerateCosignKeyPairCmd)
+		cmdManager.RegisterFlagForCmd(&keyOutputKeyPrefixFlag, KeyGenerateCosignKeyPairCmd)
 	})
 }
 

--- a/cmd/internal/cli/key_generatecosignkeypair.go
+++ b/cmd/internal/cli/key_generatecosignkeypair.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2025, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"os"
+
+	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/v4/docs"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/v4/pkg/cmdline"
+	"github.com/sylabs/singularity/v4/pkg/sylog"
+)
+
+var (
+	cosignKeyPairPrefix string
+
+	// --output-key-prefix
+	keyOutputKeyPrefixFlag = cmdline.Flag{
+		ID:           "keyOutputKeyPrefixFlag",
+		Value:        &cosignKeyPairPrefix,
+		DefaultValue: "singularity-cosign",
+		Name:         "output-key-prefix",
+		Usage:        "prefix for .key / .pub files",
+	}
+
+	// KeyNewPairCmd is 'singularity key newpair' and generate a new OpenPGP key pair
+	KeyGenerateCosignKeyPairCmd = &cobra.Command{
+		Args:                  cobra.ExactArgs(0),
+		DisableFlagsInUseLine: true,
+		Run:                   runGenerateCosignKeyPairCmd,
+		Use:                   docs.KeyGenerateCosignKeyPairUse,
+		Short:                 docs.KeyGenerateCosignKeyPairShort,
+		Long:                  docs.KeyGenerateCosignKeyPairLong,
+		Example:               docs.KeyGenerateCosignKeyPairExample,
+	}
+)
+
+func runGenerateCosignKeyPairCmd(_ *cobra.Command, _ []string) {
+	priKey := cosignKeyPairPrefix + ".key"
+	pubKey := cosignKeyPairPrefix + ".pub"
+
+	exists, err := fs.PathExists(priKey)
+	if err != nil {
+		sylog.Fatalf("%v", err)
+	}
+	if exists {
+		sylog.Fatalf("file exists, will not overwrite: %s", priKey)
+	}
+
+	exists, err = fs.PathExists(pubKey)
+	if err != nil {
+		sylog.Fatalf("%v", err)
+	}
+	if exists {
+		sylog.Fatalf("file exists, will not overwrite: %s", pubKey)
+	}
+
+	sylog.Infof("Creating cosign key-pair %s.key/.pub", cosignKeyPairPrefix)
+
+	kb, err := cosign.GenerateKeyPair(cryptoutils.GetPasswordFromStdIn)
+	if err != nil {
+		sylog.Fatalf("%v", err)
+	}
+
+	if err := os.WriteFile(priKey, kb.PrivateBytes, 0o600); err != nil {
+		sylog.Fatalf("%v", err)
+	}
+	if err := os.WriteFile(pubKey, kb.PublicBytes, 0o644); err != nil {
+		sylog.Fatalf("%v", err)
+	}
+}

--- a/docs/content.go
+++ b/docs/content.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2017-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -261,7 +261,7 @@ Enterprise Performance Computing (EPC)`
 	// key newpair
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	KeyNewPairUse   string = `newpair`
-	KeyNewPairShort string = `Create a new key pair`
+	KeyNewPairShort string = `Create a new PGP key-pair`
 	KeyNewPairLong  string = `
   The 'key newpair' command allows you to create a new key or public/private
   keys to be stored in the default user local keyring location (e.g., 
@@ -339,6 +339,18 @@ Enterprise Performance Computing (EPC)`
   the local or the global keyring.`
 	KeyRemoveExample string = `
   $ singularity key remove D87FE3AF5C1F063FCBCC9B02F812842B5EEE5934`
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// key new-cosign-pair
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	KeyGenerateCosignKeyPairUse   string = `generate-cosign-key-pair`
+	KeyGenerateCosignKeyPairShort string = `Generate a new cosign key-pair`
+	KeyGenerateCosignKeyPairLong  string = `
+  The 'key generate-cosign-key-pair' command allows you to create a new public/private
+  key-pair that can be used to sign OCI-SIF images with a cosign compatible signature.`
+	KeyGenerateCosignKeyPairExample string = `
+  $ singularity key generate-cosign-keypair
+  $ singularity key generate-cosign-keypair --output-key-prefix=mykeypair`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// delete


### PR DESCRIPTION
## Description of the Pull Request (PR):

Adds a new subcommand that will generate a key-pair suitable for signing OCI-SIF images with a cosign-compatible signature.

Intentionally uses output prefix flag matching `cosign generate-key-pair`.


### This fixes or addresses the following GitHub issues:

 - Fixes #3489


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
