### PR TITLE
oci: fix: No relatime for bind workdir / scratch mounts (release-4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SingularityCE Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Don't attempt to set `relatime` on workdir / scratch mounts in OCI-Mode.
+
 ## 4.3.6 \[2025-12-16\]
 
 ### Security Related Fixes

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -139,7 +139,6 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) error {
 
 		opts := []string{
 			"rbind",
-			"relatime",
 		}
 		if !l.cfg.AllowSUID {
 			opts = append(opts, "nosuid")
@@ -503,7 +502,6 @@ func (l *Launcher) addScratchMounts(mounts *[]specs.Mount) error {
 
 			opts := []string{
 				"rbind",
-				"relatime",
 				"nodev",
 			}
 			if !l.cfg.AllowSUID {


### PR DESCRIPTION
## Description of the Pull Request (PR):

In OCI-Mode, prior to this PR, we were setting the `relatime` option for bind mounted workdir and scratch mounts.

It is relatively common for `/tmp`, from which workdir & scratch dirs may be mounted, to be a tmpfs defined as a systemd default mount. This mount uses `strictatime`, so a mount with `relatime` will fail.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
