### PR TITLE
hardening: Use FDs at IsOwner check locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Behaviour Changes
+
+- In setuid mode, root-ownership checks on singularity.conf and the capabilities
+  / ecl configuration now assert that these files are not writable except by the
+  root owner. Management of these files by an administrator group is no longer
+  possible. The files cannot be relocated by symlink.
+- External helper binaries executed with elevated privileges must also be
+  root-owned, regular executable files that are not writable by group or others.
+- If `ecl.toml` is missing, SIF execution is rejected rather than assuming an
+  inactive ECL configuration. The default install ships an `activated = false`
+  template, so standard installations are unaffected; sites with custom or
+  partial installs must ensure `ecl.toml` is present and valid.
+
 ### Developer / API
 
 The following have been removed:

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -1224,26 +1224,35 @@ func (c configTests) configFile(t *testing.T) {
 		},
 	}
 
-	// Create a temp testfile
-	f, err := fs.MakeTmpFile(c.env.TestDir, "config-", 0o644)
-	if err != nil {
-		t.Fatal(err)
-	}
-	configFile := f.Name()
-	defer os.Remove(configFile)
-	f.Close()
+	// Create a temp configfile, owned by root.
+	configFile := ""
+	e2e.Privileged(func(t *testing.T) {
+		f, err := fs.MakeTmpFile(c.env.TestDir, "config-", 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		configFile = f.Name()
+		f.Close()
+	})(t)
+	cleanup := e2e.Privileged(func(t *testing.T) {
+		if err := os.Remove(configFile); err != nil {
+			t.Errorf("could not remove temporary file %s: %s", configFile, err)
+		}
+	})
+	defer cleanup(t)
 
 	for _, tt := range tests {
+		e2e.Privileged(func(t *testing.T) {
+			if err := fs.WriteFileNoFollow(configFile, []byte(tt.conf), 0o644); err != nil {
+				t.Errorf("could not write configuration file %s: %s", configFile, err)
+			}
+		})(t)
+
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithGlobalOptions("--config", configFile),
 			e2e.WithProfile(tt.profile),
-			e2e.PreRun(func(t *testing.T) {
-				if err := fs.WriteFileNoFollow(configFile, []byte(tt.conf), 0o644); err != nil {
-					t.Errorf("could not write configuration file %s: %s", configFile, err)
-				}
-			}),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.argv...),
 			e2e.ExpectExit(tt.exit),

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -287,7 +287,11 @@ func (c *Config) AddGIDMappings(gids []specs.LinuxIDMapping) error {
 	return nil
 }
 
-func setNewIDMapPath(command string, pathPointer unsafe.Pointer) error {
+func (c *Config) setNewIDMapPath(command string, pathPointer unsafe.Pointer) error {
+	if c.GetIsSUID() {
+		return fmt.Errorf("%s path is not required in SUID workflow - setNewIDMapPath should not be called", command)
+	}
+
 	path, err := bin.FindBin(command)
 	if err != nil {
 		return fmt.Errorf(
@@ -296,6 +300,10 @@ func setNewIDMapPath(command string, pathPointer unsafe.Pointer) error {
 		)
 	}
 
+	// This is just a sanity check, not a security measure...
+	// newuidmap/newgidmap must be root owned for setuid bit or caps to allow it
+	// to function. The starter only calls the executable in an unprivileged
+	// non-setuid flow.
 	if !fs.IsOwner(path, 0) {
 		return fmt.Errorf("%s must be owned by the root user to setup fakeroot ID mappings in an unprivileged installation", path)
 	}
@@ -315,7 +323,7 @@ func setNewIDMapPath(command string, pathPointer unsafe.Pointer) error {
 
 // SetNewUIDMapPath sets absolute path to newuidmap binary if found.
 func (c *Config) SetNewUIDMapPath() error {
-	return setNewIDMapPath(
+	return c.setNewIDMapPath(
 		"newuidmap",
 		unsafe.Pointer(&c.config.container.privileges.newuidmapPath[0]),
 	)
@@ -323,7 +331,7 @@ func (c *Config) SetNewUIDMapPath() error {
 
 // SetNewGIDMapPath sets absolute path to newgidmap binary if found.
 func (c *Config) SetNewGIDMapPath() error {
-	return setNewIDMapPath(
+	return c.setNewIDMapPath(
 		"newgidmap",
 		unsafe.Pointer(&c.config.container.privileges.newgidmapPath[0]),
 	)

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -69,12 +69,19 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 
 	configurationFile := buildcfg.SINGULARITY_CONF_FILE
 
-	// check for ownership of singularity.conf
-	if starterConfig.GetIsSUID() && !fs.IsOwner(configurationFile, 0) {
-		return fmt.Errorf("%s must be owned by root", configurationFile)
+	var fileConfig *singularityconf.File
+	var err error
+	if starterConfig.GetIsSUID() {
+		var file *os.File
+		file, err = fs.OpenTrustedFile(configurationFile, 0)
+		if err != nil {
+			return fmt.Errorf("%s must be owned by root: %s", configurationFile, err)
+		}
+		defer file.Close()
+		fileConfig, err = singularityconf.ParseFile(file)
+	} else {
+		fileConfig, err = singularityconf.Parse(configurationFile)
 	}
-
-	fileConfig, err := singularityconf.Parse(configurationFile)
 	if err != nil {
 		return fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -102,6 +102,8 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 		return fmt.Errorf("no root filesystem image provided")
 	}
 
+	inUserNS, _ := namespaces.IsInsideUserNamespace(os.Getpid())
+
 	configurationFile := buildcfg.SINGULARITY_CONF_FILE
 	if buildcfg.SINGULARITY_SUID_INSTALL == 0 || os.Geteuid() == 0 {
 		configFile := engine.EngineConfig.GetConfigurationFile()
@@ -110,7 +112,17 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 		}
 	}
 
-	engine.EngineConfig.File, err = singularityconf.Parse(configurationFile)
+	if inUserNS {
+		engine.EngineConfig.File, err = singularityconf.Parse(configurationFile)
+	} else {
+		var file *os.File
+		file, err = fs.OpenTrustedFile(configurationFile, 0)
+		if err != nil {
+			return fmt.Errorf("%s must be owned by root: %s", configurationFile, err)
+		}
+		defer file.Close()
+		engine.EngineConfig.File, err = singularityconf.ParseFile(file)
+	}
 	if err != nil {
 		return fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}
@@ -165,12 +177,10 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 		c.suidFlag = 0
 	}
 
-	// user namespace was not requested but we need to check
-	// if we are currently running in a user namespace and set
-	// value accordingly to avoid remount errors while running
-	// inside a user namespace
+	// user namespace was not requested but if we are still currently running in
+	// a user namespace then set value accordingly to avoid remount errors.
 	if !c.userNS {
-		c.userNS, _ = namespaces.IsInsideUserNamespace(os.Getpid())
+		c.userNS = inUserNS
 	}
 
 	p := &mount.Points{}

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -84,28 +84,24 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		}
 	}
 
-	e.EngineConfig.File, err = singularityconf.Parse(configurationFile)
+	if starterConfig.GetIsSUID() {
+		var file *os.File
+		file, err = fs.OpenTrustedFile(configurationFile, 0)
+		if err != nil {
+			return fmt.Errorf("%s must be owned by root: %s", configurationFile, err)
+		}
+		defer file.Close()
+
+		e.EngineConfig.File, err = singularityconf.ParseFile(file)
+	} else {
+		e.EngineConfig.File, err = singularityconf.Parse(configurationFile)
+	}
 	if err != nil {
 		return fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}
 
 	if !e.EngineConfig.File.AllowSetuid && starterConfig.GetIsSUID() {
 		return fmt.Errorf("suid workflow disabled by administrator")
-	}
-
-	if starterConfig.GetIsSUID() {
-		// check for ownership of singularity.conf
-		if !fs.IsOwner(configurationFile, 0) {
-			return fmt.Errorf("%s must be owned by root", configurationFile)
-		}
-		// check for ownership of capability.json
-		if !fs.IsOwner(buildcfg.CAPABILITY_FILE, 0) {
-			return fmt.Errorf("%s must be owned by root", buildcfg.CAPABILITY_FILE)
-		}
-		// check for ownership of ecl.toml
-		if !fs.IsOwner(buildcfg.ECL_FILE, 0) {
-			return fmt.Errorf("%s must be owned by root", buildcfg.ECL_FILE)
-		}
 	}
 
 	// Save the current working directory if not set
@@ -203,15 +199,22 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	return nil
 }
 
+func openCapabilityFile(suid bool) (*os.File, error) {
+	if suid {
+		return fs.OpenTrustedFile(buildcfg.CAPABILITY_FILE, 0)
+	}
+	return os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY|unix.O_NOFOLLOW, 0o644)
+}
+
 // prepareUserCaps is responsible for checking that user's requested
 // capabilities are authorized.
-func (e *EngineOperations) prepareUserCaps(enforced bool) error {
+func (e *EngineOperations) prepareUserCaps(enforced, suid bool) error {
 	commonCaps := make([]string, 0)
 	commonUnauthorizedCaps := make([]string, 0)
 
 	e.EngineConfig.OciConfig.SetProcessNoNewPrivileges(true)
 
-	file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY|unix.O_NOFOLLOW, 0o644)
+	file, err := openCapabilityFile(suid)
 	if err != nil {
 		return fmt.Errorf("while opening capability config file: %s", err)
 	}
@@ -313,7 +316,7 @@ func (e *EngineOperations) prepareUserCaps(enforced bool) error {
 
 // prepareRootCaps is responsible for setting root capabilities
 // based on capability/configuration files and requested capabilities.
-func (e *EngineOperations) prepareRootCaps() error {
+func (e *EngineOperations) prepareRootCaps(suid bool) error {
 	commonCaps := make([]string, 0)
 	defaultCapabilities := e.EngineConfig.File.RootDefaultCapabilities
 
@@ -341,7 +344,7 @@ func (e *EngineOperations) prepareRootCaps() error {
 		e.EngineConfig.OciConfig.SetupPrivileged(true)
 		commonCaps = e.EngineConfig.OciConfig.Process.Capabilities.Permitted
 	case "file":
-		file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY|unix.O_NOFOLLOW, 0o644)
+		file, err := openCapabilityFile(suid)
 		if err != nil {
 			return fmt.Errorf("while opening capability config file: %s", err)
 		}
@@ -623,12 +626,12 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 	}
 
 	if os.Getuid() == 0 {
-		if err := e.prepareRootCaps(); err != nil {
+		if err := e.prepareRootCaps(starterConfig.GetIsSUID()); err != nil {
 			return err
 		}
 	} else {
 		enforced := starterConfig.GetIsSUID()
-		if err := e.prepareUserCaps(enforced); err != nil {
+		if err := e.prepareUserCaps(enforced, starterConfig.GetIsSUID()); err != nil {
 			return err
 		}
 	}
@@ -948,11 +951,11 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 	// unauthorized capabilities from current set according to capability
 	// configuration file
 	if uid == 0 {
-		if err := e.prepareRootCaps(); err != nil {
+		if err := e.prepareRootCaps(starterConfig.GetIsSUID()); err != nil {
 			return err
 		}
 	} else {
-		if err := e.prepareUserCaps(suidRequired); err != nil {
+		if err := e.prepareUserCaps(suidRequired, starterConfig.GetIsSUID()); err != nil {
 			return err
 		}
 	}
@@ -1249,7 +1252,7 @@ func (e *EngineOperations) loadImages(starterConfig *starter.Config) error {
 	// SIF images have additional handling to check against ECL configuration
 	// and look for overlay partitions.
 	case image.SIF:
-		writableOverlayPath, err = e.handleSIFImage(img, rootFs)
+		writableOverlayPath, err = e.handleSIFImage(img, rootFs, starterConfig.GetIsSUID())
 		if err != nil {
 			return err
 		}
@@ -1337,34 +1340,50 @@ func (e *EngineOperations) handleSandboxImage(img *image.Image, starterConfig *s
 	return nil
 }
 
-func (e *EngineOperations) handleSIFImage(img *image.Image, rootFs *image.Section) (string, error) {
+func (e *EngineOperations) handleSIFImage(img *image.Image, rootFs *image.Section, suid bool) (string, error) {
 	writableOverlayPath := ""
 
-	// query the ECL module, proceed if an ecl config file is found
-	ecl, err := syecl.LoadConfig(buildcfg.ECL_FILE)
-	if err == nil {
-		if err = ecl.ValidateConfig(); err != nil {
-			return "", fmt.Errorf("while validating ECL configuration: %s", err)
+	// Load and validate ECL configuration. Fail if ECL config not valid.
+	var eclFile *os.File
+	var err error
+	if suid {
+		eclFile, err = fs.OpenTrustedFile(buildcfg.ECL_FILE, 0)
+		if err != nil {
+			return "", err
 		}
+	} else {
+		eclFile, err = os.OpenFile(buildcfg.ECL_FILE, os.O_RDONLY|unix.O_NOFOLLOW, 0)
+	}
+	if err != nil {
+		return "", err
+	}
+	defer eclFile.Close()
 
-		// Only try to load the global keyring here if the ECL is active.
-		// Otherwise pass through an empty keyring rather than avoiding calling
-		// the ECL functions as this keeps the logic for applying / ignoring ECL in a
-		// single location.
-		var kr openpgp.KeyRing = openpgp.EntityList{}
-		if ecl.Activated {
-			keyring := sypgp.NewHandle(buildcfg.SINGULARITY_CONFDIR, sypgp.GlobalHandleOpt())
-			kr, err = keyring.LoadPubKeyring()
-			if err != nil {
-				return "", fmt.Errorf("while obtaining keyring for ECL: %s", err)
-			}
-		}
+	ecl, err := syecl.LoadConfigFile(eclFile)
+	if err != nil {
+		return "", fmt.Errorf("while loading ECL configuration: %s", err)
+	}
+	if err = ecl.ValidateConfig(); err != nil {
+		return "", fmt.Errorf("while validating ECL configuration: %s", err)
+	}
 
-		if ok, err := ecl.ShouldRunFp(context.TODO(), img.File, kr); err != nil {
-			return "", fmt.Errorf("while checking container image with ECL: %s", err)
-		} else if !ok {
-			return "", errors.New("image prohibited by ECL")
+	// Only try to load the global keyring here if the ECL is active.
+	// Otherwise pass through an empty keyring rather than avoiding calling
+	// the ECL functions as this keeps the logic for applying / ignoring ECL in a
+	// single location.
+	var kr openpgp.KeyRing = openpgp.EntityList{}
+	if ecl.Activated {
+		keyring := sypgp.NewHandle(buildcfg.SINGULARITY_CONFDIR, sypgp.GlobalHandleOpt())
+		kr, err = keyring.LoadPubKeyring()
+		if err != nil {
+			return "", fmt.Errorf("while obtaining keyring for ECL: %s", err)
 		}
+	}
+
+	if ok, err := ecl.ShouldRunFp(context.TODO(), img.File, kr); err != nil {
+		return "", fmt.Errorf("while checking container image with ECL: %s", err)
+	} else if !ok {
+		return "", errors.New("image prohibited by ECL")
 	}
 
 	// look for potential overlay partition in SIF image

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -63,6 +63,12 @@ func LoadConfig(confPath string) (ecl EclConfig, err error) {
 		return
 	}
 	defer f.Close()
+
+	return LoadConfigFile(f)
+}
+
+// LoadConfigFile unmarshals an ECL config from an open file.
+func LoadConfigFile(f *os.File) (ecl EclConfig, err error) {
 	b, err := io.ReadAll(f)
 	if err != nil {
 		return

--- a/internal/pkg/util/crypt/crypt_dev.go
+++ b/internal/pkg/util/crypt/crypt_dev.go
@@ -62,15 +62,25 @@ func createLoop(path string, offset, size uint64) (string, error) {
 	return fmt.Sprintf("/dev/loop%d", idx), nil
 }
 
+func trustedCryptsetup() (int, string, error) {
+	cryptsetup, err := bin.FindBin("cryptsetup")
+	if err != nil {
+		return -1, "", err
+	}
+	fd, trustedPath, err := fs.OpenTrustedExecutable(cryptsetup, 0)
+	if err != nil {
+		return -1, "", err
+	}
+	return fd, trustedPath, nil
+}
+
 // CloseCryptDevice closes the crypt device
 func (crypt *Device) CloseCryptDevice(path string) error {
-	cryptsetup, err := bin.FindBin("cryptsetup")
+	cryptsetupFd, cryptsetupPath, err := trustedCryptsetup()
 	if err != nil {
 		return err
 	}
-	if !fs.IsOwner(cryptsetup, 0) {
-		return fmt.Errorf("%s must be owned by root", cryptsetup)
-	}
+	defer unix.Close(cryptsetupFd)
 
 	fd, err := lock.Exclusive("/dev/mapper")
 	if err != nil {
@@ -78,7 +88,7 @@ func (crypt *Device) CloseCryptDevice(path string) error {
 	}
 	defer lock.Release(fd)
 
-	cmd := exec.Command(cryptsetup, "close", path)
+	cmd := exec.Command(cryptsetupPath, "close", path)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Credential: &syscall.Credential{Uid: 0, Gid: 0},
 	}
@@ -171,15 +181,13 @@ func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) 
 	// investigated. To do that, at least one additional partition is required, which is
 	// not encrypted.
 
-	cryptsetup, err := bin.FindBin("cryptsetup")
+	cryptsetupFd, cryptsetupPath, err := trustedCryptsetup()
 	if err != nil {
 		return "", err
 	}
-	if !fs.IsOwner(cryptsetup, 0) {
-		return "", fmt.Errorf("%s must be owned by root", cryptsetup)
-	}
+	defer unix.Close(cryptsetupFd)
 
-	cmd := exec.Command(cryptsetup, "luksFormat", "--batch-mode", "--type", "luks2", "--key-file", "-", loop)
+	cmd := exec.Command(cryptsetupPath, "luksFormat", "--batch-mode", "--type", "luks2", "--key-file", "-", loop)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return "", err
@@ -193,7 +201,7 @@ func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) 
 	sylog.Debugf("Running %s %s", cmd.Path, strings.Join(cmd.Args, " "))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		err = checkCryptsetupVersion(cryptsetup)
+		err = checkCryptsetupVersion(cryptsetupPath)
 		if err == ErrUnsupportedCryptsetupVersion {
 			// Special case of unsupported version of cryptsetup. We return the raw error
 			// so it can propagate up and a user-friendly message be displayed. This error
@@ -211,7 +219,7 @@ func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) 
 
 	copyDeviceContents(path, "/dev/mapper/"+nextCrypt, fSize)
 
-	cmd = exec.Command(cryptsetup, "close", nextCrypt)
+	cmd = exec.Command(cryptsetupPath, "close", nextCrypt)
 	sylog.Debugf("Running %s %s", cmd.Path, strings.Join(cmd.Args, " "))
 	err = cmd.Run()
 	if err != nil {
@@ -282,13 +290,11 @@ func (crypt *Device) Open(key []byte, path string) (string, error) {
 
 	maxRetries := 3 // Arbitrary number of retries.
 
-	cryptsetup, err := bin.FindBin("cryptsetup")
+	cryptsetupFd, cryptsetupPath, err := trustedCryptsetup()
 	if err != nil {
 		return "", err
 	}
-	if !fs.IsOwner(cryptsetup, 0) {
-		return "", fmt.Errorf("%s must be owned by root", cryptsetup)
-	}
+	defer unix.Close(cryptsetupFd)
 
 	for range maxRetries {
 		nextCrypt, err := getNextAvailableCryptDevice()
@@ -296,7 +302,7 @@ func (crypt *Device) Open(key []byte, path string) (string, error) {
 			return "", err
 		}
 
-		cmd := exec.Command(cryptsetup, "open", "--batch-mode", "--type", "luks2", "--key-file", "-", path, nextCrypt)
+		cmd := exec.Command(cryptsetupPath, "open", "--batch-mode", "--type", "luks2", "--key-file", "-", path, nextCrypt)
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: 0, Gid: 0}
 		sylog.Debugf("Running %s %s", cmd.Path, strings.Join(cmd.Args, " "))
@@ -307,7 +313,7 @@ func (crypt *Device) Open(key []byte, path string) (string, error) {
 			if strings.Contains(string(out), "Device already exists") {
 				continue
 			}
-			err = checkCryptsetupVersion(cryptsetup)
+			err = checkCryptsetupVersion(cryptsetupPath)
 			if err == ErrUnsupportedCryptsetupVersion {
 				// Special case of unsupported version of cryptsetup. We return the raw error
 				// so it can propagate up and a user-friendly message be displayed. This error

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -100,6 +100,102 @@ func IsOwner(name string, uid uint32) bool {
 	return info.Sys().(*syscall.Stat_t).Uid == uid
 }
 
+// FileHasOwner checks if passed os.File is owned by user identified with uid.
+func FileHasOwner(f *os.File, uid uint32) bool {
+	if f == nil {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+
+	//nolint:forcetypeassert
+	return info.Sys().(*syscall.Stat_t).Uid == uid
+}
+
+func validateOwnedRegularFile(name string, owner, mode, uid uint32, executable bool) error {
+	if owner != uid {
+		return fmt.Errorf("%s must be owned by uid %d", name, uid)
+	}
+	if mode&syscall.S_IFMT != syscall.S_IFREG {
+		return fmt.Errorf("%s must be a regular file", name)
+	}
+	if mode&0o022 != 0 {
+		return fmt.Errorf("%s must not be writable by group or other", name)
+	}
+	if executable && mode&0o111 == 0 {
+		return fmt.Errorf("%s must be executable", name)
+	}
+
+	return nil
+}
+
+// OpenTrustedFile opens name without following a final symlink and returns
+// the open file only if it is owned by user identified with uid, is regular,
+// and is not writable by group or other.
+func OpenTrustedFile(name string, uid uint32) (*os.File, error) {
+	f, err := os.OpenFile(name, os.O_RDONLY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+
+	//nolint:forcetypeassert
+	st := info.Sys().(*syscall.Stat_t)
+	if err := validateOwnedRegularFile(name, st.Uid, st.Mode, uid, false); err != nil {
+		f.Close()
+		return nil, err
+	}
+
+	return f, nil
+}
+
+// ProcFdPath returns a /proc/self/fd path for fd.
+func ProcFdPath(fd uintptr) string {
+	return fmt.Sprintf("/proc/self/fd/%d", fd)
+}
+
+// OpenTrustedExecutable opens name without following a final symlink and
+// returns a file descriptor path only if the opened file is owned by uid, is
+// regular, is not writable by group or other, and has an executable bit set.
+// The returned descriptor does not have close-on-exec set, so callers must
+// close it when it is no longer needed or intentionally keep it open for a
+// later exec.
+func OpenTrustedExecutable(name string, uid uint32) (int, string, error) {
+	fd, err := unix.Open(name, unix.O_PATH|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return -1, "", err
+	}
+
+	var st unix.Stat_t
+	if err := unix.Fstat(fd, &st); err != nil {
+		unix.Close(fd)
+		return -1, "", err
+	}
+
+	if err := validateOwnedRegularFile(name, st.Uid, st.Mode, uid, true); err != nil {
+		unix.Close(fd)
+		return -1, "", err
+	}
+
+	return fd, fmt.Sprintf("/proc/self/fd/%d", fd), nil
+}
+
+// NewFileFromFd wraps fd in an *os.File.
+func NewFileFromFd(fd int, name string) (*os.File, error) {
+	fdPtr, err := safecast.Convert[uintptr](fd)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(fdPtr, name), nil
+}
+
 // IsGroup checks if named file is owned by group identified with gid.
 func IsGroup(name string, gid uint32) bool {
 	info, err := os.Stat(name)

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ccoveille/go-safecast/v2"
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
+	"golang.org/x/sys/unix"
 )
 
 func TestEnsureFileWithPermission(t *testing.T) {
@@ -174,6 +176,155 @@ func TestIsOwner(t *testing.T) {
 
 	if IsOwner("/etc/passwd", 0) != true {
 		t.Errorf("IsOwner returns false for /etc/passwd root ownership")
+	}
+}
+
+func TestFileIsOwner(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	f, err := os.Open("/etc/passwd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if FileHasOwner(f, 0) != true {
+		t.Errorf("FileIsOwner returns false for /etc/passwd root ownership")
+	}
+}
+
+func TestOpenTrustedFile(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	tmpDir := t.TempDir()
+	file := filepath.Join(tmpDir, "owned")
+	if err := os.WriteFile(file, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	uid, err := safecast.Convert[uint32](os.Geteuid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := OpenTrustedFile(file, uid)
+	if err != nil {
+		t.Fatalf("OpenTrustedFile rejected matching owner: %s", err)
+	}
+	f.Close()
+
+	wrongUID := uid + 1
+	if wrongUID == uid {
+		wrongUID = uid - 1
+	}
+	if f, err := OpenTrustedFile(file, wrongUID); err == nil {
+		f.Close()
+		t.Fatalf("OpenTrustedFile accepted wrong owner")
+	}
+
+	missing := filepath.Join(tmpDir, "missing")
+	if f, err := OpenTrustedFile(missing, uid); err == nil {
+		f.Close()
+		t.Fatalf("OpenTrustedFile accepted missing file")
+	}
+
+	link := filepath.Join(tmpDir, "link")
+	if err := os.Symlink(file, link); err != nil {
+		t.Fatal(err)
+	}
+	if f, err := OpenTrustedFile(link, uid); err == nil {
+		f.Close()
+		t.Fatalf("OpenTrustedFile followed final symlink")
+	}
+
+	writable := filepath.Join(tmpDir, "writable")
+	if err := os.WriteFile(writable, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(writable, 0o664); err != nil {
+		t.Fatal(err)
+	}
+	if f, err := OpenTrustedFile(writable, uid); err == nil {
+		f.Close()
+		t.Fatalf("OpenTrustedFile accepted group-writable file")
+	}
+
+	dir := filepath.Join(tmpDir, "dir")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if f, err := OpenTrustedFile(dir, uid); err == nil {
+		f.Close()
+		t.Fatalf("OpenTrustedFile accepted directory")
+	}
+}
+
+func TestOpenTrustedExecutable(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	tmpDir := t.TempDir()
+	file := filepath.Join(tmpDir, "executable")
+	if err := os.WriteFile(file, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(file, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	uid, err := safecast.Convert[uint32](os.Geteuid())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fd, fdPath, err := OpenTrustedExecutable(file, uid)
+	if err != nil {
+		t.Fatalf("OpenTrustedExecutable rejected matching executable: %s", err)
+	}
+	defer unix.Close(fd)
+	if fdPath == "" {
+		t.Fatalf("OpenTrustedExecutable returned empty fd path")
+	}
+	fdPtr, err := safecast.Convert[uintptr](fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flags, err := unix.FcntlInt(fdPtr, unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flags&unix.FD_CLOEXEC != 0 {
+		t.Fatalf("OpenTrustedExecutable returned close-on-exec fd")
+	}
+
+	nonExec := filepath.Join(tmpDir, "non-executable")
+	if err := os.WriteFile(nonExec, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if fd, _, err := OpenTrustedExecutable(nonExec, uid); err == nil {
+		unix.Close(fd)
+		t.Fatalf("OpenTrustedExecutable accepted non-executable file")
+	}
+
+	writable := filepath.Join(tmpDir, "writable")
+	if err := os.WriteFile(writable, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(writable, 0o775); err != nil {
+		t.Fatal(err)
+	}
+	if fd, _, err := OpenTrustedExecutable(writable, uid); err == nil {
+		unix.Close(fd)
+		t.Fatalf("OpenTrustedExecutable accepted group-writable executable")
+	}
+
+	link := filepath.Join(tmpDir, "link")
+	if err := os.Symlink(file, link); err != nil {
+		t.Fatal(err)
+	}
+	if fd, _, err := OpenTrustedExecutable(link, uid); err == nil {
+		unix.Close(fd)
+		t.Fatalf("OpenTrustedExecutable followed final symlink")
 	}
 }
 

--- a/internal/pkg/util/gpu/nvidia.go
+++ b/internal/pkg/util/gpu/nvidia.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"github.com/sylabs/singularity/v4/pkg/util/capabilities"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -81,10 +82,16 @@ func NVCLIConfigure(nvidiaEnv []string, rootfs string, userNS bool) error {
 	if err != nil {
 		return err
 	}
+	nvCCLIExec := nvCCLIPath
 	// If we will run nvidia-container-cli as the host root user then ensure
 	// it is trusted, i.e. owned by them.
-	if !userNS && !fs.IsOwner(nvCCLIPath, 0) {
-		return errNvCCLIInsecure
+	if !userNS {
+		var nvCCLIFd int
+		nvCCLIFd, nvCCLIExec, err = fs.OpenTrustedExecutable(nvCCLIPath, 0)
+		if err != nil {
+			return fmt.Errorf("%w: %s", errNvCCLIInsecure, err)
+		}
+		defer unix.Close(nvCCLIFd)
 	}
 
 	// Translate the passed in NVIDIA_ env vars to option flags
@@ -100,12 +107,24 @@ func NVCLIConfigure(nvidiaEnv []string, rootfs string, userNS bool) error {
 	if err != nil {
 		return err
 	}
+	ldConfigArg := ldConfig
+	var ldConfigFile *os.File
 	// If we will run nvidia-container-cli as the host root user then ensure
 	// ldconfig is trusted, i.e. owned by them.
-	if !userNS && !fs.IsOwner(ldConfig, 0) {
-		return errLdconfigInsecure
+	if !userNS {
+		ldConfigFd, _, err := fs.OpenTrustedExecutable(ldConfig, 0)
+		if err != nil {
+			return fmt.Errorf("%w: %s", errLdconfigInsecure, err)
+		}
+		ldConfigFile, err = fs.NewFileFromFd(ldConfigFd, ldConfig)
+		if err != nil {
+			unix.Close(ldConfigFd)
+			return err
+		}
+		defer ldConfigFile.Close()
+		ldConfigArg = "/proc/self/fd/3"
 	}
-	flags = append(flags, "--ldconfig=@"+ldConfig)
+	flags = append(flags, "--ldconfig=@"+ldConfigArg)
 
 	nccArgs := make([]string, 0, 1+len(flags)+1)
 	nccArgs = append(nccArgs, "configure")
@@ -119,7 +138,10 @@ func NVCLIConfigure(nvidiaEnv []string, rootfs string, userNS bool) error {
 
 	sylog.Debugf("nvidia-container-cli binary: %q args: %q", nvCCLIPath, nccArgs)
 
-	cmd := exec.Command(nvCCLIPath, nccArgs...)
+	cmd := exec.Command(nvCCLIExec, nccArgs...)
+	if ldConfigFile != nil {
+		cmd.ExtraFiles = []*os.File{ldConfigFile}
+	}
 	cmd.Env = os.Environ()
 	// We are called from the RPC server which has an empty PATH.
 	// nvidia-container-cli requires a default sensible PATH to work correctly.

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -467,7 +467,7 @@ func Init(path string, writable bool) (*Image, error) {
 			sylog.Warningf("failed to set O_CLOEXEC flags on image")
 		}
 
-		img.Source = fmt.Sprintf("/proc/self/fd/%d", img.File.Fd())
+		img.Source = fs.ProcFdPath(img.File.Fd())
 		img.Fd = img.File.Fd()
 
 		if err := rf.format.lock(img); err != nil {

--- a/pkg/util/singularityconf/parser.go
+++ b/pkg/util/singularityconf/parser.go
@@ -172,7 +172,12 @@ func Parse(filepath string) (*File, error) {
 	}
 	defer c.Close()
 
-	directives, err := GetDirectives(c)
+	return ParseFile(c)
+}
+
+// ParseFile parses configuration from an open file.
+func ParseFile(file *os.File) (*File, error) {
+	directives, err := GetDirectives(file)
 	if err != nil {
 		return nil, fmt.Errorf("while parsing data: %s", err)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In various places in the code, fs.IsOwner has been used to verify that files are root-owned prior to using them in setuid mode.

Replace fs.IsOwner checks, which are based on a path, with OpenTrustedFile/Executable that perform the checks on an os.File or file descriptor - returning it for subsequent use. This avoids TOCTOU attacks if the parent dir of the config files is insecure, or the files can be replaced / modified in another way.

Also enforce that these 'trusted' files must only be writable by their owner, not group or world writable.

Codex was used to explore the code for this issue, and produce draft changes that have been manually reviewed and modified.

Co-authored-by: Codex