### PR TITLE
Ignore invalid environment variables when pulling oci/docker containers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Write StdErr messages from starter to terminal StdErr when an instance fails
   to start. Previously incorrectly written to terminal StdOut.
 - Fix incorrect debug message in Cgroups checks.
+- Skip invalid environment variables when pulling pulling OCI images to
+  native SIF, so environment sourcing does not fail.
 
 ### New Features & Functionality
 


### PR DESCRIPTION
Pick of https://github.com/apptainer/apptainer/issues/2582