### PR TITLE
fix: better error for non-oci spec with build --oci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   a new file, the container sees the update in `/etc/resolv.conf`.
 - Correctly escape ENV vars when importing OCI containers to native SIF, so that
   they match podman / docker behaviour.
+- Clarify error when trying to build --oci from a non-Dockerfile spec.
 
 ### New Features & Functionality
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -211,6 +211,10 @@ func runBuild(cmd *cobra.Command, args []string) {
 	}
 
 	if isOCI {
+		if !fs.IsFile(spec) {
+			sylog.Fatalf("When building with --oci the build source must be a Dockerfile.")
+		}
+
 		reqArch := ""
 		if cmd.Flags().Lookup("arch").Changed {
 			reqArch = buildArgs.arch

--- a/docs/content.go
+++ b/docs/content.go
@@ -49,9 +49,9 @@ Enterprise Performance Computing (EPC)`
 
   BUILD SPEC:
 
-  The build spec target is a definition (def) file, local image, or URI that can 
-  be used to create a Singularity container. Several different local target 
-  formats exist:
+  In native mode, the build spec target is a definition (def) file, local image,
+  or URI that can be used to create a Singularity container. Several different
+  local target formats exist:
 
       def file  : This is a recipe for building a container (examples below)
       directory:  A directory structure containing a (ch)root file system
@@ -63,7 +63,10 @@ Enterprise Performance Computing (EPC)`
       library://  an image library (default https://cloud.sylabs.io/library)
       docker://   a Docker/OCI registry (default Docker Hub)
       shub://     a Singularity registry (default Singularity Hub)
-      oras://     an OCI registry that holds SIF files using ORAS`
+      oras://     an OCI registry that holds SIF files using ORAS
+
+  When run with the --oci flag, the spec must be a valid Dockerfile, and output
+  is always an OCI-SIF image.`
 
 	BuildExample string = `
 
@@ -160,7 +163,10 @@ Enterprise Performance Computing (EPC)`
       Build a base sandbox from DockerHub, make changes to it, then build sif
           $ singularity build --sandbox /tmp/debian docker://debian:latest
           $ singularity exec --writable /tmp/debian apt-get install python
-          $ singularity build /tmp/debian2.sif /tmp/debian`
+          $ singularity build /tmp/debian2.sif /tmp/debian
+
+      Build an OCI-SIF image from a Dockerfile:
+          $ singularity build --oci /tmp/myimage.oci.sif /path/to/Dockerfile`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Cache


### PR DESCRIPTION
The second (spec) argument when building with --oci must be a Dockerfile. Do the simple check that it is a file early, and fail with a clear error message if not.

Clarify build help output.

Fixes #3484