### PR TITLE
fix: pick apptainer#3329 ENV quoting on oci imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   directory of the target of the symlink is bind-mounted from the host.
   The result is that even if the target of the symlink is replaced with
   a new file, the container sees the update in `/etc/resolv.conf`.
+- Correctly escape ENV vars when importing OCI containers to native SIF, so that
+  they match podman / docker behaviour.
 
 ### New Features & Functionality
 

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -366,9 +366,9 @@ func (cp *OCIConveyorPacker) insertEnv() error {
 			export = fmt.Sprintf("export %s=\"${%s:-}\"\n", envParts[0], envParts[0])
 		} else {
 			if envParts[0] == "PATH" {
-				export = fmt.Sprintf("export %s=%q\n", envParts[0], shell.Escape(envParts[1]))
+				export = fmt.Sprintf("export %s=\"%s\"\n", envParts[0], shell.Escape(envParts[1]))
 			} else {
-				export = fmt.Sprintf("export %s=\"${%s:-%q}\"\n", envParts[0], envParts[0], shell.Escape(envParts[1]))
+				export = fmt.Sprintf("export %s=\"${%s:-\"%s\"}\"\n", envParts[0], envParts[0], shell.Escape(envParts[1]))
 			}
 		}
 		_, err = f.WriteString(export)


### PR DESCRIPTION
Pick https://github.com/apptainer/apptainer/pull/3329

Original commit message:

remove double backslashes in env variables imported from oci containers