### PR TITLE
e2e: disable test using CERN registry

### DIFF
--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -64,6 +64,8 @@ func (c ctx) issue4524(t *testing.T) {
 }
 
 func (c ctx) issue4943(t *testing.T) {
+	t.Skip(t, "Disabled due to CERN registry unavailability.")
+
 	require.Arch(t, "amd64")
 
 	const (


### PR DESCRIPTION
The CERN registry has been unavailable relatively frequently, causing issues with working through dependency updates and other PRs.

Disable the test that uses it.