### PR TITLE
chore: workaround revive/nolintlint issue under golangci-lint

### DIFF
--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-//nolint:revive
+//revive:disable:var-naming
 package net
 
 import (

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//revive:disable:var-naming
 package types
 
 import (

--- a/pkg/build/types/bundle_test.go
+++ b/pkg/build/types/bundle_test.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//revive:disable:var-naming
 package types
 
 import (

--- a/pkg/build/types/definition.go
+++ b/pkg/build/types/definition.go
@@ -5,6 +5,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//revive:disable:var-naming
 package types
 
 import (

--- a/pkg/build/types/definition_test.go
+++ b/pkg/build/types/definition_test.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-//nolint:revive
+//revive:disable:var-naming
 package types
 
 import (


### PR DESCRIPTION
## Description of the Pull Request (PR):

Revive and nolintlint are fighting under golangci-lint 2.8.0, where revive applies the var-naming rule to a packag name.

Different runs will report different revive & nolintlint locations.

Switch to using `revive:disable` vs `nolint:revive` for this case as a workaround for now.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
