### PR TITLE
chore: bump CI / docs go version to 1.25.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.25.5'
+    default: '1.25.6'
 
 executors:
   node:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -163,7 +163,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.25.5 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.25.6 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz

--- a/e2e/testdata/Dockerfile.nested
+++ b/e2e/testdata/Dockerfile.nested
@@ -1,6 +1,6 @@
 FROM ubuntu:25.04
 
-ARG GOVERSION="go1.25.5"
+ARG GOVERSION="go1.25.6"
 ARG GOOS="linux"
 ARG GOARCH="amd64"
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump CI / docs go version to 1.25.6

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
