### PR TITLE
e2e: fix: use Fedora version currently on mirrors

### DIFF
--- a/examples/fedora-amd64/Singularity
+++ b/examples/fedora-amd64/Singularity
@@ -1,5 +1,5 @@
 BootStrap: dnf
-OSVersion: 40
+OSVersion: 42
 MirrorURL: http://dfw.mirror.rackspace.com/fedora/releases/%{OSVERSION}/Everything/x86_64/os/
 Include: fedora-release-container dnf
 Setopt: install_weak_deps=False

--- a/examples/fedora-arm64/Singularity
+++ b/examples/fedora-arm64/Singularity
@@ -1,5 +1,5 @@
 BootStrap: dnf
-OSVersion: 40
+OSVersion: 42
 MirrorURL: http://dfw.mirror.rackspace.com/fedora/releases/%{OSVERSION}/Everything/aarch64/os/
 Include: fedora-release-container dnf
 Setopt: install_weak_deps=False


### PR DESCRIPTION
Fedora 40 is no longer on the main mirrors - it has been archived. Use current 42.