### PR TITLE
singularity-buildkitd: sync loglevels, explicit GC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Clarify error when trying to build --oci from a non-Dockerfile spec.
 - When images are pulled implicitly by actions (run/shell/exec...), and the
   cache is disabled, correctly clean up the temporary files.
+- Ensure singularity-buildkitd runs effective GC at the start of each run.
+- Apply --debug flag to buildkit logging correctly.
 
 ### New Features & Functionality
 

--- a/cmd/singularity-buildkitd/main.go
+++ b/cmd/singularity-buildkitd/main.go
@@ -44,6 +44,8 @@ func main() {
 		RootDir: rootDir,
 	}
 
+	sylog.SyncLogrusLevel()
+
 	if err := bkdaemon.Run(context.Background(), daemonOpts, bkSocket); err != nil {
 		sylog.Fatalf("%s: %v", bkdaemon.DaemonName, err)
 	}

--- a/internal/pkg/build/buildkit/client/client.go
+++ b/internal/pkg/build/buildkit/client/client.go
@@ -197,6 +197,7 @@ func startBuildkitd(ctx context.Context, opts *Opts) (bkSocket string, cleanup f
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), sylog.GetEnvVar())
 
 	cleanup = func() {
 		if err := cmd.Cancel(); err != nil {
@@ -275,6 +276,8 @@ func isBuildkitdRunning(ctx context.Context, bkSocket, reqVersion string) (bool,
 }
 
 func buildImage(ctx context.Context, opts *Opts, tarFile *os.File, listenSocket, spec string, clientsideFrontend bool) error {
+	sylog.SyncLogrusLevel()
+
 	c, err := client.New(ctx, listenSocket)
 	if err != nil {
 		return err

--- a/pkg/sylog/sylog_common.go
+++ b/pkg/sylog/sylog_common.go
@@ -5,6 +5,10 @@
 
 package sylog
 
+import (
+	"github.com/sirupsen/logrus"
+)
+
 type messageLevel int
 
 // Log levels.
@@ -41,4 +45,19 @@ var messageLabels = map[messageLevel]string{
 	Verbose2Level: "VERBOSE",
 	Verbose3Level: "VERBOSE",
 	DebugLevel:    "DEBUG",
+}
+
+func SyncLogrusLevel() {
+	switch messageLevel(GetLevel()) {
+	case FatalLevel:
+		logrus.SetLevel(logrus.FatalLevel)
+	case ErrorLevel:
+		logrus.SetLevel(logrus.ErrorLevel)
+	case WarnLevel:
+		logrus.SetLevel(logrus.WarnLevel)
+	case LogLevel, InfoLevel, VerboseLevel, Verbose2Level, Verbose3Level:
+		logrus.SetLevel(logrus.InfoLevel)
+	case DebugLevel:
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 }


### PR DESCRIPTION
Synchronize the logrus level used in the buildkit client code, and singularity-buildkitd properly. This ensures that `--debug` will display all buildkit DEBUG level log messages.

Re-arrange some of the default config code so that it is a closer match to current upstream builtkitd source, for ease of comparison.

Drop the gateway handler and remotecache importer / exporter, which are unused.

Manually invoke worker garbage collection on startup, and disable automatic garbage collection. It is ineffective as we have very short-running workers here.

Fixes #3988