### PR TITLE
oci: cgroupsv2 namespace / mount handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Skip attempting to bind inaccessible mount points when handling the
   `mount hostfs = yes` configuration option.
+- In OCI mode, on a cgroups v2 system with functioning systemd cgroup
+  management, a cgroup namespace is created for the container, and
+  `/sys/fs/cgroup` is mounted. The cgroups mount is read-only by default, or
+  read-write if the `--keep-privs` flag is used.
+- In OCI mode, a cgroup is now created for the container when possible, even
+  where resource limits have not been requested.
 
 ### Bug Fixes
 

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -769,7 +769,13 @@ func (c *ctx) actionFlagV2(t *testing.T, tt resourceFlagTest, profile e2e.Profil
 	shellCmd := fmt.Sprintf("cat /sys/fs/cgroup$(cat /proc/self/cgroup | grep '^0::' | cut -d ':' -f 3)/%s", tt.resourceV2)
 
 	args := tt.args
-	args = append(args, "-B", "/sys/fs/cgroup", imageRef, "/bin/sh", "-c", shellCmd)
+	// OCI-mode with v2 cgroups will have a namespaced cgroup mount in the
+	// container. In other flows we need to bind from the host to see the
+	// cgroups tree.
+	if !profile.OCI() {
+		args = append(args, "-B", "/sys/fs/cgroup")
+	}
+	args = append(args, imageRef, "/bin/sh", "-c", shellCmd)
 
 	c.env.RunSingularity(
 		t,

--- a/internal/pkg/cgroups/util.go
+++ b/internal/pkg/cgroups/util.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/opencontainers/runc/libcontainer/cgroups"
 	lccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/rootless"
@@ -149,7 +148,7 @@ func CanUseCgroups(systemd bool, warn bool) bool {
 
 	rootlessOK := true
 
-	if !cgroups.IsCgroup2UnifiedMode() {
+	if !lccgroups.IsCgroup2UnifiedMode() {
 		rootlessOK = false
 		if warn {
 			sylog.Warningf("Rootless cgroups require the system to be configured for cgroups v2 in unified mode.")

--- a/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux_test.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"testing"
 
+	lccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/sylabs/singularity/v4/internal/pkg/cgroups"
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/launcher"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/fuse"
@@ -31,6 +33,9 @@ func TestNewLauncher(t *testing.T) {
 		t.Fatalf("while getting current user: %s", err)
 	}
 
+	cgroupsV2 := lccgroups.IsCgroup2UnifiedMode()
+	cgroupsSupport := cgroups.CanUseCgroups(sc.SystemdCgroups, false)
+
 	tests := []struct {
 		name    string
 		opts    []launcher.Option
@@ -47,6 +52,8 @@ func TestNewLauncher(t *testing.T) {
 				homeDest:                u.HomeDir,
 				imageMountsByImagePath:  make(map[string]*fuse.ImageMount),
 				imageMountsByMountpoint: make(map[string]*fuse.ImageMount),
+				cgroupsV2:               cgroupsV2,
+				cgroupsSupport:          cgroupsSupport,
 			},
 		},
 		{
@@ -62,6 +69,8 @@ func TestNewLauncher(t *testing.T) {
 				homeDest:                "/home/dest",
 				imageMountsByImagePath:  make(map[string]*fuse.ImageMount),
 				imageMountsByMountpoint: make(map[string]*fuse.ImageMount),
+				cgroupsV2:               cgroupsV2,
+				cgroupsSupport:          cgroupsSupport,
 			},
 			wantErr: false,
 		},
@@ -78,6 +87,8 @@ func TestNewLauncher(t *testing.T) {
 				homeDest:                "/home/dest",
 				imageMountsByImagePath:  make(map[string]*fuse.ImageMount),
 				imageMountsByMountpoint: make(map[string]*fuse.ImageMount),
+				cgroupsV2:               cgroupsV2,
+				cgroupsSupport:          cgroupsSupport,
 			},
 			wantErr: false,
 		},
@@ -94,6 +105,8 @@ func TestNewLauncher(t *testing.T) {
 				homeDest:                u.HomeDir,
 				imageMountsByImagePath:  make(map[string]*fuse.ImageMount),
 				imageMountsByMountpoint: make(map[string]*fuse.ImageMount),
+				cgroupsV2:               cgroupsV2,
+				cgroupsSupport:          cgroupsSupport,
 			},
 			wantErr: false,
 		},
@@ -111,6 +124,8 @@ func TestNewLauncher(t *testing.T) {
 				homeDest:                u.HomeDir,
 				imageMountsByImagePath:  make(map[string]*fuse.ImageMount),
 				imageMountsByMountpoint: make(map[string]*fuse.ImageMount),
+				cgroupsV2:               cgroupsV2,
+				cgroupsSupport:          cgroupsSupport,
 			},
 			wantErr: false,
 		},

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -392,6 +392,20 @@ func (l *Launcher) addSysMount(mounts *[]specs.Mount) error {
 			})
 	}
 
+	if l.cgroupsV2 {
+		cgroupRORW := "ro"
+		if l.cfg.KeepPrivs {
+			cgroupRORW = "rw"
+		}
+		*mounts = append(*mounts,
+			specs.Mount{
+				Source:      "cgroup",
+				Destination: "/sys/fs/cgroup",
+				Type:        "cgroup",
+				Options:     []string{"nosuid", "noexec", "nodev", cgroupRORW},
+			})
+	}
+
 	return nil
 }
 

--- a/internal/pkg/runtime/launcher/oci/spec_linux.go
+++ b/internal/pkg/runtime/launcher/oci/spec_linux.go
@@ -68,7 +68,7 @@ func minimalSpec() runtimespec.Spec {
 
 // addNamespaces adds requested namespace, if appropriate, to an existing spec.
 // It is assumed that spec contains at least the defaultNamespaces.
-func addNamespaces(spec *runtimespec.Spec, ns launcher.Namespaces) error {
+func (l *Launcher) addNamespaces(spec *runtimespec.Spec, ns launcher.Namespaces) error {
 	if ns.IPC {
 		sylog.Infof("--oci runtime always uses an IPC namespace, ipc flag is redundant.")
 	}
@@ -113,6 +113,13 @@ func addNamespaces(spec *runtimespec.Spec, ns launcher.Namespaces) error {
 		spec.Linux.Namespaces = append(
 			spec.Linux.Namespaces,
 			runtimespec.LinuxNamespace{Type: runtimespec.UTSNamespace},
+		)
+	}
+
+	if l.cgroupsV2 && l.cgroupsSupport {
+		spec.Linux.Namespaces = append(
+			spec.Linux.Namespaces,
+			runtimespec.LinuxNamespace{Type: runtimespec.CgroupNamespace},
 		)
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

In OCI-Mode, try to create a cgroup for the container even when no resource limits have been requested.

On a cgroups v2 system, with functioning cgroups management, create a cgroups namespace for OCI-Mode containers, and perform an explicit `/sys/fs/cgroups` mount. The mount is `ro` by default, or `rw` when `--keep-privs` is specified.

This fixes issues with nested container execution in OCI-Mode, and improves compatibility with other OCI runtimes.

Verified manually on cgroups v2 (Fedora/Ubuntu 24.04) and checked for regression on cgroups v1 (RHEL8).

### This fixes or addresses the following GitHub issues:

 - Fixes #3538


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
