### PR TITLE
rpc: only mount from fd in LoopDevice rpc

### DIFF
--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -656,7 +656,17 @@ func (c *container) mountImage(mnt *mount.Point) error {
 	}
 
 	shared := c.engine.EngineConfig.File.SharedLoopDevices
-	number, err := c.rpcOps.LoopDevice(mnt.Source, attachFlag, *info, maxDevices, shared)
+
+	strFd, ok := strings.CutPrefix(mnt.Source, "/proc/self/fd/")
+	if !ok {
+		return fmt.Errorf("mountImage source %s is not a /proc/self/fd/X value", mnt.Source)
+	}
+	fd, err := strconv.ParseUint(strFd, 10, 32)
+	if err != nil {
+		return fmt.Errorf("failed to convert image file descriptor: %v", err)
+	}
+
+	number, err := c.rpcOps.LoopDevice(uintptr(fd), attachFlag, *info, maxDevices, shared)
 	if err != nil {
 		return fmt.Errorf("failed to find loop device: %s", err)
 	}

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -105,7 +105,7 @@ type ChrootArgs struct {
 
 // LoopArgs defines the arguments to create a loop device.
 type LoopArgs struct {
-	Image      string
+	ImageFd    uintptr
 	Mode       int
 	Info       unix.LoopInfo64
 	MaxDevices int

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -82,9 +82,9 @@ func (t *RPC) Chroot(root string, method string) (int, error) {
 }
 
 // LoopDevice calls the loop device RPC using the supplied arguments.
-func (t *RPC) LoopDevice(image string, mode int, info unix.LoopInfo64, maxDevices int, shared bool) (int, error) {
+func (t *RPC) LoopDevice(imageFd uintptr, mode int, info unix.LoopInfo64, maxDevices int, shared bool) (int, error) {
 	arguments := &args.LoopArgs{
-		Image:      image,
+		ImageFd:    imageFd,
 		Mode:       mode,
 		Info:       info,
 		MaxDevices: maxDevices,

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -284,26 +284,13 @@ func (t *Methods) Chroot(arguments *args.ChrootArgs, _ *int) (err error) {
 
 // LoopDevice attaches a loop device with the specified arguments.
 func (t *Methods) LoopDevice(arguments *args.LoopArgs, reply *int) (err error) {
-	var image *os.File
-
 	loopdev := &loop.Device{}
 	loopdev.MaxLoopDevices = arguments.MaxDevices
 	loopdev.Info = &arguments.Info
 	loopdev.Shared = arguments.Shared
-
-	if after, ok := strings.CutPrefix(arguments.Image, "/proc/self/fd/"); ok {
-		strFd := after
-		fd, err := strconv.ParseUint(strFd, 10, 32)
-		if err != nil {
-			return fmt.Errorf("failed to convert image file descriptor: %v", err)
-		}
-		image = os.NewFile(uintptr(fd), "")
-	} else {
-		var err error
-		image, err = os.OpenFile(arguments.Image, arguments.Mode, 0o600)
-		if err != nil {
-			return fmt.Errorf("could not open image file: %v", err)
-		}
+	image := os.NewFile(arguments.ImageFd, "")
+	if image == nil {
+		return fmt.Errorf("invalid file descriptor: %v", arguments.ImageFd)
 	}
 
 	if diskGID == -1 {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Prior to this PR, the LoopDevice rpc accepted a path for the image to attach to a loop device. The only call is from mount_image, which always passes a `/proc/self/fd/X` obtained from the relevant `image.Source`, resulting in an fd flow being invoked in the LoopDevice rpc.

Remove generic path handling, and require that the LoopDevice rpc is called with an fd value.

Move the parsing of the fd value from a `/proc/self/fd/X` string up into the `mountImage` code.

This simplifies the LoopDevice rpc, and ensures the source image cannot be swapped during the rpc call.
