### PR TITLE
util/fs: O_NOFOLLOW for EnsureFileWithPermission

### DIFF
--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -40,7 +40,7 @@ func Abs(path string) (string, error) {
 // the specified permission, or 2. ensures a file is the specified
 // permission.
 func EnsureFileWithPermission(fn string, mode os.FileMode) error {
-	fs, err := os.OpenFile(fn, os.O_CREATE, mode)
+	fs, err := os.OpenFile(fn, os.O_CREATE|unix.O_NOFOLLOW, mode)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -128,6 +128,16 @@ func TestEnsureFileWithPermission(t *testing.T) {
 	// Finally, check the file permission.
 	if currentMode := einfo.Mode(); currentMode != 0o544 {
 		t.Errorf("Unexpected file permission: expecting 544, got %o", currentMode)
+	}
+
+	// Don't allow symlink as last path part.
+	symlink := filepath.Join(tmpDir, "symlink")
+	if err := os.Symlink(existFile, symlink); err != nil {
+		t.Fatalf("Unable to create symlink: %s", err)
+	}
+	err = EnsureFileWithPermission(symlink, 0o755)
+	if err == nil {
+		t.Errorf("Didn't fail to ensure file permission through final symlink")
 	}
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

The fs.EnsureFileWithPermission function is used to ensure that some files with sensitive content (gpg keyring, remote config) are present with restrictive perms enforced.

Adding O_NOFOLLOW ensures the chmod can't be redirected through a symlink in the final path element. This isn't a big risk, as we are only applying restrictive 0o600 perms via EnsureFilePermission, but is worth adding, and is something cursory LLM analysis will pick up.