### PR TITLE
chore: switch to golangci-lint v2.1 (release-4.3)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ executors:
       - image: ubuntu:24.04
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.64
+      - image: golangci/golangci-lint:v2.1
   ubuntu-machine:
     machine:
       image: ubuntu-2404:2024.05.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   concurrency: 2
   timeout: 5m
@@ -12,8 +14,7 @@ run:
     - sylog
 
 linters:
-  disable-all: true
-  enable-all: false
+  default: none
   enable:
     - asciicheck
     - bidichk
@@ -26,12 +27,9 @@ linters:
     - dupl
     - dupword
     - forcetypeassert
-    - gofumpt
-    - goimports
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - grouper
     - ineffassign
@@ -44,39 +42,38 @@ linters:
     - reassign
     - revive
     - staticcheck
-    - typecheck
     - unparam
     - unused
     - usetesting
     - whitespace
-
-linters-settings:
-  misspell:
-    locale: US
-
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-  exclude:
-    # EXC0004 excluded due to spurious "should have signature XYZ" errors on
-    # MarshalJSON methods. See
-    # https://golangci-lint.run/usage/false-positives/#exc0004 for more
-    # information.
-    - EXC0004
-  exclude-rules:
-    - linters:
+  settings:
+    misspell:
+      locale: US
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: 'e2e/'
+        linters:
+          # The usetesting linter shows a lot of lint for env var handling and
+          # tempdir creation in e2e tests. It's not really valid lint - the e2e
+          # tests were explicitly written to keep tempdirs in a per-run outer dir,
+          # and env var handling is complicated by the e2e.SingularityCmd
+          # execution flow etc.
+          - usetesting
+      - linters:
         - gosec
       # G107 disallows making http calls to a URL stored in a variable
       # G204 disallows exec.Command() with a command/args stored in variables
       # G306 disallows creation of files with permissions greater than 0600
-      text: "^(G107|G204|G306):"
-    - path: 'e2e/'
-      linters:
-        # The usetesting linter shows a lot of lint for env var handling and
-        # tempdir creation in e2e tests. It's not really valid lint - the e2e
-        # tests were explicitly written to keep tempdirs in a per-run outer dir,
-        # and env var handling is complicated by the e2e.SingularityCmd
-        # execution flow etc.
-        - usetesting
-  exclude-files:
-    - "internal/pkg/util/user/cgo_lookup_unix.go"
+        text: "^(G107|G204|G306):"
+    paths:
+      - "internal/pkg/util/user/cgo_lookup_unix.go"
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -176,7 +176,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Custom authfile is not supported for remote build")
 	}
 
-	if buildArgs.arch != runtime.GOARCH && !(buildArgs.remote || isOCI) {
+	if buildArgs.arch != runtime.GOARCH && !buildArgs.remote && !isOCI {
 		sylog.Fatalf("Requested architecture (%s) does not match host (%s). Cannot build locally.", buildArgs.arch, runtime.GOARCH)
 	}
 
@@ -534,7 +534,7 @@ func getEncryptionMaterial(cmd *cobra.Command) (*cryptkey.KeyInfo, error) {
 	pemPathEnv, pemPathEnvOK := os.LookupEnv("SINGULARITY_ENCRYPTION_PEM_PATH")
 
 	// checks for no flags/envvars being set
-	if !(PEMFlag.Changed || pemPathEnvOK || passphraseFlag.Changed || passphraseEnvOK) {
+	if !PEMFlag.Changed && !pemPathEnvOK && !passphraseFlag.Changed && !passphraseEnvOK {
 		return nil, nil
 	}
 

--- a/cmd/internal/cli/capability_linux.go
+++ b/cmd/internal/cli/capability_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -143,7 +143,7 @@ var CapabilityListCmd = &cobra.Command{
 // CapabilityCmd is the capability command
 var CapabilityCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, _ []string) error {
-		return errors.New("Invalid command")
+		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,
 

--- a/cmd/internal/cli/data.go
+++ b/cmd/internal/cli/data.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2024-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,7 +23,7 @@ func init() {
 // DataCmd is the 'data' command that provides management of data containers.
 var DataCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, _ []string) error {
-		return errors.New("Invalid command")
+		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,
 

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -280,20 +280,20 @@ func (c *command) setAttribute(section, value, file string) error {
 	case "apps":
 		c.metadata.AddApp(value)
 	case "deffile":
-		if c.metadata.Data.Attributes.Deffile == "" {
-			c.metadata.Data.Attributes.Deffile = value
+		if c.metadata.Attributes.Deffile == "" {
+			c.metadata.Attributes.Deffile = value
 		}
 	case "test":
 		if app != "" {
-			c.metadata.Data.Attributes.Apps[app].Test = value
+			c.metadata.Attributes.Apps[app].Test = value
 		} else {
-			c.metadata.Data.Attributes.Test = value
+			c.metadata.Attributes.Test = value
 		}
 	case "helpfile":
 		if app != "" {
-			c.metadata.Data.Attributes.Apps[app].Helpfile = value
+			c.metadata.Attributes.Apps[app].Helpfile = value
 		} else {
-			c.metadata.Data.Attributes.Helpfile = value
+			c.metadata.Attributes.Helpfile = value
 		}
 	case "labels":
 		labels := make(map[string]string)
@@ -301,27 +301,27 @@ func (c *command) setAttribute(section, value, file string) error {
 			sylog.Warningf("Unable to parse labels: %s", err)
 		}
 		if app != "" {
-			c.metadata.Data.Attributes.Apps[app].Labels = labels
+			c.metadata.Attributes.Apps[app].Labels = labels
 		} else {
-			c.metadata.Data.Attributes.Labels = labels
+			c.metadata.Attributes.Labels = labels
 		}
 	case "runscript":
 		if app != "" {
-			c.metadata.Data.Attributes.Apps[app].Runscript = value
+			c.metadata.Attributes.Apps[app].Runscript = value
 		} else {
-			c.metadata.Data.Attributes.Runscript = value
+			c.metadata.Attributes.Runscript = value
 		}
 	case "startscript":
 		if app != "" {
-			c.metadata.Data.Attributes.Apps[app].Startscript = value
+			c.metadata.Attributes.Apps[app].Startscript = value
 		} else {
-			c.metadata.Data.Attributes.Startscript = value
+			c.metadata.Attributes.Startscript = value
 		}
 	case "environment":
 		if app != "" {
-			c.metadata.Data.Attributes.Apps[app].Environment[file] = value
+			c.metadata.Attributes.Apps[app].Environment[file] = value
 		} else {
-			c.metadata.Data.Attributes.Environment[file] = value
+			c.metadata.Attributes.Environment[file] = value
 		}
 	default:
 		return fmt.Errorf("badly formatted content, unknown section %s", section)
@@ -624,7 +624,7 @@ func printSortedMap(m map[string]string, fn func(key string)) {
 
 // returns true if flags for other forms of information are unset.
 func defaultToLabels() bool {
-	return !(helpfile || deffile || runscript || startscript || testfile || environment || listApps)
+	return !helpfile && !deffile && !runscript && !startscript && !testfile && !environment && !listApps
 }
 
 // InspectCmd represents the 'inspect' command.
@@ -701,9 +701,9 @@ var InspectCmd = &cobra.Command{
 			sylog.Fatalf("%s", err)
 		}
 
-		for app := range inspectData.Data.Attributes.Apps {
+		for app := range inspectData.Attributes.Apps {
 			if !listApps && !allData && appName != app {
-				delete(inspectData.Data.Attributes.Apps, app)
+				delete(inspectData.Attributes.Apps, app)
 			}
 		}
 
@@ -715,47 +715,47 @@ var InspectCmd = &cobra.Command{
 			}
 			fmt.Printf("%s\n", string(jsonObj))
 		} else {
-			appAttr := inspectData.Data.Attributes.Apps[appName]
+			appAttr := inspectData.Attributes.Apps[appName]
 
 			if listApps {
-				printSortedApp(inspectData.Data.Attributes.Apps)
+				printSortedApp(inspectData.Attributes.Apps)
 			}
 
-			if inspectData.Data.Attributes.Deffile != "" {
-				fmt.Printf("%s\n", inspectData.Data.Attributes.Deffile)
+			if inspectData.Attributes.Deffile != "" {
+				fmt.Printf("%s\n", inspectData.Attributes.Deffile)
 			}
-			if inspectData.Data.Attributes.Runscript != "" {
-				fmt.Printf("%s\n", inspectData.Data.Attributes.Runscript)
+			if inspectData.Attributes.Runscript != "" {
+				fmt.Printf("%s\n", inspectData.Attributes.Runscript)
 			} else if appAttr != nil && appAttr.Runscript != "" {
 				fmt.Printf("%s\n", appAttr.Runscript)
 			}
-			if inspectData.Data.Attributes.Startscript != "" {
-				fmt.Printf("%s\n", inspectData.Data.Attributes.Startscript)
+			if inspectData.Attributes.Startscript != "" {
+				fmt.Printf("%s\n", inspectData.Attributes.Startscript)
 			} else if appAttr != nil && appAttr.Startscript != "" {
 				fmt.Printf("%s\n", appAttr.Startscript)
 			}
-			if inspectData.Data.Attributes.Test != "" {
-				fmt.Printf("%s\n", inspectData.Data.Attributes.Test)
+			if inspectData.Attributes.Test != "" {
+				fmt.Printf("%s\n", inspectData.Attributes.Test)
 			} else if appAttr != nil && appAttr.Test != "" {
 				fmt.Printf("%s\n", appAttr.Test)
 			}
-			if inspectData.Data.Attributes.Helpfile != "" {
-				fmt.Printf("%s\n", inspectData.Data.Attributes.Helpfile)
+			if inspectData.Attributes.Helpfile != "" {
+				fmt.Printf("%s\n", inspectData.Attributes.Helpfile)
 			} else if appAttr != nil && appAttr.Helpfile != "" {
 				fmt.Printf("%s\n", appAttr.Helpfile)
 			}
-			if len(inspectData.Data.Attributes.Environment) > 0 {
-				printSortedMap(inspectData.Data.Attributes.Environment, func(k string) {
-					fmt.Printf("=== %s ===\n%s\n\n", k, inspectData.Data.Attributes.Environment[k])
+			if len(inspectData.Attributes.Environment) > 0 {
+				printSortedMap(inspectData.Attributes.Environment, func(k string) {
+					fmt.Printf("=== %s ===\n%s\n\n", k, inspectData.Attributes.Environment[k])
 				})
 			} else if appAttr != nil && len(appAttr.Environment) > 0 {
 				printSortedMap(appAttr.Environment, func(k string) {
 					fmt.Printf("=== %s ===\n%s\n\n", k, appAttr.Environment[k])
 				})
 			}
-			if len(inspectData.Data.Attributes.Labels) > 0 {
-				printSortedMap(inspectData.Data.Attributes.Labels, func(k string) {
-					fmt.Printf("%s: %s\n", k, inspectData.Data.Attributes.Labels[k])
+			if len(inspectData.Attributes.Labels) > 0 {
+				printSortedMap(inspectData.Attributes.Labels, func(k string) {
+					fmt.Printf("%s: %s\n", k, inspectData.Attributes.Labels[k])
 				})
 			} else if appAttr != nil && len(appAttr.Labels) > 0 {
 				printSortedMap(appAttr.Labels, func(k string) {

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -111,7 +111,7 @@ func checkGlobal(cmd *cobra.Command, _ []string) {
 // KeyCmd is the 'key' command that allows management of keyrings
 var KeyCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, _ []string) error {
-		return errors.New("Invalid command")
+		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,
 	Aliases:               []string{"keys"},

--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -26,7 +26,7 @@ func init() {
 // OverlayCmd is the 'overlay' command that allows to manage writable overlay.
 var OverlayCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, _ []string) error {
-		return errors.New("Invalid command")
+		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,
 

--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -176,7 +176,7 @@ func signSIF(cmd *cobra.Command, cpath string) error {
 
 		s, err := signature.LoadSignerFromPEMFile(priKeyPath, crypto.SHA256, cryptoutils.GetPasswordFromStdIn)
 		if err != nil {
-			return fmt.Errorf("Failed to load key material: %v", err)
+			return fmt.Errorf("failed to load key material: %v", err)
 		}
 		opts = append(opts, sifsignature.OptSignWithSigner(s))
 
@@ -206,7 +206,7 @@ func signSIF(cmd *cobra.Command, cpath string) error {
 
 	// Sign the image.
 	if err := sifsignature.Sign(cmd.Context(), cpath, opts...); err != nil {
-		return fmt.Errorf("Failed to sign container: %w", err)
+		return fmt.Errorf("failed to sign container: %w", err)
 	}
 	sylog.Infof("Signature created and applied to image '%v'", cpath)
 	return nil

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -385,7 +385,7 @@ func setSylogMessageLevel() {
 		level = 1
 	}
 
-	color := true
+	color := true //nolint:staticcheck
 	if nocolor || !term.IsTerminal(2) {
 		color = false
 	}

--- a/cmd/internal/cli/verify.go
+++ b/cmd/internal/cli/verify.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2017-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2017-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -273,14 +273,14 @@ func verifySIF(cmd *cobra.Command, cpath string) error {
 
 		c, err := loadCertificate(certificatePath)
 		if err != nil {
-			return fmt.Errorf("Failed to load certificate: %w", err)
+			return fmt.Errorf("failed to load certificate: %w", err)
 		}
 		opts = append(opts, sifsignature.OptVerifyWithCertificate(c))
 
 		if cmd.Flag(verifyCertificateIntermediatesFlag.Name).Changed {
 			p, err := loadCertificatePool(certificateIntermediatesPath)
 			if err != nil {
-				return fmt.Errorf("Failed to load intermediate certificates: %w", err)
+				return fmt.Errorf("failed to load intermediate certificates: %w", err)
 			}
 			opts = append(opts, sifsignature.OptVerifyWithIntermediates(p))
 		}
@@ -288,7 +288,7 @@ func verifySIF(cmd *cobra.Command, cpath string) error {
 		if cmd.Flag(verifyCertificateRootsFlag.Name).Changed {
 			p, err := loadCertificatePool(certificateRootsPath)
 			if err != nil {
-				return fmt.Errorf("Failed to load root certificates: %w", err)
+				return fmt.Errorf("failed to load root certificates: %w", err)
 			}
 			opts = append(opts, sifsignature.OptVerifyWithRoots(p))
 		}
@@ -302,7 +302,7 @@ func verifySIF(cmd *cobra.Command, cpath string) error {
 
 		v, err := signature.LoadVerifierFromPEMFile(pubKeyPath, crypto.SHA256)
 		if err != nil {
-			return fmt.Errorf("Failed to load key material: %w", err)
+			return fmt.Errorf("failed to load key material: %w", err)
 		}
 		opts = append(opts, sifsignature.OptVerifyWithVerifier(v))
 
@@ -315,7 +315,7 @@ func verifySIF(cmd *cobra.Command, cpath string) error {
 		} else {
 			co, err := getKeyserverClientOpts(keyServerURI, endpoint.KeyserverVerifyOp)
 			if err != nil {
-				return fmt.Errorf("Error while getting keyserver client config: %w", err)
+				return fmt.Errorf("error while getting keyserver client config: %w", err)
 			}
 			opts = append(opts, sifsignature.OptVerifyWithPGP(co...))
 		}
@@ -351,17 +351,17 @@ func verifySIF(cmd *cobra.Command, cpath string) error {
 
 		// Always output JSON.
 		if err := outputJSON(os.Stdout, kl); err != nil {
-			return fmt.Errorf("Failed to output JSON: %v", err)
+			return fmt.Errorf("failed to output JSON: %v", err)
 		}
 
 		if verifyErr != nil {
-			return fmt.Errorf("Failed to verify container: %v", verifyErr)
+			return fmt.Errorf("failed to verify container: %v", verifyErr)
 		}
 	} else {
 		opts = append(opts, sifsignature.OptVerifyCallback(outputVerify))
 
 		if err := sifsignature.Verify(cmd.Context(), cpath, opts...); err != nil {
-			return fmt.Errorf("Failed to verify container: %v", err)
+			return fmt.Errorf("failed to verify container: %v", err)
 		}
 
 		sylog.Infof("Verified signature(s) from image '%v'", cpath)
@@ -374,7 +374,7 @@ func verifyCosign(ctx context.Context, sifPath, keyPath string) error {
 
 	v, err := signature.LoadVerifierFromPEMFile(keyPath, crypto.SHA256)
 	if err != nil {
-		return fmt.Errorf("Failed to load key material: %w", err)
+		return fmt.Errorf("failed to load key material: %w", err)
 	}
 
 	payloads, err := cosignsignature.VerifyOCISIF(ctx, sifPath, v)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -85,13 +85,13 @@ func TestMain(m *testing.M) {
 					os.Exit(status.ExitStatus())
 				}
 			}
+		case syscall.SIGURG:
+			// ignore goroutine preemption
+			break
 		default:
 			// forward signals to e2e test command
 			//nolint:forcetypeassert
 			syscall.Kill(cmdPid, s.(syscall.Signal))
-		case syscall.SIGURG:
-			// ignore goroutine preemption
-			break
 		}
 	}
 }

--- a/e2e/internal/e2e/docker_auth_server.go
+++ b/e2e/internal/e2e/docker_auth_server.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -64,11 +64,8 @@ func (a *authnz) Authorize(req *registry.AuthorizationRequest) ([]string, error)
 	// release previous lock
 	defer a.Unlock()
 
-	requireAuth := false
+	requireAuth := strings.HasPrefix(req.Name, privateNamespace) || req.Type == ""
 
-	if strings.HasPrefix(req.Name, privateNamespace) || req.Type == "" {
-		requireAuth = true
-	}
 	if requireAuth {
 		if a.username != DefaultUsername || a.password != DefaultPassword {
 			return nil, fmt.Errorf("unauthorized")

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -274,11 +274,11 @@ func verifyFile(t *testing.T, original, duplicated string) error {
 	}
 
 	if ofi.Size() != cfi.Size() {
-		return fmt.Errorf("Incorrect file sizes. Original: %v, Copy: %v", ofi.Size(), cfi.Size())
+		return fmt.Errorf("incorrect file sizes. Original: %v, Copy: %v", ofi.Size(), cfi.Size())
 	}
 
 	if ofi.Mode() != cfi.Mode() {
-		return fmt.Errorf("Incorrect file modes. Original: %v, Copy: %v", ofi.Mode(), cfi.Mode())
+		return fmt.Errorf("incorrect file modes. Original: %v, Copy: %v", ofi.Mode(), cfi.Mode())
 	}
 
 	o, err := os.ReadFile(original)
@@ -292,7 +292,7 @@ func verifyFile(t *testing.T, original, duplicated string) error {
 	}
 
 	if !bytes.Equal(o, c) {
-		return fmt.Errorf("Incorrect file content")
+		return fmt.Errorf("incorrect file content")
 	}
 
 	return nil
@@ -306,7 +306,7 @@ func verifyHelp(t *testing.T, fileName string, contents []string) error {
 
 	// do perm check
 	if fi.Mode().Perm() != 0o644 {
-		return fmt.Errorf("Incorrect help script perms: %v", fi.Mode().Perm())
+		return fmt.Errorf("incorrect help script perms: %v", fi.Mode().Perm())
 	}
 
 	s, err := os.ReadFile(fileName)
@@ -317,7 +317,7 @@ func verifyHelp(t *testing.T, fileName string, contents []string) error {
 	helpScript := string(s)
 	for _, c := range contents {
 		if !strings.Contains(helpScript, c) {
-			return fmt.Errorf("Missing help script content")
+			return fmt.Errorf("missing help script content")
 		}
 	}
 
@@ -332,7 +332,7 @@ func verifyScript(t *testing.T, fileName string, contents []string) error {
 
 	// do perm check
 	if fi.Mode().Perm() != 0o755 {
-		return fmt.Errorf("Incorrect script perms: %v", fi.Mode().Perm())
+		return fmt.Errorf("incorrect script perms: %v", fi.Mode().Perm())
 	}
 
 	s, err := os.ReadFile(fileName)
@@ -343,7 +343,7 @@ func verifyScript(t *testing.T, fileName string, contents []string) error {
 	script := string(s)
 	for _, c := range contents {
 		if !strings.Contains(script, c) {
-			return fmt.Errorf("Missing script content")
+			return fmt.Errorf("missing script content")
 		}
 	}
 
@@ -368,7 +368,7 @@ func verifyEnv(t *testing.T, cmdPath, imagePath string, env []string, flags []st
 
 	for _, e := range env {
 		if !strings.Contains(out, e) {
-			return fmt.Errorf("Environment is missing: %v", e)
+			return fmt.Errorf("environment is missing: %v", e)
 		}
 	}
 

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -537,7 +537,7 @@ func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 		if privileged {
 			i := 0
 			for _, e := range cmd.Env {
-				if !(strings.HasPrefix(e, "DBUS_SESSION_BUS_ADDRESS=") || strings.HasPrefix(e, "XDG_RUNTIME_DIR=")) {
+				if !strings.HasPrefix(e, "DBUS_SESSION_BUS_ADDRESS=") && !strings.HasPrefix(e, "XDG_RUNTIME_DIR=") {
 					cmd.Env[i] = e
 					i++
 				}

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sylabs/sif/v2/pkg/sif"
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
-	"github.com/sylabs/singularity/v4/internal/pkg/client/oras"
 	syoras "github.com/sylabs/singularity/v4/internal/pkg/client/oras"
 	"github.com/sylabs/singularity/v4/internal/pkg/ocisif"
 	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/require"
@@ -654,7 +653,7 @@ func orasPushNoCheck(path, ref, layerMediaType string) error {
 		return err
 	}
 
-	im, err := oras.NewImageFromSIF(path, types.MediaType(layerMediaType))
+	im, err := syoras.NewImageFromSIF(path, types.MediaType(layerMediaType))
 	if err != nil {
 		return err
 	}

--- a/e2e/sign/oci.go
+++ b/e2e/sign/oci.go
@@ -18,7 +18,7 @@ import (
 func (c *ctx) signOCICosign(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.TestEnv)
 	testSif := filepath.Join(t.TempDir(), "test.sif")
-	if err := fs.CopyFile(c.TestEnv.OCISIFPath, testSif, 0o755); err != nil {
+	if err := fs.CopyFile(c.OCISIFPath, testSif, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	keyPath := filepath.Join("..", "test", "keys", "cosign.key")

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -119,7 +119,7 @@ func (c *ctx) sign(t *testing.T) {
 			expectCode: 255,
 			expectOps: []e2e.SingularityCmdResultOp{
 				e2e.ExpectError(e2e.ContainMatch, "Signing image with PGP key material"),
-				e2e.ExpectError(e2e.ContainMatch, "Failed to sign container: index out of range"),
+				e2e.ExpectError(e2e.ContainMatch, "failed to sign container: index out of range"),
 			},
 		},
 		{

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -184,7 +184,7 @@ func (c *ctx) verify(t *testing.T) {
 			expectCode: 255,
 			expectOps: []e2e.SingularityCmdResultOp{
 				// Expect OCSP to fail due to https://github.com/sylabs/singularity/issues/1152
-				e2e.ExpectError(e2e.ContainMatch, "Failed to verify container: OCSP verification has failed"),
+				e2e.ExpectError(e2e.ContainMatch, "failed to verify container: OCSP verification has failed"),
 			},
 		},
 		{
@@ -200,7 +200,7 @@ func (c *ctx) verify(t *testing.T) {
 			expectCode: 255,
 			expectOps: []e2e.SingularityCmdResultOp{
 				// Expect OCSP to fail due to https://github.com/sylabs/singularity/issues/1152
-				e2e.ExpectError(e2e.ContainMatch, "Failed to verify container: OCSP verification has failed"),
+				e2e.ExpectError(e2e.ContainMatch, "failed to verify container: OCSP verification has failed"),
 			},
 		},
 		{
@@ -214,10 +214,10 @@ func (c *ctx) verify(t *testing.T) {
 			needOCSP:   true,
 			expectCode: 255,
 			expectOps: []e2e.SingularityCmdResultOp{
-				e2e.ExpectError(e2e.ContainMatch, "Failed to verify container: x509: certificate specifies an incompatible key usage"),
+				e2e.ExpectError(e2e.ContainMatch, "failed to verify container: x509: certificate specifies an incompatible key usage"),
 				// https://github.com/sylabs/singularity/pull/1213#pullrequestreview-1240524316
 				// Error Expect OCSP to succeed, but signature verification to fail.
-				// e2e.ExpectError(e2e.ContainMatch, "Failed to verify container: integrity: signature object 3 not valid: dsse: verify envelope failed: Accepted signatures do not match threshold, Found: 0, Expected 1"),
+				// e2e.ExpectError(e2e.ContainMatch, "failed to verify container: integrity: signature object 3 not valid: dsse: verify envelope failed: Accepted signatures do not match threshold, Found: 0, Expected 1"),
 			},
 		},
 	}

--- a/examples/plugins/cli-plugin/main.go
+++ b/examples/plugins/cli-plugin/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the URIs of this project regarding your
 // rights to use or distribute this software.
@@ -92,10 +92,10 @@ func callbackTestCmd(manager *cmdline.CommandManager) {
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.MinimumNArgs(1),
 		Use:                   "test-cmd [args ...]",
-		Short:                 "Test test test",
+		Short:                 "Short test",
 		Long:                  "Long test long test long test",
 		Example:               "singularity test-cmd my test",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			fmt.Println("test-cmd is printing args:", args)
 		},
 		TraverseChildren: true,

--- a/examples/plugins/config-plugin/main_linux.go
+++ b/examples/plugins/config-plugin/main_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -45,7 +45,7 @@ func callbackCgroups(common *config.Common) {
 
 	data, err := cfg.MarshalJSON()
 	if err != nil {
-		sylog.Errorf("While Marshalling cgroups config to JSON: %s", err)
+		sylog.Errorf("While Marshaling cgroups config to JSON: %s", err)
 		return
 	}
 	sylog.Infof("Overriding cgroups config")

--- a/internal/app/singularity/delete.go
+++ b/internal/app/singularity/delete.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,11 +10,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sylabs/scs-library-client/client"
-	scs "github.com/sylabs/scs-library-client/client"
 )
 
 // DeleteImage deletes an image from a remote library.
-func DeleteImage(ctx context.Context, scsConfig *scs.Config, imageRef, arch string) error {
+func DeleteImage(ctx context.Context, scsConfig *client.Config, imageRef, arch string) error {
 	libraryClient, err := client.NewClient(scsConfig)
 	if err != nil {
 		return errors.Wrap(err, "couldn't create a new client")

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -220,7 +220,7 @@ func (pl *BuildApp) createAllApps(b *types.Bundle) error {
 	for _, name := range b.Recipe.AppOrder {
 		app, ok := pl.Apps[name]
 		if !ok {
-			return fmt.Errorf("No BuildApp record for app %s", name)
+			return fmt.Errorf("no BuildApp record for app %s", name)
 		}
 
 		sylog.Debugf("Creating %s app in bundle", name)
@@ -477,7 +477,7 @@ func (pl *BuildApp) HandlePost(b *types.Bundle) (string, error) {
 		sylog.Debugf("Fetching app[%s] post script section", name)
 		app, ok := pl.Apps[name]
 		if !ok {
-			return "", fmt.Errorf("No BuildApp record for app %s", name)
+			return "", fmt.Errorf("no BuildApp record for app %s", name)
 		}
 
 		sylog.Debugf("Building app[%s] post script section", name)

--- a/internal/pkg/build/buildkit/client/client.go
+++ b/internal/pkg/build/buildkit/client/client.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2023-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -349,9 +349,10 @@ func buildImage(ctx context.Context, opts *Opts, tarFile *os.File, listenSocket,
 }
 
 func newSolveOpt(_ context.Context, opts *Opts, w io.WriteCloser, buildDir, spec string, clientsideFrontend bool) (*client.SolveOpt, error) {
-	if buildDir == "" {
+	switch buildDir {
+	case "":
 		return nil, errors.New("please specify build context (e.g. \".\" for the current directory)")
-	} else if buildDir == "-" {
+	case "-":
 		return nil, errors.New("stdin not supported yet")
 	}
 

--- a/internal/pkg/build/buildkit/daemon/daemon.go
+++ b/internal/pkg/build/buildkit/daemon/daemon.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2023-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -293,7 +293,7 @@ func ociWorkerInitializer(ctx context.Context, common workerInitializerOpt) ([]w
 	}
 
 	// Force "host" network mode always, to avoid buildkitd doing any CNI setup
-	common.config.Workers.OCI.NetworkConfig.Mode = "host"
+	common.config.Workers.OCI.Mode = "host"
 
 	if cfg.Rootless {
 		sylog.Debugf("%s: running in rootless mode", DaemonName)
@@ -313,7 +313,7 @@ func ociWorkerInitializer(ctx context.Context, common workerInitializerOpt) ([]w
 	dns := getDNSConfig(common.config.DNS)
 
 	nc := netproviders.Opt{
-		Mode: common.config.Workers.OCI.NetworkConfig.Mode,
+		Mode: common.config.Workers.OCI.Mode,
 		CNI: cniprovider.Opt{
 			Root:       common.config.Root,
 			ConfigPath: common.config.Workers.OCI.CNIConfigPath,

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -70,12 +70,12 @@ func (s *stage) insertMetadata() error {
 }
 
 func insertEnvScript(b *types.Bundle) error {
-	if b.RunSection("environment") && b.Recipe.ImageData.Environment.Script != "" {
+	if b.RunSection("environment") && b.Recipe.Environment.Script != "" {
 		sylog.Infof("Adding environment to container")
 		envScriptPath := filepath.Join(b.RootfsPath, "/.singularity.d/env/90-environment.sh")
 		_, err := os.Stat(envScriptPath)
 		if os.IsNotExist(err) {
-			err := os.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Environment.Script+"\n"), 0o755)
+			err := os.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.Environment.Script+"\n"), 0o755)
 			if err != nil {
 				return err
 			}
@@ -87,7 +87,7 @@ func insertEnvScript(b *types.Bundle) error {
 			}
 			defer f.Close()
 
-			_, err = f.WriteString("\n" + b.Recipe.ImageData.Environment.Script + "\n")
+			_, err = f.WriteString("\n" + b.Recipe.Environment.Script + "\n")
 			if err != nil {
 				return err
 			}
@@ -119,9 +119,9 @@ func handleShebangScript(s types.Script) (string, string) {
 }
 
 func insertRunScript(b *types.Bundle) error {
-	if b.RunSection("runscript") && b.Recipe.ImageData.Runscript.Script != "" {
+	if b.RunSection("runscript") && b.Recipe.Runscript.Script != "" {
 		sylog.Infof("Adding runscript")
-		shebang, script := handleShebangScript(b.Recipe.ImageData.Runscript)
+		shebang, script := handleShebangScript(b.Recipe.Runscript)
 		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
@@ -131,9 +131,9 @@ func insertRunScript(b *types.Bundle) error {
 }
 
 func insertStartScript(b *types.Bundle) error {
-	if b.RunSection("startscript") && b.Recipe.ImageData.Startscript.Script != "" {
+	if b.RunSection("startscript") && b.Recipe.Startscript.Script != "" {
 		sylog.Infof("Adding startscript")
-		shebang, script := handleShebangScript(b.Recipe.ImageData.Startscript)
+		shebang, script := handleShebangScript(b.Recipe.Startscript)
 		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
@@ -143,9 +143,9 @@ func insertStartScript(b *types.Bundle) error {
 }
 
 func insertTestScript(b *types.Bundle) error {
-	if b.RunSection("test") && b.Recipe.ImageData.Test.Script != "" {
+	if b.RunSection("test") && b.Recipe.Test.Script != "" {
 		sylog.Infof("Adding testscript")
-		shebang, script := handleShebangScript(b.Recipe.ImageData.Test)
+		shebang, script := handleShebangScript(b.Recipe.Test)
 		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
@@ -155,11 +155,11 @@ func insertTestScript(b *types.Bundle) error {
 }
 
 func insertHelpScript(b *types.Bundle) error {
-	if b.RunSection("help") && b.Recipe.ImageData.Help.Script != "" {
+	if b.RunSection("help") && b.Recipe.Help.Script != "" {
 		_, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"))
 		if err != nil || b.Opts.Force {
 			sylog.Infof("Adding help info")
-			err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.ImageData.Help.Script+"\n"), 0o644)
+			err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.Help.Script+"\n"), 0o644)
 			if err != nil {
 				return err
 			}
@@ -231,11 +231,11 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 		return err
 	}
 
-	if b.RunSection("labels") && len(b.Recipe.ImageData.Labels) > 0 {
+	if b.RunSection("labels") && len(b.Recipe.Labels) > 0 {
 		sylog.Infof("Adding labels")
 
 		// add new labels to new map and check for collisions
-		for key, value := range b.Recipe.ImageData.Labels {
+		for key, value := range b.Recipe.Labels {
 			// check if label already exists
 			if _, ok := labels[key]; ok {
 				// overwrite collision if it exists and force flag is set
@@ -326,7 +326,7 @@ func addBuildLabels(labels map[string]string, b *types.Bundle) error {
 	labels["org.label-schema.usage.singularity.version"] = buildcfg.PACKAGE_VERSION
 
 	// help info if help exists in the definition and is run in the build
-	if b.RunSection("help") && b.Recipe.ImageData.Help.Script != "" {
+	if b.RunSection("help") && b.Recipe.Help.Script != "" {
 		labels["org.label-schema.usage"] = "/.singularity.d/runscript.help"
 		labels["org.label-schema.usage.singularity.runscript.help"] = "/.singularity.d/runscript.help"
 	}

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -164,7 +164,7 @@ func (cp *DebootstrapConveyorPacker) Get(ctx context.Context, b *types.Bundle) (
 	// Debian port arch values do not always match GOARCH values, so we need to look it up.
 	debArch, ok := debootstrapArchs[runtime.GOARCH]
 	if !ok {
-		return fmt.Errorf("Debian arch not known for GOARCH %s", runtime.GOARCH)
+		return fmt.Errorf("Debian arch not known for GOARCH %s", runtime.GOARCH) //nolint:staticcheck
 	}
 
 	insideUserNs, setgroupsAllowed := namespaces.IsInsideUserNamespace(os.Getpid())
@@ -261,7 +261,7 @@ func (cp *DebootstrapConveyorPacker) getRecipeHeaderInfo() (err error) {
 	include = strings.TrimSpace(include)
 
 	// convert Requires string to comma separated list
-	cp.include = strings.Replace(include, ` `, `,`, -1)
+	cp.include = strings.ReplaceAll(include, ` `, `,`)
 
 	return nil
 }

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -153,7 +153,7 @@ func (c *YumConveyor) getRPMPath() (err error) {
 				"Place the following lines into the '.rpmmacros' file:\n"+
 				"%s\n"+
 				"%s\n"+
-				"After creating the file, re-run the bootstrap.\n",
+				"After creating the file, re-run the bootstrap",
 				rpmDBPath, os.Getenv("HOME"), `%_var /var`, `%_dbpath %{_var}/lib/rpm`)
 		}
 	}

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -130,7 +130,7 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) error 
 			return fmt.Errorf("SUSEConnect is not in PATH: %v", err)
 		}
 
-		array := strings.SplitN(osversion, ".", -1)
+		array := strings.Split(osversion, ".")
 		osmajor := array[0]
 		iosmajor, err = strconv.Atoi(osmajor)
 		if err != nil {
@@ -155,7 +155,7 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) error 
 			mirrorurl = regex.ReplaceAllString(mirrorurl, osmajor+osservicepack)
 		}
 		sleproduct = regex.ReplaceAllString(sleproduct, osmajor+osservicepack)
-		array = strings.SplitN(sleproduct, "/", -1)
+		array = strings.Split(sleproduct, "/")
 		machine, _ := machine()
 		if len(array) == 3 {
 			machine = array[2]
@@ -296,7 +296,7 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) error 
 			return fmt.Errorf("while registering: %v", err)
 		}
 		if slemodulesOk {
-			array := strings.SplitN(slemodules, ",", -1)
+			array := strings.Split(slemodules, ",")
 			for i := 0; i < len(array); i++ {
 				array[i] = strings.TrimSpace(array[i])
 				cmd := exec.Command(suseconnectPath, `--root`, cp.b.RootfsPath,
@@ -427,7 +427,7 @@ func (cp *ZypperConveyorPacker) prepareFakerootRpmMacros() (func(), error) {
 	}
 
 	insideUserNs, setgroupsAllowed := namespaces.IsInsideUserNamespace(os.Getpid())
-	if !(insideUserNs && setgroupsAllowed) {
+	if !insideUserNs || !setgroupsAllowed {
 		return cleanupFunc, nil
 	}
 
@@ -611,7 +611,7 @@ func rpmPathCheck() (err error) {
 			"%s\n"+
 			"%s\n"+
 			"After creating the file, re-run the bootstrap.\n"+
-			"More info: https://github.com/sylabs/singularity/issues/241\n",
+			"More info: https://github.com/sylabs/singularity/issues/241",
 			rpmDBPath, os.Getenv("HOME"), `%_var /var`, `%_dbpath %{_var}/lib/rpm`)
 	}
 

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -74,7 +74,7 @@ func DownloadImage(ctx context.Context, filePath string, netURL string) error {
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(res.Body)
 		s := buf.String()
-		return fmt.Errorf("Download did not succeed: %d %s\n\t",
+		return fmt.Errorf("download did not succeed: %d %s\n\t",
 			res.StatusCode, s)
 	}
 

--- a/internal/pkg/client/ocisif/ocisif.go
+++ b/internal/pkg/client/ocisif/ocisif.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/match"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -168,7 +167,7 @@ func createOciSif(ctx context.Context, tOpts *ociimage.TransportOptions, imgCach
 	return nil
 }
 
-func canPullSignatures(img v1.Image, keepLayers bool) error {
+func canPullSignatures(img ggcrv1.Image, keepLayers bool) error {
 	layers, err := img.Layers()
 	if err != nil {
 		return err
@@ -333,7 +332,7 @@ func PushOCISIF(ctx context.Context, sourceFile, destRef string, opts PushOption
 	return nil
 }
 
-func transformLayers(base v1.Image, opts PushOptions) (v1.Image, error) {
+func transformLayers(base ggcrv1.Image, opts PushOptions) (ggcrv1.Image, error) {
 	ls, err := base.Layers()
 	if err != nil {
 		return nil, err

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -204,9 +204,10 @@ func (i *File) isExited() bool {
 	// delete instance files after checking that instance
 	// parent process
 	err := syscall.Kill(i.PPid, 0)
-	if err == syscall.ESRCH {
+	switch err {
+	case syscall.ESRCH:
 		return true
-	} else if err == nil {
+	case nil:
 		// process is alive and is owned by you otherwise
 		// we would have obtained permission denied error,
 		// now check if it's an instance parent process

--- a/internal/pkg/ocisif/overlay_test.go
+++ b/internal/pkg/ocisif/overlay_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sylabs Inc. All rights reserved.
+// Copyright (c) 2024-2025 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -19,7 +18,7 @@ import (
 
 const extfsOverlayPath = "../../../test/images/extfs-for-overlay.img"
 
-var extfsOverlayDigest = v1.Hash{
+var extfsOverlayDigest = ggcrv1.Hash{
 	Algorithm: "sha256",
 	Hex:       "be6a627e7c4226eacd50f530ce82e83f0efb8e0f7d28a9bcee9d6b4bc208cfd1",
 }
@@ -197,7 +196,7 @@ func modifyOverlayFF(t *testing.T, imgFile string) {
 }
 
 // Digest of extfsOverlayPath, modified by modifyOverlayFF above
-var modifiedOverlayDigest = v1.Hash{
+var modifiedOverlayDigest = ggcrv1.Hash{
 	Algorithm: "sha256",
 	Hex:       "1d2b7729ac057ceb9a3b301eec078ef89df5ea54188973e9a9b5f0f9aedf0615",
 }
@@ -211,7 +210,7 @@ func TestSyncOverlay(t *testing.T) {
 	tests := []struct {
 		name          string
 		modifyOverlay func(t *testing.T, imgFile string)
-		expectDigest  v1.Hash
+		expectDigest  ggcrv1.Hash
 	}{
 		{
 			name:         "Unmodified",

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2023-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -50,7 +50,7 @@ func ensurePassword(password string) (string, error) {
 			return "", fmt.Errorf("failed to read password: %s", err)
 		}
 		if input == "" {
-			return "", fmt.Errorf("A password is required")
+			return "", fmt.Errorf("a password is required")
 		}
 		return input, nil
 	}

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -55,7 +55,7 @@ func NewConfig(config SConfig) *Config {
 // GetIsSUID returns true if the SUID workflow is enabled.
 // This field is set by starter at the very beginning of its execution.
 func (c *Config) GetIsSUID() bool {
-	return c.config.starter.isSuid == true //nolint:gosimple
+	return c.config.starter.isSuid == true //nolint:gosimple,staticcheck
 }
 
 // GetContainerPid returns the container PID (if any).

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -581,7 +581,7 @@ mount:
 				goto mount
 			} else if mnt.Type == "overlay" && err == syscall.EINVAL {
 				sylog.Verbosef("Overlay mount failed with %s, mounting without xino option", err)
-				optsString = strings.Replace(optsString, ",xino=on", "", -1)
+				optsString = strings.ReplaceAll(optsString, ",xino=on", "")
 				goto mount
 			}
 			// mount error for other filesystems is considered fatal
@@ -2244,7 +2244,7 @@ func (c *container) addResolvConfMount(system *mount.System) error {
 				return err
 			}
 		} else {
-			dns = strings.Replace(dns, " ", "", -1)
+			dns = strings.ReplaceAll(dns, " ", "")
 			content, err = files.ResolvConf(strings.Split(dns, ","))
 			if err != nil {
 				return err

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -72,7 +72,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		return fmt.Errorf("incorrect engine")
 	}
 
-	if e.EngineConfig.OciConfig.Generator.Config != &e.EngineConfig.OciConfig.Spec {
+	if e.EngineConfig.OciConfig.Config != &e.EngineConfig.OciConfig.Spec {
 		return fmt.Errorf("bad engine configuration provided")
 	}
 
@@ -588,7 +588,7 @@ func (e *EngineOperations) joinNetns(starterConfig *starter.Config) error {
 		return fmt.Errorf("%q is not an allowed netns path in singularity.conf", netnsPath)
 	}
 
-	if !(allowedNetUser || allowedNetGroup) {
+	if !allowedNetUser && !allowedNetGroup {
 		return fmt.Errorf("you are not permitted to join network namespaces in singularity.conf")
 	}
 
@@ -914,7 +914,7 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 			return fmt.Errorf("failed to read %s: %s", path, err)
 		}
 		// check that we are currently joining sinit process
-		if "sinit" != strings.Trim(string(b), "\n") {
+		if strings.Trim(string(b), "\n") != "sinit" {
 			return fmt.Errorf("sinit not found in %s, wrong instance process", path)
 		}
 	}
@@ -1246,7 +1246,8 @@ func (e *EngineOperations) loadImages(starterConfig *starter.Config) error {
 	}
 
 	// sandbox are handled differently for security reasons
-	if img.Type == image.SANDBOX {
+	switch img.Type {
+	case image.SANDBOX:
 		if img.Path == "/" {
 			return fmt.Errorf("/ as sandbox is not authorized")
 		}
@@ -1300,7 +1301,7 @@ func (e *EngineOperations) loadImages(starterConfig *starter.Config) error {
 				return fmt.Errorf("while checking image compatibility with overlay: %s", err)
 			}
 		}
-	} else if img.Type == image.SIF {
+	case image.SIF:
 		// query the ECL module, proceed if an ecl config file is found
 		ecl, err := syecl.LoadConfig(buildcfg.ECL_FILE)
 		if err == nil {

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -648,7 +648,7 @@ func injectEnvHandler(senv map[string]string, noEval bool) interpreter.OpenHandl
 				export PATH=%q
 			fi
 			`
-			b.WriteString(fmt.Sprintf(defaultPathSnippet, env.DefaultPath))
+			fmt.Fprintf(b, defaultPathSnippet, env.DefaultPath)
 
 			snippet := `
 			if test -v %[1]s; then
@@ -667,7 +667,7 @@ func injectEnvHandler(senv map[string]string, noEval bool) interpreter.OpenHandl
 					// Shell evaluation when the export is sourced
 					value = "\"" + shell.EscapeDoubleQuotes(value) + "\""
 				}
-				b.WriteString(fmt.Sprintf(snippet, key, value))
+				fmt.Fprintf(b, snippet, key, value)
 			}
 		})
 
@@ -735,7 +735,7 @@ func getAllEnvBuiltin() interpreter.ShellBuiltin {
 			// string in the action script. This is too awkward and slow in
 			// shell code. If we can use `printf -v VAR "%b" ...` from mvdan.cc/sh
 			// in future, we may be able to revisit this.
-			env := strings.Replace(env, "\n", "\\u000A", -1)
+			env := strings.ReplaceAll(env, "\n", "\\u000A")
 			fmt.Fprintf(hc.Stdout, "%s\n", env)
 		}
 		return nil

--- a/internal/pkg/runtime/launcher/oci/cdi_linux.go
+++ b/internal/pkg/runtime/launcher/oci/cdi_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -37,7 +37,7 @@ func addCDIDevices(spec *specs.Spec, cdiDevices []string, cdiRegOptions ...cdi.O
 	}
 
 	if _, err := cdi.InjectDevices(spec, cdiDevices...); err != nil {
-		return fmt.Errorf("Error encountered setting up CDI devices: %w", err)
+		return fmt.Errorf("while setting up CDI devices: %w", err)
 	}
 
 	return nil

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -594,7 +594,7 @@ func (l *Launcher) prepareResolvConf(bundlePath string) (*specs.Mount, error) {
 	var resolvConfData []byte
 	var err error
 	if len(l.cfg.DNS) > 0 {
-		dns := strings.Replace(l.cfg.DNS, " ", "", -1)
+		dns := strings.ReplaceAll(l.cfg.DNS, " ", "")
 		ips := strings.Split(dns, ",")
 		for _, ip := range ips {
 			if net.ParseIP(ip) == nil {

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -699,7 +699,7 @@ func (l *Launcher) addBindMount(mounts *[]specs.Mount, b bind.Path, allowSUID bo
 	}
 	if _, err := os.Stat(absSource); err != nil {
 		_, ok := l.imageMountsByMountpoint[absSource]
-		if !(errors.Is(err, os.ErrNotExist) && ok) {
+		if !errors.Is(err, os.ErrNotExist) || !ok {
 			return fmt.Errorf("cannot stat bind source %s: %w", b.Source, err)
 		}
 	}

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -74,7 +74,7 @@ func (l *Launcher) getProcess(ctx context.Context, imgSpec imgspecv1.Image, bund
 	}
 
 	// OCI default is NoNewPrivileges = false
-	noNewPrivs := false
+	noNewPrivs := false //nolint:staticcheck
 	// --no-privs sets NoNewPrivileges
 	if l.cfg.NoPrivs {
 		noNewPrivs = true

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/samber/lo"
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/engine/config/oci"
@@ -432,7 +431,7 @@ func TestGetProcessEnvNative(t *testing.T) {
 				nativeSIF: true,
 			}
 			imgSpec := imgspecv1.Image{
-				Config: v1.ImageConfig{
+				Config: imgspecv1.ImageConfig{
 					Env: []string{"PATH=" + env.DefaultPath},
 				},
 			}

--- a/internal/pkg/signature/verify_ocsp.go
+++ b/internal/pkg/signature/verify_ocsp.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020-2022, ICS-FORTH.  All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
@@ -114,7 +114,7 @@ func revocationCheck(cert *x509.Certificate, pool map[string]*x509.Certificate) 
 			return false
 		}
 
-		if !(isCase1() || isCase2() || isCase3()) {
+		if !isCase1() && !isCase2() && !isCase3() {
 			return fmt.Errorf("ocsp response is rejected")
 		}
 

--- a/internal/pkg/sypgp/sypgp.go
+++ b/internal/pkg/sypgp/sypgp.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -661,13 +661,14 @@ func formatMROutput(mrString string, longOutput bool) (int, []byte, error) {
 	gotName := false
 	for _, l := range lines {
 		fields := strings.Split(strings.TrimSpace(l), ":")
-		if fields[0] == "info" {
+		switch fields[0] {
+		case "info":
 			var err error
 			numKeys, err = strconv.Atoi(fields[2])
 			if err != nil {
 				return -1, nil, fmt.Errorf("unable to check number of keys")
 			}
-		} else if fields[0] == "pub" {
+		case "pub":
 			if !first {
 				if !gotName {
 					// there was a pub without uid; end line
@@ -689,13 +690,14 @@ func formatMROutput(mrString string, longOutput bool) (int, []byte, error) {
 				keyDateExpired := date(fields[5])
 
 				keyStatus := ""
-				if fields[6] == "r" {
+				switch fields[6] {
+				case "r":
 					keyStatus = "[revoked]"
-				} else if fields[6] == "d" {
+				case "d":
 					keyStatus = "[disabled]"
-				} else if fields[6] == "e" {
+				case "e":
 					keyStatus = "[expired]"
-				} else {
+				default:
 					keyStatus = "[enabled]"
 				}
 
@@ -706,7 +708,7 @@ func formatMROutput(mrString string, longOutput bool) (int, []byte, error) {
 				fmt.Fprintf(tw, shortFmt, keyFingerprint[len(fields[1])-8:], keyBits)
 			}
 			count++
-		} else if fields[0] == "uid" {
+		case "uid":
 			// And the key name/email is on fields[1]
 			// There may be more than one of these for each pub
 			if !gotName {

--- a/internal/pkg/test/privilege_linux.go
+++ b/internal/pkg/test/privilege_linux.go
@@ -126,7 +126,7 @@ func getProcInfo(pid int) (ppid int, uid int, gid int) {
 // process with a non-root UID, then returns the UID and GID of that process.
 // Calls os.Exit on error, or if no non-root process is found.
 func getUnprivIDs(pid int) (uid int, gid int) {
-	if 1 == pid {
+	if pid == 1 {
 		log.Fatal("no unprivileged process found")
 	}
 

--- a/internal/pkg/util/shell/escape.go
+++ b/internal/pkg/util/shell/escape.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021 Sylabs, Inc. All rights reserved.
+// Copyright (c) 2018-2025 Sylabs, Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license.  Please
 // consult LICENSE.md file distributed with the sources of this project regarding
 // your rights to use or distribute this software.
@@ -19,19 +19,19 @@ func ArgsQuoted(a []string) (quoted string) {
 // Escape performs escaping of shell double quotes, backticks and $ characters.
 // Does not escape single quotes - apply EscapeSingleQuotes separately for this.
 func Escape(s string) string {
-	escaped := strings.Replace(s, `\`, `\\`, -1)
-	escaped = strings.Replace(escaped, `"`, `\"`, -1)
-	escaped = strings.Replace(escaped, "`", "\\`", -1)
-	escaped = strings.Replace(escaped, `$`, `\$`, -1)
+	escaped := strings.ReplaceAll(s, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, "`", "\\`")
+	escaped = strings.ReplaceAll(escaped, `$`, `\$`)
 	return escaped
 }
 
 // EscapeQuotes performs shell escaping of double quotes only
 func EscapeDoubleQuotes(s string) string {
-	return strings.Replace(s, `"`, `\"`, -1)
+	return strings.ReplaceAll(s, `"`, `\"`)
 }
 
 // EscapeSingleQuotes performs shell escaping of single quotes only
 func EscapeSingleQuotes(s string) string {
-	return strings.Replace(s, `'`, `'"'"'`, -1)
+	return strings.ReplaceAll(s, `'`, `'"'"'`)
 }

--- a/pkg/build/types/definition.go
+++ b/pkg/build/types/definition.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -245,14 +245,14 @@ func populateRaw(d *Definition, w io.Writer) {
 	}
 	fmt.Fprintln(w)
 
-	writeLabelsIfExists(w, d.ImageData.Labels)
+	writeLabelsIfExists(w, d.Labels)
 	writeFilesIfExists(w, d.BuildData.Files)
 
-	writeSectionIfExists(w, "help", d.ImageData.Help)
-	writeSectionIfExists(w, "environment", d.ImageData.Environment)
-	writeSectionIfExists(w, "runscript", d.ImageData.Runscript)
-	writeSectionIfExists(w, "test", d.ImageData.Test)
-	writeSectionIfExists(w, "startscript", d.ImageData.Startscript)
+	writeSectionIfExists(w, "help", d.Help)
+	writeSectionIfExists(w, "environment", d.Environment)
+	writeSectionIfExists(w, "runscript", d.Runscript)
+	writeSectionIfExists(w, "test", d.Test)
+	writeSectionIfExists(w, "startscript", d.Startscript)
 	writeSectionIfExists(w, "pre", d.BuildData.Pre)
 	writeSectionIfExists(w, "setup", d.BuildData.Setup)
 	writeSectionIfExists(w, "post", d.BuildData.Post)

--- a/pkg/build/types/definition_test.go
+++ b/pkg/build/types/definition_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -129,7 +129,7 @@ func TestNewDefinitionFromJSON(t *testing.T) {
 	if def1Err != nil {
 		t.Fatal("NewDefinitionFromJSON() failed with a valid JSON", def1Err)
 	}
-	if len(def1.ImageData.Labels) != 2 {
+	if len(def1.Labels) != 2 {
 		t.Fatal("Invalid number of labels")
 	}
 
@@ -139,7 +139,7 @@ func TestNewDefinitionFromJSON(t *testing.T) {
 	if def2Err != nil {
 		t.Fatal("NewDefinitionFromJSON() failed with a Singularity JSON", def2Err)
 	}
-	if len(def2.ImageData.Labels) != 1 {
+	if len(def2.Labels) != 1 {
 		t.Fatal("Invalid number of labels")
 	}
 }

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -24,7 +24,7 @@ import (
 
 var (
 	errInvalidSection  = errors.New("invalid section(s) specified")
-	errEmptyDefinition = errors.New("Empty definition file")
+	errEmptyDefinition = errors.New("empty definition file")
 	// Match space but not within double quotes
 	fileSplitter = regexp.MustCompile(`([^\s"']*{{\s*\w+\s*}}*[^\s{}"']*)+|([^\s"']+|"([^"]*)"|'([^']*))`)
 )

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -260,14 +260,14 @@ func TestIsInvalidSectionErrors(t *testing.T) {
 	if IsInvalidSectionError(myValidErr1) == false ||
 		IsInvalidSectionError(myValidErr2) == false ||
 		IsInvalidSectionError(myInvalidErr) == true {
-		t.Fatal("unexpecter return value for IsInvalidSectionError()")
+		t.Fatal("unexpected return value for IsInvalidSectionError()")
 	}
 
 	// Test of Error()
 	expectedStr1 := "invalid section(s) specified: " + strings.Join(dummyKeys, ", ")
-	expectedStr2 := "Empty definition file: " + strings.Join(dummyKeys, ", ")
+	expectedStr2 := "empty definition file: " + strings.Join(dummyKeys, ", ")
 	if myValidErr1.Error() != expectedStr1 || myValidErr2.Error() != expectedStr2 {
-		t.Fatal("unexpecter result from Error()", myValidErr1.Error())
+		t.Fatal("unexpected result from Error()", myValidErr1.Error())
 	}
 }
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -365,12 +365,13 @@ func lockSection(i *Image, section Section) error {
 		}
 	}
 
-	if err == lock.ErrByteRangeAcquired {
+	switch err {
+	case lock.ErrByteRangeAcquired:
 		if i.Writable {
 			return fmt.Errorf("can't open %s for writing, currently in use by another process", i.Path)
 		}
 		return fmt.Errorf("can't open %s for reading, currently in use for writing by another process", i.Path)
-	} else if err == lock.ErrLockNotSupported {
+	case lock.ErrLockNotSupported:
 		// ENOLCK means that the underlying filesystem doesn't support
 		// lock, so we simply ignore the error in order to allow ext3
 		// images located on the underlying filesystem to run correctly

--- a/pkg/network/network_linux.go
+++ b/pkg/network/network_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -280,7 +280,8 @@ func (m *Setup) SetArgs(args []string) error {
 		for _, kv := range argList {
 			key := kv[0]
 			value := kv[1]
-			if key == "portmap" {
+			switch key {
+			case "portmap":
 				pm := &PortMapEntry{}
 
 				splittedPort := strings.SplitN(value, "/", 2)
@@ -318,7 +319,7 @@ func (m *Setup) SetArgs(args []string) error {
 				if err := m.SetCapability(networkName, "portMappings", *pm); err != nil {
 					return err
 				}
-			} else if key == "ipRange" {
+			case "ipRange":
 				ipRange := make([]allocator.Range, 1)
 				_, subnet, err := net.ParseCIDR(value)
 				if err != nil {
@@ -328,7 +329,7 @@ func (m *Setup) SetArgs(args []string) error {
 				if err := m.SetCapability(networkName, "ipRanges", ipRange); err != nil {
 					return err
 				}
-			} else {
+			default:
 				for i := range m.networks {
 					if m.networks[i] == networkName {
 						m.runtimeConf[i].Args = append(m.runtimeConf[i].Args, kv)
@@ -471,7 +472,8 @@ func (m *Setup) command(ctx context.Context, command string) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	if command == "ADD" {
+	switch command {
+	case "ADD":
 		m.result = make([]types.Result, len(m.networkConfList))
 		for i := 0; i < len(m.networkConfList); i++ {
 			var err error
@@ -484,12 +486,13 @@ func (m *Setup) command(ctx context.Context, command string) error {
 				return err
 			}
 		}
-	} else if command == "DEL" {
+	case "DEL":
 		for i := 0; i < len(m.networkConfList); i++ {
 			if err := config.DelNetworkList(ctx, m.networkConfList[i], m.runtimeConf[i]); err != nil {
 				return err
 			}
 		}
 	}
+
 	return nil
 }

--- a/pkg/runtime/engine/config/config.go
+++ b/pkg/runtime/engine/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -28,7 +28,7 @@ func (c *Common) GetPluginConfig(pl plugin.Plugin, cfg interface{}) error {
 	if c.PluginConfig == nil {
 		c.PluginConfig = make(map[string]json.RawMessage)
 	}
-	if raw, found := c.PluginConfig[pl.Manifest.Name]; found {
+	if raw, found := c.PluginConfig[pl.Name]; found {
 		return json.Unmarshal(raw, cfg)
 	}
 	return nil
@@ -43,7 +43,7 @@ func (c *Common) SetPluginConfig(pl plugin.Plugin, cfg interface{}) error {
 	if c.PluginConfig == nil {
 		c.PluginConfig = make(map[string]json.RawMessage)
 	}
-	c.PluginConfig[pl.Manifest.Name] = raw
+	c.PluginConfig[pl.Name] = raw
 	return nil
 }
 

--- a/pkg/util/archive/archive.go
+++ b/pkg/util/archive/archive.go
@@ -121,7 +121,7 @@ loop:
 				continue
 			}
 
-			if !(fi.IsDir() && hdr.Typeflag == tar.TypeDir) {
+			if !fi.IsDir() || !(hdr.Typeflag == tar.TypeDir) { //nolint:staticcheck
 				if err := os.RemoveAll(path); err != nil {
 					return err
 				}
@@ -216,7 +216,7 @@ func createTarFile(path, extractDir, extractRoot string, hdr *tar.Header, reader
 	case tar.TypeDir:
 		// Create directory unless it exists as a directory already.
 		// In that case we just want to merge the two
-		if fi, err := os.Lstat(path); !(err == nil && fi.IsDir()) {
+		if fi, err := os.Lstat(path); err != nil || !fi.IsDir() {
 			if err := os.Mkdir(path, hdrInfo.Mode()); err != nil {
 				return err
 			}

--- a/pkg/util/archive/copy.go
+++ b/pkg/util/archive/copy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -123,7 +123,7 @@ func CopyWithTarWithRoot(src, dst, dstRoot string, disableIDMapping bool) error 
 		}
 
 		if tarArchive == nil {
-			return fmt.Errorf("Empty archive")
+			return fmt.Errorf("empty archive")
 		}
 		dest = filepath.Clean(dest)
 		if options == nil {

--- a/pkg/util/cryptkey/key.go
+++ b/pkg/util/cryptkey/key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -29,7 +29,7 @@ var (
 	// ErrNoEncryptedKeyData indicates there is no encrypted key data.
 	ErrNoEncryptedKeyData = errors.New("no encrypted key data")
 	// ErrNoPEMData indicates there is no PEM data.
-	ErrNoPEMData = errors.New("No PEM data")
+	ErrNoPEMData = errors.New("no PEM data")
 )
 
 const (

--- a/pkg/util/fs/lock/lock.go
+++ b/pkg/util/fs/lock/lock.go
@@ -63,9 +63,11 @@ func (r *ByteRange) flock(lockType int16) error {
 	}
 
 	err := unix.FcntlFlock(uintptr(r.fd), setLk, lk)
-	if err == unix.EAGAIN || err == unix.EACCES {
+
+	switch err {
+	case unix.EAGAIN, unix.EACCES:
 		return ErrByteRangeAcquired
-	} else if err == unix.ENOLCK {
+	case unix.ENOLCK:
 		return ErrLockNotSupported
 	}
 

--- a/pkg/util/sysctl/sysctl_linux.go
+++ b/pkg/util/sysctl/sysctl_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,7 +15,7 @@ import (
 const procSys = "/proc/sys"
 
 func convertKey(key string) string {
-	return strings.Replace(strings.TrimSpace(key), ".", string(os.PathSeparator), -1)
+	return strings.ReplaceAll(strings.TrimSpace(key), ".", string(os.PathSeparator))
 }
 
 func getPath(key string) (string, error) {


### PR DESCRIPTION
Pick #3641 to release-4.3

Bump the linter, and fix new lint.