### PR TITLE
e2e: fix: concatenate HOME to environment correctly

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -152,7 +152,7 @@ func (c ctx) testDockerHost(t *testing.T) {
 	e2e.Privileged(func(t *testing.T) {
 		cmd := exec.Command("docker", "build", "-t", dockerRef, tmpPath)
 		cmd.Dir = tmpPath
-		cmd.Env = append(cmd.Env, "HOME="+tmpHome)
+		cmd.Env = append(os.Environ(), "HOME="+tmpHome)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {
@@ -261,7 +261,7 @@ func (c ctx) testDockerHost(t *testing.T) {
 	// Clean up docker image
 	e2e.Privileged(func(t *testing.T) {
 		cmd := exec.Command("docker", "rmi", dockerRef)
-		cmd.Env = append(cmd.Env, "HOME="+tmpHome)
+		cmd.Env = append(os.Environ(), "HOME="+tmpHome)
 		_, err = cmd.Output()
 		if err != nil {
 			t.Fatalf("Unexpected error while cleaning up docker image.\n%s", err)

--- a/e2e/nested/nested.go
+++ b/e2e/nested/nested.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2025-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,6 +6,7 @@
 package nested
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -52,7 +53,7 @@ func dockerBuild(t *testing.T, dockerFile, dockerRef, contextPath, homeDir strin
 			"--build-arg", "GOOS="+runtime.GOOS,
 			"--build-arg", "GOARCH="+runtime.GOARCH,
 			"-t", dockerRef, "-f", dockerFile, contextPath)
-		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		cmd.Env = append(os.Environ(), "HOME="+homeDir)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {
@@ -64,7 +65,7 @@ func dockerBuild(t *testing.T, dockerFile, dockerRef, contextPath, homeDir strin
 func dockerRMI(t *testing.T, dockerRef, homeDir string) {
 	t.Run("rmi/"+dockerRef, e2e.Privileged(func(t *testing.T) {
 		cmd := exec.Command("docker", "rmi", dockerRef)
-		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		cmd.Env = append(os.Environ(), "HOME="+homeDir)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {
@@ -78,7 +79,7 @@ func dockerRunPrivileged(t *testing.T, name, dockerRef, homeDir string, args ...
 		cmdArgs := []string{"run", "-i", "--rm", "--privileged", "--network=host", dockerRef}
 		cmdArgs = append(cmdArgs, args...)
 		cmd := exec.Command("docker", cmdArgs...)
-		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		cmd.Env = append(os.Environ(), "HOME="+homeDir)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {
@@ -118,7 +119,7 @@ func podmanBuild(t *testing.T, dockerFile, dockerRef, contextPath, homeDir strin
 			"--build-arg", "GOOS="+runtime.GOOS,
 			"--build-arg", "GOARCH="+runtime.GOARCH,
 			"-t", dockerRef, "-f", dockerFile, contextPath)
-		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		cmd.Env = append(os.Environ(), "HOME="+homeDir)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {
@@ -130,7 +131,7 @@ func podmanBuild(t *testing.T, dockerFile, dockerRef, contextPath, homeDir strin
 func podmanRMI(t *testing.T, dockerRef, homeDir string) {
 	t.Run("rmi/"+dockerRef, func(t *testing.T) {
 		cmd := exec.Command("podman", "rmi", dockerRef)
-		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		cmd.Env = append(os.Environ(), "HOME="+homeDir)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {
@@ -144,7 +145,7 @@ func podmanRun(t *testing.T, name, dockerRef, homeDir string, args ...string) { 
 		cmdArgs := []string{"run", "-i", "--rm", "--privileged", "--network=host", dockerRef}
 		cmdArgs = append(cmdArgs, args...)
 		cmd := exec.Command("podman", cmdArgs...)
-		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		cmd.Env = append(os.Environ(), "HOME="+homeDir)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -200,7 +200,7 @@ func (c ctx) testPushOCITarLayers(t *testing.T) {
 		e2e.Privileged(func(t *testing.T) {
 			dockerRef := strings.TrimPrefix(imgRef, "docker://")
 			cmd := exec.Command("docker", "run", "-i", "--rm", dockerRef, "/bin/true")
-			cmd.Env = append(cmd.Env, "HOME="+tmpHome)
+			cmd.Env = append(os.Environ(), "HOME="+tmpHome)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("Unexpected error while running command.\n%s: %s", err, string(out))


### PR DESCRIPTION
## Description of the Pull Request (PR):

"HOME=xxx" must be concatenated to the os.Environ(). If concatenated to an empty cmd.Env then *only* HOME will be set.

This causes issues on OpenSuSE 16 - default PATH values must differ on this distro.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
