### PR TITLE
chore: drop github.com/containerd/continuity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/buger/jsonparser v1.1.1
 	github.com/ccoveille/go-safecast v1.8.2
 	github.com/containerd/containerd/v2 v2.2.1
-	github.com/containerd/continuity v0.4.5
 	github.com/containerd/go-runc v1.1.0
 	github.com/containerd/platforms v1.0.0-rc.2
 	github.com/containernetworking/cni v1.3.0
@@ -104,6 +103,7 @@ require (
 	github.com/containerd/cgroups/v3 v3.1.2 // indirect
 	github.com/containerd/console v1.0.5 // indirect
 	github.com/containerd/containerd/api v1.10.0 // indirect
+	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect

--- a/internal/pkg/build/buildkit/daemon/executor.go
+++ b/internal/pkg/build/buildkit/daemon/executor.go
@@ -43,9 +43,9 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/plugins/content/local"
 	"github.com/containerd/containerd/v2/plugins/diff/walking"
-	"github.com/containerd/continuity/fs"
 	runc "github.com/containerd/go-runc"
 	"github.com/containerd/platforms"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/cache/metadata"
 	"github.com/moby/buildkit/executor"
@@ -455,7 +455,7 @@ func (w *buildExecutor) Run(ctx context.Context, id string, root executor.Mount,
 		spec.Root.Readonly = true
 	}
 
-	newp, err := fs.RootPath(rootFSPath, meta.Cwd)
+	newp, err := securejoin.SecureJoin(rootFSPath, meta.Cwd)
 	if err != nil {
 		return nil, errors.Wrapf(err, "working dir %s points to invalid target", newp)
 	}


### PR DESCRIPTION
We have a single call to fs.RootPath that can be replaced with filepath.SecureJoin which we use elsewhere.

Closes #3967