### PR TITLE
fix: clean up temp images created for actions with --disable-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Correctly escape ENV vars when importing OCI containers to native SIF, so that
   they match podman / docker behaviour.
 - Clarify error when trying to build --oci from a non-Dockerfile spec.
+- When images are pulled implicitly by actions (run/shell/exec...), and the
+  cache is disabled, correctly clean up the temporary files.
 
 ### New Features & Functionality
 

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -159,24 +159,17 @@ func pullOCI(ctx context.Context, imgCache *cache.Handle, directTo string, pullF
 	return ocisif.PullOCISIF(ctx, imgCache, directTo, pullRef, ocisifOpts)
 }
 
-// Pull will pull a library image to the cache or direct to a temporary file if cache is disabled
-func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom *scslibrary.Ref, opts PullOptions) (imagePath string, err error) {
-	directTo := ""
-
+// PullToCache will pull a library image to the cache, returning the path to the cached image.
+func PullToCache(ctx context.Context, imgCache *cache.Handle, pullFrom *scslibrary.Ref, opts PullOptions) (imagePath string, err error) {
 	if imgCache.IsDisabled() {
-		file, err := os.CreateTemp(opts.TmpDir, "sbuild-tmp-cache-")
-		if err != nil {
-			return "", fmt.Errorf("unable to create tmp file: %v", err)
-		}
-		directTo = file.Name()
-		sylog.Infof("Downloading library image to tmp cache: %s", directTo)
+		return "", fmt.Errorf("cache is disabled, cannot pull to cache")
 	}
 
 	if opts.RequireOciSif {
-		return pullOCI(ctx, imgCache, directTo, pullFrom, opts)
+		return pullOCI(ctx, imgCache, "", pullFrom, opts)
 	}
 
-	return pull(ctx, imgCache, directTo, pullFrom, opts)
+	return pull(ctx, imgCache, "", pullFrom, opts)
 }
 
 // PullToFile will pull a library image to the specified location, through the cache, or directly if cache is disabled

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -171,20 +171,13 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 	return imagePath, nil
 }
 
-// Pull will pull a http(s) image to the cache or direct to a temporary file if cache is disabled
-func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, tmpDir string) (imagePath string, err error) {
-	directTo := ""
-
+// PullToCache will pull a http(s) image to the cache, returning the path to the cached image.
+func PullToCache(ctx context.Context, imgCache *cache.Handle, pullFrom string) (imagePath string, err error) {
 	if imgCache.IsDisabled() {
-		file, err := os.CreateTemp(tmpDir, "sbuild-tmp-cache-")
-		if err != nil {
-			return "", fmt.Errorf("unable to create tmp file: %v", err)
-		}
-		directTo = file.Name()
-		sylog.Infof("Downloading library image to tmp cache: %s", directTo)
+		return "", fmt.Errorf("cache is disabled, cannot pull to cache")
 	}
 
-	return pull(ctx, imgCache, directTo, pullFrom)
+	return pull(ctx, imgCache, "", pullFrom)
 }
 
 // PullToFile will pull an http(s) image to the specified location, through the cache, or directly if cache is disabled

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -8,7 +8,6 @@ package oras
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
@@ -60,20 +59,12 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 	return imagePath, nil
 }
 
-// Pull will pull an oras image to the cache or direct to a temporary file if cache is disabled
-func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, ociAuth *authn.AuthConfig, reqAuthFile string) (imagePath string, err error) {
-	directTo := ""
-
+// PullToCache will pull an oras image to the cache, and return the path to the cached image.
+func PullToCache(ctx context.Context, imgCache *cache.Handle, pullFrom string, ociAuth *authn.AuthConfig, reqAuthFile string) (imagePath string, err error) {
 	if imgCache.IsDisabled() {
-		file, err := os.CreateTemp(tmpDir, "sbuild-tmp-cache-")
-		if err != nil {
-			return "", fmt.Errorf("unable to create tmp file: %v", err)
-		}
-		directTo = file.Name()
-		sylog.Infof("Downloading oras image to tmp cache: %s", directTo)
+		return "", fmt.Errorf("cache is disabled, cannot pull to cache")
 	}
-
-	return pull(ctx, imgCache, directTo, pullFrom, ociAuth, reqAuthFile)
+	return pull(ctx, imgCache, "", pullFrom, ociAuth, reqAuthFile)
 }
 
 // PullToFile will pull an oras image to the specified location, through the cache, or directly if cache is disabled

--- a/internal/pkg/client/shub/pull.go
+++ b/internal/pkg/client/shub/pull.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -173,20 +173,12 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 	return imagePath, nil
 }
 
-// Pull will pull a shub image to the cache or direct to a temporary file if cache is disabled
-func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, noHTTPS bool) (imagePath string, err error) {
-	directTo := ""
-
+// PullToCache will pull a shub image to the cache, and return the path to the cached image.
+func PullToCache(ctx context.Context, imgCache *cache.Handle, pullFrom string, noHTTPS bool) (imagePath string, err error) {
 	if imgCache.IsDisabled() {
-		file, err := os.CreateTemp(tmpDir, "sbuild-tmp-cache-")
-		if err != nil {
-			return "", fmt.Errorf("unable to create tmp file: %v", err)
-		}
-		directTo = file.Name()
-		sylog.Infof("Downloading shub image to tmp cache: %s", directTo)
+		return "", fmt.Errorf("cache is disabled, cannot pull to cache")
 	}
-
-	return pull(ctx, imgCache, directTo, pullFrom, noHTTPS)
+	return pull(ctx, imgCache, "", pullFrom, noHTTPS)
 }
 
 // PullToFile will pull a shub image to the specified location, through the cache, or directly if cache is disabled

--- a/internal/pkg/runtime/launcher/launcher.go
+++ b/internal/pkg/runtime/launcher/launcher.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -28,6 +28,10 @@ type Launcher interface {
 type ExecParams struct {
 	// Image is the container image to execute, as a bare path, or <transport>:<path>.
 	Image string
+	// PullTempDir is a temporary directory used to store an image that was
+	// implicitly pulled with cache disabled, and which must be cleaned up on
+	// container exit.
+	PullTempDir string
 	// Action is one of exec/run/shell/start/test as specified on the CLI.
 	Action string
 	// Process is the command to execute as the container process, where applicable.

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -360,6 +360,12 @@ func (l *Launcher) Exec(ctx context.Context, ep launcher.ExecParams) error {
 	// Get image ready to run, if needed, via FUSE mount / extraction.
 	if err := l.prepareImage(ctx, ep.Image); err != nil {
 		return fmt.Errorf("while preparing image: %s", err)
+	}
+
+	// If the image we are running was pulled into a temp dir, because cache is
+	// disabled, make sure to clean that up on exit.
+	if ep.PullTempDir != "" {
+		l.engineConfig.SetDeletePullTempDir(ep.PullTempDir)
 	}
 
 	// Call the starter binary using our prepared config.

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -799,6 +799,15 @@ func (l *Launcher) Exec(ctx context.Context, ep launcher.ExecParams) error {
 		sylog.Errorf("Couldn't unmount session directory: %v", err)
 	}
 
+	// If the original image was implicitly pulled to a temporary dir due to
+	// disabled cache, remove it.
+	if l.cfg.PullTempDir != "" {
+		sylog.Debugf("Removing image pull temp dir: %s", l.cfg.PullTempDir)
+		if cleanupErr := fs.ForceRemoveAll(l.cfg.PullTempDir); cleanupErr != nil {
+			sylog.Errorf("Couldn't remove image pull temp dir %s: %v", l.cfg.PullTempDir, cleanupErr)
+		}
+	}
+
 	if e, ok := err.(*exec.ExitError); ok {
 		status, ok := e.Sys().(syscall.WaitStatus)
 		if ok && status.Signaled() {

--- a/internal/pkg/runtime/launcher/options.go
+++ b/internal/pkg/runtime/launcher/options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -150,6 +150,10 @@ type Options struct {
 	// userns flows we will need to delete the redundant temporary pulled image after
 	// conversion to sandbox.
 	CacheDisabled bool
+	// PullTempDir is a temporary directory used to store an image that was
+	// implicitly pulled with cache disabled, and which must be cleaned up on
+	// container exit.
+	PullTempDir string
 
 	// TransportOptions holds Docker/OCI image transport configuration (auth etc.)
 	// This will be used by a launcher handling OCI images directly.
@@ -565,6 +569,16 @@ func OptNoTmpSandbox(b bool) Option {
 func OptCacheDisabled(b bool) Option {
 	return func(lo *Options) error {
 		lo.CacheDisabled = b
+		return nil
+	}
+}
+
+// OptPullTempDir sets a temporary directory used to store an image that was
+// implicitly pulled with cache disabled, and which must be cleaned up on
+// container exit.
+func OptPullTempDir(d string) Option {
+	return func(lo *Options) error {
+		lo.PullTempDir = d
 		return nil
 	}
 }

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -134,6 +134,7 @@ type JSONConfig struct {
 	SignalPropagation     bool              `json:"signalPropagation,omitempty"`
 	RestoreUmask          bool              `json:"restoreUmask,omitempty"`
 	DeleteTempDir         string            `json:"deleteTempDir,omitempty"`
+	DeletePullTempDir     string            `json:"deletePullTempDir,omitempty"`
 	ImageFuse             bool              `json:"imageFuse,omitempty"`
 	Umask                 int               `json:"umask,omitempty"`
 	XdgRuntimeDir         string            `json:"xdgRuntimeDir,omitempty"`
@@ -666,16 +667,33 @@ func (e *EngineConfig) GetFakeroot() bool {
 	return e.JSON.Fakeroot
 }
 
-// GetDeleteTempDir returns the path of the temporary directory containing the root filesystem
-// which must be deleted after use. If no deletion is required, the empty string is returned.
+// GetDeleteTempDir returns the path of a temporary directory containing the
+// root filesystem which must be deleted after use, if a temporary sandbox was
+// created from an image or an image was FUSE mounted. If no deletion is
+// required, the empty string is returned.
 func (e *EngineConfig) GetDeleteTempDir() string {
 	return e.JSON.DeleteTempDir
 }
 
-// SetDeleteTempDir sets dir as the path of the temporary directory containing the root filesystem,
-// which must be deleted after use.
+// SetDeleteTempDir sets dir as the path of a temporary directory containing
+// the root filesystem which must be deleted after use, if a temporary sandbox
+// was created from an image or an image was FUSE mounted.
 func (e *EngineConfig) SetDeleteTempDir(dir string) {
 	e.JSON.DeleteTempDir = dir
+}
+
+// GetDeletePullTempDir returns the path of a temporary directory containing
+// an image that was implicitly pulled with cache disabled, and which must be
+// deleted after use. If no deletion is required, the empty string is returned.
+func (e *EngineConfig) GetDeletePullTempDir() string {
+	return e.JSON.DeletePullTempDir
+}
+
+// SetDeletePullTempDir sets the path of a temporary directory containing
+// an image that was implicitly pulled with cache disabled, and which must be
+// deleted after use.
+func (e *EngineConfig) SetDeletePullTempDir(dir string) {
+	e.JSON.DeletePullTempDir = dir
 }
 
 // SetImageFuse sets whether the ImageDir is a FUSE mount.


### PR DESCRIPTION
When an action (run/exec/shell...) is performed against a remote image URI then it is implicitly pulled before execution.

If the cache is active, the image is pulled into the cache and executed using the image in the cache. If the cache is disabled then the image is pulled to a temporary location, and executed from there.

Prior to this PR, a temporary image pulled when the cache is disabled was not being cleaned-up on exit. This means that TMPDIR space is consumed, and not released, each time singularity is run against a remote image URI with --disable-cache.

This PR corrects the issue by:

1. Moving the implicit temporary image creation behaviour out of the client packages, into the CLI level.

2. Adding a new 'PullTempDir` value to launcher and engine configuration, which tracks the created temporary directory that must be cleaned-up on exit.

3. Adding code to the cleanup routines of the native runtime engine, and OCI launcher, to perform the actual deletion of the temp dir on container exit.

To test, run/shell/exec containers from remote (library, docker etc.) URIs with `--disable-cache`. During execution note that there is a `/tmp/singularity-action-pull-xxxx` directory containing the image, and that it is removed on container exit. The `--debug` output contains messages detailing this. e.g.:

```
$ singularity --debug run --disable-cache library://alpine
DEBUG   [U=1000,P=193493]  persistentPreRun()            Singularity version: 4.3.0+333-geb189737a
DEBUG   [U=1000,P=193493]  persistentPreRun()            Parsing configuration file /usr/local/etc/singularity/singularity.conf
DEBUG   [U=1000,P=193493]  maybeReExec()                 Checking whether to re-exec
DEBUG   [U=1000,P=193493]  handleConfDir()               /home/dtrudg-sylabs/.singularity already exists. Not creating.
DEBUG   [U=1000,P=193493]  handleRemoteConf()            Ensuring file permission of 0600 on /home/dtrudg-sylabs/.singularity/remote.yaml
DEBUG   [U=1000,P=193493]  uriToTempImage()              Cache disabled, pulling image to temporary file: /tmp/singularity-action-pull-4160879587/image
DEBUG   [U=1000,P=193493]  PullToFile()                  Cache disabled, pulling directly to: /tmp/singularity-action-pull-4160879587/image
...
Singularity> exit
...
INFO    [U=1000,P=193493]  CleanupContainer()            Cleaning up image temporary dir(s)...
VERBOSE [U=1000,P=193493]  CleanupContainer()            Removing /tmp/singularity-action-pull-4160879587
DEBUG   [U=1000,P=193493]  Master()                      Child exited with exit status 0
``` 

Fixes: #3940