### PR TITLE
archive: use os.Root when extracting tar files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/moby/go-archive v0.2.0
 	github.com/moby/moby/client v0.4.1
 	github.com/moby/profiles/seccomp v0.2.3
-	github.com/moby/sys/sequential v0.6.0
 	github.com/moby/sys/user v0.4.0
 	github.com/moby/sys/userns v0.1.0
 	github.com/moby/term v0.5.2
@@ -201,6 +200,7 @@ require (
 	github.com/moby/sys/mount v0.3.4 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/reexec v0.1.0 // indirect
+	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/signal v0.7.1 // indirect
 	github.com/morikuni/aec v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/pkg/util/archive/archive.go
+++ b/pkg/util/archive/archive.go
@@ -27,31 +27,101 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
 
-	"github.com/moby/go-archive"
-	"github.com/moby/sys/sequential"
-	"github.com/moby/sys/user"
-	"github.com/moby/sys/userns"
+	mobyarchive "github.com/moby/go-archive"
+	mobyuser "github.com/moby/sys/user"
+	mobyuserns "github.com/moby/sys/userns"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
-// Unpack unpacks the decompressedArchive to dest with options. The target of
-// any symlinks and hard links must be under destRoot. This differs from the
-// unmodified upstream code, which requires that they are under dest.
-func UnpackWithRoot(decompressedArchive io.Reader, dest, destRoot string, options *archive.TarOptions) error {
+type unpacker struct {
+	rootPath string
+	destPath string
+	destRel  string // destPath relative to rootPath
+	root     *os.Root
+	options  *mobyarchive.TarOptions
+}
+
+// newUnpacker creates a new unpacker which will unpack to destPath. All created
+// files will be under destPath, and links must not target outside rootPath. The
+// caller must call unpacker.Close() when finished, to release the os.Root.
+func newUnpacker(rootPath, destPath string, options *mobyarchive.TarOptions) (*unpacker, error) {
+	if options == nil {
+		options = &mobyarchive.TarOptions{}
+	}
+	if options.ExcludePatterns == nil {
+		options.ExcludePatterns = []string{}
+	}
+	if options.WhiteoutFormat != 0 {
+		return nil, fmt.Errorf("options.WhiteoutFormat is not supported by unpacker")
+	}
+
+	if !filepath.IsAbs(rootPath) {
+		return nil, fmt.Errorf("rootPath must be an absolute path: %q", rootPath)
+	}
+	rootPath = filepath.Clean(rootPath)
+
+	if !filepath.IsAbs(destPath) {
+		return nil, fmt.Errorf("destPath must be an absolute path: %q", destPath)
+	}
+	destPath = filepath.Clean(destPath)
+
+	rel, err := filepath.Rel(rootPath, destPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to calculate relative path from rootPath to destPath: %w", err)
+	}
+	if !filepath.IsLocal(rel) {
+		return nil, fmt.Errorf("destPath %q is not under rootPath %q", destPath, rootPath)
+	}
+
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &unpacker{
+		rootPath: rootPath,
+		destPath: destPath,
+		destRel:  rel,
+		root:     root,
+		options:  options,
+	}, nil
+}
+
+func (u *unpacker) close() error {
+	if u.root != nil {
+		return u.root.Close()
+	}
+	return nil
+}
+
+// unpackWithRoot unpacks the decompressedArchive to dest with options.  All
+// created files will be under destPath, and links must not target outside
+// rootPath.
+func unpackWithRoot(decompressedArchive io.Reader, destPath, rootPath string, options *mobyarchive.TarOptions) error {
 	tr := tar.NewReader(decompressedArchive)
 	trBuf := BufioReader32KPool.Get(nil)
 	defer BufioReader32KPool.Put(trBuf)
 
 	var dirs []*tar.Header
 
-	if options.WhiteoutFormat != 0 {
-		return fmt.Errorf("options.WhiteoutFormat is not supported by UnpackWithRoot")
+	destPath, err := filepath.Abs(destPath)
+	if err != nil {
+		return err
 	}
+	rootPath, err = filepath.Abs(rootPath)
+	if err != nil {
+		return err
+	}
+
+	u, err := newUnpacker(rootPath, destPath, options)
+	if err != nil {
+		return err
+	}
+	defer u.close()
 
 	// Iterate through the files in the archive.
 loop:
@@ -76,43 +146,36 @@ loop:
 		// This keeps "..\" as-is, but normalizes "\..\" to "\".
 		hdr.Name = filepath.Clean(hdr.Name)
 
-		for _, exclude := range options.ExcludePatterns {
+		for _, exclude := range u.options.ExcludePatterns {
 			if strings.HasPrefix(hdr.Name, exclude) {
 				continue loop
 			}
 		}
 
-		// Ensure that the parent directory exists.
-		err = createImpliedDirectories(dest, hdr, options)
+		relPath, err := u.destToRoot(hdr.Name)
 		if err != nil {
 			return err
 		}
 
-		// #nosec G305 -- The joined path is checked for path traversal.
-		path := filepath.Join(dest, hdr.Name)
-		rel, err := filepath.Rel(dest, path)
-		if err != nil {
+		if err := u.createImpliedDirectories(relPath, hdr); err != nil {
 			return err
-		}
-		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-			return fmt.Errorf("%q is outside of %q", hdr.Name, dest)
 		}
 
 		// If path exits we almost always just want to remove and replace it
 		// The only exception is when it is a directory *and* the file from
 		// the layer is also a directory. Then we want to merge them (i.e.
 		// just apply the metadata from the layer).
-		if fi, err := os.Lstat(path); err == nil {
-			if options.NoOverwriteDirNonDir && fi.IsDir() && hdr.Typeflag != tar.TypeDir {
+		if fi, err := u.root.Lstat(relPath); err == nil {
+			if u.options.NoOverwriteDirNonDir && fi.IsDir() && hdr.Typeflag != tar.TypeDir {
 				// If NoOverwriteDirNonDir is true then we cannot replace
 				// an existing directory with a non-directory from the archive.
-				return fmt.Errorf("cannot overwrite directory %q with non-directory %q", path, dest)
+				return fmt.Errorf("cannot overwrite directory %q with non-directory %q", filepath.Join(u.rootPath, relPath), u.destPath)
 			}
 
-			if options.NoOverwriteDirNonDir && !fi.IsDir() && hdr.Typeflag == tar.TypeDir {
+			if u.options.NoOverwriteDirNonDir && !fi.IsDir() && hdr.Typeflag == tar.TypeDir {
 				// If NoOverwriteDirNonDir is true then we cannot replace
 				// an existing non-directory with a directory from the archive.
-				return fmt.Errorf("cannot overwrite non-directory %q with directory %q", path, dest)
+				return fmt.Errorf("cannot overwrite non-directory %q with directory %q", filepath.Join(u.rootPath, relPath), u.destPath)
 			}
 
 			if fi.IsDir() && hdr.Name == "." {
@@ -120,18 +183,20 @@ loop:
 			}
 
 			if !fi.IsDir() || !(hdr.Typeflag == tar.TypeDir) { //nolint:staticcheck
-				if err := os.RemoveAll(path); err != nil {
+				if err := u.root.RemoveAll(relPath); err != nil {
 					return err
 				}
 			}
+		} else if !os.IsNotExist(err) {
+			return err
 		}
 		trBuf.Reset(tr)
 
-		if err := remapIDs(options.IDMap, hdr); err != nil {
+		if err := remapIDs(u.options.IDMap, hdr); err != nil {
 			return err
 		}
 
-		if err := createTarFile(path, dest, destRoot, hdr, trBuf, options); err != nil {
+		if err := u.createTarFile(relPath, hdr, trBuf); err != nil {
 			return err
 		}
 
@@ -143,14 +208,40 @@ loop:
 	}
 
 	for _, hdr := range dirs {
-		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
-		path := filepath.Join(dest, hdr.Name)
+		relPath, err := u.destToRoot(hdr.Name)
+		if err != nil {
+			return err
+		}
 
-		if err := Chtimes(path, hdr.AccessTime, hdr.ModTime); err != nil {
+		if err := Chtimes(u.root, relPath, hdr.AccessTime, hdr.ModTime); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// destToRoot converts a tar entry name (relative to destPath) into a path
+// relative to rootPath / the os.Root. The entry must not escape destPath, so
+// that all created files remain under destPath.
+func (u *unpacker) destToRoot(name string) (string, error) {
+	if !filepath.IsLocal(name) {
+		return "", fmt.Errorf("%q is outside of destination", name)
+	}
+	return filepath.Join(u.destRel, name), nil
+}
+
+// relToRoot converts a path relative to destPath into a path relative
+// to rootPath / the os.Root. Unlike destToRoot, the target may resolve above
+// destPath, as long as it remains under rootPath.
+func (u *unpacker) relToRoot(name string) (string, error) {
+	if filepath.IsAbs(name) {
+		return "", fmt.Errorf("%q is outside of root", name)
+	}
+	relPath := filepath.Join(u.destRel, name)
+	if !filepath.IsLocal(relPath) {
+		return "", fmt.Errorf("%q is outside of root", name)
+	}
+	return relPath, nil
 }
 
 // createImpliedDirectories will create all parent directories of the current path with default permissions, if they do
@@ -161,19 +252,17 @@ loop:
 // The caller should have performed filepath.Clean(hdr.Name), so hdr.Name will now be in the filepath format for the OS
 // on which the daemon is running. This precondition is required because this function assumes a OS-specific path
 // separator when checking that a path is not the root.
-func createImpliedDirectories(dest string, hdr *tar.Header, options *archive.TarOptions) error {
+func (u *unpacker) createImpliedDirectories(relPath string, hdr *tar.Header) error {
 	// Not the root directory, ensure that the parent directory exists
 	if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
-		parent := filepath.Dir(hdr.Name)
-		parentPath := filepath.Join(dest, parent)
-		if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
+		parent := filepath.Dir(relPath)
+		if parent != "." {
 			// RootPair() is confined inside this loop as most cases will not require a call, so we can spend some
 			// unneeded function calls in the uncommon case to encapsulate logic -- implied directories are a niche
 			// usage that reduces the portability of an image.
-			uid, gid := options.IDMap.RootPair()
+			uid, gid := u.options.IDMap.RootPair()
 
-			err = user.MkdirAllAndChown(parentPath, archive.ImpliedDirectoryMode, uid, gid, user.WithOnlyNew)
-			if err != nil {
+			if err := u.mkdirAllAndChown(parent, mobyarchive.ImpliedDirectoryMode, uid, gid); err != nil {
 				return err
 			}
 		}
@@ -182,7 +271,7 @@ func createImpliedDirectories(dest string, hdr *tar.Header, options *archive.Tar
 	return nil
 }
 
-func remapIDs(idMapping user.IdentityMapping, hdr *tar.Header) error {
+func remapIDs(idMapping mobyuser.IdentityMapping, hdr *tar.Header) error {
 	uid, gid, err := idMapping.ToHost(hdr.Uid, hdr.Gid)
 	hdr.Uid, hdr.Gid = uid, gid
 	return err
@@ -190,20 +279,12 @@ func remapIDs(idMapping user.IdentityMapping, hdr *tar.Header) error {
 
 const paxSchilyXattr = "SCHILY.xattr."
 
-// createTarFile creates a file from a tar record. The target of any symlinks
-// and hard links must be under extractRoot. This differs from the unmodified upstream
-// code, which requires that they are under extractDir.
-func createTarFile(path, extractDir, extractRoot string, hdr *tar.Header, reader io.Reader, opts *archive.TarOptions) error {
-	var (
-		Lchown           = true
-		bestEffortXattrs bool
-		chownOpts        *archive.ChownOpts
-	)
-	if opts != nil {
-		Lchown = !opts.NoLchown
-		chownOpts = opts.ChownOpts
-		bestEffortXattrs = opts.BestEffortXattrs
-	}
+// createTarFile creates a file from a tar record through u.root. Hard links
+// and symlinks must target a path under u.rootPath.
+func (u *unpacker) createTarFile(path string, hdr *tar.Header, reader io.Reader) error {
+	Lchown := !u.options.NoLchown
+	bestEffortXattrs := u.options.BestEffortXattrs
+	chownOpts := u.options.ChownOpts
 
 	// hdr.Mode is in linux format, which we can use for sycalls,
 	// but for os.Foo() calls we need the mode converted to os.FileMode,
@@ -214,16 +295,14 @@ func createTarFile(path, extractDir, extractRoot string, hdr *tar.Header, reader
 	case tar.TypeDir:
 		// Create directory unless it exists as a directory already.
 		// In that case we just want to merge the two
-		if fi, err := os.Lstat(path); err != nil || !fi.IsDir() {
-			if err := os.Mkdir(path, hdrInfo.Mode()); err != nil {
+		if fi, err := u.root.Lstat(path); err != nil || !fi.IsDir() {
+			if err := u.root.Mkdir(path, hdrInfo.Mode()&0o777); err != nil {
 				return err
 			}
 		}
 
 	case tar.TypeReg:
-		// Source is regular file. We use sequential file access to avoid depleting
-		// the standby list on Windows. On Linux, this equates to a regular os.OpenFile.
-		file, err := sequential.OpenFile(path, os.O_CREATE|os.O_WRONLY, hdrInfo.Mode())
+		file, err := u.root.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, hdrInfo.Mode()&0o777)
 		if err != nil {
 			return err
 		}
@@ -239,31 +318,30 @@ func createTarFile(path, extractDir, extractRoot string, hdr *tar.Header, reader
 
 	case tar.TypeFifo:
 		// Handle this is an OS-specific way
-		sylog.Warningf("Skipping %s - fifos are not copied", path)
+		sylog.Warningf("Skipping %s - fifos are not copied", filepath.Join(u.rootPath, path))
 
 	case tar.TypeLink:
-		// #nosec G305 -- The target path is checked for path traversal.
-		targetPath := filepath.Join(extractDir, hdr.Linkname)
-		// check for hardlink breakout
-		if !strings.HasPrefix(targetPath, extractRoot) {
-			return fmt.Errorf("invalid symlink target: %s, resolves to %s, not in root: %s", hdr.Linkname, targetPath, extractRoot)
+		targetPath, err := u.relToRoot(filepath.Clean(hdr.Linkname))
+		if err != nil {
+			return fmt.Errorf("invalid hard link target: %s: %w", hdr.Linkname, err)
 		}
 
-		if err := os.Link(targetPath, path); err != nil {
+		if err := u.root.Link(targetPath, path); err != nil {
 			return err
 		}
 
 	case tar.TypeSymlink:
-		// 	path 				-> hdr.Linkname = targetPath
-		// e.g. /extractDir/path/to/symlink 	-> ../2/file	= /extractDir/path/2/file
-		targetPath := filepath.Join(filepath.Dir(path), hdr.Linkname) // #nosec G305 -- The target path is checked for path traversal.
-
-		// the reason we don't need to check symlinks in the path (with FollowSymlinkInScope) is because
-		// that symlink would first have to be created, which would be caught earlier, at this very check:
-		if !strings.HasPrefix(targetPath, extractRoot) {
-			return fmt.Errorf("invalid symlink target: %s, resolves to %s, not in root: %s", hdr.Linkname, targetPath, extractRoot)
+		// path is the location of a symlink relative to the unpacker.root.
+		// Linkname is the target relative to the location of the symlink. Check
+		// it doesn't point outside of the root, if it's relative.
+		//
+		// The Join here explicitly allows absolute symlink targets, which must
+		// be copied as part of a rootfs for it to be functional.
+		targetRel := filepath.Join(filepath.Dir(path), hdr.Linkname) //nolint:gosec
+		if !filepath.IsLocal(targetRel) {
+			return fmt.Errorf("invalid symlink target: %s: %q is outside of root", hdr.Linkname, targetRel)
 		}
-		if err := os.Symlink(hdr.Linkname, path); err != nil {
+		if err := u.root.Symlink(hdr.Linkname, path); err != nil {
 			return err
 		}
 
@@ -275,17 +353,16 @@ func createTarFile(path, extractDir, extractRoot string, hdr *tar.Header, reader
 		return fmt.Errorf("unhandled tar header type %d", hdr.Typeflag)
 	}
 
-	// Lchown is not supported on Windows.
-	if Lchown && runtime.GOOS != "windows" {
+	if Lchown {
 		if chownOpts == nil {
-			chownOpts = &archive.ChownOpts{UID: hdr.Uid, GID: hdr.Gid}
+			chownOpts = &mobyarchive.ChownOpts{UID: hdr.Uid, GID: hdr.Gid}
 		}
-		if err := os.Lchown(path, chownOpts.UID, chownOpts.GID); err != nil {
+		if err := u.root.Lchown(path, chownOpts.UID, chownOpts.GID); err != nil {
 			msg := "failed to Lchown %q for UID %d, GID %d"
-			if errors.Is(err, syscall.EINVAL) && userns.RunningInUserNS() {
+			if errors.Is(err, syscall.EINVAL) && mobyuserns.RunningInUserNS() {
 				msg += " (try increasing the number of subordinate IDs in /etc/subuid and /etc/subgid)"
 			}
-			return fmt.Errorf("%s %s %d %d: %w", msg, path, hdr.Uid, hdr.Gid, err)
+			return fmt.Errorf("%s %s %d %d: %w", msg, filepath.Join(u.rootPath, path), hdr.Uid, hdr.Gid, err)
 		}
 	}
 
@@ -295,7 +372,7 @@ func createTarFile(path, extractDir, extractRoot string, hdr *tar.Header, reader
 		if !ok {
 			continue
 		}
-		if err := Lsetxattr(path, xattr, []byte(value), 0); err != nil {
+		if err := Lsetxattr(filepath.Join(u.rootPath, path), xattr, []byte(value), 0); err != nil {
 			if bestEffortXattrs && errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.EPERM) {
 				// EPERM occurs if modifying xattrs is not allowed. This can
 				// happen when running in userns with restrictions (ChromeOS).
@@ -312,7 +389,7 @@ func createTarFile(path, extractDir, extractRoot string, hdr *tar.Header, reader
 
 	// There is no LChmod, so ignore mode for symlink. Also, this
 	// must happen after chown, as that can modify the file mode
-	if err := handleLChmod(hdr, path, hdrInfo); err != nil {
+	if err := u.handleLChmod(hdr, path, hdrInfo); err != nil {
 		return err
 	}
 
@@ -324,33 +401,64 @@ func createTarFile(path, extractDir, extractRoot string, hdr *tar.Header, reader
 
 	// Chtimes doesn't support a NOFOLLOW flag atm
 	if hdr.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			if err := Chtimes(path, aTime, hdr.ModTime); err != nil {
+		if fi, err := u.root.Lstat(path); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+			if err := Chtimes(u.root, path, aTime, hdr.ModTime); err != nil {
 				return err
 			}
 		}
 	} else if hdr.Typeflag != tar.TypeSymlink {
-		if err := Chtimes(path, aTime, hdr.ModTime); err != nil {
+		if err := Chtimes(u.root, path, aTime, hdr.ModTime); err != nil {
 			return err
 		}
 	} else {
 		ts := []syscall.Timespec{timeToTimespec(aTime), timeToTimespec(hdr.ModTime)}
-		if err := LUtimesNano(path, ts); err != nil {
+		// LUtimesNano is path based because the platform API is path based.
+		// Creation was rooted above, but this timestamp update is not fd-relative.
+		if err := LUtimesNano(filepath.Join(u.rootPath, path), ts); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+func (u *unpacker) handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
 	if hdr.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+		if fi, err := u.root.Lstat(path); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+			if err := u.root.Chmod(path, hdrInfo.Mode()); err != nil {
 				return err
 			}
 		}
 	} else if hdr.Typeflag != tar.TypeSymlink {
-		if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+		if err := u.root.Chmod(path, hdrInfo.Mode()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (u *unpacker) mkdirAllAndChown(path string, perm os.FileMode, uid, gid int) error {
+	var current string
+	for _, part := range strings.Split(path, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		if fi, err := u.root.Lstat(current); err == nil {
+			if !fi.IsDir() {
+				return fmt.Errorf("%s exists and is not a directory", current)
+			}
+			continue
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+
+		if err := u.root.Mkdir(current, perm&0o777); err != nil {
+			if !os.IsExist(err) {
+				return err
+			}
+			continue
+		}
+		if err := u.root.Lchown(current, uid, gid); err != nil {
 			return err
 		}
 	}

--- a/pkg/util/archive/archive_test.go
+++ b/pkg/util/archive/archive_test.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2026, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mobyarchive "github.com/moby/go-archive"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
+)
+
+func TestUnpackWithRoot(t *testing.T) {
+	// An entry cannot be written outside unpacker.destpath.
+	t.Run("entryEscape", func(t *testing.T) {
+		dst := t.TempDir()
+		outside := filepath.Join(filepath.Dir(dst), "escape")
+
+		entries := []tarEntry{{name: "../escape", body: "foo", typeflag: tar.TypeReg}}
+
+		if err := unpackTestArchive(t, entries, dst, dst); err == nil {
+			t.Fatal("expected unpack to reject entry outside destination")
+		}
+		if _, err := os.Lstat(outside); !os.IsNotExist(err) {
+			t.Fatalf("outside path was created or could not be checked: %v", err)
+		}
+	})
+
+	// When replacing a symlink with a tar entry, replace the symlink itself.
+	// Don't follow a symlink and replace a target outside the
+	// unpacker.destpath.
+	t.Run("replaceSymlink", func(t *testing.T) {
+		// outside is a symlink to a file outside of unpacker.destpath.
+		tmpDir := t.TempDir()
+		dst := filepath.Join(tmpDir, "dst")
+		outside := filepath.Join(tmpDir, "outside")
+		if err := os.Mkdir(dst, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := fs.WriteFileNoFollow(outside, []byte("outside"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(dst, "file")); err != nil {
+			t.Fatal(err)
+		}
+
+		entries := []tarEntry{{name: "file", body: "inside"}}
+
+		if err := unpackTestArchive(t, entries, dst, dst); err != nil {
+			t.Fatalf("unexpected unpack error: %v", err)
+		}
+
+		gotOutside, err := os.ReadFile(outside)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(gotOutside) != "outside" {
+			t.Fatalf("outside file was modified: %q", gotOutside)
+		}
+		gotInside, err := os.ReadFile(filepath.Join(dst, "file"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(gotInside) != "inside" {
+			t.Fatalf("destination file content = %q, want inside", gotInside)
+		}
+		if fs.IsLink(filepath.Join(dst, "file")) {
+			t.Fatal("destination should have been replaced with a regular file")
+		}
+	})
+
+	// Must not traverse a symlink to write a file outside of unpacker.destpath.
+	t.Run("parentSymlinkOutside", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dst := filepath.Join(tmpDir, "dst")
+		outside := filepath.Join(tmpDir, "outside")
+		if err := os.Mkdir(dst, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(outside, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(dst, "dir")); err != nil {
+			t.Fatal(err)
+		}
+
+		entries := []tarEntry{{name: "dir/file", body: "bad"}}
+
+		if err := unpackTestArchive(t, entries, dst, dst); err == nil {
+			t.Fatal("expected unpack through parent symlink to fail")
+		}
+		if _, err := os.Lstat(filepath.Join(outside, "file")); !os.IsNotExist(err) {
+			t.Fatalf("outside file was created or could not be checked: %v", err)
+		}
+	})
+
+	// Hard link targets cannot be outside of unpacker.rootPath.
+	t.Run("hardlinkOutsideRoot", func(t *testing.T) {
+		dst := t.TempDir()
+
+		entries := []tarEntry{{name: "link", linkname: "../target", typeflag: tar.TypeLink}}
+
+		if err := unpackTestArchive(t, entries, dst, dst); err == nil {
+			t.Fatal("expected hardlink outside destination root to fail")
+		}
+		if _, err := os.Lstat(filepath.Join(dst, "link")); !os.IsNotExist(err) {
+			t.Fatalf("hardlink was created or could not be checked: %v", err)
+		}
+	})
+
+	// Hard link targets can be outside of unpacker.destpath, if they are under unpacker.rootPath.
+	t.Run("hardlinkWithinRootAboveDestination", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dst := filepath.Join(tmpDir, "dst")
+		if err := os.Mkdir(dst, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := fs.WriteFileNoFollow(filepath.Join(tmpDir, "target"), []byte("target"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		entries := []tarEntry{{name: "link", linkname: "../target", typeflag: tar.TypeLink}}
+
+		if err := unpackTestArchive(t, entries, dst, tmpDir); err != nil {
+			t.Fatalf("unexpected unpack error: %v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(dst, "link"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "target" {
+			t.Fatalf("hardlink content = %q, want target", got)
+		}
+	})
+
+	// Symlink targets cannot be outside of unpacker.rootPath.
+	t.Run("symlinkOutsideRoot", func(t *testing.T) {
+		dst := t.TempDir()
+
+		entries := []tarEntry{{name: "link", linkname: "../target", typeflag: tar.TypeSymlink}}
+
+		if err := unpackTestArchive(t, entries, dst, dst); err == nil {
+			t.Fatal("expected symlink outside destination root to fail")
+		}
+		if _, err := os.Lstat(filepath.Join(dst, "link")); !os.IsNotExist(err) {
+			t.Fatalf("symlink was created or could not be checked: %v", err)
+		}
+	})
+
+	// Symlink targets can be outside of unpacker.destpath, if they are under unpacker.rootPath.
+	t.Run("symlinkWithinRootAboveDestination", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dst := filepath.Join(tmpDir, "dst")
+		if err := os.Mkdir(dst, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := fs.WriteFileNoFollow(filepath.Join(tmpDir, "target"), []byte("target"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		entries := []tarEntry{{name: "link", linkname: "../target", typeflag: tar.TypeSymlink}}
+
+		if err := unpackTestArchive(t, entries, dst, tmpDir); err != nil {
+			t.Fatalf("unexpected unpack error: %v", err)
+		}
+		got, err := os.Readlink(filepath.Join(dst, "link"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "../target" {
+			t.Fatalf("symlink target = %q, want ../target", got)
+		}
+	})
+}
+
+type tarEntry struct {
+	name     string
+	linkname string
+	body     string
+	typeflag byte
+}
+
+func unpackTestArchive(t *testing.T, entries []tarEntry, dest, destRoot string) error {
+	t.Helper()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, entry := range entries {
+		typeflag := entry.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		hdr := &tar.Header{
+			Name:     entry.name,
+			Linkname: entry.linkname,
+			Mode:     0o644,
+			Size:     int64(len(entry.body)),
+			Typeflag: typeflag,
+		}
+		if typeflag != tar.TypeReg {
+			hdr.Size = 0
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if typeflag == tar.TypeReg {
+			if _, err := tw.Write([]byte(entry.body)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return unpackWithRoot(bytes.NewReader(buf.Bytes()), dest, destRoot, &mobyarchive.TarOptions{
+		NoLchown: true,
+	})
+}

--- a/pkg/util/archive/copy.go
+++ b/pkg/util/archive/copy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/moby/go-archive"
 	"github.com/moby/go-archive/compression"
@@ -19,62 +18,26 @@ import (
 
 // CopyWithTar is a wrapper around the docker pkg/archive/copy CopyWithTar
 // function allowing unprivileged use. It forces ownership to the current
-// uid/gid in unprivileged situations. No file may be copied into a location
-// above dst, and hard links / symlinks may not target a file above dst.
+// uid/gid in unprivileged situations. No archive entries may be written above
+// dst. Hard links to files outside of dst are not allowed. Relative symlinks to
+// targets outside of dst are not allowed. Absolute symlink targets are allowed,
+// but will not be traversed outside of dst when extracting entries.
 func CopyWithTar(src, dst string, disableIDMapping bool) error {
-	ar := archive.NewDefaultArchiver()
-
-	// If we are running unprivileged, then squash uid / gid as necessary.
-	// TODO: In future, we want to think about preserving effective ownership
-	// for fakeroot cases where there will be a mapping allowing non-root, non-user
-	// ownership to be preserved.
-	euid := os.Geteuid()
-	egid := os.Getgid()
-	if (euid != 0 || egid != 0) && !disableIDMapping {
-		sylog.Debugf("Using unprivileged CopyWithTar (uid=%d, gid=%d)", euid, egid)
-		// The docker CopytWithTar function assumes it should create the top-level of dst as the
-		// container root user. If we are unprivileged this means setting up an ID mapping
-		// from UID/GID 0 to our host UID/GID.
-		ar.IDMapping = user.IdentityMapping{
-			// Single entry mapping of container root (0) to current uid only
-			UIDMaps: []user.IDMap{
-				{
-					ID:       0,
-					ParentID: int64(euid),
-					Count:    1,
-				},
-			},
-			// Single entry mapping of container root (0) to current gid only
-			GIDMaps: []user.IDMap{
-				{
-					ID:       0,
-					ParentID: int64(egid),
-					Count:    1,
-				},
-			},
-		}
-		// Actual extraction of files needs to be *always* squashed to our current uid & gid.
-		// This requires clearing the IDMaps, and setting a forced UID/GID with ChownOpts for
-		// the lower level Untar func called by the archiver.
-		chownOpts := &archive.ChownOpts{
-			UID: euid,
-			GID: egid,
-		}
-		ar.Untar = func(tarArchive io.Reader, dest string, options *archive.TarOptions) error {
-			options.IDMap = user.IdentityMapping{}
-			options.ChownOpts = chownOpts
-			return archive.Untar(tarArchive, dest, options)
-		}
-	}
-
+	ar := newRootedArchiver("", disableIDMapping)
 	return ar.CopyWithTar(src, dst)
 }
 
 // CopyWithTarWithRoots copies files as with CopyWithTar, but uses a custom
-// ar.Untar which checks that hard link / symlink targets are under dstRoot,
-// and not dst. This allows copying a directory src to dst, where the directory
-// contains a link to a location above dst, but under dstroot.
-func CopyWithTarWithRoot(src, dst, dstRoot string, disableIDMapping bool) error {
+// ar.Untar rooted at root, and not dst. This allows copying from src to dst,
+// where this will create a hard link or symlink to a location above dst, but
+// under dstRoot.
+func CopyWithTarWithRoot(src, dst, root string, disableIDMapping bool) error {
+	ar := newRootedArchiver(root, disableIDMapping)
+	return ar.CopyWithTar(src, dst)
+}
+
+// newRootedArchiver returns an Archiver whose Untar is confined to an os.Root at root.
+func newRootedArchiver(root string, disableIDMapping bool) *archive.Archiver {
 	ar := archive.NewDefaultArchiver()
 
 	// If we are running unprivileged, then squash uid / gid as necessary.
@@ -118,20 +81,18 @@ func CopyWithTarWithRoot(src, dst, dstRoot string, disableIDMapping bool) error 
 	}
 
 	ar.Untar = func(tarArchive io.Reader, dest string, options *archive.TarOptions) error {
-		if chownOpts != nil {
-			options.IDMap = user.IdentityMapping{}
-			options.ChownOpts = chownOpts
-		}
-
 		if tarArchive == nil {
 			return fmt.Errorf("empty archive")
 		}
-		dest = filepath.Clean(dest)
 		if options == nil {
 			options = &archive.TarOptions{}
 		}
 		if options.ExcludePatterns == nil {
 			options.ExcludePatterns = []string{}
+		}
+		if chownOpts != nil {
+			options.IDMap = user.IdentityMapping{}
+			options.ChownOpts = chownOpts
 		}
 
 		decompressedArchive, err := compression.DecompressStream(tarArchive)
@@ -140,8 +101,16 @@ func CopyWithTarWithRoot(src, dst, dstRoot string, disableIDMapping bool) error 
 		}
 		defer decompressedArchive.Close()
 
-		return UnpackWithRoot(decompressedArchive, dest, dstRoot, options)
+		// For CopyFileWithTar, root is "" and we root at dest, so that a copy
+		// of a single file src to dst still succeeds (dest passed to us will be
+		// the parent dir for the destination file).
+		unpackRoot := root
+		if unpackRoot == "" {
+			unpackRoot = dest
+		}
+
+		return unpackWithRoot(decompressedArchive, dest, unpackRoot, options)
 	}
 
-	return ar.CopyWithTar(src, dst)
+	return ar
 }

--- a/pkg/util/archive/copy_test.go
+++ b/pkg/util/archive/copy_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
-	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
 
 func TestCopyWithTar(t *testing.T) {
@@ -23,13 +22,15 @@ func TestCopyWithTar(t *testing.T) {
 
 	t.Run("privileged", func(t *testing.T) {
 		test.EnsurePrivilege(t)
-		testCopy(t, copyFunc)
+		testCopyFile(t, copyFunc)
+		testCopyDir(t, copyFunc)
 	})
 
 	t.Run("unprivileged", func(t *testing.T) {
 		test.DropPrivilege(t)
 		defer test.ResetPrivilege(t)
-		testCopy(t, copyFunc)
+		testCopyFile(t, copyFunc)
+		testCopyDir(t, copyFunc)
 	})
 }
 
@@ -40,20 +41,41 @@ func TestCopyWithTarRoot(t *testing.T) {
 
 	t.Run("privileged", func(t *testing.T) {
 		test.EnsurePrivilege(t)
-		testCopy(t, copyFunc)
+		testCopyDir(t, copyFunc)
 	})
 
 	t.Run("unprivileged", func(t *testing.T) {
 		test.DropPrivilege(t)
 		defer test.ResetPrivilege(t)
-		testCopy(t, copyFunc)
+		testCopyDir(t, copyFunc)
 	})
 
 	test.DropPrivilege(t)
 	t.Run("relLinkTarget", testRelLinkTarget)
 }
 
-func testCopy(t *testing.T, copyFunc func(src, dst string) error) {
+func testCopyFile(t *testing.T, copyFunc func(src, dst string) error) {
+	srcRoot := t.TempDir()
+	src := filepath.Join(srcRoot, "srcFile")
+	if err := fs.WriteFileNoFollow(src, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "sub", "dstFile")
+	if err := copyFunc(src, dst); err != nil {
+		t.Fatalf("unexpected error copying single file: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "test" {
+		t.Fatalf("destination content = %q, want test", got)
+	}
+}
+
+func testCopyDir(t *testing.T, copyFunc func(src, dst string) error) {
 	srcRoot := t.TempDir()
 	t.Logf("srcRoot location: %s\n", srcRoot)
 
@@ -141,7 +163,7 @@ func testCopy(t *testing.T, copyFunc func(src, dst string) error) {
 }
 
 // Test that CopyWithTarWithRoot doesn't allow relative symlink targets above
-// the dstRoot, but does allow them within the dstRoot, above dst.
+// dstRoot, but does allow them within dstRoot, above dst.
 //
 // See - https://github.com/sylabs/singularity/issues/2607
 func testRelLinkTarget(t *testing.T) {
@@ -191,10 +213,10 @@ func testRelLinkTarget(t *testing.T) {
 			}
 			err := CopyWithTarWithRoot(tt.src, tt.dst, tt.dstRoot, false)
 			if err == nil && tt.expectError {
-				sylog.Errorf("expected error, but none returned")
+				t.Errorf("expected error, but none returned")
 			}
 			if err != nil && !tt.expectError {
-				sylog.Errorf("unexpected error %v", err)
+				t.Errorf("unexpected error %v", err)
 			}
 		})
 	}

--- a/pkg/util/archive/system.go
+++ b/pkg/util/archive/system.go
@@ -48,11 +48,12 @@ func init() {
 	}
 }
 
-// Chtimes changes the access time and modified time of a file at the given path.
-// If the modified time is prior to the Unix Epoch (unixMinTime), or after the
-// end of Unix Time (unixEpochTime), os.Chtimes has undefined behavior. In this
-// case, Chtimes defaults to Unix Epoch, just in case.
-func Chtimes(name string, atime time.Time, mtime time.Time) error {
+// Chtimes changes the access time and modified time of a file at the given path,
+// resolved relative to root. If the modified time is prior to the Unix Epoch
+// (unixMinTime), or after the end of Unix Time (unixEpochTime), os.Chtimes has
+// undefined behavior. In this case, Chtimes defaults to Unix Epoch, just in
+// case.
+func Chtimes(root *os.Root, name string, atime time.Time, mtime time.Time) error {
 	if atime.Before(unixEpochTime) || atime.After(unixMaxTime) {
 		atime = unixEpochTime
 	}
@@ -61,11 +62,7 @@ func Chtimes(name string, atime time.Time, mtime time.Time) error {
 		mtime = unixEpochTime
 	}
 
-	if err := os.Chtimes(name, atime, mtime); err != nil {
-		return err
-	}
-
-	return nil
+	return root.Chtimes(name, atime, mtime)
 }
 
 // LUtimesNano is used to change access and modification time of the specified path.

--- a/pkg/util/archive/system_test.go
+++ b/pkg/util/archive/system_test.go
@@ -31,17 +31,24 @@ import (
 
 // TestChtimesATime tests Chtimes access time on a tempfile.
 func TestChtimesATime(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "exist")
+	dir := t.TempDir()
+	file := filepath.Join(dir, "exist")
+	fileRel := filepath.Base(file)
 	if err := fs.WriteFileNoFollow(file, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
 
 	beforeUnixEpochTime := unixEpochTime.Add(-100 * time.Second)
 	afterUnixEpochTime := unixEpochTime.Add(100 * time.Second)
 
 	// Test both aTime and mTime set to Unix Epoch
 	t.Run("both aTime and mTime set to Unix Epoch", func(t *testing.T) {
-		if err := Chtimes(file, unixEpochTime, unixEpochTime); err != nil {
+		if err := Chtimes(root, fileRel, unixEpochTime, unixEpochTime); err != nil {
 			t.Error(err)
 		}
 
@@ -59,7 +66,7 @@ func TestChtimesATime(t *testing.T) {
 
 	// Test aTime before Unix Epoch and mTime set to Unix Epoch
 	t.Run("aTime before Unix Epoch and mTime set to Unix Epoch", func(t *testing.T) {
-		if err := Chtimes(file, beforeUnixEpochTime, unixEpochTime); err != nil {
+		if err := Chtimes(root, fileRel, beforeUnixEpochTime, unixEpochTime); err != nil {
 			t.Error(err)
 		}
 
@@ -77,7 +84,7 @@ func TestChtimesATime(t *testing.T) {
 
 	// Test aTime set to Unix Epoch and mTime before Unix Epoch
 	t.Run("aTime set to Unix Epoch and mTime before Unix Epoch", func(t *testing.T) {
-		if err := Chtimes(file, unixEpochTime, beforeUnixEpochTime); err != nil {
+		if err := Chtimes(root, fileRel, unixEpochTime, beforeUnixEpochTime); err != nil {
 			t.Error(err)
 		}
 
@@ -95,7 +102,7 @@ func TestChtimesATime(t *testing.T) {
 
 	// Test both aTime and mTime set to after Unix Epoch (valid time)
 	t.Run("both aTime and mTime set to after Unix Epoch (valid time)", func(t *testing.T) {
-		if err := Chtimes(file, afterUnixEpochTime, afterUnixEpochTime); err != nil {
+		if err := Chtimes(root, fileRel, afterUnixEpochTime, afterUnixEpochTime); err != nil {
 			t.Error(err)
 		}
 
@@ -113,7 +120,7 @@ func TestChtimesATime(t *testing.T) {
 
 	// Test both aTime and mTime set to Unix max time
 	t.Run("both aTime and mTime set to Unix max time", func(t *testing.T) {
-		if err := Chtimes(file, unixMaxTime, unixMaxTime); err != nil {
+		if err := Chtimes(root, fileRel, unixMaxTime, unixMaxTime); err != nil {
 			t.Error(err)
 		}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Rather than using path-based checks to prevent escape from the destination / specified root, use os.Root operations whenever possible.

Lsetxattr is not supported in a root, so xattrs are still set via a path, though this path is previously subject to the root controls for the creation of the file / dir / link.

Some additional helper functions are brought in from moby/go-archive and adapted to work with an os.Root.

Initial exploration of hardening opportunities across the codebase, and generation of draft changes used Claude code. However, the changes committed here have been re-written by hand. The Co-authored-by tag is added on this basis.

Co-authored-by: Claude Code
