### PR TITLE
e2e: don't use t.TempDir in e2e tests

### DIFF
--- a/e2e/data/data.go
+++ b/e2e/data/data.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2024-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,7 +23,8 @@ type ctx struct {
 func (c ctx) testDataPackage(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.env)
 	// <tmpdir>/innner/file
-	outerDir := t.TempDir()
+	outerDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "data-package-", "")
+	defer cleanup(t)
 	innerDir := filepath.Join(outerDir, "inner")
 	innerFile := filepath.Join(innerDir, "file")
 	content := []byte("TEST")

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -729,7 +729,8 @@ func (c ctx) singularityKeyCmd(t *testing.T) {
 }
 
 func (c *ctx) generateCosignKeypair(t *testing.T) {
-	testDir := t.TempDir()
+	testDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "cosign-keypair-", "")
+	defer cleanup(t)
 
 	tests := []struct {
 		name          string

--- a/e2e/nested/nested.go
+++ b/e2e/nested/nested.go
@@ -161,7 +161,13 @@ func (c ctx) singularity(t *testing.T) {
 	e2e.EnsureRegistryOCISIF(t, c.env)
 
 	nestedDef := "e2e/testdata/nested.def"
-	nestedSIF := filepath.Join(t.TempDir(), "nested.sif")
+	testDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "nested-singularity-", "")
+	t.Cleanup(func() {
+		if !t.Failed() {
+			e2e.Privileged(cleanup)(t)
+		}
+	})
+	nestedSIF := filepath.Join(testDir, "nested.sif")
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("build"),
@@ -177,7 +183,7 @@ func (c ctx) singularity(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 
-	tmpBuildSIF := filepath.Join(t.TempDir(), "build.sif")
+	tmpBuildSIF := filepath.Join(testDir, "build.sif")
 
 	tests := []struct {
 		name         string

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -196,7 +196,8 @@ func (c ctx) testOverlayOCI(t *testing.T) {
 	require.MkfsExt3(t)
 	e2e.EnsureOCISIF(t, c.env)
 
-	tmpDir := t.TempDir()
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "nested-singularity-", "")
+	defer cleanup(t)
 	pgpDir, _ := e2e.MakeSyPGPDir(t, tmpDir)
 	c.env.KeyringDir = pgpDir
 	ocisifSigned := filepath.Join(tmpDir, "signed.sif")

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -917,9 +917,12 @@ func (c ctx) testPullOCIOverlay(t *testing.T) {
 			}
 			args = append(args, dest, imgRef)
 
+			tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "pull-oci-overlay-", "")
+			defer cleanup(t)
+
 			c.env.RunSingularity(
 				t,
-				e2e.WithDir(t.TempDir()),
+				e2e.WithDir(tmpDir),
 				e2e.WithProfile(e2e.OCIUserProfile),
 				e2e.WithCommand("pull"),
 				e2e.WithArgs(args...),
@@ -945,8 +948,11 @@ func (c ctx) testCosignRoundTrip(t *testing.T) {
 	priKeyPath := filepath.Join("..", "test", "keys", "cosign.key")
 	pubKeyPath := filepath.Join("..", "test", "keys", "cosign.pub")
 
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "cosign-round-trip-", "")
+	defer cleanup(t)
+
 	// Create a signed OCI-SIF
-	pushedSIF := filepath.Join(t.TempDir(), "signed.sif")
+	pushedSIF := filepath.Join(tmpDir, "signed-push.sif")
 	if err := fs.CopyFile(c.env.OCISIFPath, pushedSIF, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -971,7 +977,7 @@ func (c ctx) testCosignRoundTrip(t *testing.T) {
 	)
 
 	// Pull from local registry
-	pulledSIF := filepath.Join(t.TempDir(), "signed.sif")
+	pulledSIF := filepath.Join(tmpDir, "signed-pull.sif")
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("pull"),

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -213,7 +213,8 @@ func (c ctx) testPushOCIOverlay(t *testing.T) {
 	imgRef := fmt.Sprintf("docker://%s/docker_oci-overlay:test", c.env.TestRegistry)
 
 	// OCI-SIF image with overlay
-	tmpDir := t.TempDir()
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "push-oci-overlay-", "")
+	defer cleanup(t)
 	overlaySIF := filepath.Join(tmpDir, "overlay.sif")
 	if err := fs.CopyFile(c.env.OCISIFPath, overlaySIF, 0o755); err != nil {
 		t.Fatal(err)
@@ -275,7 +276,9 @@ func (c ctx) testPushOCICosign(t *testing.T) {
 
 	imgRef := fmt.Sprintf("docker://%s/docker_oci-cosign:test", c.env.TestRegistry)
 
-	testSif := filepath.Join(t.TempDir(), "signed.sif")
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "push-oci-cosign-", "")
+	defer cleanup(t)
+	testSif := filepath.Join(tmpDir, "signed.sif")
 	if err := fs.CopyFile(c.env.OCISIFPath, testSif, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/e2e/sign/oci.go
+++ b/e2e/sign/oci.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2025-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,7 +17,9 @@ import (
 
 func (c *ctx) signOCICosign(t *testing.T) {
 	e2e.EnsureOCISIF(t, c.TestEnv)
-	testSif := filepath.Join(t.TempDir(), "test.sif")
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.TestDir, "sign-oci-cosign-", "")
+	defer cleanup(t)
+	testSif := filepath.Join(tmpDir, "test.sif")
 	if err := fs.CopyFile(c.OCISIFPath, testSif, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/e2e/verify/oci.go
+++ b/e2e/verify/oci.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2025-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -20,7 +20,9 @@ func (c *ctx) verifyOCICosign(t *testing.T) {
 	signedSIF := corpus.SIF(t, "hello-world-cosign-manifest")
 	unsignedSIF := corpus.SIF(t, "hello-world-docker-v2-manifest")
 	goodKeyPath := filepath.Join("..", "test", "keys", "cosign.pub")
-	badKeyPath := filepath.Join(t.TempDir(), "bad.pub")
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.TestDir, "verify-oci-cosign-", "")
+	defer cleanup(t)
+	badKeyPath := filepath.Join(tmpDir, "bad.pub")
 	kb, err := cosign.GenerateKeyPair(nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Change uses of t.TempDir to e2e.MakeTempDir inside main e2e test directory.

Over the past couple of years, we adopted t.TempDir in test code as it is handy to avoid explicit tmpdir cleanup etc.

However, this didn't take into consideration that our e2e tests have always been written to create their temporary dirs / files inside a single root e2e temporary directory. This pattern is useful as it allows easy distinction of temporary files created as part of e2e tests, versus any which are created, and might be erroneously left, by the invocations of the singularity binary.

Fixes #3941