### PR TITLE
Configurable root / non-root search paths for external binaries (release-4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # SingularityCE Changelog
 
-## Unreleased Changes
+## Unreleased
+
+## Change Defaults / Behaviours
+
+Although SingularityCE does not aim to contain execution / prevent host
+modification when started as the host root user, the following changes have been
+adopted to permit finer control over the use of external binaries, with a
+modified default search path when `singularity` is run as the host root user:
+
+- When started as host root, external binaries (except those with explicit
+  configuration entries) are now found using the `root search path` in
+  `singularity.conf`. By default this excludes searching the environment
+  `$PATH`. Add `$PATH:` to the start of `root search path` in `singularity.conf`
+  to restore previous behavior.
+- When started as non-root / fake root, external binaries (except those with
+  explicit configuration entires) are now found using the `user search path` in
+  `singularity.conf`. By default this includes `$PATH`, so there is no effective
+  behaviour change vs previous versions.
+
+Thank you to @KoseceMehmet for suggesting this change.
 
 ## 4.4.1 \[2026-03-23\]
 

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -795,6 +795,23 @@ func (c configTests) configGlobal(t *testing.T) {
 			directiveValue: "no",
 			exit:           0,
 			resultOp:       e2e.ExpectError(e2e.UnwantedContainMatch, "Running a non-OCI SIF in OCI mode."),
+		},
+		// Setting search paths to nonsense should result in failure to find external binaries (runc/crun here).
+		{
+			name:           "UserSearchPathFail",
+			argv:           []string{c.env.ImagePath, "which", "true"},
+			profile:        e2e.OCIUserProfile,
+			directive:      "user search path",
+			directiveValue: "/nonsense",
+			exit:           255,
+		},
+		{
+			name:           "RootSearchPathFail",
+			argv:           []string{c.env.ImagePath, "which", "true"},
+			profile:        e2e.OCIRootProfile,
+			directive:      "root search path",
+			directiveValue: "/nonsense",
+			exit:           255,
 		},
 	}
 

--- a/internal/pkg/util/bin/bin_singularity.go
+++ b/internal/pkg/util/bin/bin_singularity.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,24 +12,44 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
-	"github.com/sylabs/singularity/v4/internal/pkg/util/env"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/user"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
 )
 
-// findOnPath performs a simple search on PATH for the named executable, returning its full path.
-// env.DefaultPath` is appended to PATH to ensure standard locations are searched. This
-// is necessary as some distributions don't include sbin on user PATH etc.
+// findOnPath performs a search for the given executable name within the search path
+// values specified for host root / non-root in singularity.conf.
 func findOnPath(name string) (path string, err error) {
+	cfg := singularityconf.GetCurrentConfig()
+	if cfg == nil {
+		cfg, err = singularityconf.Parse(buildcfg.SINGULARITY_CONF_FILE)
+		if err != nil {
+			return "", fmt.Errorf("unable to parse singularity configuration file: %w", err)
+		}
+	}
+
+	// Search paths for host root and non-root / fake root differ.
+	u, err := user.CurrentOriginal()
+	if err != nil {
+		return "", fmt.Errorf("while retrieving current user information: %w", err)
+	}
+	searchPath := cfg.UserSearchPath
+	if u.UID == 0 {
+		searchPath = cfg.RootSearchPath
+	}
+
+	// Handle $PATH if present in path config.
+	searchPath = parsePath(searchPath)
+
 	oldPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", oldPath)
-	os.Setenv("PATH", oldPath+":"+env.DefaultPath)
-
+	os.Setenv("PATH", searchPath)
 	path, err = exec.LookPath(name)
 	if err == nil {
-		sylog.Debugf("Found %q at %q", name, path)
+		sylog.Debugf("Found %q at %q, searching %q", name, path, searchPath)
 	}
 	return path, err
 }
@@ -118,4 +138,23 @@ func findSquashfuse(name string) (path string, err error) {
 func FindSingularityBuildkitd() (path string, err error) {
 	bkd := filepath.Join(buildcfg.LIBEXECDIR, "singularity", "bin", "singularity-buildkitd")
 	return exec.LookPath(bkd)
+}
+
+// parsePath parses a path string, replacing $PATH with PATH from the environment
+func parsePath(p string) string {
+	if strings.Contains(p, "$PATH") {
+		envPath := os.Getenv("PATH")
+		p = strings.Replace(p, "$PATH", envPath, 1)
+	}
+
+	// Drop any empty PATH elements, which would be treated as CWD. os.LookPath
+	// will return ErrDot on these, but let's avoid CWD lookup entirely.
+	parts := filepath.SplitList(p)
+	validParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			validParts = append(validParts, part)
+		}
+	}
+	return strings.Join(validParts, string(os.PathListSeparator))
 }

--- a/internal/pkg/util/bin/bin_singularity_test.go
+++ b/internal/pkg/util/bin/bin_singularity_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build singularity_engine
+
+package bin
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parsePath(t *testing.T) {
+	tests := []struct {
+		name string
+		p    string
+		want string
+	}{
+		{
+			name: "empty path",
+			p:    "",
+		},
+		{
+			name: "simple path",
+			p:    "/usr/bin:/bin",
+			want: "/usr/bin:/bin",
+		},
+		{
+			name: "$PATH first",
+			p:    "$PATH:/an/other/dir",
+			want: os.Getenv("PATH") + ":/an/other/dir",
+		},
+		{
+			name: "$PATH last",
+			p:    "/an/other/dir:$PATH",
+			want: "/an/other/dir:" + os.Getenv("PATH"),
+		},
+		{
+			name: "trim empty entries",
+			p:    ":$PATH:/usr/bin::/bin:::/usr/local/bin:",
+			want: os.Getenv("PATH") + ":/usr/bin:/bin:/usr/local/bin",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsePath(tt.p)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/pkg/util/bin/bin_test.go
+++ b/internal/pkg/util/bin/bin_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -20,9 +20,8 @@ import (
 )
 
 func TestFindOnPath(t *testing.T) {
-	// findOnPath should give same as exec.LookPath, but additionally work
-	// in the case where $PATH doesn't include default sensible directories
-	// as these are added to $PATH before the lookup.
+	// Ensure that, by default, TestFindOnPath can always find cp ... i.e it is
+	// looking in a sensible search path even when $PATH is not sensible.
 
 	// Find the true path of 'cp' under a sensible PATH=env.DefaultPath
 	// Forcing this avoid issues with PATH across sudo calls for the tests,

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -82,6 +82,8 @@ type File struct {
 	SIFFUSE                 bool     `default:"no" authorized:"yes,no" directive:"sif fuse"`
 	OCIMode                 bool     `default:"no" authorized:"yes,no" directive:"oci mode"`
 	TmpSandboxAllowed       bool     `default:"yes" authorized:"yes,no" directive:"tmp sandbox"`
+	RootSearchPath          string   `default:"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" directive:"root search path"`
+	UserSearchPath          string   `default:"$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" directive:"user search path"`
 }
 
 const TemplateAsset = `# SINGULARITY.CONF
@@ -456,6 +458,24 @@ root default capabilities = {{ .RootDefaultCapabilities }}
 # use tmpfs, so on affected version it's recommended to set this value to ramfs to avoid
 # kernel panic
 memory fs type = {{ .MemoryFSType }}
+
+# ROOT SEARCH PATH: [STRING]
+# DEFAULT: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# When run as host root (not as a fake root user in a user namespace),
+# singularity will search for external executables in this list of paths.
+# The string "$PATH" will be replaced with the PATH environment variable of
+# the calling user. Note that executables with explicit path settings below
+# will always be found using those settings.
+root search path = {{ .RootSearchPath }}
+
+# USER SEARCH PATH: [STRING]
+# DEFAULT: $PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# When run as a non-root user (including as a fake root user in a user
+# namespace), singularity will search for external executables in this list of
+# paths. The string "$PATH" will be replaced with the PATH environment variable
+# of the calling user. Note that executables with explicit path settings below
+# will always be found using those settings.
+user search path = {{ .UserSearchPath }}
 
 # CNI CONFIGURATION PATH: [STRING]
 # DEFAULT: Undefined


### PR DESCRIPTION
Pick #4095 to release-4.4

Prior to this PR, except for executables that have their own explicit path entry in singularity.conf, we search the value of $PATH in the environment, plus sensible default directories.

Although singularity is not intended to contain / prevent host modification when run as host-root, there is a valid defence-in-depth argument for performing / allowing search path sanitization.

Add `user search path` and `root search path` to `singularity.conf`, which control where bin.FindOnPath looks for things.

When started as host root, external binaries (except those with explicit configuration entries) are now found using the `root search path` in `singularity.conf`. By default this excludes searching the environment `$PATH`. Add `$PATH:` to the start of `root search path` in `singularity.conf` to restore previous behavior.

When started as non-root / fake root, external binaries (except those with explicit configuration entires) are now found using the `user search path` in `singularity.conf`. By default this includes `$PATH`, so there is no effective behaviour change vs previous versions.

Thank you to @KoseceMehmet for suggesting this change.