### PR TITLE
hardening: use O_NOFOLLOW widely at possible file creation points

### DIFF
--- a/cmd/bash_completion/bash_completion.go
+++ b/cmd/bash_completion/bash_completion.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,10 +10,11 @@ import (
 	"os"
 
 	"github.com/sylabs/singularity/v4/cmd/internal/cli"
+	"golang.org/x/sys/unix"
 )
 
 func main() {
-	fh, err := os.Create(os.Args[1])
+	fh, err := os.OpenFile(os.Args[1], os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/cmd/internal/cli/key_generatecosignkeypair.go
+++ b/cmd/internal/cli/key_generatecosignkeypair.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2025-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,8 +6,6 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/spf13/cobra"
@@ -68,10 +66,10 @@ func runGenerateCosignKeyPairCmd(_ *cobra.Command, _ []string) {
 		sylog.Fatalf("%v", err)
 	}
 
-	if err := os.WriteFile(priKey, kb.PrivateBytes, 0o600); err != nil {
+	if err := fs.WriteFileNoFollow(priKey, kb.PrivateBytes, 0o600); err != nil {
 		sylog.Fatalf("%v", err)
 	}
-	if err := os.WriteFile(pubKey, kb.PublicBytes, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(pubKey, kb.PublicBytes, 0o644); err != nil {
 		sylog.Fatalf("%v", err)
 	}
 }

--- a/cmd/internal/cli/key_pull.go
+++ b/cmd/internal/cli/key_pull.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2017-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2017-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -18,6 +18,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/v4/internal/pkg/sypgp"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 // KeyPullCmd is `singularity key pull' and fetches public keys from a key server
@@ -69,7 +70,7 @@ func doKeyPullCmd(ctx context.Context, fingerprint string, co ...client.Option) 
 	}
 
 	// store in local cache
-	fp, err := os.OpenFile(keyring.PublicPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, mode)
+	fp, err := os.OpenFile(keyring.PublicPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY|unix.O_NOFOLLOW, mode)
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -38,6 +38,7 @@ import (
 	"github.com/sylabs/singularity/v4/pkg/syfs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
+	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 )
 
@@ -667,7 +668,7 @@ var VersionCmd = &cobra.Command{
 }
 
 func loadRemoteConf(filepath string) (*remote.Config, error) {
-	f, err := os.OpenFile(filepath, os.O_RDONLY, 0o600)
+	f, err := os.OpenFile(filepath, os.O_RDONLY|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		return nil, fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/cmd/internal/cli/singularity_test.go
+++ b/cmd/internal/cli/singularity_test.go
@@ -9,6 +9,8 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 func TestCreateConfDir(t *testing.T) {
@@ -27,7 +29,7 @@ func TestCreateConfDir(t *testing.T) {
 		t.Errorf("failed to create directory %s", dir)
 	} else {
 		// stick something in the directory and make sure it isn't deleted
-		os.WriteFile(dir+"/foo", []byte(""), 0o655)
+		fs.WriteFileNoFollow(dir+"/foo", []byte(""), 0o655)
 		handleConfDir(dir)
 		if _, err := os.Stat(dir + "/foo"); os.IsNotExist(err) {
 			t.Errorf("inadvertently overwrote existing directory %s", dir)

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1827,7 +1827,7 @@ func (c actionTests) fuseMount(t *testing.T) {
 				t.Errorf("could not read ssh private key: %s", err)
 				return
 			}
-			if err := os.WriteFile(userPrivKey, content, 0o600); err != nil {
+			if err := fs.WriteFileNoFollow(userPrivKey, content, 0o600); err != nil {
 				t.Errorf("could not write ssh user private key: %s", err)
 				return
 			}

--- a/e2e/actions/oci.go
+++ b/e2e/actions/oci.go
@@ -1164,13 +1164,13 @@ func (c actionTests) actionOciOverlay(t *testing.T) {
 					os.RemoveAll(fullPath)
 				}
 			})
-			if err = os.WriteFile(
+			if err = fs.WriteFileNoFollow(
 				filepath.Join(upperPath, fmt.Sprintf("testfile.%d", i)),
 				fmt.Appendf(nil, "test_string_%d\n", i),
 				0o644); err != nil {
 				t.Fatal(err)
 			}
-			if err = os.WriteFile(
+			if err = fs.WriteFileNoFollow(
 				filepath.Join(upperPath, "maskable_testfile"),
 				fmt.Appendf(nil, "maskable_string_%d\n", i),
 				0o644); err != nil {
@@ -2222,7 +2222,7 @@ func (c actionTests) actionOciNoCompat(t *testing.T) {
 	}
 	canaryContent := "CANARY"
 	workCanary := filepath.Join(workDir, "canary")
-	if err := os.WriteFile(workCanary, []byte(canaryContent), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(workCanary, []byte(canaryContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/e2e/build/regressions.go
+++ b/e2e/build/regressions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -217,7 +217,7 @@ func (c *imgBuildTests) issue5166(t *testing.T) {
 	sensibleDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "sensible-dir-", "")
 
 	secret := filepath.Join(sensibleDir, "secret")
-	if err := os.WriteFile(secret, []byte("secret"), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(secret, []byte("secret"), 0o644); err != nil {
 		t.Fatalf("could not create %s: %s", secret, err)
 	}
 
@@ -502,7 +502,7 @@ from: %s
 		}
 	})
 
-	err = os.WriteFile(defFileName, []byte(defFileContents), 0o644)
+	err = fs.WriteFileNoFollow(defFileName, []byte(defFileContents), 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -1240,7 +1240,7 @@ func (c configTests) configFile(t *testing.T) {
 			e2e.WithGlobalOptions("--config", configFile),
 			e2e.WithProfile(tt.profile),
 			e2e.PreRun(func(t *testing.T) {
-				if err := os.WriteFile(configFile, []byte(tt.conf), 0o644); err != nil {
+				if err := fs.WriteFileNoFollow(configFile, []byte(tt.conf), 0o644); err != nil {
 					t.Errorf("could not write configuration file %s: %s", configFile, err)
 				}
 			}),

--- a/e2e/data/data.go
+++ b/e2e/data/data.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 type ctx struct {
@@ -31,7 +32,7 @@ func (c ctx) testDataPackage(t *testing.T) {
 	if err := os.Mkdir(innerDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(innerFile, content, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(innerFile, content, 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -154,7 +154,7 @@ func (c ctx) testDockerHost(t *testing.T) {
 
 	dockerfile := filepath.Join(tmpPath, "Dockerfile")
 	dockerfileContent := []byte("FROM alpine:latest\n")
-	if err := os.WriteFile(dockerfile, dockerfileContent, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(dockerfile, dockerfileContent, 0o644); err != nil {
 		t.Fatalf("failed to create temporary Dockerfile: %+v", err)
 	}
 

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/require"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 // This test will build a sandbox, as a non-root user from a dockerhub image
@@ -97,7 +98,7 @@ func (c ctx) issue5172(t *testing.T) {
 	// add our test registry as insecure and test build/pull
 	b := new(bytes.Buffer)
 	b.WriteString("[registries.insecure]\nregistries = ['localhost']")
-	if err := os.WriteFile(regFile, b.Bytes(), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(regFile, b.Bytes(), 0o644); err != nil {
 		t.Fatalf("can't create %s: %s", regFile, err)
 	}
 	defer os.RemoveAll(regDir)

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 type ctx struct {
@@ -432,7 +433,7 @@ func (c ctx) singularityEnvFile(t *testing.T) {
 		if len(tt.envFiles) > 0 {
 			for i, envFile := range tt.envFiles {
 				filename := fmt.Sprint(p, i)
-				os.WriteFile(filename, []byte(envFile), 0o644)
+				fs.WriteFileNoFollow(filename, []byte(envFile), 0o644)
 				args = append(args, "--env-file", filename)
 			}
 		}

--- a/e2e/env/oci.go
+++ b/e2e/env/oci.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 func (c ctx) ociSingularityEnv(t *testing.T) {
@@ -420,7 +421,7 @@ func (c ctx) ociEnvFile(t *testing.T) {
 			if len(tt.envFiles) > 0 {
 				for i, envFile := range tt.envFiles {
 					filename := fmt.Sprint(p, i)
-					os.WriteFile(filename, []byte(envFile), 0o644)
+					fs.WriteFileNoFollow(filename, []byte(envFile), 0o644)
 					args = append(args, "--env-file", filename)
 				}
 			}

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/v4/pkg/image"
 	"github.com/sylabs/singularity/v4/pkg/inspect"
+	"golang.org/x/sys/unix"
 )
 
 type ctx struct {
@@ -57,7 +58,7 @@ func (c ctx) singularityInspect(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to get root partition: %s", err)
 			}
-			f, err := os.Create(squashImage)
+			f, err := os.OpenFile(squashImage, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 			if err != nil {
 				t.Fatalf("failed to create %s: %s", squashImage, err)
 			}

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 	"github.com/sylabs/singularity/v4/e2e/internal/testhelper"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/util/fs/proc"
 )
 
@@ -198,7 +199,7 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 
 	// Create and populate a temporary file.
 	tempFile := filepath.Join(dir, fileName)
-	err = os.WriteFile(tempFile, fileContents, 0o644)
+	err = fs.WriteFileNoFollow(tempFile, fileContents, 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temporary test file %s: %v", tempFile, err)
 	}

--- a/e2e/internal/e2e/config.go
+++ b/e2e/internal/e2e/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -30,7 +30,7 @@ func SetupDefaultConfig(t *testing.T, path string) {
 	c.UnsquashfsPath = buildcfg.UNSQUASHFS_PATH
 
 	Privileged(func(t *testing.T) {
-		f, err := os.Create(path)
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 		if err != nil {
 			t.Fatalf("while creating singularity configuration: %s", err)
 		}

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/ociimage"
 	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	"github.com/sylabs/singularity/v4/pkg/syfs"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -252,7 +253,7 @@ func EnsureRegistryOCISIF(t *testing.T, env TestEnv) {
 }
 
 func DownloadFile(url string, path string) error {
-	dl, err := os.Create(path)
+	dl, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return err
 	}

--- a/e2e/internal/e2e/remote.go
+++ b/e2e/internal/e2e/remote.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2026 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"golang.org/x/sys/unix"
 )
 
@@ -24,7 +25,7 @@ func SetupSystemRemoteFile(t *testing.T, testDir string) {
 		if err != nil {
 			t.Fatalf("while reading %s: %s", orig, err)
 		}
-		if err := os.WriteFile(source, data, 0o644); err != nil {
+		if err := fs.WriteFileNoFollow(source, data, 0o644); err != nil {
 			t.Fatalf("while creating %s: %s", source, err)
 		}
 		if err := unix.Mount(source, dest, "", unix.MS_BIND, ""); err != nil {

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -546,7 +546,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 			// In order to actually test force, there must already be a file present in
 			// the expected location
 			if tt.createDst {
-				fh, err := os.Create(tt.expectedImage)
+				fh, err := os.OpenFile(tt.expectedImage, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 				if err != nil {
 					t.Fatalf("failed to create file %q: %+v\n", tt.expectedImage, err)
 				}

--- a/e2e/verify/oci.go
+++ b/e2e/verify/oci.go
@@ -6,12 +6,12 @@
 package verify
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/test/oci"
 )
 
@@ -27,7 +27,7 @@ func (c *ctx) verifyOCICosign(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(badKeyPath, kb.PublicBytes, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(badKeyPath, kb.PublicBytes, 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/app/singularity/capability_list_linux.go
+++ b/internal/app/singularity/capability_list_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/sylabs/singularity/v4/pkg/util/capabilities"
+	"golang.org/x/sys/unix"
 )
 
 // CapListConfig instructs CapabilityList on what to list
@@ -30,7 +31,7 @@ func CapabilityList(capFile string, c CapListConfig) error {
 	oldmask := syscall.Umask(0)
 	defer syscall.Umask(oldmask)
 
-	file, err := os.OpenFile(capFile, os.O_RDONLY, 0o644)
+	file, err := os.OpenFile(capFile, os.O_RDONLY|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening capability config file: %s", err)
 	}

--- a/internal/app/singularity/capability_manage_linux.go
+++ b/internal/app/singularity/capability_manage_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -14,6 +14,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/util/user"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"github.com/sylabs/singularity/v4/pkg/util/capabilities"
+	"golang.org/x/sys/unix"
 )
 
 // CapManageConfig specifies what capability set to edit in the capability file
@@ -64,7 +65,7 @@ func manageCaps(capFile string, c CapManageConfig, t manageType) error {
 	oldmask := syscall.Umask(0)
 	defer syscall.Umask(oldmask)
 
-	file, err := os.OpenFile(capFile, os.O_RDWR|os.O_CREATE, 0o644)
+	file, err := os.OpenFile(capFile, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening capability config file: %s", err)
 	}

--- a/internal/app/singularity/config_global_linux.go
+++ b/internal/app/singularity/config_global_linux.go
@@ -88,7 +88,7 @@ func GlobalConfig(args []string, configFile string, dry bool, op GlobalConfigOp)
 		return fmt.Errorf("%q is not a valid configuration directive", directive)
 	}
 
-	f, err := os.OpenFile(configFile, os.O_RDONLY, 0o644)
+	f, err := os.OpenFile(configFile, os.O_RDONLY|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening configuration file %s: %s", configFile, err)
 	}

--- a/internal/app/singularity/keyserver_add.go
+++ b/internal/app/singularity/keyserver_add.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
+	"golang.org/x/sys/unix"
 )
 
 func KeyserverAdd(name, uri string, order uint32, insecure bool) error {
@@ -23,7 +24,7 @@ func KeyserverAdd(name, uri string, order uint32, insecure bool) error {
 	}
 
 	// opening config file
-	file, err := os.OpenFile(remote.SystemConfigPath, os.O_RDWR|os.O_CREATE, 0o644)
+	file, err := os.OpenFile(remote.SystemConfigPath, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/keyserver_list.go
+++ b/internal/app/singularity/keyserver_list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -16,6 +16,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/credential"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
+	"golang.org/x/sys/unix"
 )
 
 // KeyserverList prints information about remote configurations
@@ -23,7 +24,7 @@ func KeyserverList(remoteName string, usrConfigFile string) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("no remote configurations")

--- a/internal/app/singularity/keyserver_login.go
+++ b/internal/app/singularity/keyserver_login.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -13,12 +13,13 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 // KeyserverLogin logs in to a keyserver.
 func KeyserverLogin(usrConfigFile string, args *LoginArgs) (err error) {
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/keyserver_remove.go
+++ b/internal/app/singularity/keyserver_remove.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
+	"golang.org/x/sys/unix"
 )
 
 func KeyserverRemove(name, uri string) error {
@@ -23,7 +24,7 @@ func KeyserverRemove(name, uri string) error {
 	}
 
 	// opening config file
-	file, err := os.OpenFile(remote.SystemConfigPath, os.O_RDWR|os.O_CREATE, 0o644)
+	file, err := os.OpenFile(remote.SystemConfigPath, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/plugin_compile_linux.go
+++ b/internal/app/singularity/plugin_compile_linux.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
 	pluginapi "github.com/sylabs/singularity/v4/pkg/plugin"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 // source file that should be present in a valid Singularity source tree
@@ -209,7 +210,7 @@ func generateManifest(sourceDir string, _ buildToolchain) (string, error) {
 		return "", fmt.Errorf("while loading plugin %s: %s", in, err)
 	}
 
-	f, err := os.OpenFile(out, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	f, err := os.OpenFile(out, os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return "", fmt.Errorf("while creating manifest %s: %s", out, err)
 	}

--- a/internal/app/singularity/registry_list.go
+++ b/internal/app/singularity/registry_list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/credential"
+	"golang.org/x/sys/unix"
 )
 
 // RegistryList prints information about remote configurations
@@ -21,7 +22,7 @@ func RegistryList(usrConfigFile string) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("no remote configurations")

--- a/internal/app/singularity/registry_login.go
+++ b/internal/app/singularity/registry_login.go
@@ -12,12 +12,13 @@ import (
 	"os"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
+	"golang.org/x/sys/unix"
 )
 
 // RegistryLogin logs in to an OCI/Docker registry.
 func RegistryLogin(usrConfigFile string, args *LoginArgs, reqAuthFile string) (err error) {
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return fmt.Errorf("while opening configuration file: %s", err)
 	}

--- a/internal/app/singularity/remote_add.go
+++ b/internal/app/singularity/remote_add.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
+	"golang.org/x/sys/unix"
 )
 
 // RemoteAdd adds remote to configuration
@@ -34,7 +35,7 @@ func RemoteAdd(configFile, name, uri string, global, insecure, makeDefault bool)
 	}
 
 	// opening config file
-	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, perm)
+	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, perm)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/remote_add_test.go
+++ b/internal/app/singularity/remote_add_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"go.yaml.in/yaml/v4"
 )
 
@@ -39,7 +40,7 @@ func createInvalidCfgFile(t *testing.T) string {
 		t.Fatalf("cannot marshal YAML: %s\n", err)
 	}
 
-	if err := os.WriteFile(path, yaml, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(path, yaml, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -69,7 +70,7 @@ func createValidCfgFile(t *testing.T) string {
 		t.Fatalf("cannot marshal YAML: %s\n", err)
 	}
 
-	if err := os.WriteFile(path, yaml, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(path, yaml, 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -13,6 +13,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
+	"golang.org/x/sys/unix"
 )
 
 const listLine = "%s\t%s\t%s\t%s\t%s\t%s\n"
@@ -22,7 +23,7 @@ func RemoteList(usrConfigFile string) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("no remote configurations")

--- a/internal/app/singularity/remote_login.go
+++ b/internal/app/singularity/remote_login.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -17,6 +17,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/util/auth"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/interactive"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 type LoginArgs struct {
@@ -35,7 +36,7 @@ var ErrLoginAborted = errors.New("user aborted login")
 // to use the default remote.
 func RemoteLogin(usrConfigFile string, args *LoginArgs) (err error) {
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/remote_logout.go
+++ b/internal/app/singularity/remote_logout.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -13,12 +13,13 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
+	"golang.org/x/sys/unix"
 )
 
 // RemoteLogout logs out from an endpoint.
 func RemoteLogout(usrConfigFile, name string) (err error) {
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}
@@ -70,7 +71,7 @@ func RemoteLogout(usrConfigFile, name string) (err error) {
 // RemoteLogout logs out from a keyserver or OCI/Docker registry.
 func OtherLogout(usrConfigFile, name string, reqAuthFile string) (err error) {
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return fmt.Errorf("while opening configuration file: %s", err)
 	}

--- a/internal/app/singularity/remote_remove.go
+++ b/internal/app/singularity/remote_remove.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -11,12 +11,13 @@ import (
 	"os"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
+	"golang.org/x/sys/unix"
 )
 
 // RemoteRemove deletes a remote endpoint from the configuration
 func RemoteRemove(configFile, name string) (err error) {
 	// opening config file
-	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,6 +17,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -41,7 +42,7 @@ func RemoteStatus(usrConfigFile, name string) (err error) {
 	}
 
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0o600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("no remote configurations")

--- a/internal/app/singularity/remote_use.go
+++ b/internal/app/singularity/remote_use.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,11 +12,12 @@ import (
 	"os"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/remote"
+	"golang.org/x/sys/unix"
 )
 
 func syncSysConfig(cUsr *remote.Config) error {
 	// opening system config file
-	f, err := os.OpenFile(remote.SystemConfigPath, os.O_RDONLY, 0o600)
+	f, err := os.OpenFile(remote.SystemConfigPath, os.O_RDONLY|unix.O_NOFOLLOW, 0o600)
 	if err != nil && os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
@@ -51,7 +52,7 @@ func RemoteUse(usrConfigFile, name string, global, exclusive bool) (err error) {
 	}
 
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, perm)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE|unix.O_NOFOLLOW, perm)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
@@ -252,7 +253,7 @@ func (pl *BuildApp) createAllApps(b *types.Bundle) error {
 		globalEnv94.WriteString(globalAppEnv(b, app))
 	}
 
-	return os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/env/94-appsbase.sh"), []byte(globalEnv94.String()), 0o755)
+	return fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/env/94-appsbase.sh"), []byte(globalEnv94.String()), 0o755)
 }
 
 func createAppRoot(b *types.Bundle, a *App) error {
@@ -286,7 +287,7 @@ func createAppRoot(b *types.Bundle, a *App) error {
 // %appenv and 01-base.sh
 func writeEnvFile(b *types.Bundle, a *App) error {
 	content := fmt.Sprintf(scifEnv01Base, a.Name)
-	if err := os.WriteFile(filepath.Join(appMeta(b, a), "/env/01-base.sh"), []byte(content), 0o755); err != nil {
+	if err := fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/env/01-base.sh"), []byte(content), 0o755); err != nil {
 		return err
 	}
 
@@ -294,7 +295,7 @@ func writeEnvFile(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	return os.WriteFile(filepath.Join(appMeta(b, a), "/env/90-environment.sh"), []byte(a.Env), 0o755)
+	return fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/env/90-environment.sh"), []byte(a.Env), 0o755)
 }
 
 func globalAppEnv(b *types.Bundle, a *App) string {
@@ -328,7 +329,7 @@ func writeRunscriptFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifRunscriptBase, a.Run)
-	return os.WriteFile(filepath.Join(appMeta(b, a), "/runscript"), []byte(content), 0o755)
+	return fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/runscript"), []byte(content), 0o755)
 }
 
 // %appstart
@@ -338,7 +339,7 @@ func writeStartscriptFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifStartscriptBase, a.Start)
-	return os.WriteFile(filepath.Join(appMeta(b, a), "/startscript"), []byte(content), 0o755)
+	return fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/startscript"), []byte(content), 0o755)
 }
 
 // %apptest
@@ -348,7 +349,7 @@ func writeTestFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifTestBase, a.Test)
-	return os.WriteFile(filepath.Join(appMeta(b, a), "/test"), []byte(content), 0o755)
+	return fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/test"), []byte(content), 0o755)
 }
 
 // %apphelp
@@ -357,7 +358,7 @@ func writeHelpFile(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	return os.WriteFile(filepath.Join(appMeta(b, a), "/runscript.help"), []byte(a.Help), 0o644)
+	return fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/runscript.help"), []byte(a.Help), 0o644)
 }
 
 // %appfile
@@ -428,7 +429,7 @@ func writeLabels(b *types.Bundle, a *App) error {
 	}
 
 	appBase := filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)
-	err = os.WriteFile(filepath.Join(appBase, "scif/labels.json"), text, 0o644)
+	err = fs.WriteFileNoFollow(filepath.Join(appBase, "scif/labels.json"), text, 0o644)
 	return err
 }
 

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -346,7 +346,7 @@ func (b *Build) Full(ctx context.Context) error {
 		// write the build configuration used for %post and %test sections
 		// as a root or non-setuid user.
 		configFile := filepath.Join(stage.b.TmpDir, "singularity.conf")
-		if err := os.WriteFile(configFile, configData, 0o644); err != nil {
+		if err := fs.WriteFileNoFollow(configFile, configData, 0o644); err != nil {
 			return fmt.Errorf("while creating %s: %s", configFile, err)
 		}
 		defer os.Remove(configFile)

--- a/internal/pkg/build/buildkit/auth/authprovider.go
+++ b/internal/pkg/build/buildkit/auth/authprovider.go
@@ -49,6 +49,7 @@ import (
 	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/moby/buildkit/util/progress/progresswriter"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/credential/ociauth"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"github.com/sylabs/singularity/v4/pkg/util/maps"
 	"golang.org/x/crypto/nacl/sign"
@@ -350,7 +351,7 @@ func (ts *tokenSeeds) getSeed(host string) ([]byte, error) {
 		return nil, err
 	}
 
-	if err := os.WriteFile(fp, dt, 0o600); err != nil {
+	if err := fs.WriteFileNoFollow(fp, dt, 0o600); err != nil {
 		if !errors.Is(err, syscall.EROFS) && !errors.Is(err, os.ErrPermission) {
 			return nil, err
 		}

--- a/internal/pkg/build/buildkit/daemon/executor.go
+++ b/internal/pkg/build/buildkit/daemon/executor.go
@@ -72,6 +72,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
+	"golang.org/x/sys/unix"
 )
 
 // BkSnapshotterFactory instantiates a snapshotter
@@ -420,7 +421,7 @@ func (w *buildExecutor) Run(ctx context.Context, id string, root executor.Mount,
 		return nil, err
 	}
 
-	f, err := os.Create(filepath.Join(bundle, "config.json"))
+	f, err := os.OpenFile(filepath.Join(bundle, "config.json"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -85,12 +85,12 @@ func TestCopyFromHost(t *testing.T) {
 
 	// Source Files
 	srcFile := filepath.Join(dir, "srcFile")
-	if err := os.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	srcFileGlob := filepath.Join(dir, "srcFi?*")
 	srcSpaceFile := filepath.Join(dir, "src File")
-	if err := os.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(srcSpaceFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
@@ -106,7 +106,7 @@ func TestCopyFromHost(t *testing.T) {
 	srcGlob := filepath.Join(dir, "src*")
 	// Nested File (to test multi level glob)
 	srcFileNested := filepath.Join(dir, "srcDir/srcFileNested")
-	if err := os.WriteFile(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	srcFileNestedGlob := filepath.Join(dir, "srcDi?/srcFil?Nested")
@@ -372,7 +372,7 @@ func TestCopyFromHostNested(t *testing.T) {
 	}
 	// Source Files
 	srcFile := filepath.Join(innerDir, "srcFile")
-	if err := os.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
@@ -472,11 +472,11 @@ func TestCopyFromStage(t *testing.T) {
 
 	// Source Files
 	srcFile := filepath.Join(srcRoot, "srcFile")
-	if err := os.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	srcSpaceFile := filepath.Join(srcRoot, "src File")
-	if err := os.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(srcSpaceFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
@@ -490,7 +490,7 @@ func TestCopyFromStage(t *testing.T) {
 	}
 	// Nested File (to test multi level glob)
 	srcFileNested := filepath.Join(srcRoot, "srcDir/srcFileNested")
-	if err := os.WriteFile(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Symlinks
@@ -774,7 +774,7 @@ func TestCopyFromStageNested(t *testing.T) {
 	}
 	// Source Files
 	srcFile := filepath.Join(innerDir, "srcFile")
-	if err := os.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -19,11 +19,13 @@ import (
 	"time"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/build/types/parser"
 	"github.com/sylabs/singularity/v4/pkg/image"
 	"github.com/sylabs/singularity/v4/pkg/inspect"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 func (s *stage) insertMetadata() error {
@@ -76,13 +78,13 @@ func insertEnvScript(b *types.Bundle) error {
 		envScriptPath := filepath.Join(b.RootfsPath, "/.singularity.d/env/90-environment.sh")
 		_, err := os.Stat(envScriptPath)
 		if os.IsNotExist(err) {
-			err := os.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.Environment.Script+"\n"), 0o755)
+			err := fs.WriteFileNoFollow(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.Environment.Script+"\n"), 0o755)
 			if err != nil {
 				return err
 			}
 		} else {
 			// append to script if it already exists
-			f, err := os.OpenFile(envScriptPath, os.O_APPEND|os.O_WRONLY, 0o755)
+			f, err := os.OpenFile(envScriptPath, os.O_APPEND|os.O_WRONLY|unix.O_NOFOLLOW, 0o755)
 			if err != nil {
 				return err
 			}
@@ -123,7 +125,7 @@ func insertRunScript(b *types.Bundle) error {
 	if b.RunSection("runscript") && b.Recipe.Runscript.Script != "" {
 		sylog.Infof("Adding runscript")
 		shebang, script := handleShebangScript(b.Recipe.Runscript)
-		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -135,7 +137,7 @@ func insertStartScript(b *types.Bundle) error {
 	if b.RunSection("startscript") && b.Recipe.Startscript.Script != "" {
 		sylog.Infof("Adding startscript")
 		shebang, script := handleShebangScript(b.Recipe.Startscript)
-		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -147,7 +149,7 @@ func insertTestScript(b *types.Bundle) error {
 	if b.RunSection("test") && b.Recipe.Test.Script != "" {
 		sylog.Infof("Adding testscript")
 		shebang, script := handleShebangScript(b.Recipe.Test)
-		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -160,7 +162,7 @@ func insertHelpScript(b *types.Bundle) error {
 		_, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"))
 		if err != nil || b.Opts.Force {
 			sylog.Infof("Adding help info")
-			err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.Help.Script+"\n"), 0o644)
+			err := fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.Help.Script+"\n"), 0o644)
 			if err != nil {
 				return err
 			}
@@ -198,7 +200,7 @@ func insertDefinition(b *types.Bundle) error {
 		}
 	}
 
-	err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), b.Recipe.FullRaw, 0o644)
+	err := fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), b.Recipe.FullRaw, 0o644)
 	if err != nil {
 		return err
 	}
@@ -256,7 +258,7 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 		return err
 	}
 
-	err = os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
+	err = fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
 	return err
 }
 

--- a/internal/pkg/build/remotebuilder/remotebuilder.go
+++ b/internal/pkg/build/remotebuilder/remotebuilder.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
+	"golang.org/x/sys/unix"
 )
 
 // RemoteBuilder contains the build request and response
@@ -185,7 +186,7 @@ func (rb *RemoteBuilder) Build(ctx context.Context) (err error) {
 
 	// If image destination is local file, pull image.
 	if !strings.HasPrefix(rb.ImagePath, "library://") {
-		f, err := os.OpenFile(rb.ImagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o777)
+		f, err := os.OpenFile(rb.ImagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR|unix.O_NOFOLLOW, 0o777)
 		if err != nil {
 			return fmt.Errorf("unable to open file %s for writing: %w", rb.ImagePath, err)
 		}

--- a/internal/pkg/build/sources/base_environment.go
+++ b/internal/pkg/build/sources/base_environment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -358,7 +359,7 @@ func makeFile(name string, perm os.FileMode, s string, overwrite bool) (err erro
 	}
 	// Create the file if it's not in the container, or truncate and write s
 	// into it otherwise.
-	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, perm)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -212,7 +212,7 @@ func (cp *ArchConveyorPacker) insertBaseEnv() (err error) {
 }
 
 func (cp *ArchConveyorPacker) insertRunScript() (err error) {
-	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -14,8 +14,10 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 // BusyBoxConveyor only needs to hold the conveyor to have the needed data to pack
@@ -76,15 +78,15 @@ func (cp *BusyBoxConveyorPacker) Pack(context.Context) (b *types.Bundle, err err
 }
 
 func (c *BusyBoxConveyor) insertBaseFiles() error {
-	if err := os.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/passwd"), []byte("root:!:0:0:root:/root:/bin/sh"), 0o664); err != nil {
+	if err := fs.WriteFileNoFollow(filepath.Join(c.b.RootfsPath, "/etc/passwd"), []byte("root:!:0:0:root:/root:/bin/sh"), 0o664); err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/group"), []byte(" root:x:0:"), 0o664); err != nil {
+	if err := fs.WriteFileNoFollow(filepath.Join(c.b.RootfsPath, "/etc/group"), []byte(" root:x:0:"), 0o664); err != nil {
 		return err
 	}
 
-	return os.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0o664)
+	return fs.WriteFileNoFollow(filepath.Join(c.b.RootfsPath, "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0o664)
 }
 
 func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, err error) {
@@ -96,7 +98,7 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 	}
 	defer resp.Body.Close()
 
-	f, err := os.Create(filepath.Join(c.b.RootfsPath, "/bin/busybox"))
+	f, err := os.OpenFile(filepath.Join(c.b.RootfsPath, "/bin/busybox"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return "", err
 	}
@@ -128,7 +130,7 @@ func (c *BusyBoxConveyor) insertBaseEnv() (err error) {
 }
 
 func (cp *BusyBoxConveyorPacker) insertRunScript() error {
-	return os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	return fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 }
 
 // CleanUp removes any tmpfs owned by the conveyorPacker on the filesystem

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,6 +23,7 @@ import (
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"github.com/sylabs/singularity/v4/pkg/util/namespaces"
+	"golang.org/x/sys/unix"
 )
 
 // debootstrapArchs is a map of GO Archs to official Debian ports
@@ -113,8 +114,14 @@ func (cp *DebootstrapConveyorPacker) prepareFakerootEnv(ctx context.Context) (fu
 				break
 			case <-time.After(100 * time.Millisecond):
 				if _, err := os.Stat(makedevPath); err == nil {
-					os.Truncate(makedevPath, 0)
-					os.Create(filepath.Join(cp.b.RootfsPath, "/dev/tty1"))
+					if err := os.Truncate(makedevPath, 0); err != nil {
+						sylog.Warningf("while truncating %s: %s", makedevPath, err)
+					}
+					f, err := os.OpenFile(filepath.Join(cp.b.RootfsPath, "/dev/tty1"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
+					if err != nil {
+						sylog.Warningf("while creating %s: %s", filepath.Join(cp.b.RootfsPath, "/dev/tty1"), err)
+					}
+					f.Close()
 					break
 				}
 			}
@@ -274,7 +281,7 @@ func (cp *DebootstrapConveyorPacker) insertBaseEnv(b *types.Bundle) (err error) 
 }
 
 func (cp *DebootstrapConveyorPacker) insertRunScript(b *types.Bundle) (err error) {
-	f, err := os.Create(b.RootfsPath + "/.singularity.d/runscript")
+	f, err := os.OpenFile(b.RootfsPath+"/.singularity.d/runscript", os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_local_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_local_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -49,7 +49,7 @@ func TestLocalPackerSquashfs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("while reading test file: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(rootfs, testfile), data, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(filepath.Join(rootfs, testfile), data, 0o644); err != nil {
 		t.Fatalf("while writing test file: %v", err)
 	}
 	image := filepath.Join(tempDirPath, "issue_3084.img")

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -24,11 +24,13 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
 	"github.com/sylabs/singularity/v4/internal/pkg/ociimage"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/credential/ociauth"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/shell"
 	sytypes "github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/image"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
+	"golang.org/x/sys/unix"
 )
 
 type ociRunscriptData struct {
@@ -259,7 +261,7 @@ func (cp *OCIConveyorPacker) insertBaseEnv() (err error) {
 }
 
 func (cp *OCIConveyorPacker) insertRunScript() error {
-	f, err := os.Create(cp.b.RootfsPath + "/.singularity.d/runscript")
+	f, err := os.OpenFile(cp.b.RootfsPath+"/.singularity.d/runscript", os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return err
 	}
@@ -342,7 +344,7 @@ func (cp *OCIConveyorPacker) insertRunScript() error {
 }
 
 func (cp *OCIConveyorPacker) insertEnv() error {
-	f, err := os.Create(cp.b.RootfsPath + "/.singularity.d/env/10-docker2singularity.sh")
+	f, err := os.OpenFile(cp.b.RootfsPath+"/.singularity.d/env/10-docker2singularity.sh", os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return err
 	}
@@ -397,7 +399,7 @@ func (cp *OCIConveyorPacker) insertOCILabels() (err error) {
 		return err
 	}
 
-	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
+	err = fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
 	return err
 }
 

--- a/internal/pkg/build/sources/conveyorPacker_scratch.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -8,9 +8,9 @@ package sources
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 )
 
@@ -54,7 +54,7 @@ func (c *ScratchConveyor) insertBaseEnv() (err error) {
 }
 
 func (cp *ScratchConveyorPacker) insertRunScript() (err error) {
-	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -18,6 +18,7 @@ import (
 	"syscall"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/rpm"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
@@ -256,7 +257,7 @@ func (c *YumConveyor) genYumConfig() (err error) {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.RootfsPath, "/etc"), err)
 	}
 
-	err = os.WriteFile(filepath.Join(c.b.RootfsPath, yumConf), []byte(fileContent), 0o664)
+	err = fs.WriteFileNoFollow(filepath.Join(c.b.RootfsPath, yumConf), []byte(fileContent), 0o664)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.RootfsPath, yumConf), err)
 	}
@@ -346,7 +347,7 @@ func (cp *YumConveyorPacker) insertBaseEnv() (err error) {
 }
 
 func (cp *YumConveyorPacker) insertRunScript() (err error) {
-	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -21,9 +21,11 @@ import (
 
 	"github.com/samber/lo/mutable"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"github.com/sylabs/singularity/v4/pkg/util/namespaces"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -369,7 +371,7 @@ func (cp *ZypperConveyorPacker) insertBaseEnv() (err error) {
 }
 
 func (cp *ZypperConveyorPacker) insertRunScript() (err error) {
-	f, err := os.Create(cp.b.RootfsPath + "/.singularity.d/runscript")
+	f, err := os.OpenFile(cp.b.RootfsPath+"/.singularity.d/runscript", os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return
 	}
@@ -401,7 +403,7 @@ func (cp *ZypperConveyorPacker) genZypperConfig() (err error) {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(cp.b.RootfsPath, "/etc/zypp"), err)
 	}
 
-	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, zypperConf), []byte("[main]\ncachedir=/val/cache/zypp-bootstrap\n\n"), 0o664)
+	err = fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, zypperConf), []byte("[main]\ncachedir=/val/cache/zypp-bootstrap\n\n"), 0o664)
 	if err != nil {
 		return
 	}
@@ -481,7 +483,7 @@ func (cp *ZypperConveyorPacker) prepareFakerootRpmMacros() (func(), error) {
 	if os.IsNotExist(err) {
 		// User .rpmmacros does not exist; create an empty file, just so we have
 		// a mount target
-		if err := os.WriteFile(homeRpmMacros, contents, 0o644); err != nil {
+		if err := fs.WriteFileNoFollow(homeRpmMacros, contents, 0o644); err != nil {
 			return cleanupFunc, fmt.Errorf("could not blank user .rpmmacros file %q: %w", homeRpmMacros, err)
 		}
 	} else if err != nil {
@@ -528,7 +530,7 @@ func (cp *ZypperConveyorPacker) prepareFakerootRpmMacros() (func(), error) {
 	sylog.Debugf("Custom .rpmmacros contents: %q", newContents)
 	customRpmMacros := filepath.Join(parentDir, ".rpmmacros")
 	sylog.Debugf("Writing custom .rpmmacros at: %s", customRpmMacros)
-	if err := os.WriteFile(customRpmMacros, []byte(newContents), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(customRpmMacros, []byte(newContents), 0o644); err != nil {
 		return cleanupFunc, fmt.Errorf("could not write contents to custom .rpmmacros file %q: %w", customRpmMacros, err)
 	}
 	cleanupTasks = append(cleanupTasks, func() {

--- a/internal/pkg/build/util.go
+++ b/internal/pkg/build/util.go
@@ -26,7 +26,7 @@ func createStageFile(source string, b *types.Bundle, warnMsg string) (string, er
 	}
 
 	sessionFile := filepath.Join(b.TmpDir, filepath.Base(source))
-	stageFile, err := os.Create(sessionFile)
+	stageFile, err := os.OpenFile(sessionFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return "", fmt.Errorf("failed to create staging %s file: %s", sessionFile, err)
 	}
@@ -56,7 +56,7 @@ func createStageFile(source string, b *types.Bundle, warnMsg string) (string, er
 }
 
 func createScript(path string, content []byte) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o755)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return fmt.Errorf("failed to create script: %s", err)
 	}

--- a/internal/pkg/buildcfg/confgen/gen.go
+++ b/internal/pkg/buildcfg/confgen/gen.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+
+	"golang.org/x/sys/unix"
 )
 
 func parseLine(s string) (d Define) {
@@ -120,7 +122,7 @@ func IsReproducibleBuild() bool {
 `))
 
 func main() {
-	outFile, err := os.Create("config.go")
+	outFile, err := os.OpenFile("config.go", os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/internal/pkg/cgroups/config_linux.go
+++ b/internal/pkg/cgroups/config_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/cgroups/manager_linux_v1_test.go
+++ b/internal/pkg/cgroups/manager_linux_v1_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,7 +6,6 @@
 package cgroups
 
 import (
-	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/require"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 // This file contains tests that will run under cgroups v1 only.
@@ -119,7 +119,7 @@ func testNewUpdateV1(t *testing.T, systemd bool) {
 	// Write a new config with [pids] limit = 512
 	content := []byte("[pids]\nlimit = 512")
 	tmpfile := filepath.Join(t.TempDir(), "cgroups")
-	if err := os.WriteFile(tmpfile, content, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(tmpfile, content, 0o644); err != nil {
 		t.Fatalf("While writing update file: %v", err)
 	}
 

--- a/internal/pkg/cgroups/manager_linux_v2_test.go
+++ b/internal/pkg/cgroups/manager_linux_v2_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,7 +6,6 @@
 package cgroups
 
 import (
-	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 	"github.com/sylabs/singularity/v4/internal/pkg/test/tool/require"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 // This file contains tests that will run under cgroups v2 only.
@@ -110,7 +110,7 @@ func testNewUpdateV2(t *testing.T, systemd bool) {
 	// Write a new config with [pids] limit = 512
 	content := []byte("[pids]\nlimit = 512")
 	tmpfile := filepath.Join(t.TempDir(), "cgroups")
-	if err := os.WriteFile(tmpfile, content, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(tmpfile, content, 0o644); err != nil {
 		t.Fatalf("While writing update file: %v", err)
 	}
 

--- a/internal/pkg/client/library/library.go
+++ b/internal/pkg/client/library/library.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,6 +17,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
+	"golang.org/x/sys/unix"
 
 	scslibrary "github.com/sylabs/scs-library-client/client"
 )
@@ -111,7 +112,7 @@ func getDownloadConfig() (scslibrary.Downloader, error) {
 // DownloadImage is a helper function to wrap library image download operation
 func DownloadImage(ctx context.Context, c *scslibrary.Client, imagePath, arch string, libraryRef *scslibrary.Ref, pb scslibrary.ProgressBar) error {
 	// open destination file for writing
-	f, err := os.OpenFile(imagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o777)
+	f, err := os.OpenFile(imagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR|unix.O_NOFOLLOW, 0o777)
 	if err != nil {
 		return fmt.Errorf("error opening file %s for writing: %v", imagePath, err)
 	}

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,6 +23,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
+	"golang.org/x/sys/unix"
 )
 
 // Timeout for an image pull in seconds - could be a large download...
@@ -82,7 +83,7 @@ func DownloadImage(ctx context.Context, filePath string, netURL string) error {
 	sylog.Debugf("OK response received, beginning body download\n")
 
 	// Perms are 777 *prior* to umask
-	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o777)
+	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|unix.O_NOFOLLOW, 0o777)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -26,6 +26,7 @@ import (
 	"github.com/sylabs/singularity/v4/pkg/image"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
+	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 )
 
@@ -89,7 +90,7 @@ func DownloadImage(ctx context.Context, path, ref string, ociAuth *authn.AuthCon
 		return err
 	}
 	defer blob.Close()
-	outFile, err := os.Create(path)
+	outFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/client/shub/pull.go
+++ b/internal/pkg/client/shub/pull.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	useragent "github.com/sylabs/singularity/v4/pkg/util/user-agent"
+	"golang.org/x/sys/unix"
 )
 
 // Timeout for an image pull in seconds (2 hours)
@@ -85,7 +86,7 @@ func DownloadImage(ctx context.Context, manifest APIResponse, filePath, shubRef 
 	}
 
 	// Perms are 777 *prior* to umask
-	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o777)
+	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|unix.O_NOFOLLOW, 0o777)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/fakeroot/config.go
+++ b/internal/pkg/fakeroot/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/util/user"
 	"github.com/sylabs/singularity/v4/pkg/util/fs/lock"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -84,7 +85,7 @@ func GetConfig(filename string, edit bool, getUserFn GetUserFn) (*Config, error)
 
 	flags := os.O_RDONLY
 	if !config.readOnly {
-		flags = os.O_CREATE | os.O_RDWR
+		flags = os.O_CREATE | os.O_RDWR | unix.O_NOFOLLOW
 		umask := syscall.Umask(0)
 		defer syscall.Umask(umask)
 	}

--- a/internal/pkg/image/unpacker/squashfs_singularity.go
+++ b/internal/pkg/image/unpacker/squashfs_singularity.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
@@ -224,7 +225,7 @@ func unsquashfsSandboxCmd(squashfs *Squashfs, dest string, filename string, filt
 		if err := os.MkdirAll(rootfsDir, 0o700); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", rootfsDir, err)
 		}
-		if err := os.WriteFile(rootfsFile, []byte(""), 0o600); err != nil {
+		if err := fs.WriteFileNoFollow(rootfsFile, []byte(""), 0o600); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", rootfsFile, err)
 		}
 		// Simple read-only bind, dest in container same as source on host
@@ -240,7 +241,7 @@ func unsquashfsSandboxCmd(squashfs *Squashfs, dest string, filename string, filt
 		if err := os.MkdirAll(rootfsDir, 0o700); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", rootfsDir, err)
 		}
-		if err := os.WriteFile(rootfsFile, []byte(""), 0o600); err != nil {
+		if err := fs.WriteFileNoFollow(rootfsFile, []byte(""), 0o600); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", rootfsFile, err)
 		}
 		// Read only bind, dest in container may not match source on host due

--- a/internal/pkg/ociimage/fetch.go
+++ b/internal/pkg/ociimage/fetch.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,6 +23,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/client/progress"
 	"github.com/sylabs/singularity/v4/internal/pkg/ociplatform"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 // cachedImage will ensure that the provided v1.Image is present in the Singularity
@@ -252,7 +253,7 @@ func extractTarNaive(src string, dst string) error {
 			if err != nil {
 				return err
 			}
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(tarMode))
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|unix.O_NOFOLLOW, os.FileMode(tarMode))
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/plugin/create.go
+++ b/internal/pkg/plugin/create.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2026 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
@@ -69,13 +70,13 @@ func Create(path, name string) error {
 	// create main.go skeleton
 	filename := filepath.Join(dir, "main.go")
 	content := fmt.Sprintf(mainGo, name)
-	if err := os.WriteFile(filename, []byte(content), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(filename, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("while creating plugin %s: %s", filename, err)
 	}
 
 	// create .gitignore skeleton
 	filename = filepath.Join(dir, ".gitignore")
-	if err := os.WriteFile(filename, []byte(gitIgnore), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(filename, []byte(gitIgnore), 0o644); err != nil {
 		return fmt.Errorf("while creating plugin %s: %s", filename, err)
 	}
 

--- a/internal/pkg/plugin/meta.go
+++ b/internal/pkg/plugin/meta.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -18,6 +18,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/plugin/callback"
 	"github.com/sylabs/singularity/v4/pkg/image"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -109,7 +110,7 @@ func (m *Meta) install(img *image.Image) error {
 }
 
 func (m *Meta) installBinary(img *image.Image) error {
-	fh, err := os.Create(m.binaryName())
+	fh, err := os.OpenFile(m.binaryName(), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return err
 	}
@@ -125,7 +126,7 @@ func (m *Meta) installBinary(img *image.Image) error {
 }
 
 func (m *Meta) installManifest(img *image.Image) error {
-	fh, err := os.Create(m.manifestName())
+	fh, err := os.OpenFile(m.manifestName(), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return err
 	}
@@ -162,7 +163,7 @@ func (m *Meta) runInstall() error {
 func (m *Meta) installMeta() error {
 	fn := metaPath(m.Name)
 
-	fh, err := os.Create(fn)
+	fh, err := os.OpenFile(fn, os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,6 +17,7 @@ import (
 	"github.com/gosimple/slug"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/credential"
 	"github.com/sylabs/singularity/v4/pkg/syfs"
+	"golang.org/x/sys/unix"
 )
 
 var cacheDuration = 720 * time.Hour
@@ -100,7 +101,7 @@ func getCachedConfig(uri string) io.ReadCloser {
 	} else if fi.ModTime().Add(cacheDuration).Before(time.Now()) {
 		return nil
 	}
-	rc, err := os.Open(config)
+	rc, err := os.OpenFile(config, os.O_RDONLY|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		return nil
 	}
@@ -113,5 +114,10 @@ func updateCachedConfig(uri string, data []byte) {
 		return
 	}
 	config := filepath.Join(dir, uri+".json")
-	os.WriteFile(config, data, 0o600)
+	f, err := os.OpenFile(config, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	f.Write(data)
 }

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -211,7 +211,7 @@ func (e *EngineOperations) prepareUserCaps(enforced bool) error {
 
 	e.EngineConfig.OciConfig.SetProcessNoNewPrivileges(true)
 
-	file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY, 0o644)
+	file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening capability config file: %s", err)
 	}
@@ -341,7 +341,7 @@ func (e *EngineOperations) prepareRootCaps() error {
 		e.EngineConfig.OciConfig.SetupPrivileged(true)
 		commonCaps = e.EngineConfig.OciConfig.Process.Capabilities.Permitted
 	case "file":
-		file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY, 0o644)
+		file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY|unix.O_NOFOLLOW, 0o644)
 		if err != nil {
 			return fmt.Errorf("while opening capability config file: %s", err)
 		}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -529,7 +529,7 @@ func (l *Launcher) preparePasswd(bundlePath string, uid uint32) (*specs.Mount, e
 		sylog.Warningf("%s", err)
 		return nil, nil
 	}
-	if err := os.WriteFile(containerPasswd, content, 0o755); err != nil {
+	if err := fs.WriteFileNoFollow(containerPasswd, content, 0o755); err != nil {
 		return nil, fmt.Errorf("while writing passwd file: %w", err)
 	}
 	passwdMount := specs.Mount{
@@ -561,7 +561,7 @@ func (l *Launcher) prepareGroup(bundlePath string, uid, gid uint32) (*specs.Moun
 		// E.g. container doesn't contain an /etc/group
 		sylog.Warningf("%s", err)
 		return nil, nil
-	} else if err := os.WriteFile(containerGroup, content, 0o755); err != nil {
+	} else if err := fs.WriteFileNoFollow(containerGroup, content, 0o755); err != nil {
 		return nil, fmt.Errorf("while writing passwd file: %w", err)
 	}
 	groupMount := specs.Mount{
@@ -610,7 +610,7 @@ func (l *Launcher) prepareResolvConf(bundlePath string) (*specs.Mount, error) {
 		}
 	}
 
-	if err := os.WriteFile(containerResolvConfPath, resolvConfData, 0o755); err != nil {
+	if err := fs.WriteFileNoFollow(containerResolvConfPath, resolvConfData, 0o755); err != nil {
 		return nil, fmt.Errorf("while writing container's resolv.conf file: %v", err)
 	}
 
@@ -672,7 +672,7 @@ fi
 		b.WriteString(fmt.Sprintf(hostEnvSnippet, k, "'"+shell.EscapeSingleQuotes(v)+"'"))
 	}
 
-	if err := os.WriteFile(hostEnvPath, b.Bytes(), 0o755); err != nil {
+	if err := fs.WriteFileNoFollow(hostEnvPath, b.Bytes(), 0o755); err != nil {
 		return specs.Mount{}, fmt.Errorf("while writing container's %s file: %v", containerEnvPath, err)
 	}
 

--- a/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -18,6 +18,7 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/launcher"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/user"
 	"github.com/sylabs/singularity/v4/pkg/util/bind"
 	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
@@ -505,10 +506,10 @@ func TestLauncher_addLibrariesMounts(t *testing.T) {
 	lib1 := filepath.Join(tmpDir, "lib1.so")
 	lib2 := filepath.Join(tmpDir, "lib2.so")
 	libInvalid := filepath.Join(tmpDir, "invalid")
-	if err := os.WriteFile(lib1, []byte("lib1"), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(lib1, []byte("lib1"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(lib2, []byte("lib2"), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(lib2, []byte("lib2"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,6 +15,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,6 +24,7 @@ import (
 	toml "github.com/pelletier/go-toml/v2"
 	"github.com/sylabs/sif/v2/pkg/integrity"
 	"github.com/sylabs/sif/v2/pkg/sif"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -56,7 +58,12 @@ type Execgroup struct {
 // LoadConfig opens an ECL config file and unmarshals it into structures
 func LoadConfig(confPath string) (ecl EclConfig, err error) {
 	// read in the ECL config file
-	b, err := os.ReadFile(confPath)
+	f, err := os.OpenFile(confPath, os.O_RDONLY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return
 	}
@@ -73,7 +80,13 @@ func PutConfig(ecl EclConfig, confPath string) (err error) {
 		return
 	}
 
-	return os.WriteFile(confPath, data, 0o644)
+	f, err := os.OpenFile(confPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	return
 }
 
 // ValidateConfig makes sure paths from configs are fully resolved and that

--- a/internal/pkg/sypgp/sypgp.go
+++ b/internal/pkg/sypgp/sypgp.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -36,6 +36,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/util/interactive"
 	"github.com/sylabs/singularity/v4/pkg/syfs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -172,7 +173,7 @@ func createOrAppendFile(fn string, mode os.FileMode) (*os.File, error) {
 	oldumask := syscall.Umask(0)
 	defer syscall.Umask(oldumask)
 
-	f, err := os.OpenFile(fn, os.O_APPEND|os.O_CREATE|os.O_WRONLY, mode)
+	f, err := os.OpenFile(fn, os.O_APPEND|os.O_CREATE|os.O_WRONLY|unix.O_NOFOLLOW, mode)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +187,7 @@ func createOrTruncateFile(fn string, mode os.FileMode) (*os.File, error) {
 	oldumask := syscall.Umask(0)
 	defer syscall.Umask(oldumask)
 
-	f, err := os.OpenFile(fn, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, mode)
+	f, err := os.OpenFile(fn, os.O_TRUNC|os.O_CREATE|os.O_WRONLY|unix.O_NOFOLLOW, mode)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +217,7 @@ func (keyring *Handle) PathsCheck() error {
 }
 
 func loadKeyring(fn string) (openpgp.EntityList, error) {
-	f, err := os.Open(fn)
+	f, err := os.OpenFile(fn, os.O_RDONLY|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return openpgp.EntityList{}, nil
@@ -921,7 +922,7 @@ func (keyring *Handle) ExportPrivateKey(kpath string, armor bool) error {
 	}
 
 	// Create the file that we will be exporting to
-	file, err := os.Create(kpath)
+	file, err := os.OpenFile(kpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return err
 	}
@@ -963,7 +964,7 @@ func (keyring *Handle) ExportPubKey(kpath string, armor bool) error {
 		return err
 	}
 
-	file, err := os.Create(kpath)
+	file, err := os.OpenFile(kpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return fmt.Errorf("unable to create file: %v", err)
 	}

--- a/internal/pkg/util/bin/bin_test.go
+++ b/internal/pkg/util/bin/bin_test.go
@@ -9,13 +9,13 @@ package bin
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/env"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/util/singularityconf"
 )
 
@@ -163,7 +163,7 @@ func TestFindFromConfigOrPath(t *testing.T) {
 
 			testConf := filepath.Join(t.TempDir(), "test.conf")
 			cfg := fmt.Sprintf("%s = %s\n", tc.configKey, tc.configVal)
-			os.WriteFile(testConf, []byte(cfg), 0o644)
+			fs.WriteFileNoFollow(testConf, []byte(cfg), 0o644)
 
 			conf, err := singularityconf.Parse(testConf)
 			if err != nil {
@@ -292,7 +292,7 @@ func TestFindFromConfigOnly(t *testing.T) {
 
 			testConf := filepath.Join(t.TempDir(), "test.conf")
 			cfg := fmt.Sprintf("%s = %s\n", tc.configKey, tc.configVal)
-			os.WriteFile(testConf, []byte(cfg), 0o644)
+			fs.WriteFileNoFollow(testConf, []byte(cfg), 0o644)
 
 			conf, err := singularityconf.Parse(testConf)
 			if err != nil {

--- a/internal/pkg/util/env/env_test.go
+++ b/internal/pkg/util/env/env_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,12 +6,12 @@
 package env
 
 import (
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 func TestSetFromList(t *testing.T) {
@@ -189,7 +189,7 @@ func TestEnvFileMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := os.WriteFile(envFile, []byte(tt.envFile), 0o755); err != nil {
+			if err := fs.WriteFileNoFollow(envFile, []byte(tt.envFile), 0o755); err != nil {
 				t.Fatalf("Could not write test env-file: %v", err)
 			}
 

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -283,7 +283,7 @@ func EvalRelative(path string, root string) string {
 
 // Touch behaves like touch command.
 func Touch(path string) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return err
 	}
@@ -344,7 +344,7 @@ func CopyFile(from, to string, mode os.FileMode) (err error) {
 		return fmt.Errorf("file %s already exists", to)
 	}
 
-	dstFile, err := os.OpenFile(to, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	dstFile, err := os.OpenFile(to, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|unix.O_NOFOLLOW, mode)
 	if err != nil {
 		return fmt.Errorf("could not open %s: %w", to, err)
 	}
@@ -627,4 +627,17 @@ func FindSize(size int64) string {
 		unit = "TiB"
 	}
 	return fmt.Sprintf("%.2f %s", float64(size)/factor, unit)
+}
+
+// WriteFileNoFollow mimics fs.WriteFileNoFollow but with O_NOFOLLOW to avoid following
+// symlinks in the last part of the path. This prevents e.g. creating a file
+// through a dangling symlink.
+func WriteFileNoFollow(path string, data []byte, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, mode)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	return err
 }

--- a/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_item_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -382,7 +382,7 @@ func TestExtfsRW(t *testing.T) {
 	checkForStringInOverlay(t, "extfs", testFileStagedPath, extfsTestString)
 	otherTestFileStagedPath := item.GetMountDir() + "_other"
 	otherExtfsTestString := "another string"
-	err = os.WriteFile(otherTestFileStagedPath, []byte(otherExtfsTestString), 0o755)
+	err = fs.WriteFileNoFollow(otherTestFileStagedPath, []byte(otherExtfsTestString), 0o755)
 	if err != nil {
 		t.Errorf("could not write to file %q in extfs image %q: %s", otherTestFileStagedPath, writableExtfsImgPath, err)
 	}

--- a/internal/pkg/util/fs/overlay/overlay_set_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_set_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2023-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -186,7 +186,7 @@ func performPersistentWriteTest(ctx context.Context, t *testing.T, s Set) {
 	bytes := []byte(expectStr)
 	testFilePath := "my_test_file"
 	testFileMountedPath := filepath.Join(rootfsDir, testFilePath)
-	if err := os.WriteFile(testFileMountedPath, bytes, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(testFileMountedPath, bytes, 0o644); err != nil {
 		t.Fatalf("while trying to write file inside mounted overlay-set: %s", err)
 	}
 

--- a/internal/pkg/util/gpu/paths_test.go
+++ b/internal/pkg/util/gpu/paths_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,6 +13,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 const testLibFile = "testdata/testliblist.conf"
@@ -73,7 +75,7 @@ func TestSoLinks(t *testing.T) {
 	aFile := filepath.Join(tmpDir, "a.so")
 	a1Link := filepath.Join(tmpDir, "a.so.1")
 	a12Link := filepath.Join(tmpDir, "a.so.1.2")
-	if err := os.WriteFile(aFile, nil, 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(aFile, nil, 0o644); err != nil {
 		t.Fatalf("Could not create file: %v", err)
 	}
 	if err := os.Symlink(aFile, a1Link); err != nil {
@@ -83,7 +85,7 @@ func TestSoLinks(t *testing.T) {
 		t.Fatalf("Could not symlink: %v", err)
 	}
 	bFile := filepath.Join(tmpDir, "b.so")
-	err := os.WriteFile(bFile, nil, 0o644)
+	err := fs.WriteFileNoFollow(bFile, nil, 0o644)
 	if err != nil {
 		t.Fatalf("Could not create file: %v", err)
 	}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/util/user"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"github.com/sylabs/singularity/v4/pkg/util/fs/lock"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -436,7 +437,7 @@ func Init(path string, writable bool) (*Image, error) {
 			}
 		}
 
-		img.File, err = os.OpenFile(resolvedPath, mode, 0)
+		img.File, err = os.OpenFile(resolvedPath, mode|unix.O_NOFOLLOW, 0)
 		if err != nil {
 			continue
 		}

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,6 +23,7 @@ import (
 	"github.com/containernetworking/cni/libcni"
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 var confFiles = []struct {
@@ -608,7 +609,7 @@ func TestMain(m *testing.M) {
 	for _, conf := range confFiles {
 		testNetworks = append(testNetworks, conf.name)
 		path := filepath.Join(defaultCNIConfPath, conf.file)
-		if err := os.WriteFile(path, []byte(conf.content), 0o644); err != nil {
+		if err := fs.WriteFileNoFollow(path, []byte(conf.content), 0o644); err != nil {
 			os.RemoveAll(defaultCNIConfPath)
 			os.Exit(1)
 		}

--- a/pkg/util/archive/copy_test.go
+++ b/pkg/util/archive/copy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -59,7 +59,7 @@ func testCopy(t *testing.T, copyFunc func(src, dst string) error) {
 
 	// Source Files
 	srcFile := filepath.Join(srcRoot, "srcFile")
-	if err := os.WriteFile(srcFile, []byte("test"), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(srcFile, []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
@@ -148,7 +148,7 @@ func testRelLinkTarget(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	linkTargetFile := filepath.Join(tmpDir, "target")
-	if err := os.WriteFile(linkTargetFile, []byte("test"), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(linkTargetFile, []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/util/archive/system_test.go
+++ b/pkg/util/archive/system_test.go
@@ -25,12 +25,14 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 // TestChtimesATime tests Chtimes access time on a tempfile.
 func TestChtimesATime(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "exist")
-	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(file, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -134,7 +136,7 @@ func prepareFiles(t *testing.T) (file, invalid, symlink string) {
 	dir := t.TempDir()
 
 	file = filepath.Join(dir, "exist")
-	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(file, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/util/cryptkey/rsa.go
+++ b/pkg/util/cryptkey/rsa.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,6 +15,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -77,7 +79,7 @@ func SavePublicPEM(fileName string, key *rsa.PrivateKey) error {
 		return err
 	}
 
-	pemfile, err := os.Create(fileName)
+	pemfile, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return fmt.Errorf("unable to create key file: %v", err)
 	}
@@ -102,7 +104,7 @@ func SavePrivatePEM(fileName string, key *rsa.PrivateKey) error {
 		return fmt.Errorf("cannot save invalid key: %v", err)
 	}
 
-	outFile, err := os.Create(fileName)
+	outFile, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return fmt.Errorf("unable to create key file: %v", err)
 	}

--- a/pkg/util/fs/lock/lock_test.go
+++ b/pkg/util/fs/lock/lock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 func TestExclusive(t *testing.T) {
@@ -58,7 +59,7 @@ func TestByteRange(t *testing.T) {
 	// create the temporary test file used for locking
 	testFile := filepath.Join(t.TempDir(), "byterange")
 	// write some content in test file
-	if err := os.WriteFile(testFile, []byte("testing\n"), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(testFile, []byte("testing\n"), 0o644); err != nil {
 		t.Fatalf("failed to write content in testfile %s: %s", testFile, err)
 	}
 

--- a/pkg/util/fs/proc/proc_linux_test.go
+++ b/pkg/util/fs/proc/proc_linux_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 func TestHasFilesystem(t *testing.T) {
@@ -139,7 +140,7 @@ func TestGetMountInfo(t *testing.T) {
 	}
 
 	tmpfile := filepath.Join(t.TempDir(), "mountinfo")
-	if err := os.WriteFile(tmpfile, []byte(mountInfoData), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(tmpfile, []byte(mountInfoData), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -256,7 +257,7 @@ func TestGetMountPointMap(t *testing.T) {
 	}
 
 	tmpfile := filepath.Join(t.TempDir(), "mountinfo")
-	if err := os.WriteFile(tmpfile, []byte(mountInfoData), 0o644); err != nil {
+	if err := fs.WriteFileNoFollow(tmpfile, []byte(mountInfoData), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -357,7 +358,7 @@ func TestReadIDMap(t *testing.T) {
 	//nolint:dupword
 	for _, e := range []string{"a a a", "0 a a"} {
 		fname := filepath.Join(t.TempDir(), "uid-map")
-		if err := os.WriteFile(fname, []byte(e), 0o644); err != nil {
+		if err := fs.WriteFileNoFollow(fname, []byte(e), 0o644); err != nil {
 			t.Fatalf("failed to create test file")
 		}
 

--- a/pkg/util/loop/loop.go
+++ b/pkg/util/loop/loop.go
@@ -104,7 +104,7 @@ func (loop *Device) shareLoop(imageIno, imageDev uint64, mode int, number *int) 
 		*number = device
 
 		// Try to open an existing loop device, but don't create a new one
-		loopFd, err := openLoopDev(device, mode, false)
+		loopFd, err := openLoopDev(device, mode|unix.O_NOFOLLOW, false)
 		if err != nil {
 			if !os.IsNotExist(err) {
 				sylog.Debugf("Couldn't open loop device %d: %v\n", device, err)
@@ -240,7 +240,7 @@ func openLoopDev(device, mode int, create bool) (loopFd int, err error) {
 func addLoopDev(device int) error {
 	const loopControl = "/dev/loop-control"
 
-	lc, err := os.OpenFile(loopControl, os.O_RDWR, 0o600)
+	lc, err := os.OpenFile(loopControl, os.O_RDWR|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return fmt.Errorf("while opening loop-control device: %w", err)
 	}

--- a/pkg/util/singularityconf/parser.go
+++ b/pkg/util/singularityconf/parser.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	"golang.org/x/sys/unix"
 )
 
 // Directives represents the configuration directives type
@@ -164,7 +166,7 @@ func Parse(filepath string) (*File, error) {
 		return GetConfig(nil)
 	}
 
-	c, err := os.Open(filepath)
+	c, err := os.OpenFile(filepath, os.O_RDONLY|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/test/certs/gen_certs.go
+++ b/test/certs/gen_certs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 )
 
 var start = time.Date(2020, 4, 1, 0, 0, 0, 0, time.UTC)
@@ -188,7 +189,7 @@ func writeCerts() error {
 			return err
 		}
 
-		if err := os.WriteFile(output.path, b, 0o644); err != nil {
+		if err := fs.WriteFileNoFollow(output.path, b, 0o644); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

We don't want to create any files across a dangling symlink, so use O_NOFOLLOW if we have O_CREAT without O_EXCL.

There isn't really a valid use case for various config files, at known system / user locations, being re-directed by a single symlink. Add O_NOFOLLOW when working with these.

Drop os.Create, in favour of an os.OpenFile with O_NOFOLLOW.

Add a helper fs.WriteFileNoFollow, which is the same as os.WriteFile but with O_FOLLOW specified. Switch to using this instead of os.WriteFile.