### PR TITLE
chore: prep 4.3.1 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.24.0'
+    default: '1.24.2'
 
 executors:
   node:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SingularityCE Changelog
 
+## 4.3.1 \[2025-04-11\]
+
+This is a maintenance release updating dependencies and providing packages
+built with Go 1.24.2. No bug-fix or feature additions are included.
+
 ## 4.3.0 \[2025-03-13\]
 
 ### Behaviour Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 4.3.1 \[2025-04-11\]
 
-This is a maintenance release updating dependencies and providing packages
-built with Go 1.24.2. No bug-fix or feature additions are included.
+### Bug Fixes
+
+- Update bundled squashfuse to 0.6.0, which includes `.`, `..` entries in
+  `getdents()` results, fixing errors with some applications.
 
 ## 4.3.0 \[2025-03-13\]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -162,7 +162,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.24.0 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.24.2 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz

--- a/e2e/testdata/Dockerfile.nested
+++ b/e2e/testdata/Dockerfile.nested
@@ -1,6 +1,6 @@
 FROM ubuntu:24.10
 
-ARG GOVERSION="go1.24.0"
+ARG GOVERSION="go1.24.2"
 ARG GOOS="linux"
 ARG GOARCH="amd64"
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin


### PR DESCRIPTION
Bump go version.

Bump squashfuse to 0.6.0.