### PR TITLE
Pick limit container paths fix and prepare 4.4.2 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.26.1'
+    default: '1.26.4'
 
 executors:
   node:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # SingularityCE Changelog
 
-## Unreleased
+## 4.4.2 \[2026-06-04\]
 
 ### Security Related Fixes
 
@@ -8,7 +8,7 @@
   GHSA-wqcr-7rf3-f64m](https://github.com/sylabs/singularity/security/advisories/GHSA-wqcr-7rf3-f64m)
   Incorrect path matching for 'limit container paths' directive
 
-## Change Defaults / Behaviours
+### Changed Defaults / Behaviours
 
 Although SingularityCE does not aim to contain execution / prevent host
 modification when started as the host root user, the following changes have been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Security Related Fixes
+
+- Fix for [CVE-2026-47215 /
+  GHSA-wqcr-7rf3-f64m](https://github.com/sylabs/singularity/security/advisories/GHSA-wqcr-7rf3-f64m)
+  Incorrect path matching for 'limit container paths' directive
+
 ## Change Defaults / Behaviours
 
 Although SingularityCE does not aim to contain execution / prevent host

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -163,7 +163,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.26.1 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.26.4 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz

--- a/e2e/testdata/Dockerfile.nested
+++ b/e2e/testdata/Dockerfile.nested
@@ -1,6 +1,6 @@
 FROM ubuntu:25.04
 
-ARG GOVERSION="go1.26.0"
+ARG GOVERSION="go1.26.4"
 ARG GOOS="linux"
 ARG GOARCH="amd64"
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/ccoveille/go-safecast/v2"
@@ -143,26 +142,31 @@ type Image struct {
 	Usage      Usage     `json:"usage"`
 }
 
-// AuthorizedPath checks if image is in a path supplied in paths
+// AuthorizedPath checks if the image is in a directory tree rooted at any of
+// the supplied paths. Paths must be absolute. Symlinks are resolved.
 func (i *Image) AuthorizedPath(paths []string) (bool, error) {
 	if err := i.initFile(); err != nil {
 		return false, err
 	}
 
-	authorized := false
-	dirname := i.Path
-
 	for _, path := range paths {
-		match, err := filepath.EvalSymlinks(filepath.Clean(path))
+		abs, err := filepath.Abs(filepath.Clean(path))
 		if err != nil {
-			return authorized, fmt.Errorf("failed to resolve path %s: %s", path, err)
+			return false, fmt.Errorf("failed to resolve path %s: %w", path, err)
 		}
-		if strings.HasPrefix(dirname, match) {
-			authorized = true
-			break
+		match, err := filepath.EvalSymlinks(abs)
+		if err != nil {
+			return false, fmt.Errorf("failed to resolve path %s: %w", path, err)
+		}
+		rel, err := filepath.Rel(match, i.Path)
+		if err != nil {
+			return false, fmt.Errorf("failed to compare path %s against %s: %w", i.Path, match, err)
+		}
+		if rel == "." || filepath.IsLocal(rel) {
+			return true, nil
 		}
 	}
-	return authorized, nil
+	return false, nil
 }
 
 // AuthorizedOwner checks whether the image is owned by any user from the supplied users list.

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -174,6 +174,34 @@ func TestAuthorizedPath(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	// Test image is in xxx/foobar/test.sif
+	testDir := t.TempDir()
+	imageDir := filepath.Join(testDir, "foobar")
+	if err := os.Mkdir(imageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Test image is not in xxx/foo ... which is a string prefix of xxx/foobar
+	stringPrefixPath := filepath.Join(testDir, "foo")
+	if err := os.Mkdir(stringPrefixPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Symlink xxx/link -> xxx/foobar, so the limit path resolves into the
+	// image directory via the symlink.
+	symlinkToImageDir := filepath.Join(testDir, "link")
+	if err := os.Symlink(imageDir, symlinkToImageDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// XXX(mem): This is what makes this test slow
+	path := filepath.Join(imageDir, "test.sif")
+	if err := fs.CopyFileAtomic(busyboxSIF, path, 0o755); err != nil {
+		t.Fatalf("Could not copy test image: %v", err)
+	}
+	img, err := Init(path, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		name       string
 		path       []string
@@ -194,11 +222,34 @@ func TestAuthorizedPath(t *testing.T) {
 			path:       []string{"/"},
 			shouldPass: true,
 		},
+		{
+			name:       "parent path",
+			path:       []string{imageDir},
+			shouldPass: true,
+		},
+		{
+			name:       "parent path trailing slash",
+			path:       []string{imageDir + string(os.PathSeparator)},
+			shouldPass: true,
+		},
+		{
+			name:       "image file as limit path",
+			path:       []string{path},
+			shouldPass: true,
+		},
+		{
+			name:       "symlink to image dir",
+			path:       []string{symlinkToImageDir},
+			shouldPass: true,
+		},
+		// See GHSA-wqcr-7rf3-f64m
+		// Image in xxx/foobar must not be authorized for xxx/foo.
+		{
+			name:       "string prefix",
+			path:       []string{stringPrefixPath},
+			shouldPass: false,
+		},
 	}
-
-	// XXX(mem): This is what makes this test slow
-	img, path := createImage(t)
-	defer os.Remove(path)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**fix: limit container paths using path prefix, not string prefix**

The Image.AuthorizedPath function, which is passed the values of the 'limit container paths' singularity.conf directive, previously used plain string prefix matching. This meant an image in a sibling directory, e.g. `/tmp/foobar` would be allowed when the directive was set to `/tmp/foo`.

Because of explicit and implicit filepath.Clean it's also not possible to match on `/tmp/foo/` as the final slash will be stripped by the Clean.

Modify the code to evaluate the relative path of the image from each limit path, and assess based on this.

**chore: prepare 4.4.2 release**