### PR TITLE
e2e: fix: revise issue1528 test

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -1758,7 +1758,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			// Regressions
 			t.Run("issue 4524", c.issue4524)
 			t.Run("issue 1286", c.issue1286)
-			t.Run("issue 1528", c.issue1528)
 			t.Run("issue 1586", c.issue1586)
 			t.Run("issue 1670", c.issue1670)
 		},

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -244,65 +244,6 @@ func (c ctx) issue1286(t *testing.T) {
 	}
 }
 
-// https://github.com/sylabs/singularity/issues/1528
-// Check that host's TERM value gets passed to OCI container.
-func (c ctx) issue1528(t *testing.T) {
-	e2e.EnsureOCISIF(t, c.env)
-
-	imageRef := "oci-sif:" + c.env.OCISIFPath
-
-	_, wasHostTermSet := os.LookupEnv("TERM")
-	if !wasHostTermSet {
-		if err := os.Setenv("TERM", "xterm"); err != nil {
-			t.Errorf("could not set TERM environment variable on host")
-		}
-		defer os.Unsetenv("TERM")
-	}
-
-	singEnvTermPrevious, wasHostSingEnvTermSet := os.LookupEnv("SINGULARITYENV_TERM")
-	if wasHostSingEnvTermSet {
-		if err := os.Unsetenv("SINGULARITYENV_TERM"); err != nil {
-			t.Errorf("could not unset SINGULARITYENV_TERM environment variable on host")
-		}
-		defer os.Setenv("SINGULARITYENV_TERM", singEnvTermPrevious)
-	} else {
-		defer os.Unsetenv("SINGULARITYENV_TERM")
-	}
-
-	envTerm := os.Getenv("TERM")
-	wantTermString := fmt.Sprintf("TERM=%s\n", envTerm)
-	for _, profile := range e2e.OCIProfiles {
-		t.Run(profile.String(), func(t *testing.T) {
-			c.env.RunSingularity(
-				t,
-				e2e.AsSubtest("issue1528"),
-				e2e.WithProfile(profile),
-				e2e.WithCommand("exec"),
-				e2e.WithArgs(imageRef, "env"),
-				e2e.ExpectExit(0, e2e.ExpectOutput(e2e.ContainMatch, wantTermString)),
-			)
-		})
-	}
-
-	singEnvTerm := envTerm + "testsuffix"
-	if err := os.Setenv("SINGULARITYENV_TERM", singEnvTerm); err != nil {
-		t.Errorf("could not set SINGULARITYENV_TERM environment variable on host")
-	}
-	wantTermString = fmt.Sprintf("TERM=%s\n", singEnvTerm)
-	for _, profile := range e2e.OCIProfiles {
-		t.Run(profile.String(), func(t *testing.T) {
-			c.env.RunSingularity(
-				t,
-				e2e.AsSubtest("issue1528override"),
-				e2e.WithProfile(profile),
-				e2e.WithCommand("exec"),
-				e2e.WithArgs(imageRef, "env"),
-				e2e.ExpectExit(0, e2e.ExpectOutput(e2e.ContainMatch, wantTermString)),
-			)
-		})
-	}
-}
-
 // https://github.com/sylabs/singularity/issues/1586
 // In OCI mode, ensure that nothing is left in TMPDIR from a docker:// image with restrictive file permissions.
 func (c ctx) issue1586(t *testing.T) {

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -660,5 +660,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"oci environment file":           c.ociEnvFile,
 		"oci native env eval":            c.ociNativeEnvEval,
 		"oci nocompat host":              c.ociNoCompatHost,
+		"issue 1528":                     c.issue1528,
 	}
 }

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -148,3 +148,37 @@ func (c ctx) issue1263(t *testing.T) {
 		),
 	)
 }
+
+// https://github.com/sylabs/singularity/issues/1528
+// Check that host's TERM value gets passed to OCI container.
+func (c ctx) issue1528(t *testing.T) {
+	e2e.EnsureOCISIF(t, c.env)
+
+	imageRef := "oci-sif:" + c.env.OCISIFPath
+
+	for _, profile := range e2e.OCIProfiles {
+		t.Run(profile.String()+"/TERM", func(t *testing.T) {
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(profile),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs(imageRef, "sh", "-c", "echo $TERM"),
+				e2e.WithEnv(append(os.Environ(), "TERM=xterm")),
+				e2e.ExpectExit(0, e2e.ExpectOutput(e2e.ExactMatch, "xterm")),
+			)
+		})
+	}
+
+	for _, profile := range e2e.OCIProfiles {
+		t.Run(profile.String()+"/SINGULARITYENV_TERM", func(t *testing.T) {
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(profile),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs(imageRef, "sh", "-c", "echo $TERM"),
+				e2e.WithEnv(append(os.Environ(), "TERM=xterm", "SINGULARITYENV_TERM=xterm-override")),
+				e2e.ExpectExit(0, e2e.ExpectOutput(e2e.ExactMatch, "xterm-override")),
+			)
+		})
+	}
+}


### PR DESCRIPTION
Move the test from DOCKER to ENV section of the e2e tests as it doesn't use a docker:// source.

Rewrite the test to set env for the RunSingularity call, rather than manipulating global env via os.Setenv.

Fixes #4007