### PR TITLE
fix: Use ggcr file backed buffering for docker-daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
   cache is disabled, correctly clean up the temporary files.
 - Ensure singularity-buildkitd runs effective GC at the start of each run.
 - Apply --debug flag to buildkit logging correctly.
+- Avoid OOM by buffering `docker-daemon:` images via a temporary file instead of
+  memory. Note that the file is created in `$TMPDIR` - the dependency involved
+  cannot be instructed to use `$SINGULARITY_TMPDIR` at this time.
 
 ### New Features & Functionality
 

--- a/internal/pkg/ociimage/sourcesink.go
+++ b/internal/pkg/ociimage/sourcesink.go
@@ -146,6 +146,7 @@ func getDaemonImage(ctx context.Context, src string, tOpts *TransportOptions) (v
 
 	dOpts := []daemon.Option{
 		daemon.WithContext(ctx),
+		daemon.WithFileBufferedOpener(),
 	}
 
 	if tOpts != nil && tOpts.DockerDaemonHost != "" {
@@ -155,7 +156,6 @@ func getDaemonImage(ctx context.Context, src string, tOpts *TransportOptions) (v
 		}
 		dOpts = append(dOpts, daemon.WithClient(dc))
 	}
-
 	return daemon.Image(srcRef, dOpts...)
 }
 


### PR DESCRIPTION
Prior to this change, images retrieved from a docker-daemon URI were buffered in memory. This could lead to an OOM condition with large images.

This PR uses the new `WithFileBufferedOpener` functionality in the latest ggcr update. The image is now buffered via a temporary file.

Unfortunately ggcr does not allow an alternative temporary directory to be specified, so `$SINGULARITY_TMPDIR` cannot be honored at this time. `$TMPDIR` is used.

Fixes #3992 