### PR TITLE
e2e: Tidy up some e2e temp file/dir locations

### DIFF
--- a/e2e/build/build.go
+++ b/e2e/build/build.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -40,7 +40,7 @@ func (c ctx) testNvidiaLegacy(t *testing.T) {
 	// Use Ubuntu 20.04 as this is a recent distro officially supported by Nvidia CUDA.
 	// We can't use our test image as it's alpine based and we need a compatible glibc.
 	imageURL := "docker://ubuntu:20.04"
-	imageFile, err := fs.MakeTmpFile("", "test-nvidia-legacy-", 0o755)
+	imageFile, err := fs.MakeTmpFile(c.env.TestDir, "test-nvidia-legacy-", 0o755)
 	if err != nil {
 		t.Fatalf("Could not create test file: %v", err)
 	}
@@ -147,7 +147,7 @@ func (c ctx) testNvCCLI(t *testing.T) {
 	// Use Ubuntu 20.04 as this is a recent distro officially supported by Nvidia CUDA.
 	// We can't use our test image as it's alpine based and we need a compatible glibc.
 	imageURL := "docker://ubuntu:20.04"
-	imageFile, err := fs.MakeTmpFile("", "test-nvccli-", 0o755)
+	imageFile, err := fs.MakeTmpFile(c.env.TestDir, "test-nvccli-", 0o755)
 	if err != nil {
 		t.Fatalf("Could not create test file: %v", err)
 	}
@@ -257,7 +257,7 @@ func (c ctx) testRocm(t *testing.T) {
 	// Use Ubuntu 22.04 as this is the most recent distro officially supported by ROCm.
 	// We can't use our test image as it's alpine based and we need a compatible glibc.
 	imageURL := "docker://ubuntu:22.04"
-	imageFile, err := fs.MakeTmpFile("", "test-rocm-", 0o755)
+	imageFile, err := fs.MakeTmpFile(c.env.TestDir, "test-rocm-", 0o755)
 	if err != nil {
 		t.Fatalf("Could not create test file: %v", err)
 	}

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the

--- a/e2e/internal/e2e/imagebuild.go
+++ b/e2e/internal/e2e/imagebuild.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -662,7 +662,7 @@ func orasPushNoCheck(path, ref, layerMediaType string) error {
 }
 
 func (c ctx) testPullDisableCacheCmd(t *testing.T) {
-	cacheDir, err := os.MkdirTemp("", "e2e-imgcache-")
+	cacheDir, err := os.MkdirTemp(c.env.TestDir, "e2e-imgcache-")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s", err)
 	}

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -19,8 +19,8 @@ type ctx struct {
 	e2e.TestEnv
 }
 
-func getImage(t *testing.T) string {
-	dst, err := os.CreateTemp("", "e2e-sign-keyring-*")
+func (c *ctx) getImage(t *testing.T) string {
+	dst, err := os.CreateTemp(c.TestDir, "e2e-sign-keyring-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func (c *ctx) sign(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		imgPath := getImage(t)
+		imgPath := c.getImage(t)
 		defer os.Remove(imgPath)
 
 		c.RunSingularity(t,
@@ -176,7 +176,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			var err error
 
 			// Create a temporary PGP keyring.
-			c.KeyringDir, err = os.MkdirTemp("", "e2e-sign-keyring-")
+			c.KeyringDir, err = os.MkdirTemp(c.TestDir, "e2e-sign-keyring-")
 			if err != nil {
 				t.Fatalf("failed to create temporary directory: %s", err)
 			}

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -287,7 +287,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			var err error
 
 			// Create a temporary PGP keyring.
-			c.KeyringDir, err = os.MkdirTemp("", "e2e-sign-keyring-")
+			c.KeyringDir, err = os.MkdirTemp(c.TestDir, "e2e-sign-keyring-")
 			if err != nil {
 				t.Fatalf("failed to create temporary directory: %s", err)
 			}


### PR DESCRIPTION
## Description of the Pull Request (PR):

The e2e suite creates a main env.TestDir, which is intended to be a 'root' temporary directory for temporary dirs/files created by the e2e test code.

Some e2e tests have been creating files outside of this location, which can make it harder to distinguish between things that might have been created by singularity invocations, rather than the test code itself.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
