### PR TITLE
chore: drop pkg/errors

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
 	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/exec"
@@ -365,9 +364,8 @@ func (c actionTests) actionShell(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	hostname, err := os.Hostname()
-	err = errors.Wrap(err, "getting hostname")
 	if err != nil {
-		t.Fatalf("could not get hostname: %+v", err)
+		t.Fatalf("could not get hostname: %v", err)
 	}
 
 	tests := []struct {

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -23,7 +23,6 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/pkg/errors"
 	"github.com/sylabs/sif/v2/pkg/sif"
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
@@ -43,9 +42,8 @@ func (c ctx) testDockerPulls(t *testing.T) {
 	const tmpContainerFile = "test_container.sif"
 
 	tmpPath, err := fs.MakeTmpDir(c.env.TestDir, "docker-", 0o755)
-	err = errors.Wrapf(err, "creating temporary directory in %q for docker pull test", c.env.TestDir)
 	if err != nil {
-		t.Fatalf("failed to create temporary directory: %+v", err)
+		t.Fatalf("failed creating temporary directory in %q for docker pull test: %v", c.env.TestDir, err)
 	}
 	t.Cleanup(func() {
 		if !t.Failed() {
@@ -725,13 +723,11 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 	getKernelMajor := func(t *testing.T) (major int) {
 		var buf unix.Utsname
 		if err := unix.Uname(&buf); err != nil {
-			err = errors.Wrap(err, "getting current kernel information")
 			t.Fatalf("uname failed: %+v", err)
 		}
 		n, err := fmt.Sscanf(string(buf.Release[:]), "%d.", &major)
-		err = errors.Wrap(err, "getting current kernel release")
 		if err != nil {
-			t.Fatalf("Sscanf failed, n=%d: %+v", n, err)
+			t.Fatalf("kernel release Sscanf failed, n=%d: %+v", n, err)
 		}
 		if n != 1 {
 			t.Fatalf("Unexpected result while getting major release number: n=%d", n)

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
 	"github.com/sylabs/singularity/v4/pkg/util/fs/proc"
@@ -190,9 +189,8 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 	// Create and populate a temporary file.
 	tempFile := filepath.Join(dir, fileName)
 	err = os.WriteFile(tempFile, fileContents, 0o644)
-	err = errors.Wrapf(err, "creating temporary test file %s", tempFile)
 	if err != nil {
-		t.Fatalf("Failed to create file: %+v", err)
+		t.Fatalf("Failed to create temporary test file %s: %v", tempFile, err)
 	}
 
 	// Start and Run an instance with the temporary directory as the home

--- a/e2e/internal/e2e/fileutil.go
+++ b/e2e/internal/e2e/fileutil.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
@@ -40,9 +39,8 @@ func WriteTempFile(dir, pattern, content string) (string, error) {
 // image cache location since it would create thread safety problems.
 func MakeTempDir(t *testing.T, baseDir string, prefix string, context string) (string, func(t *testing.T)) {
 	dir, err := fs.MakeTmpDir(baseDir, prefix, 0o755)
-	err = errors.Wrapf(err, "creating temporary %s at %s", context, baseDir)
 	if err != nil {
-		t.Fatalf("failed to create temporary directory: %+v", err)
+		t.Fatalf("failed to create temporary directory %s at %s: %v", context, baseDir, err)
 	}
 
 	return dir, func(t *testing.T) {

--- a/e2e/internal/e2e/priv.go
+++ b/e2e/internal/e2e/priv.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,8 +10,6 @@ import (
 	"runtime"
 	"syscall"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -61,22 +59,18 @@ func Privileged(f func(*testing.T)) func(*testing.T) {
 		runtime.LockOSThread()
 
 		if err := ThreadSetresuid(0, 0, origUID); err != nil {
-			err = errors.Wrap(err, "changing user ID to 0")
-			t.Fatalf("privileges escalation failed: %+v", err)
+			t.Fatalf("privilege escalation failed changing uid to 0: %v", err)
 		}
 		if err := ThreadSetresgid(0, 0, origGID); err != nil {
-			err = errors.Wrap(err, "changing group ID to 0")
-			t.Fatalf("privileges escalation failed: %+v", err)
+			t.Fatalf("privilege escalation failed changing gid to 0: %+v", err)
 		}
 
 		defer func() {
 			if err := ThreadSetresgid(origGID, origGID, 0); err != nil {
-				err = errors.Wrapf(err, "changing group ID to %d", origUID)
-				t.Fatalf("privileges drop failed: %+v", err)
+				t.Fatalf("privilege drop failed changing gid to %d: %v", origUID, err)
 			}
 			if err := ThreadSetresuid(origUID, origUID, 0); err != nil {
-				err = errors.Wrapf(err, "changing group ID to %d", origGID)
-				t.Fatalf("privileges drop failed: %+v", err)
+				t.Fatalf("privilege drop failed changing uid to %d: %v", origUID, err)
 			}
 			runtime.UnlockOSThread()
 		}()

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/uuid"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
 	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/require"
@@ -39,8 +38,7 @@ func (c *ctx) checkOciState(t *testing.T, containerID string, state specs.Contai
 	checkStateFn := func(t *testing.T, r *e2e.SingularityCmdResult) {
 		s := &specs.State{}
 		if err := json.Unmarshal(r.Stdout, s); err != nil {
-			err = errors.Wrapf(err, "unmarshaling OCI state from JSON: %s", r.Stdout)
-			t.Errorf("can't unmarshal oci state output: %+v", err)
+			t.Errorf("can't unmarshal OCI state from JSON: %s: %v", r.Stdout, err)
 			return
 		}
 		if s.Status != specs.ContainerState(state) {
@@ -85,8 +83,7 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 
 	bundleDir, err := os.MkdirTemp(c.env.TestDir, "bundle-")
 	if err != nil {
-		err = errors.Wrapf(err, "creating temporary bundle directory at %q", c.env.TestDir)
-		t.Fatalf("failed to create bundle directory: %+v", err)
+		t.Fatalf("failed to create bundle directory at %q: %v", c.env.TestDir, err)
 	}
 	c.env.RunSingularity(
 		t,

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
 	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/require"
@@ -63,14 +62,12 @@ func (c ctx) testPushCmd(t *testing.T) {
 	// setup file and dir to use as invalid sources
 	invalidDir, err := os.MkdirTemp(c.env.TestDir, "push_dir-")
 	if err != nil {
-		err = errors.Wrap(err, "creating temporary directory")
-		t.Fatalf("unable to create src dir for push tests: %+v", err)
+		t.Fatalf("unable to create src dir for push tests: %v", err)
 	}
 
 	invalidFile, err := e2e.WriteTempFile(invalidDir, "invalid_image-", "Invalid Image Contents")
 	if err != nil {
-		err = errors.Wrap(err, "creating temporary file")
-		t.Fatalf("unable to create src file for push tests: %+v", err)
+		t.Fatalf("unable to create src file for push tests: %v", err)
 	}
 
 	tests := []struct {

--- a/e2e/version/version.go
+++ b/e2e/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
 )
@@ -63,19 +62,16 @@ func (c ctx) testEqualVersion(t *testing.T) {
 			outputVer = strings.TrimSpace(outputVer)
 			semanticVersion, err := semver.Make(outputVer)
 			if err != nil {
-				err = errors.Wrapf(err, "creating semver version from %q", outputVer)
-				t.Fatalf("Creating semver version: %+v", err)
+				t.Fatalf("Creating semver version from %q: %v", outputVer, err)
 			}
 			if tmpVersion != "" {
 				versionTmp, err := semver.Make(tmpVersion)
 				if err != nil {
-					err = errors.Wrapf(err, "creating semver version from %q", tmpVersion)
-					t.Fatalf("Creating semver version: %+v", err)
+					t.Fatalf("Creating semver version from %q: %v", tmpVersion, err)
 				}
 				// compare versions and see if they are equal
 				if semanticVersion.Compare(versionTmp) != 0 {
-					err = errors.Wrapf(err, "comparing versions %q and %q", outputVer, tmpVersion)
-					t.Fatalf("singularity version command and singularity --version give a non-matching version result: %+v", err)
+					t.Fatalf("singularity version (%s) and singularity --version (%s) do not match: %v", outputVer, tmpVersion, err)
 				}
 			} else {
 				tmpVersion = outputVer

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/opencontainers/selinux v1.13.1
 	github.com/opencontainers/umoci v0.6.0
 	github.com/pelletier/go-toml/v2 v2.2.4
-	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.52.0
 	github.com/sebdah/goldie/v2 v2.8.0
 	github.com/seccomp/libseccomp-golang v0.11.1
@@ -214,6 +213,7 @@ require (
 	github.com/petermattis/goid v0.0.0-20250721140440-ea1c0173183e // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect

--- a/internal/app/singularity/delete.go
+++ b/internal/app/singularity/delete.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,8 +7,8 @@ package singularity
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sylabs/scs-library-client/client"
 )
 
@@ -16,12 +16,12 @@ import (
 func DeleteImage(ctx context.Context, scsConfig *client.Config, imageRef, arch string) error {
 	libraryClient, err := client.NewClient(scsConfig)
 	if err != nil {
-		return errors.Wrap(err, "couldn't create a new client")
+		return fmt.Errorf("couldn't create a new client: %w", err)
 	}
 
 	err = libraryClient.DeleteImage(ctx, imageRef, arch)
 	if err != nil {
-		return errors.Wrap(err, "couldn't delete requested image")
+		return fmt.Errorf("couldn't delete requested image: %w", err)
 	}
 
 	return nil

--- a/internal/pkg/build/buildkit/client/client.go
+++ b/internal/pkg/build/buildkit/client/client.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2023-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2023-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -39,7 +39,6 @@ import (
 	dockerfile "github.com/moby/buildkit/frontend/dockerfile/builder"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/progress/progressui"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/sylabs/singularity/v4/internal/pkg/build/args"
 	bkauth "github.com/sylabs/singularity/v4/internal/pkg/build/buildkit/auth"
@@ -351,9 +350,9 @@ func buildImage(ctx context.Context, opts *Opts, tarFile *os.File, listenSocket,
 func newSolveOpt(_ context.Context, opts *Opts, w io.WriteCloser, buildDir, spec string, clientsideFrontend bool) (*client.SolveOpt, error) {
 	switch buildDir {
 	case "":
-		return nil, errors.New("please specify build context (e.g. \".\" for the current directory)")
+		return nil, fmt.Errorf("please specify build context (e.g. \".\" for the current directory)")
 	case "-":
-		return nil, errors.New("stdin not supported yet")
+		return nil, fmt.Errorf("stdin not supported yet")
 	}
 
 	localDirs := map[string]string{

--- a/internal/pkg/build/buildkit/daemon/executor.go
+++ b/internal/pkg/build/buildkit/daemon/executor.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright (c) 2023-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2023-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -25,6 +25,8 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"os"
@@ -67,7 +69,6 @@ import (
 	wlabel "github.com/moby/buildkit/worker/label"
 	"github.com/moby/sys/user"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/sync/errgroup"
@@ -272,13 +273,13 @@ func NewBuildExecutor(opt WorkerOpt, networkProviders map[pb.NetMode]bknet.Provi
 		}
 	}
 	if !found {
-		return nil, errors.Errorf("failed to find %s binary", cmd)
+		return nil, fmt.Errorf("failed to find %s binary", cmd)
 	}
 
 	root := opt.Root
 
 	if err := os.MkdirAll(root, 0o711); err != nil {
-		return nil, errors.Wrapf(err, "failed to create %s", root)
+		return nil, fmt.Errorf("failed to create %s: %w", root, err)
 	}
 
 	root, err := filepath.Abs(root)
@@ -350,7 +351,7 @@ func (w *buildExecutor) Run(ctx context.Context, id string, root executor.Mount,
 
 	provider, ok := w.networkProviders[meta.NetMode]
 	if !ok {
-		return nil, errors.Errorf("unknown network mode %s", meta.NetMode)
+		return nil, fmt.Errorf("unknown network mode %s", meta.NetMode)
 	}
 	namespace, err := provider.New(ctx, meta.Hostname)
 	if err != nil {
@@ -410,10 +411,10 @@ func (w *buildExecutor) Run(ctx context.Context, id string, root executor.Mount,
 
 	rootFSPath := filepath.Join(bundle, "rootfs")
 	if err := user.MkdirAllAndChown(rootFSPath, 0o700, rootUID, rootGID); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	if err := mount.All(rootMount, rootFSPath); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	defer mount.Unmount(rootFSPath, 0)
 
@@ -457,11 +458,11 @@ func (w *buildExecutor) Run(ctx context.Context, id string, root executor.Mount,
 
 	newp, err := fs.RootPath(rootFSPath, meta.Cwd)
 	if err != nil {
-		return nil, errors.Wrapf(err, "working dir %s points to invalid target", newp)
+		return nil, fmt.Errorf("working dir %s points to invalid target: %w", newp, err)
 	}
 	if _, err := os.Stat(newp); err != nil {
 		if err := user.MkdirAllAndChown(newp, 0o755, rootUID, rootGID); err != nil {
-			return nil, errors.Wrapf(err, "failed to create working directory %s", newp)
+			return nil, fmt.Errorf("failed to create working directory %s: %w", newp, err)
 		}
 	}
 
@@ -536,7 +537,7 @@ func exitError(ctx context.Context, err error) error {
 		}
 		select {
 		case <-ctx.Done():
-			exitErr.Err = errors.Wrap(ctx.Err(), exitErr.Error())
+			exitErr.Err = fmt.Errorf("%w: %v", ctx.Err(), exitErr.Error())
 			return exitErr
 		default:
 			return stack.Enable(exitErr)
@@ -630,23 +631,23 @@ func (k procKiller) Kill(ctx context.Context) (err error) {
 			if os.IsNotExist(err) {
 				select {
 				case <-ctx.Done():
-					return errors.New("context canceled before runc wrote pidfile")
+					return fmt.Errorf("context canceled before runc wrote pidfile")
 				case <-time.After(10 * time.Millisecond):
 					continue
 				}
 			}
-			return errors.Wrap(err, "failed to read pidfile from runc")
+			return fmt.Errorf("failed to read pidfile from runc: %w", err)
 		}
 		break
 	}
 	pid, err := strconv.Atoi(string(pidData))
 	if err != nil {
-		return errors.Wrap(err, "read invalid pid from pidfile")
+		return fmt.Errorf("read invalid pid from pidfile: %w", err)
 	}
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		// error only possible on non-unix hosts
-		return errors.Wrapf(err, "failed to find process for pid %d from pidfile", pid)
+		return fmt.Errorf("failed to find process for pid %d from pidfile: %w", pid, err)
 	}
 	defer process.Release()
 	return process.Signal(syscall.SIGKILL)
@@ -754,10 +755,10 @@ func (p *procHandle) WaitForStart(ctx context.Context, startedCh <-chan int, sta
 	defer timeout()
 	select {
 	case <-startedCtx.Done():
-		return errors.New("go-runc started message never received")
+		return fmt.Errorf("go-runc started message never received")
 	case runcPid, ok := <-startedCh:
 		if !ok {
-			return errors.New("go-runc failed to send pid")
+			return fmt.Errorf("go-runc failed to send pid")
 		}
 		if started != nil {
 			started()
@@ -766,7 +767,7 @@ func (p *procHandle) WaitForStart(ctx context.Context, startedCh <-chan int, sta
 		p.monitorProcess, err = os.FindProcess(runcPid)
 		if err != nil {
 			// error only possible on non-unix hosts
-			return errors.Wrapf(err, "failed to find runc process %d", runcPid)
+			return fmt.Errorf("failed to find runc process %d: %w", runcPid, err)
 		}
 		close(p.ready)
 	}

--- a/internal/pkg/runtime/launcher/oci/oci_attach_linux.go
+++ b/internal/pkg/runtime/launcher/oci/oci_attach_linux.go
@@ -10,6 +10,7 @@ package oci
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -17,7 +18,6 @@ import (
 	"path/filepath"
 
 	"github.com/moby/term"
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"golang.org/x/sys/unix"
 )
@@ -138,7 +138,7 @@ func redirectResponseToOutputStreams(outputStream, errorStream io.Writer, writeO
 				sylog.Infof("Received unexpected attach type %+d", buf[0])
 			}
 			if dst == nil {
-				return errors.New("output destination cannot be nil")
+				return fmt.Errorf("output destination cannot be nil")
 			}
 
 			if doWrite {

--- a/internal/pkg/signature/verify.go
+++ b/internal/pkg/signature/verify.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -11,12 +11,12 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sylabs/scs-key-client/client"
 	"github.com/sylabs/sif/v2/pkg/integrity"

--- a/internal/pkg/signature/verify_ocsp.go
+++ b/internal/pkg/signature/verify_ocsp.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020-2022, ICS-FORTH.  All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
@@ -10,13 +10,13 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"golang.org/x/crypto/ocsp"
 )

--- a/pkg/util/archive/archive.go
+++ b/pkg/util/archive/archive.go
@@ -22,6 +22,7 @@ package archive
 
 import (
 	"archive/tar"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -37,7 +38,6 @@ import (
 	"github.com/moby/sys/sequential"
 	"github.com/moby/sys/user"
 	"github.com/moby/sys/userns"
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
@@ -287,7 +287,7 @@ func createTarFile(path, extractDir, extractRoot string, hdr *tar.Header, reader
 			if errors.Is(err, syscall.EINVAL) && userns.RunningInUserNS() {
 				msg += " (try increasing the number of subordinate IDs in /etc/subuid and /etc/subgid)"
 			}
-			return errors.Wrapf(err, msg, path, hdr.Uid, hdr.Gid)
+			return fmt.Errorf("%s %s %d %d: %w", msg, path, hdr.Uid, hdr.Gid, err)
 		}
 	}
 

--- a/pkg/util/cryptkey/key_test.go
+++ b/pkg/util/cryptkey/key_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 )
 
@@ -83,7 +82,7 @@ func TestEncryptKey(t *testing.T) {
 			name:          "invalid pem",
 			keyInfo:       KeyInfo{Format: PEM, Path: invalidPemPath},
 			plaintext:     []byte(""),
-			expectedError: errors.Wrap(fmt.Errorf("open nothing: no such file or directory"), "loading public key for key encryption"),
+			expectedError: fmt.Errorf("loading public key for key encryption: open nothing: no such file or directory"),
 		},
 	}
 


### PR DESCRIPTION
Use the Go stdlib errors package. Drop pkg/errors which is now archived.

Closes #3968