### PR TITLE
e2e: fs options not valid on binds (actionOciCdi)

### DIFF
--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -866,19 +866,19 @@ func (c actionTests) actionOciCdi(t *testing.T) {
 			Mounts: []cdispecs.Mount{
 				{
 					ContainerPath: "/tmp/mount1",
-					Options:       []string{"rw", "bind", "users"},
+					Options:       []string{"rw", "bind"},
 				},
 				{
 					ContainerPath: "/tmp/mount3",
-					Options:       []string{"rw", "bind", "users"},
+					Options:       []string{"rw", "bind"},
 				},
 				{
 					ContainerPath: "/tmp/mount13",
-					Options:       []string{"rw", "bind", "users"},
+					Options:       []string{"rw", "bind"},
 				},
 				{
 					ContainerPath: "/tmp/mount17",
-					Options:       []string{"rw", "bind", "users"},
+					Options:       []string{"rw", "bind"},
 				},
 			},
 			Env: []string{


### PR DESCRIPTION
Filesystem specific options not valid on binds, and checked with runc 1.2+.

Remove `users` option from binds in `actionOciCdi` e2e test.

Fixes #3720