### PR TITLE
fix: use built-in C boolean type in starter (release-4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SingularityCE Changelog
 
+## Changes Since Last Release
+
+## Requirements / Packaging
+
+- Now compiles successfully with `-std=c23`.
+
 ## 4.2.2 \[2024-12-20\]
 
 ### Bug Fixes

--- a/cmd/starter/c/include/starter.h
+++ b/cmd/starter/c/include/starter.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2018-2023, Sylabs, Inc. All rights reserved.
+  Copyright (c) 2018-2025, Sylabs, Inc. All rights reserved.
 
   This software is licensed under a 3-clause BSD license.  Please
   consult LICENSE.md file distributed with the sources of this project regarding
@@ -10,6 +10,7 @@
 #define _SINGULARITY_STARTER_H
 
 #include <limits.h>
+#include <stdbool.h>
 #include <sys/user.h>
 
 #define fatalf(b...)     singularity_message(ERROR, b); \
@@ -69,11 +70,6 @@ enum goexec {
 #ifndef NS_CLONE_NEWCGROUP
 #define CLONE_NEWCGROUP     0x02000000
 #endif
-
-typedef enum {
-    false,
-    true
-} bool;
 
 /* container capabilities */
 struct capabilities {

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,6 +6,7 @@
 package starter
 
 /*
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -54,7 +55,7 @@ func NewConfig(config SConfig) *Config {
 // GetIsSUID returns true if the SUID workflow is enabled.
 // This field is set by starter at the very beginning of its execution.
 func (c *Config) GetIsSUID() bool {
-	return c.config.starter.isSuid == C.true
+	return c.config.starter.isSuid == true //nolint:gosimple
 }
 
 // GetContainerPid returns the container PID (if any).
@@ -67,9 +68,9 @@ func (c *Config) GetContainerPid() int {
 // instead of a regular container if the passed value is true.
 func (c *Config) SetInstance(instance bool) {
 	if instance {
-		c.config.container.isInstance = C.true
+		c.config.container.isInstance = true
 	} else {
-		c.config.container.isInstance = C.false
+		c.config.container.isInstance = false
 	}
 }
 
@@ -77,9 +78,9 @@ func (c *Config) SetInstance(instance bool) {
 // flag for a container before it starts up if noprivs is true.
 func (c *Config) SetNoNewPrivs(noprivs bool) {
 	if noprivs {
-		c.config.container.privileges.noNewPrivs = C.true
+		c.config.container.privileges.noNewPrivs = true
 	} else {
-		c.config.container.privileges.noNewPrivs = C.false
+		c.config.container.privileges.noNewPrivs = false
 	}
 }
 
@@ -88,9 +89,9 @@ func (c *Config) SetNoNewPrivs(noprivs bool) {
 // is set to MS_SHARED if propagate is true.
 func (c *Config) SetMasterPropagateMount(propagate bool) {
 	if propagate {
-		c.config.starter.masterPropagateMount = C.true
+		c.config.starter.masterPropagateMount = true
 	} else {
-		c.config.starter.masterPropagateMount = C.false
+		c.config.starter.masterPropagateMount = false
 	}
 }
 
@@ -99,9 +100,9 @@ func (c *Config) SetMasterPropagateMount(propagate bool) {
 // `singularity oci exec`) if join is true.
 func (c *Config) SetNamespaceJoinOnly(join bool) {
 	if join {
-		c.config.container.namespace.joinOnly = C.true
+		c.config.container.namespace.joinOnly = true
 	} else {
-		c.config.container.namespace.joinOnly = C.false
+		c.config.container.namespace.joinOnly = false
 	}
 }
 
@@ -109,9 +110,9 @@ func (c *Config) SetNamespaceJoinOnly(join bool) {
 // a loopback network interface during container creation if bring is true.
 func (c *Config) SetBringLoopbackInterface(bring bool) {
 	if bring {
-		c.config.container.namespace.bringLoopbackInterface = C.true
+		c.config.container.namespace.bringLoopbackInterface = true
 	} else {
-		c.config.container.namespace.bringLoopbackInterface = C.false
+		c.config.container.namespace.bringLoopbackInterface = false
 	}
 }
 
@@ -172,9 +173,9 @@ func (c *Config) KeepFileDescriptor(fd int) error {
 // nvidia-container-cli
 func (c *Config) SetNvCCLICaps(enabled bool) {
 	if enabled {
-		c.config.starter.nvCCLICaps = C.true
+		c.config.starter.nvCCLICaps = true
 	} else {
-		c.config.starter.nvCCLICaps = C.false
+		c.config.starter.nvCCLICaps = false
 	}
 }
 
@@ -185,18 +186,18 @@ func (c *Config) SetNvCCLICaps(enabled bool) {
 // lives in its own user namespace.
 func (c *Config) SetHybridWorkflow(hybrid bool) {
 	if hybrid {
-		c.config.starter.hybridWorkflow = C.true
+		c.config.starter.hybridWorkflow = true
 	} else {
-		c.config.starter.hybridWorkflow = C.false
+		c.config.starter.hybridWorkflow = false
 	}
 }
 
 // SetAllowSetgroups allows use of setgroups syscall from user namespace.
 func (c *Config) SetAllowSetgroups(allow bool) {
 	if allow {
-		c.config.container.privileges.allowSetgroups = C.true
+		c.config.container.privileges.allowSetgroups = true
 	} else {
-		c.config.container.privileges.allowSetgroups = C.false
+		c.config.container.privileges.allowSetgroups = false
 	}
 }
 
@@ -206,9 +207,9 @@ func (c *Config) SetAllowSetgroups(allow bool) {
 // inside the container.
 func (c *Config) SetNoSetgroups(noSetgroups bool) {
 	if noSetgroups {
-		c.config.container.privileges.noSetgroups = C.true
+		c.config.container.privileges.noSetgroups = true
 	} else {
-		c.config.container.privileges.noSetgroups = C.false
+		c.config.container.privileges.noSetgroups = false
 	}
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Replace use of a custom `bool` enum with the C `_Bool` aliased to `bool` via `<stdbool.h>` etc.

Fixes issues with `-std=c23` where `bool / true / false` are now defined by the language.

### This fixes or addresses the following GitHub issues:

 - Fixes #3561

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
