### PR TITLE
Fix graceful shutdown of containers fixes #947

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2130,6 +2130,8 @@ This point release addresses the following issues:
 - The command `singularity help` now only provides help regarding the usage of
   the `singularity` command. To display an image's `help` message, use
   `singularity run-help <image path>` instead
+- Fixed an issue preventing containers from gracefully shutting down upon
+  recieving SIGTERM #947.
 
 ### Removed Deprecated Commands
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -108,6 +108,7 @@ The following have contributed code and/or documentation to this repository.
 - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
 - Thomas Hamel <hmlth@t-hamel.fr>
 - Tim Wright <7im.Wright@protonmail.com>
+- Trevor Nichols <teb99@protonmail.com>
 - Tru Huynh <tru@pasteur.fr>
 - Tyson Whitehead <twhitehead@gmail.com>
 - Vanessa Sochat <vsoch@users.noreply.github.com>


### PR DESCRIPTION
## Description of the Pull Request (PR):

Handles the SIGTERM signal to the starter binary such that containers have a chance to gracefully shut down, especially when run through a system service. Should fix issue #947, ableit a slightly different approach than what was described in the issue. This also allows us to properly close and stop mounts before we get SIGKILLed by the service if relevant.


### This fixes or addresses the following GitHub issues:

 - Fixes #947

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)

Done all of the above except writing tests, may need help with this as this is my first time contributing Go. This PR should also be squashed before merging.
