### PR TITLE
fix: cleanup auto overlay-parent- tmpdir

### DIFF
--- a/internal/pkg/util/fs/overlay/overlay_item_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_item_linux.go
@@ -51,6 +51,10 @@ type Item struct {
 
 	// allowDev is set to true to mount the overlay item without the "nodev" option.
 	allowDev bool
+
+	// cleanup is an optional function that will be called on unmount, to e.g.
+	// remove an automatically created parent dir.
+	cleanup func()
 }
 
 // NewItemFromString takes a string argument, as passed to --overlay, and
@@ -129,20 +133,27 @@ func (i *Item) SetAllowSetuid(a bool) {
 // GetParentDir gets a parent-dir in which to create overlay-specific mount
 // directories. If one has not been set using SetParentDir(), one will be
 // created using os.MkdirTemp().
-func (i *Item) GetParentDir() (string, error) {
+func (i *Item) GetParentDir() (string, func(), error) {
 	// Check if we've already been given a parentDir value; if not, create
 	// one using os.MkdirTemp()
 	if len(i.parentDir) > 0 {
-		return i.parentDir, nil
+		return i.parentDir, nil, nil
 	}
 
 	d, err := os.MkdirTemp("", "overlay-parent-")
 	if err != nil {
-		return d, err
+		return d, nil, err
+	}
+	cleanup := func() {
+		sylog.Debugf("Cleanup overlay item %s, removing %s", i.SourcePath, d)
+		if err := os.Remove(d); err != nil {
+			sylog.Errorf("Failed to remove temporary parent dir %s for overlay item %s: %s", d, i.SourcePath, err)
+		}
+		i.parentDir = ""
 	}
 
 	i.parentDir = d
-	return i.parentDir, nil
+	return i.parentDir, cleanup, nil
 }
 
 // Mount performs the necessary steps to mount an individual Item. Note that
@@ -242,10 +253,11 @@ func (i *Item) mountDir() error {
 
 // mountWithFuse mounts an image to a temporary directory
 func (i *Item) mountWithFuse(ctx context.Context) error {
-	parentDir, err := i.GetParentDir()
+	parentDir, cleanup, err := i.GetParentDir()
 	if err != nil {
 		return err
 	}
+	i.cleanup = cleanup
 
 	im := fsfuse.ImageMount{
 		Type:         i.Type,
@@ -273,6 +285,10 @@ func (i *Item) mountWithFuse(ctx context.Context) error {
 // this method does not unmount the overlay itself. That happens in
 // Set.Unmount().
 func (i Item) Unmount(ctx context.Context) error {
+	if i.cleanup != nil {
+		defer i.cleanup()
+	}
+
 	switch i.Type {
 	case image.SANDBOX:
 		return i.unmountDir(ctx)

--- a/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
@@ -77,12 +77,14 @@ func TestItemMissing(t *testing.T) {
 
 func verifyAutoParentDir(t *testing.T, item *Item) {
 	const autoParentDirStr string = "overlay-parent-"
-	if parentDir, err := item.GetParentDir(); err != nil {
+	if parentDir, cleanup, err := item.GetParentDir(); err != nil {
 		t.Fatalf("unexpected error while calling Item.GetParentDir(): %s", err)
 	} else if !strings.Contains(parentDir, autoParentDirStr) {
 		t.Errorf("auto-generated parent dir %q does not contain expected identifier string %q", parentDir, autoParentDirStr)
 	} else if !strings.HasPrefix(parentDir, "/tmp/") {
 		t.Errorf("auto-generated parent dir %q is not in expected location", parentDir)
+	} else if cleanup == nil {
+		t.Errorf("parentDir did not return a cleanup function")
 	}
 }
 
@@ -106,10 +108,12 @@ func TestAutofillParentDir(t *testing.T) {
 
 func verifyExplicitParentDir(t *testing.T, item *Item, dir string) {
 	item.SetParentDir(dir)
-	if parentDir, err := item.GetParentDir(); err != nil {
+	if parentDir, cleanup, err := item.GetParentDir(); err != nil {
 		t.Fatalf("unexpected error while calling Item.GetParentDir(): %s", err)
 	} else if parentDir != dir {
 		t.Errorf("item returned parent dir %q (expected: %q)", parentDir, dir)
+	} else if cleanup != nil {
+		t.Errorf("parentDir returned cleanup function unexpectedly")
 	}
 }
 


### PR DESCRIPTION
If a FUSE mount overlay item does not have a parent dir set, then a temporary parent dir will be created.

This PR registers a cleanup function to remove the tmpdir after unmount.

This only happens in unit tests. In normal Singularity flows a parent dir is always set.

Fixes #3939