### PR TITLE
e2e: fix: add gold linker workaround for NESTED on arm64

### DIFF
--- a/e2e/testdata/Dockerfile.nested
+++ b/e2e/testdata/Dockerfile.nested
@@ -33,6 +33,11 @@ RUN wget -O /tmp/go.tar.gz https://go.dev/dl/${GOVERSION}.${GOOS}-${GOARCH}.tar.
 
 # Install SingularityCE
 ADD . singularity-src
+
+# Workaround for lack of gold linker on arm64
+# See https://github.com/golang/go/issues/22040
+RUN singularity-src/e2e/testdata/gold_workaround.sh
+
 RUN cd singularity-src && git clean -fdx || true
 RUN cd singularity-src && ./mconfig && make -C builddir && make -C builddir install
 

--- a/e2e/testdata/gold_workaround.sh
+++ b/e2e/testdata/gold_workaround.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -eux -o pipefail
+
+arch=$(uname -i)
+if [[ $arch != aarch64 ]];
+then
+  exit 0
+fi
+
+echo "aarch64 (arm64) detected - configuring gold linker workaround for go"
+
+echo "Renaming gcc to gcc.orig"
+mv /usr/bin/gcc /usr/bin/gcc.orig
+
+echo "Adding gcc wrapper script"
+
+cat << 'EOF' > /usr/bin/gcc
+#!/bin/bash
+#
+# When using CGO (which is required when using go-microsoft for FIPS builds), Go has an
+# issue on arm64 where it passes -fuse-ld=gold to GCC which is a workaround for an issue
+# that doesn't exist with AL2023 ld, and the workaround actually breaks builds.
+#
+# So this hack wraps gcc and removes any -fuse-ld=gold if passed, and generates output to
+# trick the Go compiler into thinking the workaround was applied.  This is only put in
+# place on arm64.
+#
+# Many builds of Go remove the workaround by applying
+# https://go-review.googlesource.com/c/go/+/391115 but rather than compile Microsoft's Go
+# distribution from source, we use this gcc-wrapping kludge instead.
+#
+# This wrapper can be removed when https://github.com/golang/go/issues/22040 is closed.
+args=()
+for arg in "$@"; do
+    if [[ "$arg" == "-fuse-ld=gold" ]]; then
+        # The presence of the substring "GNU gold" in stdout is required to trick the Go
+        # compiler into thinking it was used, otherwise it will abort.
+        echo "Go build hack: dropping -fuse-ld=gold arg to disable use of GNU gold (see https://github.com/golang/go/issues/22040)"
+    else
+        args+=("$arg")
+    fi
+done
+
+exec gcc.orig "${args[@]}"
+EOF
+
+chmod +x /usr/bin/gcc
+
+echo "gold linker workaround installed"

--- a/e2e/testdata/nested.def
+++ b/e2e/testdata/nested.def
@@ -31,6 +31,10 @@ From: ubuntu:25.04
     wget -O /tmp/go.tar.gz https://go.dev/dl/{{ GOVERSION }}.{{ GOOS }}-{{ GOARCH }}.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz
     export PATH="/usr/local/go/bin:$PATH"
 
+    # Workaround for lack of gold linker on arm64
+    # See https://github.com/golang/go/issues/22040
+    singularity-src/e2e/testdata/gold_workaround.sh
+
     cd /singularity-src
     git clean -fdx || true
     ./mconfig 


### PR DESCRIPTION
## Description of the Pull Request (PR):

We need to put a wrapper script in place on ARM64, to accommodate the fact that go still tries to call the gold linker, which isn't provided on newer distributions.

The default ld linker has been fixed - but upstream go doesn't accommodate this yet.

See https://github.com/golang/go/issues/22040



### This fixes or addresses the following GitHub issues:

 - Fixes #3863 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
