### PR TITLE
layout: ensure VFS operations are rooted in session dir

### DIFF
--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -2089,6 +2089,15 @@ func (c *container) createCwdDir(system *mount.System) error {
 
 	if !existingPath && c.session.Layer != nil {
 		if c.engine.EngineConfig.GetSessionLayer() == singularity.UnderlayLayer {
+			layerCwd := filepath.Join(c.session.Layer.Dir(), cwdHost)
+			if cwdHostSymlink && c.session.PathResolvesOutsideOverride(layerCwd, cwdHostResolved) {
+				// Not possible to bind this in underlay mode. Don't attempt to,
+				// because the os.Root-ed bind mount RPC will fail with error.
+				c.skipCwd = true
+				sylog.Infof("Not mounting CWD, symlink resolves outside bind source: %s -> %s", cwdHost, cwdHostResolved)
+				return nil
+			}
+
 			flags := uintptr(syscall.MS_BIND | c.suidFlag | syscall.MS_NODEV | syscall.MS_REC)
 			if err := system.Points.AddBind(mount.CwdTag, cwdHost, cwdHost, flags); err != nil {
 				return fmt.Errorf("could not bind cwd directory %s into container: %s", cwdHost, err)

--- a/internal/pkg/util/fs/layout/layer/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/overlay/overlay_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,10 +7,12 @@ package overlay
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
 
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/layout"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/mount"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
@@ -125,12 +127,16 @@ func (o *Overlay) createLayer(rootFsPath string, system *mount.System) error {
 			// get rid of symlinks and resolve the path within the
 			// rootfs path to not have false positive while creating
 			// the layer with calls below
-			dest := o.session.VFS.EvalRelative(point.Destination, rootFsPath)
+			dest := fs.EvalRelative(point.Destination, rootFsPath)
 
 			// now we are (almost) sure that we will get path information
 			// for a path in the rootfs path and we would create the right
 			// destination in the layer
-			_, err := o.session.VFS.Stat(filepath.Join(rootFsPath, dest))
+			rootfsDest, err := filepath.Rel(sessionDir, filepath.Join(rootFsPath, dest))
+			if err != nil {
+				return err
+			}
+			_, err = o.session.VFS.Stat(rootfsDest)
 			if err == nil {
 				continue
 			}
@@ -147,7 +153,7 @@ func (o *Overlay) createLayer(rootFsPath string, system *mount.System) error {
 				continue
 			}
 
-			fi, err := o.session.VFS.Stat(point.Source)
+			fi, err := os.Stat(point.Source)
 			if err != nil {
 				sylog.Warningf("skipping mount of %s: %s", point.Source, err)
 				continue

--- a/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -14,6 +14,7 @@ import (
 	"syscall"
 
 	"github.com/ccoveille/go-safecast/v2"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/layout"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/mount"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
@@ -78,7 +79,7 @@ func (u *Underlay) createLayer(rootFsPath string, system *mount.System) error {
 			// get rid of symlinks and resolve the path within the
 			// rootfs path to not have false positive while creating
 			// the layer with calls below
-			dst := u.session.VFS.EvalRelative(point.Destination, rootFsPath)
+			dst := fs.EvalRelative(point.Destination, rootFsPath)
 
 			// keep track of destination mount points to not duplicate
 			// directory uselessly
@@ -87,11 +88,15 @@ func (u *Underlay) createLayer(rootFsPath string, system *mount.System) error {
 			// now we are (almost) sure that we will get path information
 			// for a path in the rootfs path and we would create the right
 			// destination in the layer
-			_, err := u.session.VFS.Stat(filepath.Join(rootFsPath, dst))
+			rootfsDst, err := filepath.Rel(sessionDir, filepath.Join(rootFsPath, dst))
+			if err != nil {
+				return err
+			}
+			_, err = u.session.VFS.Stat(rootfsDst)
 			if err == nil {
 				continue
 			}
-			fi, err := u.session.VFS.Stat(point.Source)
+			fi, err := os.Stat(point.Source)
 			if err != nil {
 				sylog.Warningf("skipping mount of %s: %s", point.Source, err)
 				continue
@@ -176,7 +181,11 @@ func (u *Underlay) createLayer(rootFsPath string, system *mount.System) error {
 func (u *Underlay) duplicateDir(dir string, system *mount.System, existingPath string) error {
 	binds := 0
 	path := filepath.Join(u.session.RootFsPath(), dir)
-	files, err := u.session.VFS.ReadDir(path)
+	name, err := filepath.Rel(u.session.Path(), path)
+	if err != nil {
+		return err
+	}
+	files, err := u.session.VFS.ReadDir(name)
 	if err != nil {
 		// directory doesn't exists, nothing to duplicate
 		return nil
@@ -199,7 +208,11 @@ func (u *Underlay) duplicateDir(dir string, system *mount.System, existingPath s
 			}
 			binds++
 		} else if file.Type()&os.ModeSymlink != 0 {
-			tgt, err := u.session.VFS.Readlink(src)
+			srcName, err := filepath.Rel(u.session.Path(), src)
+			if err != nil {
+				return err
+			}
+			tgt, err := u.session.VFS.Readlink(srcName)
 			if err != nil {
 				return fmt.Errorf("can't read symlink information for %s: %s", src, err)
 			}

--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 
-	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
@@ -48,10 +48,12 @@ type dirOverride struct {
 	nestedBindTargets []string
 }
 
-// Manager manages a filesystem layout in a given path
+// Manager constructs a container filesystem layout in the session directory.
 type Manager struct {
-	// VFS is the virtual filesystem used to create the layout.
-	VFS DefaultVFS
+	// VFS is the virtual filesystem used to create the layout. It is rooted at
+	// the session directory. Note that nested bind targets are created using
+	// an os.Root rooted at the parent of the bind source target.
+	VFS *RootedVFS
 
 	// DirMode and FileMode are the default permissions for directories and
 	// files created by the manager.
@@ -95,12 +97,22 @@ type Manager struct {
 	dirOverrides map[string]*dirOverride
 }
 
+// NewManager returns a new layout manager with the provided path as its root.
 func NewManager(path string) (*Manager, error) {
-	m := &Manager{VFS: DefaultVFS{}}
-	if err := m.setRootPath(path); err != nil {
+	vfs, err := NewRootedVFS(path)
+	if err != nil {
 		return nil, err
 	}
-	return m, nil
+	root := &dir{mode: dirMode, uid: os.Getuid(), gid: os.Getgid()}
+	return &Manager{
+		VFS:          vfs,
+		DirMode:      dirMode,
+		FileMode:     fileMode,
+		rootPath:     filepath.Clean(path),
+		entries:      map[string]any{"/": root},
+		dirs:         []*dir{root},
+		dirOverrides: map[string]*dirOverride{},
+	}, nil
 }
 
 func (m *Manager) checkPath(path string, checkExist bool) (string, error) {
@@ -152,35 +164,6 @@ func (m *Manager) addDirs(path string) error {
 			}
 		}
 	}
-	return nil
-}
-
-// setRootPath sets layout root path
-func (m *Manager) setRootPath(path string) error {
-	if !fs.IsDir(path) {
-		return fmt.Errorf("%s is not a directory or doesn't exists", path)
-	}
-	m.rootPath = filepath.Clean(path)
-	if m.entries == nil {
-		m.entries = make(map[string]any)
-	} else {
-		return fmt.Errorf("root path is already set")
-	}
-	if m.dirOverrides == nil {
-		m.dirOverrides = map[string]*dirOverride{}
-	}
-	if m.dirs == nil {
-		m.dirs = make([]*dir, 0)
-	}
-	if m.DirMode == 0o000 {
-		m.DirMode = dirMode
-	}
-	if m.FileMode == 0o000 {
-		m.FileMode = fileMode
-	}
-	d := &dir{mode: m.DirMode, uid: os.Getuid(), gid: os.Getgid()}
-	m.entries["/"] = d
-	m.dirs = append(m.dirs, d)
 	return nil
 }
 
@@ -285,10 +268,131 @@ func (m *Manager) overrideFor(p string) (layoutOverride, overrideSource, pRel st
 	return "", "", ""
 }
 
+func validateNestedBindTarget(path string, fi os.FileInfo) error {
+	if fi.Mode()&os.ModeSymlink != 0 {
+		// Must accept symlinks to a directory, e.g. for `/home/<user>` which is
+		// symlinked to shared storage location.
+		// Ref: https://github.com/apptainer/singularity/issues/4836
+		resolved, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return fmt.Errorf("failed to resolve nested bind target %s: %s", path, err)
+		}
+		fi, err = os.Stat(resolved)
+		if err != nil {
+			return fmt.Errorf("failed to stat resolved nested bind target %s: %s", resolved, err)
+		}
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("nested bind target %s exists but is not a directory", path)
+	}
+	return nil
+}
+
+// ensureNestedBindTarget ensures that the nested bind target directory exists,
+// creating it where necessary, using os.Root on the parent directory to avoid
+// escaping the parent bind.
+func ensureNestedBindTarget(path string, mode os.FileMode) error {
+	dir, base := filepath.Dir(path), filepath.Base(path)
+	parent, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
+
+	// If override path exists, it must be a directory.
+	fi, err := parent.Lstat(base)
+	if err == nil {
+		return validateNestedBindTarget(path, fi)
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat %s: %s", path, err)
+	}
+
+	// If nested bind target doesn't exist, create it. We must accommodate another
+	// process creating the same location, where singularity has been launched
+	// in parallel with the same bind configuration.
+	sylog.Infof("Creating empty target directory for nested bind at %s", path)
+	if err := parent.Mkdir(base, mode&0o777); err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("failed to create %s directory: %s", path, err)
+		}
+		fi, err := parent.Lstat(base)
+		if err != nil {
+			return fmt.Errorf("failed to stat %s after concurrent creation: %s", path, err)
+		}
+		return validateNestedBindTarget(path, fi)
+	}
+
+	// Check for / apply high mode bits (sticky/setuid/setgid) that Mkdir does not honor.
+	if mode&0o777 == mode {
+		return nil
+	}
+	f, err := parent.OpenFile(base, os.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open %s directory: %s", path, err)
+	}
+	defer f.Close()
+	if err := f.Chmod(mode); err != nil {
+		return fmt.Errorf("failed to set mode on %s directory: %s", path, err)
+	}
+	return nil
+}
+
+// diskPath returns the absolute path where p will be materialized on disk:
+// inside the session root, or inside the bind source if p falls under an
+// overridden directory. Used for diagnostic messages.
+func (m *Manager) diskPath(p string) string {
+	if _, source, rel := m.overrideFor(p); source != "" {
+		return filepath.Join(source, rel)
+	}
+	return filepath.Join(m.rootPath, p)
+}
+
+// vfsFor returns an appropriately rooted VFS for operations on p. If p is not
+// within an override directory, the session-rooted VFS is returned. If p is
+// within an override directory, a new RootedVFS rooted at the bind source is
+// returned.
+func (m *Manager) vfsFor(p string) (*RootedVFS, string, error) {
+	layoutPath, source, rel := m.overrideFor(p)
+	if layoutPath == "" {
+		rel := strings.TrimPrefix(filepath.Clean(p), string(os.PathSeparator))
+		if rel == "" {
+			rel = "."
+		}
+		return m.VFS, rel, nil
+	}
+	v, err := NewRootedVFS(source)
+	if err != nil {
+		return nil, "", err
+	}
+	return v, rel, nil
+}
+
 // HasOverride returns true if the provided layout path is overridden by a bind, false otherwise.
 func (m *Manager) HasOverride(layoutPath string) bool {
 	_, ok := m.dirOverrides[layoutPath]
 	return ok
+}
+
+// PathResolvesOutsideOverride reports whether resolvedPath falls outside the
+// deepest bind source that overrides path. This catches symlinked paths that
+// look like they are below a bind in the container layout, but resolve to a
+// different host tree that cannot be reached through that bind target.
+func (m *Manager) PathResolvesOutsideOverride(path, resolvedPath string) bool {
+	_, source, _ := m.overrideFor(path)
+	if source == "" {
+		return false
+	}
+
+	resolvedSource, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(resolvedSource, resolvedPath)
+	if err != nil {
+		return false
+	}
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
 // GetPath returns the full host path, for path in the layout.
@@ -347,6 +451,8 @@ func (m *Manager) Update() error {
 	return m.sync()
 }
 
+// sync materializes the layout in the session directory. Directories (including
+// nested bind targets) are created first, followed by files and symlinks.
 func (m *Manager) sync() error {
 	uid := os.Getuid()
 	gid := os.Getgid()
@@ -355,8 +461,8 @@ func (m *Manager) sync() error {
 		return fmt.Errorf("root path is not set")
 	}
 
-	oldmask := m.VFS.Umask(0)
-	defer m.VFS.Umask(oldmask)
+	oldmask := syscall.Umask(0)
+	defer syscall.Umask(oldmask)
 
 	for _, d := range m.dirs[1:] {
 		if d.created {
@@ -365,16 +471,11 @@ func (m *Manager) sync() error {
 		path := ""
 		for p, e := range m.entries {
 			if e == d {
-				path = m.rootPath + p
+				path = p
 				if ovDir, ok := m.dirOverrides[p]; ok {
 					for _, nbt := range ovDir.nestedBindTargets {
-						// Already exists - maybe created by a previous bind.
-						if _, err := m.VFS.Stat(nbt); err == nil {
-							continue
-						}
-						sylog.Debugf("Creating nested bind target %s for overridden directory %s", nbt, p)
-						if err := m.VFS.Mkdir(nbt, m.DirMode); err != nil && !os.IsExist(err) {
-							return fmt.Errorf("failed to create nested bind target %s: %s", nbt, err)
+						if err := ensureNestedBindTarget(nbt, m.DirMode); err != nil {
+							return err
 						}
 					}
 				}
@@ -384,83 +485,103 @@ func (m *Manager) sync() error {
 		if path == "" {
 			continue
 		}
+		// Directories are always created in the session, even when path is
+		// under an overridden directory: they may serve as bind-mount targets
+		// for other mount points (e.g. the home staging dir). Override targets
+		// outside the session are handled separately by ensureNestedBindTarget.
+		fullPath := filepath.Join(m.rootPath, path)
+		name := strings.TrimPrefix(filepath.Clean(path), string(os.PathSeparator))
+		mode := m.DirMode
 		if d.mode != m.DirMode {
-			if err := m.VFS.Mkdir(path, d.mode); err != nil {
-				if !os.IsExist(err) {
-					return fmt.Errorf("failed to create %s directory: %s", path, err)
-				}
-				// skip owner change, not created by us
-				d.created = true
-				continue
+			mode = d.mode
+		}
+		if err := m.VFS.Mkdir(name, mode); err != nil {
+			if !os.IsExist(err) {
+				return fmt.Errorf("failed to create %s directory: %s", fullPath, err)
 			}
-		} else {
-			if err := m.VFS.Mkdir(path, m.DirMode); err != nil {
-				if !os.IsExist(err) {
-					return fmt.Errorf("failed to create %s directory: %s", path, err)
-				}
-				// skip owner change, not created by us
-				d.created = true
-				continue
-			}
+			// skip owner change, not created by us
+			d.created = true
+			continue
 		}
 		if d.uid != uid || d.gid != gid {
-			if err := m.VFS.Chown(path, d.uid, d.gid); err != nil {
-				return fmt.Errorf("failed to change owner of %s: %s", path, err)
+			if err := m.VFS.Chown(name, d.uid, d.gid); err != nil {
+				return fmt.Errorf("failed to change owner of %s: %s", fullPath, err)
 			}
 		}
 		d.created = true
 	}
 
 	for p, e := range m.entries {
-		path := m.rootPath + p
-		if _, target := m.nestedBindTargetFor(p); target != "" {
-			path = target
+		if err := m.syncEntry(p, e, uid, gid); err != nil {
+			return err
 		}
-		switch entry := e.(type) {
-		case *file:
-			if entry.created {
-				continue
-			}
-			if err := m.VFS.WriteFile(path, entry.content, entry.mode); err != nil {
-				if !os.IsExist(err) {
-					return fmt.Errorf("failed to create file %s: %s", path, err)
-				}
-				// skip content write or owner change, not created by us
-				entry.created = true
-				continue
-			}
-			if entry.uid != uid || entry.gid != gid {
-				if err := m.VFS.Chown(path, entry.uid, entry.gid); err != nil {
-					return fmt.Errorf("failed to change %s ownership: %s", path, err)
-				}
-			}
-			entry.created = true
-		case *symlink:
-			if entry.created {
-				continue
-			}
-			if err := m.VFS.Symlink(entry.target, path); err != nil {
-				if !os.IsExist(err) {
-					return fmt.Errorf("failed to create symlink %s: %s", path, err)
-				}
-				// check that current symlink point to the right target if it's a symlink
-				// otherwise we consider the entry as already created no matter if it's a
-				// file, a directory or something else
-				target, err := m.VFS.Readlink(path)
-				if err == nil && target != entry.target {
-					return fmt.Errorf("symlink %s point to %s instead of %s", path, target, entry.target)
-				}
-				// skip symlink owner change, not created by us
-				entry.created = true
-				continue
-			}
-			if entry.uid != uid || entry.gid != gid {
-				if err := m.VFS.Lchown(path, entry.uid, entry.gid); err != nil {
-					return fmt.Errorf("failed to change %s ownership: %s", path, err)
-				}
-			}
-			entry.created = true
+	}
+	return nil
+}
+
+// syncEntry materializes a single file or symlink entry. It opens the
+// appropriate VFS for p (session-rooted, or freshly rooted at the override
+// target) and closes the override VFS, if any, before returning so per-entry
+// fds don't accumulate across the whole sync.
+func (m *Manager) syncEntry(p string, e any, uid, gid int) error {
+	switch entry := e.(type) {
+	case *file:
+		if entry.created {
+			return nil
 		}
+		ops, name, err := m.vfsFor(p)
+		if err != nil {
+			return err
+		}
+		if ops != m.VFS {
+			defer ops.Close()
+		}
+		if err := ops.WriteFile(name, entry.content, entry.mode); err != nil {
+			if !os.IsExist(err) {
+				return fmt.Errorf("failed to create file %s: %s", m.diskPath(p), err)
+			}
+			// skip content write or owner change, not created by us
+			entry.created = true
+			return nil
+		}
+		if entry.uid != uid || entry.gid != gid {
+			if err := ops.Chown(name, entry.uid, entry.gid); err != nil {
+				return fmt.Errorf("failed to change %s ownership: %s", m.diskPath(p), err)
+			}
+		}
+		entry.created = true
+	case *symlink:
+		if entry.created {
+			return nil
+		}
+		ops, name, err := m.vfsFor(p)
+		if err != nil {
+			return err
+		}
+		if ops != m.VFS {
+			defer ops.Close()
+		}
+		if err := ops.Symlink(entry.target, name); err != nil {
+			if !os.IsExist(err) {
+				return fmt.Errorf("failed to create symlink %s: %s", m.diskPath(p), err)
+			}
+			// check that current symlink point to the right target if it's a symlink
+			// otherwise we consider the entry as already created no matter if it's a
+			// file, a directory or something else
+			target, err := ops.Readlink(name)
+			if err == nil && target != entry.target {
+				return fmt.Errorf("symlink %s point to %s instead of %s", m.diskPath(p), target, entry.target)
+			}
+			// skip symlink owner change, not created by us
+			entry.created = true
+			return nil
+		}
+		if entry.uid != uid || entry.gid != gid {
+			if err := ops.Lchown(name, entry.uid, entry.gid); err != nil {
+				return fmt.Errorf("failed to change %s ownership: %s", m.diskPath(p), err)
+			}
+		}
+		entry.created = true
 	}
 	return nil
 }

--- a/internal/pkg/util/fs/layout/manager_test.go
+++ b/internal/pkg/util/fs/layout/manager_test.go
@@ -8,6 +8,7 @@ package layout
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,6 +61,7 @@ func TestLayout(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Add items, create layout, verify created.
 	if err := mgr.AddDir("etc"); err == nil {
 		t.Errorf("should have failed with non absolute path")
 	}
@@ -69,32 +71,27 @@ func TestLayout(t *testing.T) {
 	if err := mgr.AddDir("/etc"); err == nil {
 		t.Error("should have failed with existent path")
 	}
-
 	if _, err := mgr.GetPath("/etcd"); err == nil {
 		t.Errorf("should have failed with non existent path")
 	}
-
 	if err := mgr.AddFile("/etc/passwd", []byte("hello")); err != nil {
 		t.Error(err)
 	}
 	if err := mgr.AddSymlink("/etc/symlink", "/etc/passwd"); err != nil {
 		t.Error(err)
 	}
-
 	if err := mgr.Chmod("/etc", 0o777); err != nil {
 		t.Error(err)
 	}
 	if err := mgr.Chmod("/etcd", 0o777); err == nil {
 		t.Error("should have failed with non existent path")
 	}
-
 	if err := mgr.Chown("/etc", uid, gid); err != nil {
 		t.Error(err)
 	}
 	if err := mgr.Chown("/etcd", uid, gid); err == nil {
 		t.Error("should have failed with non existent path")
 	}
-
 	if err := mgr.Chmod("/etc/passwd", 0o600); err != nil {
 		t.Error(err)
 	}
@@ -104,7 +101,6 @@ func TestLayout(t *testing.T) {
 	if err := mgr.Chown("/etc/symlink", uid, gid); err != nil {
 		t.Error(err)
 	}
-
 	if err := mgr.Create(); err != nil {
 		t.Fatal(err)
 	}
@@ -130,6 +126,7 @@ func TestLayout(t *testing.T) {
 		}
 	}
 
+	// Add additional items, update, verify.
 	if err := mgr.AddSymlink("/etc/symlink2", "/etc/passwd"); err != nil {
 		t.Error(err)
 	}
@@ -332,6 +329,65 @@ func TestNestedBindTargets(t *testing.T) {
 			addDirs:  []string{"/tmp/canary/dir"},
 			addFiles: []string{"/tmp/canary/dir/nested"},
 		},
+		{
+			name: "reject file through symlink outside",
+			setup: func(t *testing.T) nestedBindSetupResult {
+				hostCanaryDir := t.TempDir()
+				outsideDir := t.TempDir()
+				if err := os.Symlink(outsideDir, filepath.Join(hostCanaryDir, "dir2")); err != nil {
+					t.Fatal(err)
+				}
+				return nestedBindSetupResult{
+					overrides: []nestedBindOverride{
+						{path: "/canary", realpath: hostCanaryDir},
+					},
+					wantErr:     "path escapes",
+					wantNoFiles: []string{filepath.Join(outsideDir, "nested")},
+				}
+			},
+			addFiles: []string{"/canary/dir2/nested"},
+		},
+		{
+			name: "allow symlinked directory inside",
+			setup: func(t *testing.T) nestedBindSetupResult {
+				hostCanaryDir := t.TempDir()
+				if err := os.Mkdir(filepath.Join(hostCanaryDir, "dir"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("dir", filepath.Join(hostCanaryDir, "symlink")); err != nil {
+					t.Fatal(err)
+				}
+				return nestedBindSetupResult{
+					overrides: []nestedBindOverride{
+						{path: "/canary", realpath: hostCanaryDir},
+					},
+					wantDirs: []string{
+						filepath.Join(hostCanaryDir, "dir", "child"),
+					},
+				}
+			},
+			addDirs: []string{"/canary/symlink/child"},
+		},
+		{
+			name: "allow symlinked directory outside for CWD",
+			setup: func(t *testing.T) nestedBindSetupResult {
+				hostCanaryDir := t.TempDir()
+				outsideDir := t.TempDir()
+				if err := os.Mkdir(filepath.Join(outsideDir, "child"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(outsideDir, filepath.Join(hostCanaryDir, "symlink")); err != nil {
+					t.Fatal(err)
+				}
+				return nestedBindSetupResult{
+					overrides: []nestedBindOverride{
+						{path: "/canary", realpath: hostCanaryDir},
+					},
+					wantDirs: []string{filepath.Join(outsideDir, "child")},
+				}
+			},
+			addDirs: []string{"/canary/symlink/child"},
+		},
 	}
 
 	test.DropPrivilege(t)
@@ -506,6 +562,73 @@ func TestNestedBindTarget(t *testing.T) {
 			layoutPath, target := mgr.nestedBindTargetFor(tt.path)
 			assert.Equal(t, tt.wantLayoutOverride, layoutPath, "layoutPath")
 			assert.Equal(t, tt.wantTarget, target, "target")
+		})
+	}
+}
+
+func TestPathResolvesOutsideOverride(t *testing.T) {
+	rootDir := t.TempDir()
+	mgr, err := NewManager(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	source := t.TempDir()
+	outside := t.TempDir()
+	mgr.overrideDir("/underlay/tmp", source)
+
+	outsideCwd := filepath.Join(outside, "users", "abc123")
+	if err := os.MkdirAll(outsideCwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outsideLink := filepath.Join(source, "outside-symlink")
+	if err := os.Symlink(outside, outsideLink); err != nil {
+		t.Fatal(err)
+	}
+
+	insideCwd := filepath.Join(source, "users", "abc123")
+	if err := os.MkdirAll(insideCwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	insideLink := filepath.Join(source, "inside-symlink")
+	if err := os.Symlink(filepath.Join(source, "users"), insideLink); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "outside",
+			path: filepath.Join("/underlay/tmp", "outside-symlink", "users", "abc123"),
+			want: true,
+		},
+		{
+			name: "inside",
+			path: filepath.Join("/underlay/tmp", "inside-symlink", "abc123"),
+			want: false,
+		},
+		{
+			name: "no override",
+			path: "/underlay/var/tmp/example",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostPath := strings.TrimPrefix(tt.path, "/underlay")
+			resolved, err := filepath.EvalSymlinks(filepath.Join(source, strings.TrimPrefix(hostPath, "/tmp")))
+			if tt.name == "no override" {
+				resolved = "/var/tmp/example"
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if got := mgr.PathResolvesOutsideOverride(tt.path, resolved); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/internal/pkg/util/fs/layout/session_linux.go
+++ b/internal/pkg/util/fs/layout/session_linux.go
@@ -7,6 +7,7 @@ package layout
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"syscall"
 
@@ -38,7 +39,6 @@ func NewSession(path string, fstype string, size int, system *mount.System, laye
 		return nil, err
 	}
 	session := &Session{Manager: manager}
-
 	if err := manager.AddDir(rootFsDir); err != nil {
 		return nil, err
 	}
@@ -49,8 +49,7 @@ func NewSession(path string, fstype string, size int, system *mount.System, laye
 	if size > 0 {
 		options = fmt.Sprintf("mode=1777,size=%dm", size)
 	}
-	err = system.Points.AddFS(mount.SessionTag, path, fstype, syscall.MS_NOSUID, options)
-	if err != nil {
+	if err := system.Points.AddFS(mount.SessionTag, path, fstype, syscall.MS_NOSUID, options); err != nil {
 		return nil, err
 	}
 	if err := system.RunAfterTag(mount.SessionTag, session.createLayout); err != nil {
@@ -128,8 +127,10 @@ func (s *Session) createLayout(system *mount.System) error {
 				continue
 			}
 
-			// check if the bind source exists
-			fi, err := s.VFS.Stat(point.Source)
+			// check if the bind source exists. point.Source is the
+			// user-supplied host path, outside the session directory, so it
+			// must be statted directly rather than via the session-rooted VFS.
+			fi, err := os.Stat(point.Source)
 			if err != nil {
 				sylog.Warningf("skipping mount of: %s: %s", point.Source, err)
 				continue

--- a/internal/pkg/util/fs/layout/vfs.go
+++ b/internal/pkg/util/fs/layout/vfs.go
@@ -9,55 +9,119 @@ import (
 	"fmt"
 	iofs "io/fs"
 	"os"
-	"syscall"
+	"path/filepath"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
-type DefaultVFS struct{}
-
-func (v *DefaultVFS) Chown(name string, uid, gid int) error {
-	return os.Chown(name, uid, gid)
+type RootedVFS struct {
+	rootPath string
+	root     *os.Root
 }
 
-func (v *DefaultVFS) EvalRelative(path, root string) string {
-	return fs.EvalRelative(path, root)
+func NewRootedVFS(path string) (*RootedVFS, error) {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return nil, fmt.Errorf("%s is not an absolute directory path", path)
+	}
+	if !fs.IsDir(clean) {
+		return nil, fmt.Errorf("%s is not a directory or doesn't exist", clean)
+	}
+	return &RootedVFS{rootPath: clean}, nil
 }
 
-func (v *DefaultVFS) Lchown(name string, uid, gid int) error {
-	return os.Lchown(name, uid, gid)
-}
-
-func (v *DefaultVFS) Mkdir(name string, perm os.FileMode) error {
-	return os.Mkdir(name, perm)
-}
-
-func (v *DefaultVFS) Readlink(name string) (string, error) {
-	return os.Readlink(name)
-}
-
-func (v *DefaultVFS) ReadDir(dir string) ([]iofs.DirEntry, error) {
-	return os.ReadDir(dir)
-}
-
-func (v *DefaultVFS) Stat(name string) (os.FileInfo, error) {
-	return os.Stat(name)
-}
-
-func (v *DefaultVFS) Symlink(oldname, newname string) error {
-	return os.Symlink(oldname, newname)
-}
-
-func (v *DefaultVFS) Umask(mask int) int {
-	return syscall.Umask(mask)
-}
-
-func (v *DefaultVFS) WriteFile(filename string, data []byte, perm os.FileMode) error {
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_EXCL, perm)
+func (v *RootedVFS) ensureRoot() error {
+	if v.root != nil {
+		return nil
+	}
+	if v.rootPath == "" {
+		return fmt.Errorf("root is not set")
+	}
+	root, err := os.OpenRoot(v.rootPath)
 	if err != nil {
-		if !os.IsExist(err) {
-			return fmt.Errorf("failed to create file %s: %s", filename, err)
-		}
+		return err
+	}
+	v.root = root
+	return nil
+}
+
+func (v *RootedVFS) Close() error {
+	if v.root == nil {
+		return nil
+	}
+	err := v.root.Close()
+	v.root = nil
+	return err
+}
+
+func (v *RootedVFS) Chown(name string, uid, gid int) error {
+	if err := v.ensureRoot(); err != nil {
+		return err
+	}
+	return v.root.Chown(name, uid, gid)
+}
+
+func (v *RootedVFS) Lchown(name string, uid, gid int) error {
+	if err := v.ensureRoot(); err != nil {
+		return err
+	}
+	return v.root.Lchown(name, uid, gid)
+}
+
+func (v *RootedVFS) Mkdir(name string, perm os.FileMode) error {
+	if err := v.ensureRoot(); err != nil {
+		return err
+	}
+
+	if err := v.root.Mkdir(name, perm&0o777); err != nil {
+		return err
+	}
+	if perm&0o777 != perm {
+		return v.root.Chmod(name, perm)
+	}
+	return nil
+}
+
+func (v *RootedVFS) Readlink(name string) (string, error) {
+	if err := v.ensureRoot(); err != nil {
+		return "", err
+	}
+	return v.root.Readlink(name)
+}
+
+func (v *RootedVFS) ReadDir(dir string) ([]iofs.DirEntry, error) {
+	if err := v.ensureRoot(); err != nil {
+		return nil, err
+	}
+	f, err := v.root.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return f.ReadDir(-1)
+}
+
+func (v *RootedVFS) Stat(name string) (os.FileInfo, error) {
+	if err := v.ensureRoot(); err != nil {
+		return nil, err
+	}
+	return v.root.Stat(name)
+}
+
+func (v *RootedVFS) Symlink(oldname, newname string) error {
+	if err := v.ensureRoot(); err != nil {
+		return err
+	}
+	return v.root.Symlink(oldname, newname)
+}
+
+func (v *RootedVFS) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	if err := v.ensureRoot(); err != nil {
+		return err
+	}
+
+	f, err := v.root.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_EXCL, perm)
+	if err != nil {
 		return err
 	}
 	if len(data) > 0 {

--- a/internal/pkg/util/fs/layout/vfs_test.go
+++ b/internal/pkg/util/fs/layout/vfs_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package layout
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/sylabs/singularity/v4/internal/pkg/test"
+)
+
+func TestVFSEscape(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	rootDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "file")
+	if err := os.WriteFile(outsideFile, []byte("test"), 0o644); err != nil {
+		t.Fatalf("failed to create file outside of root dir: %v", err)
+	}
+	linkToOutside := filepath.Join(rootDir, "link-to-outside")
+	if err := os.Symlink(outsideDir, linkToOutside); err != nil {
+		t.Fatalf("failed to create symlink attack path: %v", err)
+	}
+	insideDir := filepath.Join(rootDir, "inside")
+	if err := os.Mkdir(insideDir, 0o755); err != nil {
+		t.Fatalf("failed to create directory inside root dir: %v", err)
+	}
+
+	v, err := NewRootedVFS(rootDir)
+	if err != nil {
+		t.Fatalf("failed to create rooted VFS: %v", err)
+	}
+
+	mustReject := func(name string, err error) {
+		assert.Error(t, err, "%s: expected out-of-root path to be rejected", name)
+	}
+
+	// Cannot create anything outside of the root.
+	mustReject("Mkdir", v.Mkdir(filepath.Join(linkToOutside+"/foo"), 0o755))
+	mustReject("WriteFile", v.WriteFile(filepath.Join(linkToOutside, "/foo"), []byte("x"), 0o644))
+	mustReject("Symlink", v.Symlink("target", linkToOutside+"/foo"))
+
+	// RootedVFS operations are relative to the root, like os.Root.
+	mustReject("Stat-absolute-inside-root", func() error {
+		_, err := v.Stat(insideDir)
+		return err
+	}())
+
+	// Cannot modify anything outside of the root.
+	mustReject("Chown", v.Chown(linkToOutside, os.Getuid(), os.Getgid()))
+	mustReject("Lchown", v.Lchown(filepath.Join(linkToOutside, "file"), os.Getuid(), os.Getgid()))
+
+	// Relative traversal paths must also be rejected when they escape root.
+	mustReject("Mkdir-relative", v.Mkdir("../outside", 0o755))
+	mustReject("WriteFile-relative", v.WriteFile("../outside", []byte("x"), 0o644))
+	mustReject("Symlink-relative", v.Symlink("target", "../outside"))
+	mustReject("Chown-relative", v.Chown("../outside", os.Getuid(), os.Getgid()))
+	mustReject("Lchown-relative", v.Lchown("../outside", os.Getuid(), os.Getgid()))
+	mustReject("Stat-relative", func() error {
+		_, err := v.Stat("../outside")
+		return err
+	}())
+	mustReject("ReadDir-relative", func() error {
+		_, err := v.ReadDir("../outside")
+		return err
+	}())
+	mustReject("Readlink-relative", func() error {
+		_, err := v.Readlink("../outside")
+		return err
+	}())
+
+	// Cannot examine metadata of things outside of the root.
+	mustReject("Stat", func() error {
+		_, err := v.Stat(filepath.Join(linkToOutside, "file"))
+		return err
+	}())
+	mustReject("ReadDir", func() error {
+		_, err := v.ReadDir(linkToOutside)
+		return err
+	}())
+	mustReject("Readlink", func() error {
+		_, err := v.Readlink(filepath.Join(linkToOutside, "file"))
+		return err
+	}())
+}

--- a/internal/pkg/util/fs/mount/system_linux.go
+++ b/internal/pkg/util/fs/mount/system_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -71,7 +71,7 @@ func (b *System) MountAll() error {
 		b.currentTag = tag
 		for _, fn := range b.beforeTagHooks[tag] {
 			if err := fn(b); err != nil {
-				return fmt.Errorf("hook function for tag %s returns error: %s", tag, err)
+				return fmt.Errorf("hook function before tag %s returns error: %s", tag, err)
 			}
 		}
 		for _, point := range b.Points.GetByTag(tag) {
@@ -84,7 +84,7 @@ func (b *System) MountAll() error {
 		}
 		for _, fn := range b.afterTagHooks[tag] {
 			if err := fn(b); err != nil {
-				return fmt.Errorf("hook function for tag %s returns error: %s", tag, err)
+				return fmt.Errorf("hook function after tag %s returns error: %s", tag, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a container is created using the native runtime, the structure of the session dir is setup using a session manager and VFS functions. In addition, the VFS functions are used to create target directories or files required for nested bind mounts.

Prior to this PR, the VFS operations are not rooted. Although sessiondir operations happen in a new mount namespace, which a non-root user cannot enter, ensuring that the operations do not make changes outside of a specific root is useful hardening.

This PR uses `os.Root` to ensure that VFS operations are rooted in the session dir, or the parent directory of where a nested bind mount target must be created.

Note that while the root path of the VFS is set when the VFS is created, the `os.Root` is not initialized until the first VFS operation is called. This accommodates the fact that the session tmpfs is mounted _after_ the VFS is initialized, but before it is used.

Codex 5.5 was guided to this area and identified the potential issue, and produced draft changes. These were reviewed and modified extensively to ensure correct operation was preserved, and that the code is easier to follow.

Co-authored-by: Codex
