### PR TITLE
build: Derive the GNU build ID from the Go one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 - Ubuntu deb packages are built without libsubid support.
 - The RPM spec file no longer includes rules for SLES / openSUSE package builds,
   which have been untested / unsupported for some time.
+- Make binary builds more reproducible by deriving the GNU build ID
+  from the Go build ID instead of using a randomly generated one.
 
 ### Removed Features
 

--- a/mlocal/frags/go_normal_opts.mk
+++ b/mlocal/frags/go_normal_opts.mk
@@ -1,3 +1,3 @@
 # This tells go's link command to add a GNU Build Id, needed for later
 #   symbol stripping for example as is done by rpmbuild.
-GO_LDFLAGS += -ldflags="-B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`"
+GO_LDFLAGS += -ldflags="-B gobuildid"


### PR DESCRIPTION
Pick of https://github.com/apptainer/apptainer/pull/2699

This is achieved using the linker option `-B gobuildid` See: https://pkg.go.dev/cmd/link.
This way binaries will get unique build IDs and the build will be reproducible as binaries built from identical sources will have the same build ID.
