### PR TITLE
rpc: root the RPC server Mkdir and Mount operations

### DIFF
--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -569,14 +569,14 @@ mount:
 			if mnt.Type == "devpts" {
 				sylog.Verbosef("Couldn't mount devpts filesystem, continuing with PTY allocation functionality disabled")
 				return nil
-			} else if mnt.Type == "overlay" && err == syscall.ESTALE {
+			} else if mnt.Type == "overlay" && errors.Is(err, syscall.ESTALE) {
 				// overlay mount can return this error when a previous mount was
 				// done with an upper layer and overlay inodes index is enabled
 				// by default, see https://github.com/sylabs/singularity/issues/4539
 				sylog.Verbosef("Overlay mount failed with %s, mounting with index=off", err)
 				optsString = fmt.Sprintf("%s,index=off", optsString)
 				goto mount
-			} else if mnt.Type == "overlay" && err == syscall.EINVAL {
+			} else if mnt.Type == "overlay" && errors.Is(err, syscall.EINVAL) {
 				sylog.Verbosef("Overlay mount failed with %s, mounting without xino option", err)
 				optsString = strings.ReplaceAll(optsString, ",xino=on", "")
 				goto mount
@@ -585,7 +585,7 @@ mount:
 			return fmt.Errorf("can't mount %s filesystem to %s: %s", mnt.Type, mnt.Destination, err)
 		}
 		if remount {
-			if os.IsPermission(err) && c.userNS {
+			if errors.Is(err, syscall.EPERM) && c.userNS {
 				// when using user namespace we always try to apply mount flags with
 				// remount, then if we get a permission denied error, we continue
 				// execution by ignoring the error and warn user if the bind mount
@@ -685,8 +685,8 @@ func (c *container) mountImage(mnt *mount.Point) error {
 	}
 
 	err = c.rpcOps.Mount(c.session.Path(), path, mnt.Destination, mountType, flags, optsString)
-	switch err {
-	case syscall.EINVAL:
+	switch {
+	case errors.Is(err, syscall.EINVAL):
 		if mountType == "squashfs" {
 			return fmt.Errorf(
 				"kernel reported a bad superblock for %s image partition, "+
@@ -695,7 +695,7 @@ func (c *container) mountImage(mnt *mount.Point) error {
 				mountType)
 		}
 		return fmt.Errorf("%s image partition contains a bad superblock (corrupted image ?)", mountType)
-	case syscall.ENODEV:
+	case errors.Is(err, syscall.ENODEV):
 		return fmt.Errorf("%s filesystem seems not enabled and/or supported by your kernel", mountType)
 	default:
 		if err != nil {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -288,7 +288,7 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 		// This *requires* that the container rootfs is a private mount, as it is a bind source.
 		// By default, the rootfs will be mounted shared due to requirements of the FUSE mount
 		// handling, so make it private here just before calling nvidia-container-cli.
-		if err := c.rpcOps.Mount("", c.session.FinalPath(), "", syscall.MS_PRIVATE, ""); err != nil {
+		if err := c.rpcOps.Mount(c.session.Path(), "", c.session.FinalPath(), "", syscall.MS_PRIVATE, ""); err != nil {
 			return err
 		}
 
@@ -443,7 +443,7 @@ func (c *container) setPropagationMount(*mount.System) error {
 		pflags |= syscall.MS_PRIVATE
 	}
 
-	return c.rpcOps.Mount("", "/", "", pflags, "")
+	return c.rpcOps.Mount("/", "", "/", "", pflags, "")
 }
 
 // addMountinfo handles the case where hidepid is set on /proc mount
@@ -461,7 +461,7 @@ func (c *container) addMountInfo(*mount.System) error {
 		return fmt.Errorf("while creating %s: %s", c.mountInfoPath, err)
 	}
 
-	if err := c.rpcOps.Mount(self, c.mountInfoPath, "", syscall.MS_BIND, ""); err != nil {
+	if err := c.rpcOps.Mount(c.session.Path(), self, c.mountInfoPath, "", syscall.MS_BIND, ""); err != nil {
 		return fmt.Errorf("while mounting %s to %s: %s", c.mountInfoPath, self, err)
 	}
 
@@ -540,8 +540,8 @@ func (c *container) mountGeneric(mnt *mount.Point, tag mount.AuthorizedTag) (err
 	}
 
 mount:
-	err = c.rpcOps.Mount(source, dest, mnt.Type, flags, optsString)
-	if os.IsNotExist(err) {
+	err = c.rpcOps.Mount(c.session.Path(), source, dest, mnt.Type, flags, optsString)
+	if errors.Is(err, os.ErrNotExist) {
 		switch tag {
 		case mount.KernelTag,
 			mount.HostfsTag,
@@ -684,7 +684,7 @@ func (c *container) mountImage(mnt *mount.Point) error {
 		mountType = "squashfs"
 	}
 
-	err = c.rpcOps.Mount(path, mnt.Destination, mountType, flags, optsString)
+	err = c.rpcOps.Mount(c.session.Path(), path, mnt.Destination, mountType, flags, optsString)
 	switch err {
 	case syscall.EINVAL:
 		if mountType == "squashfs" {
@@ -784,7 +784,7 @@ func (c *container) overlayUpperWork(*mount.System) error {
 	createUpperWork := func(path, label string) error {
 		fi, err := c.rpcOps.Lstat(path)
 		if os.IsNotExist(err) {
-			if err := c.rpcOps.Mkdir(path, 0o755); err != nil {
+			if err := c.rpcOps.Mkdir(c.session.Path(), path, 0o755); err != nil {
 				return fmt.Errorf("failed to create %s directory: %s", path, err)
 			}
 		} else if err == nil && !fi.IsDir() {

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -16,6 +16,7 @@ import (
 
 // MountArgs defines the arguments to mount.
 type MountArgs struct {
+	Root       string
 	Source     string
 	Target     string
 	Filesystem string
@@ -33,6 +34,7 @@ type DecryptArgs struct {
 
 // MkdirArgs defines the arguments to mkdir.
 type MkdirArgs struct {
+	Root string
 	Path string
 	Perm os.FileMode
 }

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -7,6 +7,7 @@ package rpc
 
 import (
 	"encoding/gob"
+	"errors"
 	"os"
 	"syscall"
 	"time"
@@ -22,6 +23,63 @@ type MountArgs struct {
 	Filesystem string
 	Mountflags uintptr
 	Data       string
+}
+
+// MountErrorReply wraps mount syscall errors, and preserves os.Root
+// NotExist/Permission errors which are os.PathError that cannot be sent
+// directly over RPC.
+type MountErrorReply struct {
+	Message      string
+	Errno        syscall.Errno
+	IsNotExist   bool
+	IsPermission bool
+}
+
+// NewMountErrorReply converts err to a gob-safe representation.
+func NewMountErrorReply(err error) *MountErrorReply {
+	if err == nil {
+		return nil
+	}
+
+	reply := &MountErrorReply{
+		Message:      err.Error(),
+		IsNotExist:   errors.Is(err, os.ErrNotExist),
+		IsPermission: errors.Is(err, os.ErrPermission),
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		reply.Errno = errno
+	}
+
+	return reply
+}
+
+func (e *MountErrorReply) Error() string {
+	if e == nil || e.Message == "" {
+		return ""
+	}
+	return e.Message
+}
+
+func (e *MountErrorReply) Is(target error) bool {
+	if e == nil {
+		return target == nil
+	}
+	if e.IsNotExist && target == os.ErrNotExist {
+		return true
+	}
+	if e.IsPermission && target == os.ErrPermission {
+		return true
+	}
+	return e.Errno != 0 && errors.Is(e.Errno, target)
+}
+
+// Err reconstructs an error from the gob-safe representation.
+func (e *MountErrorReply) Err() error {
+	if e == nil || e.Message == "" {
+		return nil
+	}
+	return e
 }
 
 // DecryptArgs defines the arguments to decrypt.

--- a/internal/pkg/runtime/engine/singularity/rpc/args_test.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package rpc
+
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestMountErrorReplyGob(t *testing.T) {
+	err := errors.New("path escapes from parent")
+	reply := NewMountErrorReply(err)
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(reply); err != nil {
+		t.Fatalf("failed to gob encode reply: %s", err)
+	}
+
+	var decoded MountErrorReply
+	if err := gob.NewDecoder(&buf).Decode(&decoded); err != nil {
+		t.Fatalf("failed to gob decode reply: %s", err)
+	}
+	if got := decoded.Error(); got != err.Error() {
+		t.Fatalf("got %q, want %q", got, err.Error())
+	}
+}
+
+func TestMountErrorReplyNil(t *testing.T) {
+	var reply MountErrorReply
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(reply); err != nil {
+		t.Fatalf("failed to gob encode reply: %s", err)
+	}
+
+	var decoded MountErrorReply
+	if err := gob.NewDecoder(&buf).Decode(&decoded); err != nil {
+		t.Fatalf("failed to gob decode reply: %s", err)
+	}
+	if err := decoded.Err(); err != nil {
+		t.Fatalf("got non-nil error from nil reply: %q", err)
+	}
+}
+
+func TestErrorReplyIs(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		target error
+		want   bool
+	}{
+		{
+			name:   "ErrnoMismatch",
+			err:    syscall.EPERM,
+			target: syscall.ENOENT,
+			want:   false,
+		},
+		{
+			name:   "NotExist",
+			err:    &os.PathError{Op: "open", Path: "/x", Err: os.ErrNotExist},
+			target: os.ErrNotExist,
+			want:   true,
+		},
+		{
+			name:   "Permission",
+			err:    &os.PathError{Op: "open", Path: "/x", Err: os.ErrPermission},
+			target: os.ErrPermission,
+			want:   true,
+		},
+		// Explicitly test syscall mount errors we match against in the engine.
+		{
+			name:   "EPERM",
+			err:    syscall.EPERM,
+			target: syscall.EPERM,
+			want:   true,
+		},
+		{
+			name:   "ESTALE",
+			err:    syscall.ESTALE,
+			target: syscall.ESTALE,
+			want:   true,
+		},
+		{
+			name:   "EINVAL",
+			err:    syscall.EINVAL,
+			target: syscall.EINVAL,
+			want:   true,
+		},
+		{
+			name:   "ENODEV",
+			err:    syscall.ENODEV,
+			target: syscall.ENODEV,
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := gob.NewEncoder(&buf).Encode(NewMountErrorReply(tt.err)); err != nil {
+				t.Fatalf("failed to gob encode reply: %s", err)
+			}
+			var decoded MountErrorReply
+			if err := gob.NewDecoder(&buf).Decode(&decoded); err != nil {
+				t.Fatalf("failed to gob decode reply: %s", err)
+			}
+			if got := errors.Is(decoded.Err(), tt.target); got != tt.want {
+				t.Fatalf("errors.Is(%q, %v) = %v, want %v", tt.err, tt.target, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -32,12 +32,12 @@ func (t *RPC) Mount(root, source, target string, filesystem string, flags uintpt
 		Data:       data,
 	}
 
-	var mountErr error
+	var reply args.MountErrorReply
 
-	err := t.Client.Call(t.Name+".Mount", arguments, &mountErr)
+	err := t.Client.Call(t.Name+".Mount", arguments, &reply)
 	// RPC communication will take precedence over mount error
 	if err == nil {
-		err = mountErr
+		err = reply.Err()
 	}
 
 	return err

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -19,9 +19,12 @@ type RPC struct {
 	Name   string
 }
 
-// Mount calls the mount RPC using the supplied arguments.
-func (t *RPC) Mount(source string, target string, filesystem string, flags uintptr, data string) error {
+// Mount calls the mount RPC using the supplied arguments. Note that the mount
+// target must be inside the root. Mount ensures the target does not escape root
+// via symlink.
+func (t *RPC) Mount(root, source, target string, filesystem string, flags uintptr, data string) error {
 	arguments := &args.MountArgs{
+		Root:       root,
 		Source:     source,
 		Target:     target,
 		Filesystem: filesystem,
@@ -55,9 +58,12 @@ func (t *RPC) Decrypt(offset uint64, path string, key []byte, masterPid int) (st
 	return reply, err
 }
 
-// Mkdir calls the mkdir RPC using the supplied arguments.
-func (t *RPC) Mkdir(path string, perm os.FileMode) error {
+// Mkdir calls the mkdir RPC using the supplied arguments. Note that the path
+// argument must be inside the root. Mkdir ensures that the operation does not
+// escape root via symlink.
+func (t *RPC) Mkdir(root, path string, perm os.FileMode) error {
 	arguments := &args.MkdirArgs{
+		Root: root,
 		Path: path,
 		Perm: perm,
 	}

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -65,9 +65,32 @@ func (t *Methods) Mount(arguments *args.MountArgs, mountErr *error) (err error) 
 				_, err = capabilities.SetProcessEffective(oldEffective)
 			}()
 		}
-		*mountErr = syscall.Mount(arguments.Source, arguments.Target, arguments.Filesystem, arguments.Mountflags, arguments.Data)
+
+		var root *os.Root
+		root, *mountErr = os.OpenRoot(arguments.Root)
+		if *mountErr != nil {
+			return
+		}
+
+		relTarget := ""
+		if arguments.Target == arguments.Root {
+			relTarget = "."
+		} else {
+			relTarget = strings.TrimPrefix(arguments.Target, arguments.Root)
+			relTarget = strings.TrimPrefix(relTarget, "/")
+		}
+
+		var targetFp *os.File
+		targetFp, *mountErr = root.OpenFile(relTarget, unix.O_PATH, 0)
+		if *mountErr != nil {
+			return
+		}
+		defer targetFp.Close()
+
+		targetFd := fmt.Sprintf("/proc/self/fd/%d", targetFp.Fd())
+		*mountErr = syscall.Mount(arguments.Source, targetFd, arguments.Filesystem, arguments.Mountflags, arguments.Data)
 	})
-	return
+	return err
 }
 
 // Decrypt decrypts the loop device.
@@ -140,8 +163,23 @@ func (t *Methods) Decrypt(arguments *args.DecryptArgs, reply *string) (err error
 func (t *Methods) Mkdir(arguments *args.MkdirArgs, _ *int) (err error) {
 	mainthread.Execute(func() {
 		oldmask := syscall.Umask(0)
-		err = os.Mkdir(arguments.Path, arguments.Perm)
-		syscall.Umask(oldmask)
+		defer syscall.Umask(oldmask)
+
+		var root *os.Root
+		root, err = os.OpenRoot(arguments.Root)
+		if err != nil {
+			err = fmt.Errorf("while getting root path: %s", err)
+			return
+		}
+
+		relPath, ok := strings.CutPrefix(arguments.Path, arguments.Root)
+		if !ok {
+			err = fmt.Errorf("path %s is not inside root %s", arguments.Path, arguments.Root)
+			return
+		}
+		relPath = strings.TrimPrefix(relPath, "/")
+
+		err = root.Mkdir(relPath, arguments.Perm)
 	})
 	return err
 }

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -42,7 +42,8 @@ func init() {
 type Methods int
 
 // Mount performs a mount with the specified arguments.
-func (t *Methods) Mount(arguments *args.MountArgs, mountErr *error) (err error) {
+func (t *Methods) Mount(arguments *args.MountArgs, reply *args.MountErrorReply) (err error) {
+	var mountErr error
 	mainthread.Execute(func() {
 		if arguments.Filesystem == "overlay" {
 			var oldEffective uint64
@@ -67,10 +68,11 @@ func (t *Methods) Mount(arguments *args.MountArgs, mountErr *error) (err error) 
 		}
 
 		var root *os.Root
-		root, *mountErr = os.OpenRoot(arguments.Root)
-		if *mountErr != nil {
+		root, mountErr = os.OpenRoot(arguments.Root)
+		if mountErr != nil {
 			return
 		}
+		defer root.Close()
 
 		relTarget := ""
 		if arguments.Target == arguments.Root {
@@ -81,15 +83,18 @@ func (t *Methods) Mount(arguments *args.MountArgs, mountErr *error) (err error) 
 		}
 
 		var targetFp *os.File
-		targetFp, *mountErr = root.OpenFile(relTarget, unix.O_PATH, 0)
-		if *mountErr != nil {
+		targetFp, mountErr = root.OpenFile(relTarget, unix.O_PATH, 0)
+		if mountErr != nil {
 			return
 		}
 		defer targetFp.Close()
 
 		targetFd := fmt.Sprintf("/proc/self/fd/%d", targetFp.Fd())
-		*mountErr = syscall.Mount(arguments.Source, targetFd, arguments.Filesystem, arguments.Mountflags, arguments.Data)
+		mountErr = syscall.Mount(arguments.Source, targetFd, arguments.Filesystem, arguments.Mountflags, arguments.Data)
 	})
+	if mountErr != nil {
+		*reply = *args.NewMountErrorReply(mountErr)
+	}
 	return err
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Ensure that the RPC Mkdir operation doesn't create a directory outside of a root, which can be set to the session directory.

Ensure that the RPC Mount operation doesn't mount to a target that's outside of a root, which can be set to the session directory.

Note that there is a special case for remount of  `/` in setPropagationMount where the root is not the session directory.

The RPC Mount operation can now fail with an error from os.Root. These are *PathError, which can be non-exported *errors.errorString under the hood. The RPC gob encoding doesn't handle this, so use a wrapper so that the encoding doesn't fail in this case.
    
Since we make decisions on syscall.Exxx errors, make sure our wrapping satisfies .Is comparisons on these, plus ErrNotExist/ErrPermission