### PR TITLE
plugin: logging / simplify go version check, isolate GOCACHE in e2e

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -17,7 +17,7 @@ reserved.
 
 Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 
-Copyright (c) 2018-2025, Sylabs, Inc. All rights reserved.
+Copyright (c) 2018-2026, Sylabs, Inc. All rights reserved.
 
 Copyright (c) Contributors to the Apptainer project, established as Apptainer a
 Series of LF Projects LLC.

--- a/e2e/plugin/plugin.go
+++ b/e2e/plugin/plugin.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,7 +23,11 @@ func (c ctx) testPluginBasic(t *testing.T) {
 
 	// plugin code directory
 	pluginDir, cleanup := e2e.MakeTempDir(t, "testdata", "e2e-plugin-dir-", "")
-	defer cleanup(t)
+	t.Cleanup(func() { cleanup(t) })
+
+	// temporary GOCACHE dir - isolate from any existing Go build cache etc.
+	tmpGoCache, cleanupHome := e2e.MakeTempDir(t, c.env.TestDir, "e2e-plugin-GOCACHE-", "")
+	t.Cleanup(func() { cleanupHome(t) })
 
 	// plugin sif file
 	sifFile := filepath.Join(pluginDir, "plugin.sif")
@@ -168,6 +172,7 @@ func (c ctx) testPluginBasic(t *testing.T) {
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(tt.profile),
+			e2e.WithEnv(append(os.Environ(), "GOCACHE="+tmpGoCache)),
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.args...),
 			e2e.ExpectExit(tt.expectExit, tt.expectOp),
@@ -181,7 +186,11 @@ func (c ctx) testCLICallbacks(t *testing.T) {
 
 	// plugin sif file
 	sifFile := filepath.Join(c.env.TestDir, "plugin.sif")
-	defer os.Remove(sifFile)
+	t.Cleanup(func() { os.Remove(sifFile) })
+
+	// temporary GOCACHE dir - isolate from any existing Go build cache etc.
+	tmpGoCache, cleanupHome := e2e.MakeTempDir(t, c.env.TestDir, "e2e-plugin-GOCACHE-", "")
+	t.Cleanup(func() { cleanupHome(t) })
 
 	tests := []struct {
 		name       string
@@ -232,6 +241,7 @@ func (c ctx) testCLICallbacks(t *testing.T) {
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(tt.profile),
+			e2e.WithEnv(append(os.Environ(), "GOCACHE="+tmpGoCache)),
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.args...),
 			e2e.ExpectExit(tt.expectExit),
@@ -247,7 +257,11 @@ func (c ctx) testSingularityCallbacks(t *testing.T) {
 
 	// plugin sif file
 	sifFile := filepath.Join(c.env.TestDir, "plugin.sif")
-	defer os.Remove(sifFile)
+	t.Cleanup(func() { os.Remove(sifFile) })
+
+	// temporary GOCACHE dir - isolate from any existing Go build cache etc.
+	tmpGoCache, cleanupHome := e2e.MakeTempDir(t, c.env.TestDir, "e2e-plugin-GOCACHE-", "")
+	t.Cleanup(func() { cleanupHome(t) })
 
 	tests := []struct {
 		name       string
@@ -298,6 +312,7 @@ func (c ctx) testSingularityCallbacks(t *testing.T) {
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(tt.profile),
+			e2e.WithEnv(append(os.Environ(), "GOCACHE="+tmpGoCache)),
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.args...),
 			e2e.ExpectExit(tt.expectExit),

--- a/internal/app/singularity/plugin_compile_linux.go
+++ b/internal/app/singularity/plugin_compile_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use the 'go env' command to directly get the GOVERSION of the system go, instead of running a test program.

Isolate GOCACHE for plugin tests, so any Go build cache that may be present in HOME does not impact the plugin builds.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
