### PR TITLE
e2e: fix: use updated miniforge docker image

### DIFF
--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -141,10 +141,10 @@ func (c ctx) issue274(t *testing.T) {
 	defer cleanup(t)
 	imagePath := filepath.Join(imageDir, "container")
 
-	// Create a minimal conda environment on the current miniconda3 base.
+	// Create a minimal conda environment on the current anaconda/miniconda base.
 	// Source the conda profile.d code and activate the env from `%environment`.
 	def := `Bootstrap: docker
-From: continuumio/miniconda3:latest
+From: condaforge/miniforge3:latest
 
 %post
 

--- a/test/defs/Dockerfile.scif.tmpl
+++ b/test/defs/Dockerfile.scif.tmpl
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3
+FROM condaforge/miniforge3:latest
 
 RUN pip install scif
 
@@ -6,4 +6,5 @@ ADD ./{{ .SCIFRecipeFilename }} /
 
 RUN scif install /{{ .SCIFRecipeFilename }}
 
+ENTRYPOINT []
 CMD ["scif"]


### PR DESCRIPTION
The anaconda miniconda image has moved, and the new location has more restrictive TOS.
    
The images at the previous location have deprecation messages that cause e2e tests to fail.

Switch to miniforge3 images which avoid these issues.