### PR TITLE
chore: swap deprecated tenv linter for usetesting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,10 +44,10 @@ linters:
     - reassign
     - revive
     - staticcheck
-    - tenv
     - typecheck
     - unparam
     - unused
+    - usetesting
     - whitespace
 
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,5 +70,13 @@ issues:
       # G204 disallows exec.Command() with a command/args stored in variables
       # G306 disallows creation of files with permissions greater than 0600
       text: "^(G107|G204|G306):"
+    - path: 'e2e/'
+      linters:
+        # The usetesting linter shows a lot of lint for env var handling and
+        # tempdir creation in e2e tests. It's not really valid lint - the e2e
+        # tests were explicitly written to keep tempdirs in a per-run outer dir,
+        # and env var handling is complicated by the e2e.SingularityCmd
+        # execution flow etc.
+        - usetesting
   exclude-files:
     - "internal/pkg/util/user/cgo_lookup_unix.go"

--- a/cmd/internal/cli/key_newpair_test.go
+++ b/cmd/internal/cli/key_newpair_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -61,14 +61,13 @@ func Test_collectInput_flags(t *testing.T) {
 }
 
 func TestCollectInput(t *testing.T) {
-	tf, err := os.CreateTemp("", "collect-test-")
+	tf, err := os.CreateTemp(t.TempDir(), "collect-test-")
 	assert.NilError(t, err)
 	defer tf.Close()
 
 	oldStdin := os.Stdin
 	defer func(ostdin *os.File) {
 		os.Stdin = ostdin
-		os.Remove(tf.Name())
 	}(oldStdin)
 	os.Stdin = tf
 

--- a/internal/app/singularity/remote_add_test.go
+++ b/internal/app/singularity/remote_add_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,6 +7,7 @@ package singularity
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
@@ -23,12 +24,7 @@ const (
 )
 
 func createInvalidCfgFile(t *testing.T) string {
-	f, err := os.CreateTemp("", "")
-	if err != nil {
-		t.Fatalf("cannot create temporary configuration file for testing: %s\n", err)
-	}
-
-	path := f.Name()
+	path := filepath.Join(t.TempDir(), "invalid.yml")
 
 	// Set an invalid configuration
 	type aDummyStruct struct {
@@ -40,24 +36,18 @@ func createInvalidCfgFile(t *testing.T) string {
 
 	yaml, err := yaml.Marshal(cfg)
 	if err != nil {
-		f.Close()
-		os.Remove(path)
 		t.Fatalf("cannot marshal YAML: %s\n", err)
 	}
 
-	f.Write(yaml)
-	f.Close()
+	if err := os.WriteFile(path, yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	return path
 }
 
 func createValidCfgFile(t *testing.T) string {
-	f, err := os.CreateTemp("", "")
-	if err != nil {
-		t.Fatalf("cannot create temporary configuration file for testing: %s\n", err)
-	}
-
-	path := f.Name()
+	path := filepath.Join(t.TempDir(), "valid.yml")
 
 	// Set a valid configuration
 	cfg := remote.Config{
@@ -76,13 +66,12 @@ func createValidCfgFile(t *testing.T) string {
 
 	yaml, err := yaml.Marshal(cfg)
 	if err != nil {
-		f.Close()
-		os.Remove(path)
 		t.Fatalf("cannot marshal YAML: %s\n", err)
 	}
 
-	f.Write(yaml)
-	f.Close()
+	if err := os.WriteFile(path, yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	return path
 }

--- a/internal/pkg/build/sources/conveyorPacker_local_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_local_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -20,12 +20,7 @@ import (
 
 func TestLocalPackerSquashfs(t *testing.T) {
 	require.Command(t, "mksquashfs")
-
-	tempDirPath, err := os.MkdirTemp("", "test-localpacker-squashfs")
-	if err != nil {
-		t.Fatalf("while creating temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDirPath)
+	tempDirPath := t.TempDir()
 
 	// Image root directory
 	rootfs := filepath.Join(tempDirPath, "issue_3084_rootfs")
@@ -65,9 +60,7 @@ func TestLocalPackerSquashfs(t *testing.T) {
 	defer os.Remove(image)
 
 	// Creates bundle
-	bundleTmp, _ := os.MkdirTemp("", "bundle-temp-*")
-	defer os.RemoveAll(bundleTmp)
-
+	bundleTmp := t.TempDir()
 	b, err := types.NewBundle(tempDirPath, bundleTmp)
 	if err != nil {
 		t.Fatalf("while creating bundle: %v", err)

--- a/internal/pkg/cgroups/manager_linux_v1_test.go
+++ b/internal/pkg/cgroups/manager_linux_v1_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -118,20 +118,13 @@ func testNewUpdateV1(t *testing.T, systemd bool) {
 
 	// Write a new config with [pids] limit = 512
 	content := []byte("[pids]\nlimit = 512")
-	tmpfile, err := os.CreateTemp("", "cgroups")
-	if err != nil {
-		t.Fatalf("While creating update file: %v", err)
-	}
-	defer os.Remove(tmpfile.Name())
-	if _, err := tmpfile.Write(content); err != nil {
+	tmpfile := filepath.Join(t.TempDir(), "cgroups")
+	if err := os.WriteFile(tmpfile, content, 0o644); err != nil {
 		t.Fatalf("While writing update file: %v", err)
-	}
-	if err := tmpfile.Close(); err != nil {
-		t.Fatalf("While closing update file: %v", err)
 	}
 
 	// Update existing cgroup from new config
-	if err := manager.UpdateFromFile(tmpfile.Name()); err != nil {
+	if err := manager.UpdateFromFile(tmpfile); err != nil {
 		t.Fatalf("While updating cgroup: %v", err)
 	}
 

--- a/internal/pkg/cgroups/manager_linux_v2_test.go
+++ b/internal/pkg/cgroups/manager_linux_v2_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -109,20 +109,13 @@ func testNewUpdateV2(t *testing.T, systemd bool) {
 
 	// Write a new config with [pids] limit = 512
 	content := []byte("[pids]\nlimit = 512")
-	tmpfile, err := os.CreateTemp("", "cgroups")
-	if err != nil {
-		t.Fatalf("While creating update file: %v", err)
-	}
-	defer os.Remove(tmpfile.Name())
-	if _, err := tmpfile.Write(content); err != nil {
+	tmpfile := filepath.Join(t.TempDir(), "cgroups")
+	if err := os.WriteFile(tmpfile, content, 0o644); err != nil {
 		t.Fatalf("While writing update file: %v", err)
-	}
-	if err := tmpfile.Close(); err != nil {
-		t.Fatalf("While closing update file: %v", err)
 	}
 
 	// Update existing cgroup from new config
-	if err := manager.UpdateFromFile(tmpfile.Name()); err != nil {
+	if err := manager.UpdateFromFile(tmpfile); err != nil {
 		t.Fatalf("While updating cgroup: %v", err)
 	}
 

--- a/internal/pkg/image/unpacker/squashfs_test.go
+++ b/internal/pkg/image/unpacker/squashfs_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -19,7 +19,7 @@ func createArchive(t *testing.T) *os.File {
 	if err != nil {
 		t.SkipNow()
 	}
-	f, err := os.CreateTemp("", "archive-")
+	f, err := os.CreateTemp(t.TempDir(), "archive-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func testSquashfs(t *testing.T, tmpParent string) {
 		t.Skip("unsquashfs not found")
 	}
 
-	dir, err := os.MkdirTemp(tmpParent, "test-squashfs-")
+	dir, err := os.MkdirTemp(tmpParent, "test-squashfs-") //nolint:usetesting
 	if err != nil {
 		t.Fatalf("while creating tmpdir: %v", err)
 	}
@@ -64,7 +64,6 @@ func testSquashfs(t *testing.T, tmpParent string) {
 
 	// create archive with files present in this directory
 	archive := createArchive(t)
-	defer os.Remove(archive.Name())
 
 	savedPath := s.UnsquashfsPath
 

--- a/internal/pkg/instance/logger_test.go
+++ b/internal/pkg/instance/logger_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -8,6 +8,7 @@ package instance
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
@@ -72,12 +73,7 @@ func TestLogger(t *testing.T) {
 		},
 	}
 
-	logfile, err := os.CreateTemp("", "log-")
-	if err != nil {
-		t.Errorf("failed to create temporary log file: %s", err)
-	}
-	filename := logfile.Name()
-	logfile.Close()
+	filename := filepath.Join(t.TempDir(), "log")
 
 	for _, f := range formatTest {
 		logger, err := NewLogger(filename, f.formatter)

--- a/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -501,16 +501,7 @@ func ptsFlags(t *testing.T) []string {
 }
 
 func TestLauncher_addLibrariesMounts(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "add-libraries-mounts")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		if !t.Failed() {
-			os.RemoveAll(tmpDir)
-		}
-	})
-
+	tmpDir := t.TempDir()
 	lib1 := filepath.Join(tmpDir, "lib1.so")
 	lib2 := filepath.Join(tmpDir, "lib2.so")
 	libInvalid := filepath.Join(tmpDir, "invalid")

--- a/internal/pkg/security/seccomp/seccomp_supported_test.go
+++ b/internal/pkg/security/seccomp/seccomp_supported_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -41,13 +41,10 @@ func defaultProfile() *specs.LinuxSeccomp {
 }
 
 func testFchmod(t *testing.T) {
-	tmpfile, err := os.CreateTemp("", "chmod_file")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "chmod_file-")
 	if err != nil {
 		t.Fatal(err)
 	}
-	file := tmpfile.Name()
-
-	defer os.Remove(file)
 	defer tmpfile.Close()
 
 	if hasConditionSupport() {

--- a/internal/pkg/syecl/syecl_test.go
+++ b/internal/pkg/syecl/syecl_test.go
@@ -100,18 +100,13 @@ func TestAPutConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tf, err := os.CreateTemp("", "eclconfig-test")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.Remove(tf.Name())
-			tf.Close()
+			tf := filepath.Join(t.TempDir(), "ecl.toml")
 
-			if err := PutConfig(tt.c, tf.Name()); err != nil {
+			if err := PutConfig(tt.c, tf); err != nil {
 				t.Fatal(err)
 			}
 
-			b, err := os.ReadFile(tf.Name())
+			b, err := os.ReadFile(tf)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/pkg/test/privilege_linux.go
+++ b/internal/pkg/test/privilege_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -50,7 +50,7 @@ func DropPrivilege(t *testing.T) {
 			t.Fatalf("failed to set user identity: %v", err)
 		}
 
-		if err := os.Setenv("HOME", unprivHome); err != nil {
+		if err := os.Setenv("HOME", unprivHome); err != nil { //nolint:usetesting
 			t.Fatalf("failed to set HOME environment variable: %v", err)
 		}
 	}
@@ -68,7 +68,7 @@ func ResetPrivilege(t *testing.T) {
 	// We might want restoration of HOME env var to persist past this individual
 	// test, so use os.Setenv() rather than t.Setenv()
 	//nolint:tenv
-	os.Setenv("HOME", origHome)
+	os.Setenv("HOME", origHome) //nolint:usetesting
 
 	runtime.UnlockOSThread()
 }

--- a/internal/pkg/util/bin/bin_test.go
+++ b/internal/pkg/util/bin/bin_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
@@ -161,17 +162,11 @@ func TestFindFromConfigOrPath(t *testing.T) {
 				tc.expectPath = lookPath
 			}
 
-			f, err := os.CreateTemp("", "test.conf")
-			if err != nil {
-				t.Fatalf("cannot create temporary test configuration: %+v", err)
-			}
-			f.Close()
-			defer os.Remove(f.Name())
-
+			testConf := filepath.Join(t.TempDir(), "test.conf")
 			cfg := fmt.Sprintf("%s = %s\n", tc.configKey, tc.configVal)
-			os.WriteFile(f.Name(), []byte(cfg), 0o644)
+			os.WriteFile(testConf, []byte(cfg), 0o644)
 
-			conf, err := singularityconf.Parse(f.Name())
+			conf, err := singularityconf.Parse(testConf)
 			if err != nil {
 				t.Errorf("Error parsing test singularityconf: %v", err)
 			}
@@ -296,17 +291,11 @@ func TestFindFromConfigOnly(t *testing.T) {
 				t.Skip("skipping - no buildcfg path known")
 			}
 
-			f, err := os.CreateTemp("", "test.conf")
-			if err != nil {
-				t.Fatalf("cannot create temporary test configuration: %+v", err)
-			}
-			f.Close()
-			defer os.Remove(f.Name())
-
+			testConf := filepath.Join(t.TempDir(), "test.conf")
 			cfg := fmt.Sprintf("%s = %s\n", tc.configKey, tc.configVal)
-			os.WriteFile(f.Name(), []byte(cfg), 0o644)
+			os.WriteFile(testConf, []byte(cfg), 0o644)
 
-			conf, err := singularityconf.Parse(f.Name())
+			conf, err := singularityconf.Parse(testConf)
 			if err != nil {
 				t.Errorf("Error parsing test singularityconf: %v", err)
 			}

--- a/internal/pkg/util/crypt/crypt_dev_test.go
+++ b/internal/pkg/util/crypt/crypt_dev_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,7 +23,7 @@ func TestEncrypt(t *testing.T) {
 
 	dev := &Device{}
 
-	emptyFile, err := os.CreateTemp("", "")
+	emptyFile, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}
@@ -31,7 +31,6 @@ func TestEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to close file %s: %s", emptyFile.Name(), err)
 	}
-	defer os.Remove(emptyFile.Name())
 
 	// Create a dummy squashfs file
 	dummyDir := t.TempDir()
@@ -52,16 +51,8 @@ func TestEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get path to mksquashfs binary: %s", err)
 	}
-	tempTargetFile, err := os.CreateTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temporary file: %s", err)
-	}
-	err = tempTargetFile.Close()
-	if err != nil {
-		t.Fatalf("failed to close file %s: %s", tempTargetFile.Name(), err)
-	}
-	defer os.Remove(tempTargetFile.Name())
-	squashfsArgs := []string{dummyDir, tempTargetFile.Name(), "-noappend"}
+	tempTargetFile := filepath.Join(t.TempDir(), "test.sqfs")
+	squashfsArgs := []string{dummyDir, tempTargetFile, "-noappend"}
 	cmd := exec.Command(mksquashfsBin, squashfsArgs...)
 	err = cmd.Run()
 	if err != nil {
@@ -93,7 +84,7 @@ func TestEncrypt(t *testing.T) {
 		},
 		{
 			name:      "valid file",
-			path:      tempTargetFile.Name(),
+			path:      tempTargetFile,
 			key:       []byte("dummyKey"),
 			shallPass: true,
 		},

--- a/internal/pkg/util/fs/files/files_linux_test.go
+++ b/internal/pkg/util/fs/files/files_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -31,12 +31,11 @@ func TestGroup(t *testing.T) {
 		t.Errorf("should have passed with correct group file")
 	}
 	// with an empty file
-	f, err := os.CreateTemp("", "empty-group-")
+	f, err := os.CreateTemp(t.TempDir(), "empty-group-")
 	if err != nil {
 		t.Error(err)
 	}
 	emptyGroup := f.Name()
-	defer os.Remove(emptyGroup)
 	f.Close()
 
 	_, err = Group(emptyGroup, uid, gids, nil)

--- a/internal/pkg/util/fs/files/passwd_test.go
+++ b/internal/pkg/util/fs/files/passwd_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -29,12 +29,11 @@ func TestPasswd(t *testing.T) {
 	}
 
 	// Adding current user to an empty file
-	f, err := os.CreateTemp("", "empty-passwd-")
+	f, err := os.CreateTemp(t.TempDir(), "empty-passwd-")
 	if err != nil {
 		t.Fatal(err)
 	}
 	emptyPasswd := f.Name()
-	defer os.Remove(emptyPasswd)
 	f.Close()
 
 	_, err = Passwd(emptyPasswd, "/home", uid, nil)

--- a/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -32,22 +32,8 @@ var (
 	extfsImgPath    = filepath.Join(imgsPath, "extfs-for-overlay.img")
 )
 
-func mkTempDirOrFatal(t *testing.T) string {
-	tmpDir, err := os.MkdirTemp(t.TempDir(), "testoverlayitem-")
-	if err != nil {
-		t.Fatalf("failed to create temporary dir: %s", err)
-	}
-	t.Cleanup(func() {
-		if !t.Failed() {
-			os.RemoveAll(tmpDir)
-		}
-	})
-
-	return tmpDir
-}
-
 func mkTempOlDirOrFatal(t *testing.T) string {
-	tmpOlDir := mkTempDirOrFatal(t)
+	tmpOlDir := t.TempDir()
 	dirs.MkdirOrFatal(t, filepath.Join(tmpOlDir, "upper"), 0o777)
 	dirs.MkdirOrFatal(t, filepath.Join(tmpOlDir, "lower"), 0o777)
 
@@ -174,7 +160,7 @@ func verifyDirExistsAndWritable(t *testing.T, dir string) {
 }
 
 func TestUpperAndWorkCreation(t *testing.T) {
-	tmpDir := mkTempDirOrFatal(t)
+	tmpDir := t.TempDir()
 
 	item, err := NewItemFromString(tmpDir)
 	if err != nil {
@@ -362,7 +348,7 @@ func TestExtfsRW(t *testing.T) {
 	require.Command(t, "fuse2fs")
 	require.Command(t, "fuse-overlayfs")
 	require.Command(t, "fusermount")
-	tmpDir := mkTempDirOrFatal(t)
+	tmpDir := t.TempDir()
 	ctx := context.Background()
 
 	// Create a copy of the extfs test image to be used for testing writable

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -215,7 +215,7 @@ func TestCheckLowerUpper(t *testing.T) {
 }
 
 func TestAbsOverlay(t *testing.T) {
-	tmpDir := mkTempDirOrFatal(t)
+	tmpDir := t.TempDir()
 	oldDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/pkg/util/fs/overlay/overlay_set_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_set_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2023-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -76,7 +76,7 @@ func TestAllTypesAtOnce(t *testing.T) {
 		extfsSupported := false
 		if _, err := exec.LookPath("fuse2fs"); err == nil {
 			extfsSupported = true
-			tmpDir := mkTempDirOrFatal(t)
+			tmpDir := t.TempDir()
 			readonlyExtfsImgPath := filepath.Join(tmpDir, "readonly-extfs.img")
 			if err := fs.CopyFile(extfsImgPath, readonlyExtfsImgPath, 0o444); err != nil {
 				t.Fatalf("could not copy %q to %q: %s", extfsImgPath, readonlyExtfsImgPath, err)
@@ -91,7 +91,7 @@ func TestAllTypesAtOnce(t *testing.T) {
 		}
 		s.WritableOverlay = i
 
-		rootfsDir := mkTempDirOrFatal(t)
+		rootfsDir := t.TempDir()
 		if err := s.Mount(ctx, rootfsDir); err != nil {
 			t.Fatalf("failed to mount overlay set: %s", err)
 		}
@@ -144,7 +144,7 @@ func TestPersistentWriteToExtfsImg(t *testing.T) {
 	require.Command(t, "fuse2fs")
 	require.Command(t, "fuse-overlayfs")
 	require.Command(t, "fusermount")
-	tmpDir := mkTempDirOrFatal(t)
+	tmpDir := t.TempDir()
 	ctx := context.Background()
 
 	// Create a copy of the extfs test image to be used for testing writable
@@ -165,7 +165,7 @@ func TestPersistentWriteToExtfsImg(t *testing.T) {
 }
 
 func performPersistentWriteTest(ctx context.Context, t *testing.T, s Set) {
-	rootfsDir := mkTempDirOrFatal(t)
+	rootfsDir := t.TempDir()
 
 	// This cleanup will serve adequately for both iterations of the overlay-set
 	// mounting, below. If it happens to get called while the set is not
@@ -227,7 +227,7 @@ func TestDuplicateItemsInSet(t *testing.T) {
 		addROItemOrFatal(t, &s, roI2.SourcePath+":ro")
 		addROItemOrFatal(t, &s, mkTempOlDirOrFatal(t)+":ro")
 
-		rootfsDir = mkTempDirOrFatal(t)
+		rootfsDir = t.TempDir()
 		if err := s.Mount(ctx, rootfsDir); err == nil {
 			t.Errorf("unexpected success: Mounting overlay.Set with duplicate (%q) should have failed", roI2.SourcePath)
 			if err := s.Unmount(ctx, rootfsDir); err != nil {
@@ -244,7 +244,7 @@ func TestDuplicateItemsInSet(t *testing.T) {
 		}
 		s.WritableOverlay = rwI
 
-		rootfsDir = mkTempDirOrFatal(t)
+		rootfsDir = t.TempDir()
 		if err := s.Mount(ctx, rootfsDir); err == nil {
 			t.Errorf("unexpected success: Mounting overlay.Set with duplicate (%q) should have failed", roI2.SourcePath)
 			if err := s.Unmount(ctx, rootfsDir); err != nil {

--- a/internal/pkg/util/interactive/interactive_test.go
+++ b/internal/pkg/util/interactive/interactive_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -19,7 +19,7 @@ func generateQuestionInput(t *testing.T, input string) (*os.File, *os.File) {
 	testBytes := []byte(input)
 
 	// we create a temporary file that will act as Stdin
-	testFile, err := os.CreateTemp("", "inputTest")
+	testFile, err := os.CreateTemp(t.TempDir(), "inputTest")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}
@@ -28,7 +28,6 @@ func generateQuestionInput(t *testing.T, input string) (*os.File, *os.File) {
 	_, err = testFile.Write(testBytes)
 	if err != nil {
 		testFile.Close()
-		os.Remove(testFile.Name())
 		t.Fatalf("failed to write to %s: %s", testFile.Name(), err)
 	}
 
@@ -36,7 +35,6 @@ func generateQuestionInput(t *testing.T, input string) (*os.File, *os.File) {
 	_, err = testFile.Seek(0, io.SeekStart)
 	if err != nil {
 		testFile.Close()
-		os.Remove(testFile.Name())
 		t.Fatalf("failed to seek to beginning of file %s: %s", testFile.Name(), err)
 	}
 

--- a/internal/pkg/util/rootless/rootless_test.go
+++ b/internal/pkg/util/rootless/rootless_test.go
@@ -60,8 +60,7 @@ func TestGetuid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setEnv {
-				os.Setenv(UIDEnv, tt.envVal)
-				defer os.Unsetenv(UIDEnv)
+				t.Setenv(UIDEnv, tt.envVal)
 			}
 			gotUID, err := Getuid()
 			if (err != nil) != tt.wantErr {
@@ -120,8 +119,7 @@ func TestGetgid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setEnv {
-				os.Setenv(GIDEnv, tt.envVal)
-				defer os.Unsetenv(GIDEnv)
+				t.Setenv(GIDEnv, tt.envVal)
 			}
 			gotGID, err := Getgid()
 			if (err != nil) != tt.wantErr {
@@ -184,8 +182,7 @@ func TestGetUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setEnv {
-				os.Setenv(UIDEnv, tt.envVal)
-				defer os.Unsetenv(UIDEnv)
+				t.Setenv(UIDEnv, tt.envVal)
 			}
 			got, err := GetUser()
 			if (err != nil) != tt.wantErr {

--- a/pkg/cmdline/flag_test.go
+++ b/pkg/cmdline/flag_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,7 +6,6 @@
 package cmdline
 
 import (
-	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -273,7 +272,7 @@ func TestCmdFlag(t *testing.T) {
 		} else if len(cm.GetError()) == 0 && d.expectedFailure {
 			t.Errorf("unexpected success for %s", d.desc)
 		} else if len(cm.GetError()) == 0 && d.envValue != "" && len(d.flag.EnvKeys) > 0 {
-			os.Setenv(d.flag.EnvKeys[0], d.envValue)
+			t.Setenv(d.flag.EnvKeys[0], d.envValue)
 			cmds[d.cmd] = c
 		}
 		// reset error

--- a/pkg/image/ext3_test.go
+++ b/pkg/image/ext3_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -132,12 +132,11 @@ func TestInitializer(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	// Create a temporary image which is obviously an invalid ext3 image
-	f, err := os.CreateTemp("", "image-")
+	f, err := os.CreateTemp(t.TempDir(), "image-")
 	if err != nil {
 		t.Fatalf("cannot create temporary file: %s\n", err)
 	}
 	path := f.Name()
-	defer os.Remove(path)
 	// We do not use defer f.Close() since we will be manually
 	// opening and closing the file for testing.
 	f.Close()

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -44,13 +44,7 @@ type groupTest struct {
 
 // Copy the test image to a temporary location so we don't accidentally clobber the original
 func copyImage(t *testing.T) string {
-	f, err := os.CreateTemp("", "image-")
-	if err != nil {
-		t.Fatalf("cannot create temporary file: %s\n", err)
-	}
-	name := f.Name()
-	f.Close()
-
+	name := filepath.Join(t.TempDir(), "test.sif")
 	if err := fs.CopyFileAtomic(busyboxSIF, name, 0o755); err != nil {
 		t.Fatalf("Could not copy test image: %v", err)
 	}

--- a/pkg/image/sandbox.go
+++ b/pkg/image/sandbox.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/pkg/image/sandbox_test.go
+++ b/pkg/image/sandbox_test.go
@@ -54,15 +54,12 @@ func TestSandboxInitializer(t *testing.T) {
 	}
 
 	// Invalid case using a file
-	f, err := os.CreateTemp("", "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("cannot create temporary file: %s\n", err)
 	}
 	defer f.Close()
-
 	path = f.Name()
-	defer os.Remove(path)
-
 	f.Close()
 
 	err = runSandboxInitializerTest(t, img, path)

--- a/pkg/image/squashfs_test.go
+++ b/pkg/image/squashfs_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,24 +9,14 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
 // createSquashfs creates a small but valid squashfs file that can be used
 // with an image.
 func createSquashfs(t *testing.T) string {
-	sqshFile, fileErr := os.CreateTemp("", "")
-	if fileErr != nil {
-		t.Fatalf("impossible to create temporary file: %s\n", fileErr)
-	}
-	defer sqshFile.Close()
-
-	sqshFilePath := sqshFile.Name()
-	// close and delete the temp file since we will be used with the
-	// mksquashfs command. We still use TempFile to have a clean way
-	// to get a valid path for a temporary file
-	sqshFile.Close()
-	os.Remove(sqshFilePath)
+	sqshFilePath := filepath.Join(t.TempDir(), "test.sqfs")
 
 	cmdBin, lookErr := exec.LookPath("mksquashfs")
 	if lookErr != nil {

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,7 +7,7 @@ package sifbundle
 
 import (
 	"context"
-	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -29,14 +29,7 @@ func TestFromSif(t *testing.T) {
 	test.EnsurePrivilege(t)
 
 	bundlePath := t.TempDir()
-	f, err := os.CreateTemp("", "busybox")
-	if err != nil {
-		t.Fatal(err)
-	}
-	sifFile := f.Name()
-	f.Close()
-	defer os.Remove(sifFile)
-
+	sifFile := filepath.Join(t.TempDir(), "test.sif")
 	if err := fs.CopyFileAtomic(busyboxSIF, sifFile, 0o755); err != nil {
 		t.Fatalf("Could not copy test image: %v", err)
 	}

--- a/pkg/util/fs/lock/lock_test.go
+++ b/pkg/util/fs/lock/lock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,6 +7,7 @@ package lock
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -55,22 +56,14 @@ func TestByteRange(t *testing.T) {
 	}
 
 	// create the temporary test file used for locking
-	f, err := os.CreateTemp("", "byterange-")
-	if err != nil {
-		t.Fatalf("failed to create temporary lock file: %s", err)
-	}
-	testFile := f.Name()
-	defer os.Remove(testFile)
-
-	f.Close()
-
+	testFile := filepath.Join(t.TempDir(), "byterange")
 	// write some content in test file
 	if err := os.WriteFile(testFile, []byte("testing\n"), 0o644); err != nil {
 		t.Fatalf("failed to write content in testfile %s: %s", testFile, err)
 	}
 
 	// re-open it and use it for testing
-	f, err = os.OpenFile(testFile, os.O_RDWR, 0)
+	f, err := os.OpenFile(testFile, os.O_RDWR, 0)
 	if err != nil {
 		t.Fatalf("failed to open %s: %s", testFile, err)
 	}

--- a/pkg/util/fs/proc/proc_linux_test.go
+++ b/pkg/util/fs/proc/proc_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -8,6 +8,7 @@ package proc
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 	"testing"
 
@@ -136,22 +137,14 @@ func TestGetMountInfo(t *testing.T) {
 		t.Fatalf("unexpected success while parsing bad path")
 	}
 
-	tmpfile, err := os.CreateTemp("", "mountinfo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmpfile.Name())
-
-	if _, err := tmpfile.Write([]byte(mountInfoData)); err != nil {
-		t.Fatal(err)
-	}
-	if err := tmpfile.Close(); err != nil {
+	tmpfile := filepath.Join(t.TempDir(), "mountinfo")
+	if err := os.WriteFile(tmpfile, []byte(mountInfoData), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	entries, err := GetMountInfoEntry(tmpfile.Name())
+	entries, err := GetMountInfoEntry(tmpfile)
 	if err != nil {
-		t.Fatalf("unexpected error while parsing %s: %s", tmpfile.Name(), err)
+		t.Fatalf("unexpected error while parsing %s: %s", tmpfile, err)
 	}
 
 	for _, e := range entries {
@@ -263,19 +256,13 @@ func TestGetMountPointMap(t *testing.T) {
 	if _, err := GetMountPointMap("/proc/self/fakemountinfo"); err == nil {
 		t.Errorf("should have failed with non existent path")
 	}
-	tmpfile, err := os.CreateTemp("", "mountinfo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmpfile.Name())
 
-	if _, err := tmpfile.Write([]byte(mountInfoData)); err != nil {
+	tmpfile := filepath.Join(t.TempDir(), "mountinfo")
+	if err := os.WriteFile(tmpfile, []byte(mountInfoData), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := tmpfile.Close(); err != nil {
-		t.Fatal(err)
-	}
-	m, err := GetMountPointMap(tmpfile.Name())
+
+	m, err := GetMountPointMap(tmpfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,15 +358,12 @@ func TestReadIDMap(t *testing.T) {
 
 	//nolint:dupword
 	for _, e := range []string{"a a a", "0 a a"} {
-		f, err := os.CreateTemp("", "uid_map-")
-		if err != nil {
-			t.Fatalf("failed to create temporary file")
+		fname := filepath.Join(t.TempDir(), "uid-map")
+		if err := os.WriteFile(fname, []byte(e), 0o644); err != nil {
+			t.Fatalf("failed to create test file")
 		}
-		defer os.Remove(f.Name())
-		f.WriteString(e)
-		f.Close()
 
-		_, _, err = ReadIDMap(f.Name())
+		_, _, err = ReadIDMap(fname)
 		if err == nil {
 			t.Fatalf("unexpected success with bad formatted uid_map")
 		}

--- a/pkg/util/singularityconf/parser_test.go
+++ b/pkg/util/singularityconf/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -25,12 +25,11 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestParser(t *testing.T) {
-	f, err := os.CreateTemp("", "singularity.conf-")
+	f, err := os.CreateTemp(t.TempDir(), "singularity.conf-")
 	if err != nil {
 		t.Fatalf("failed to create temporary configuration file: %s", err)
 	}
 	configFile := f.Name()
-	defer os.Remove(configFile)
 
 	defaultConfig, err := GetConfig(nil)
 	if err != nil {


### PR DESCRIPTION
Swap the deprecated `tenv` linter for `usetesting`, and fix lint excluding `e2e/` files.

The e2e test code is excluded as:    

* The usetesting linter shows a lot of lint on e2e code for tempdir handling. The e2e-tests are written, and have helper functions,  designed around keeping temp directories inside a single per-run outer directory, often with somewhat useful naming. This would be broken by a switch to t.TempDir.
    
* The usetesting linter shows a lot of lint on e2e code for env var handling. It's not often simple to switch to t.Setenv - the scope of env vars is more complex due to the e2e.Singularitycmd construct etc.
