### PR TITLE
chore: tidy up layout.Manager code

### DIFF
--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -7,12 +7,10 @@ package layout
 
 import (
 	"fmt"
-	iofs "io/fs"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
-	"syscall"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
@@ -44,80 +42,9 @@ type symlink struct {
 	target  string
 }
 
-type VFS interface {
-	Chown(string, int, int) error
-	EvalRelative(string, string) string
-	Lchown(string, int, int) error
-	Mkdir(string, os.FileMode) error
-	Readlink(string) (string, error)
-	ReadDir(string) ([]iofs.DirEntry, error)
-	Stat(string) (os.FileInfo, error)
-	Symlink(string, string) error
-	Umask(int) int
-	WriteFile(string, []byte, os.FileMode) error
-}
-
-type defaultVFS struct{}
-
-func (v *defaultVFS) Chown(name string, uid, gid int) error {
-	return os.Chown(name, uid, gid)
-}
-
-func (v *defaultVFS) EvalRelative(path, root string) string {
-	return fs.EvalRelative(path, root)
-}
-
-func (v *defaultVFS) Lchown(name string, uid, gid int) error {
-	return os.Lchown(name, uid, gid)
-}
-
-func (v *defaultVFS) Mkdir(name string, perm os.FileMode) error {
-	return os.Mkdir(name, perm)
-}
-
-func (v *defaultVFS) Readlink(name string) (string, error) {
-	return os.Readlink(name)
-}
-
-func (v *defaultVFS) ReadDir(dir string) ([]iofs.DirEntry, error) {
-	return os.ReadDir(dir)
-}
-
-func (v *defaultVFS) Stat(name string) (os.FileInfo, error) {
-	return os.Stat(name)
-}
-
-func (v *defaultVFS) Symlink(oldname, newname string) error {
-	return os.Symlink(oldname, newname)
-}
-
-func (v *defaultVFS) Umask(mask int) int {
-	return syscall.Umask(mask)
-}
-
-func (v *defaultVFS) WriteFile(filename string, data []byte, perm os.FileMode) error {
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_EXCL, perm)
-	if err != nil {
-		if !os.IsExist(err) {
-			return fmt.Errorf("failed to create file %s: %s", filename, err)
-		}
-		return err
-	}
-	if len(data) > 0 {
-		_, err = f.Write(data)
-	}
-	if err1 := f.Close(); err == nil {
-		err = err1
-	}
-	return err
-}
-
-// DefaultVFS is the default VFS.
-var DefaultVFS VFS = &defaultVFS{}
-
 // Manager manages a filesystem layout in a given path
 type Manager struct {
-	VFS      VFS
+	VFS      DefaultVFS
 	DirMode  os.FileMode
 	FileMode os.FileMode
 	rootPath string
@@ -129,6 +56,14 @@ type Manager struct {
 	// directory, the others if any are the directories to create
 	// for nested binds support
 	ovDirs map[string][]string
+}
+
+func NewManager(path string) (*Manager, error) {
+	m := &Manager{VFS: DefaultVFS{}}
+	if err := m.setRootPath(path); err != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 func (m *Manager) checkPath(path string, checkExist bool) (string, error) {
@@ -177,8 +112,8 @@ func (m *Manager) createParentDir(path string) {
 	}
 }
 
-// SetRootPath sets layout root path
-func (m *Manager) SetRootPath(path string) error {
+// setRootPath sets layout root path
+func (m *Manager) setRootPath(path string) error {
 	if !fs.IsDir(path) {
 		return fmt.Errorf("%s is not a directory or doesn't exists", path)
 	}

--- a/internal/pkg/util/fs/layout/manager_test.go
+++ b/internal/pkg/util/fs/layout/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -20,8 +20,6 @@ func TestLayout(t *testing.T) {
 	uid := os.Getuid()
 	gid := os.Getgid()
 
-	session := &Manager{VFS: DefaultVFS}
-
 	groups, err := os.Getgroups()
 	if err != nil {
 		t.Fatal(err)
@@ -35,92 +33,94 @@ func TestLayout(t *testing.T) {
 
 	dir := t.TempDir()
 
-	if err := session.AddDir("/etc"); err == nil {
+	// Uninitialized Manager.
+	mgr := &Manager{}
+	if err := mgr.AddDir("/etc"); err == nil {
 		t.Errorf("should have failed with uninitialized root path")
 	}
-	if err := session.AddFile("/etc/passwd", nil); err == nil {
+	if err := mgr.AddFile("/etc/passwd", nil); err == nil {
 		t.Errorf("should have failed with uninitialized root path")
 	}
-	if err := session.AddSymlink("/etc/symlink", "/etc/passwd"); err == nil {
+	if err := mgr.AddSymlink("/etc/symlink", "/etc/passwd"); err == nil {
 		t.Errorf("should have failed with uninitialized root path")
 	}
-	if err := session.Create(); err == nil {
+	if err := mgr.Create(); err == nil {
 		t.Errorf("should have failed with uninitialized root path")
 	}
 
-	if err := session.SetRootPath("/fakedirectory"); err == nil {
+	// Initialize with root.
+	_, err = NewManager("/fakedirectory")
+	if err == nil {
 		t.Error("should have failed with invalid root path directory")
 	}
-	if err := session.SetRootPath(dir); err != nil {
+	mgr, err = NewManager(dir)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := session.SetRootPath(dir); err == nil {
-		t.Error("should have failed with root path already set error")
-	}
 
-	if err := session.AddDir("etc"); err == nil {
+	if err := mgr.AddDir("etc"); err == nil {
 		t.Errorf("should have failed with non absolute path")
 	}
-	if err := session.AddDir("/etc"); err != nil {
+	if err := mgr.AddDir("/etc"); err != nil {
 		t.Error(err)
 	}
-	if err := session.AddDir("/etc"); err == nil {
+	if err := mgr.AddDir("/etc"); err == nil {
 		t.Error("should have failed with existent path")
 	}
 
-	if _, err := session.GetPath("/etcd"); err == nil {
+	if _, err := mgr.GetPath("/etcd"); err == nil {
 		t.Errorf("should have failed with non existent path")
 	}
 
-	if err := session.AddFile("/etc/passwd", []byte("hello")); err != nil {
+	if err := mgr.AddFile("/etc/passwd", []byte("hello")); err != nil {
 		t.Error(err)
 	}
-	if err := session.AddSymlink("/etc/symlink", "/etc/passwd"); err != nil {
+	if err := mgr.AddSymlink("/etc/symlink", "/etc/passwd"); err != nil {
 		t.Error(err)
 	}
 
-	if err := session.Chmod("/etc", 0o777); err != nil {
+	if err := mgr.Chmod("/etc", 0o777); err != nil {
 		t.Error(err)
 	}
-	if err := session.Chmod("/etcd", 0o777); err == nil {
+	if err := mgr.Chmod("/etcd", 0o777); err == nil {
 		t.Error("should have failed with non existent path")
 	}
 
-	if err := session.Chown("/etc", uid, gid); err != nil {
+	if err := mgr.Chown("/etc", uid, gid); err != nil {
 		t.Error(err)
 	}
-	if err := session.Chown("/etcd", uid, gid); err == nil {
+	if err := mgr.Chown("/etcd", uid, gid); err == nil {
 		t.Error("should have failed with non existent path")
 	}
 
-	if err := session.Chmod("/etc/passwd", 0o600); err != nil {
+	if err := mgr.Chmod("/etc/passwd", 0o600); err != nil {
 		t.Error(err)
 	}
-	if err := session.Chown("/etc/passwd", uid, gid); err != nil {
+	if err := mgr.Chown("/etc/passwd", uid, gid); err != nil {
 		t.Error(err)
 	}
-	if err := session.Chown("/etc/symlink", uid, gid); err != nil {
+	if err := mgr.Chown("/etc/symlink", uid, gid); err != nil {
 		t.Error(err)
 	}
 
-	if err := session.Create(); err != nil {
+	if err := mgr.Create(); err != nil {
 		t.Fatal(err)
 	}
-	if p, err := session.GetPath("/etc"); err == nil {
+	if p, err := mgr.GetPath("/etc"); err == nil {
 		if !fs.IsDir(p) {
 			t.Errorf("failed to create directory %s", p)
 		}
 	} else {
 		t.Error(err)
 	}
-	if p, err := session.GetPath("/etc/passwd"); err != nil {
+	if p, err := mgr.GetPath("/etc/passwd"); err != nil {
 		t.Error(err)
 	} else {
 		if !fs.IsFile(p) {
 			t.Errorf("failed to create file %s", p)
 		}
 	}
-	if p, err := session.GetPath("/etc/symlink"); err != nil {
+	if p, err := mgr.GetPath("/etc/symlink"); err != nil {
 		t.Error(err)
 	} else {
 		if !fs.IsLink(p) {
@@ -128,13 +128,13 @@ func TestLayout(t *testing.T) {
 		}
 	}
 
-	if err := session.AddSymlink("/etc/symlink2", "/etc/passwd"); err != nil {
+	if err := mgr.AddSymlink("/etc/symlink2", "/etc/passwd"); err != nil {
 		t.Error(err)
 	}
-	if err := session.Update(); err != nil {
+	if err := mgr.Update(); err != nil {
 		t.Fatal(err)
 	}
-	if p, err := session.GetPath("/etc/symlink2"); err != nil {
+	if p, err := mgr.GetPath("/etc/symlink2"); err != nil {
 		t.Error(err)
 	} else {
 		if !fs.IsLink(p) {

--- a/internal/pkg/util/fs/layout/session_linux.go
+++ b/internal/pkg/util/fs/layout/session_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -33,12 +33,12 @@ type layer interface {
 
 // NewSession creates and returns a session directory layout manager
 func NewSession(path string, fstype string, size int, system *mount.System, layer layer) (*Session, error) {
-	manager := &Manager{VFS: DefaultVFS}
-	session := &Session{Manager: manager}
-
-	if err := manager.SetRootPath(path); err != nil {
+	manager, err := NewManager(path)
+	if err != nil {
 		return nil, err
 	}
+	session := &Session{Manager: manager}
+
 	if err := manager.AddDir(rootFsDir); err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func NewSession(path string, fstype string, size int, system *mount.System, laye
 	if size > 0 {
 		options = fmt.Sprintf("mode=1777,size=%dm", size)
 	}
-	err := system.Points.AddFS(mount.SessionTag, path, fstype, syscall.MS_NOSUID, options)
+	err = system.Points.AddFS(mount.SessionTag, path, fstype, syscall.MS_NOSUID, options)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/util/fs/layout/vfs.go
+++ b/internal/pkg/util/fs/layout/vfs.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package layout
+
+import (
+	"fmt"
+	iofs "io/fs"
+	"os"
+	"syscall"
+
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
+)
+
+type DefaultVFS struct{}
+
+func (v *DefaultVFS) Chown(name string, uid, gid int) error {
+	return os.Chown(name, uid, gid)
+}
+
+func (v *DefaultVFS) EvalRelative(path, root string) string {
+	return fs.EvalRelative(path, root)
+}
+
+func (v *DefaultVFS) Lchown(name string, uid, gid int) error {
+	return os.Lchown(name, uid, gid)
+}
+
+func (v *DefaultVFS) Mkdir(name string, perm os.FileMode) error {
+	return os.Mkdir(name, perm)
+}
+
+func (v *DefaultVFS) Readlink(name string) (string, error) {
+	return os.Readlink(name)
+}
+
+func (v *DefaultVFS) ReadDir(dir string) ([]iofs.DirEntry, error) {
+	return os.ReadDir(dir)
+}
+
+func (v *DefaultVFS) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+func (v *DefaultVFS) Symlink(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
+}
+
+func (v *DefaultVFS) Umask(mask int) int {
+	return syscall.Umask(mask)
+}
+
+func (v *DefaultVFS) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_EXCL, perm)
+	if err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("failed to create file %s: %s", filename, err)
+		}
+		return err
+	}
+	if len(data) > 0 {
+		_, err = f.Write(data)
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Tidy up the layout.Manager code a bit, before we do further work on it.

Drop the VFS interface. We've only ever had, and will only have one VFS implementation.

Move the VFS implementation into a separate vfs.go file.

Create a Manager via NewManager, rather than bare struct. Set the root path in NewManager.

In TestLayout, the session var is actually a Manager... so call it mgr to be less confusing!
