### PR TITLE
ci: use fuse3 for squashfuse build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,10 @@ commands:
               build-essential \
               cryptsetup \
               fuse2fs \
+              fuse3 \
               fuse-overlayfs \
               git \
-              libfuse-dev \
+              libfuse3-dev \
               libseccomp-dev \
               libsubid-dev \
               libtool \
@@ -377,7 +378,7 @@ jobs:
               dh-golang \
               fakeroot \
               git \
-              libfuse-dev \
+              libfuse3-dev \
               libglib2.0-dev \
               libseccomp-dev \
               libtool \

--- a/debian/control
+++ b/debian/control
@@ -25,8 +25,8 @@ Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends},
   crun (>= 1.5.0) | runc,
   cryptsetup-bin,
-  fuse3,
   fuse2fs,
+  fuse3,
   libseccomp2,
   squashfs-tools,
   uidmap


### PR DESCRIPTION
Ensure CI provides FUSE 3 devel libraries / headers for the squashfuse build, and the fuse3 CLI tools for runtime.