### PR TITLE
fs: os.Root-ed fs.MkdirAt / fs.MkdirAll

### DIFF
--- a/internal/app/singularity/overlay_create.go
+++ b/internal/app/singularity/overlay_create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sylabs/sif/v2/pkg/sif"
 	"github.com/sylabs/singularity/v4/internal/pkg/ocisif"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/image"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"golang.org/x/sys/unix"
@@ -241,11 +242,9 @@ func createOverlayFile(path string, size int, sparse bool, overlayDirs ...string
 	}
 
 	for _, dir := range overlayDirs {
-		od := filepath.Join(upperDir, dir)
-		if !strings.HasPrefix(od, upperDir) {
-			return fmt.Errorf("overlay directory created outside of overlay layout %s", upperDir)
-		}
-		if err := os.MkdirAll(od, perm); err != nil {
+		rel := strings.TrimPrefix(filepath.Clean(dir), string(os.PathSeparator))
+		od := filepath.Join(upperDir, rel)
+		if err := fs.MkdirAllAt(upperDir, rel, perm); err != nil {
 			return fmt.Errorf("while creating %s: %s", od, err)
 		}
 	}

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gosimple/slug"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/credential"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/syfs"
 	"golang.org/x/sys/unix"
 )
@@ -81,7 +82,7 @@ type ServiceConfig struct {
 func cacheDir() string {
 	cacheDir := syfs.RemoteCacheDir()
 	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
-		if err := os.Mkdir(cacheDir, 0o700); err != nil {
+		if err := fs.MkdirAt(syfs.ConfigDir(), syfs.RemoteCache, 0o700); err != nil {
 			return ""
 		}
 	}

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1606,8 +1606,9 @@ func (c *container) addHomeStagingDir(system *mount.System, source string, dest 
 				return "", fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 			}
 
-			homeStage = filepath.Join(workdir, "home")
-			if err := fs.Mkdir(homeStage, 0o700); err != nil && !os.IsExist(err) {
+			homeStageRel := "home"
+			homeStage = filepath.Join(workdir, homeStageRel)
+			if err := fs.MkdirAt(workdir, homeStageRel, 0o700); err != nil && !os.IsExist(err) {
 				return "", fmt.Errorf("failed to create %s: %s", homeStage, err)
 			}
 		} else {
@@ -1811,13 +1812,15 @@ func (c *container) createTmpSource() (tmpSource, vartmpSource string, err error
 				return "", "", fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 			}
 
-			tmpSource = filepath.Join(workdir, tmpSource)
-			vartmpSource = filepath.Join(workdir, vartmpSource)
+			tmpSourceRel := strings.TrimPrefix(filepath.Clean(tmpSource), string(os.PathSeparator))
+			vartmpSourceRel := filepath.Clean(vartmpSource)
+			tmpSource = filepath.Join(workdir, tmpSourceRel)
+			vartmpSource = filepath.Join(workdir, vartmpSourceRel)
 
-			if err := fs.Mkdir(tmpSource, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+			if err := fs.MkdirAt(workdir, tmpSourceRel, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
 				return "", "", fmt.Errorf("failed to create %s: %s", tmpSource, err)
 			}
-			if err := fs.Mkdir(vartmpSource, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+			if err := fs.MkdirAt(workdir, vartmpSourceRel, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
 				return "", "", fmt.Errorf("failed to create %s: %s", vartmpSource, err)
 			}
 		} else {
@@ -1903,8 +1906,9 @@ func (c *container) addScratchMount(system *mount.System) error {
 		if err != nil {
 			return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 		}
-		sourceDir := filepath.Join(workdir, scratchSessionDir)
-		if err := fs.MkdirAll(sourceDir, 0o750); err != nil {
+		scratchSessionRel := strings.TrimPrefix(filepath.Clean(scratchSessionDir), string(os.PathSeparator))
+		sourceDir := filepath.Join(workdir, scratchSessionRel)
+		if err := fs.MkdirAllAt(workdir, scratchSessionRel, 0o750); err != nil {
 			return fmt.Errorf("could not create scratch working directory %s: %s", sourceDir, err)
 		}
 	}
@@ -1916,8 +1920,12 @@ func (c *container) addScratchMount(system *mount.System) error {
 		}
 		fullSourceDir, _ := c.session.GetPath(src)
 		if hasWorkdir {
-			fullSourceDir = filepath.Join(workdir, scratchSessionDir, dir)
-			if err := fs.MkdirAll(fullSourceDir, 0o750); err != nil {
+			scratchDirRel := filepath.Join(
+				strings.TrimPrefix(filepath.Clean(scratchSessionDir), string(os.PathSeparator)),
+				strings.TrimPrefix(filepath.Clean(dir), string(os.PathSeparator)),
+			)
+			fullSourceDir = filepath.Join(workdir, scratchDirRel)
+			if err := fs.MkdirAllAt(workdir, scratchDirRel, 0o750); err != nil {
 				return fmt.Errorf("could not create scratch working directory %s: %s", fullSourceDir, err)
 			}
 		}

--- a/internal/pkg/runtime/launcher/oci/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/oci/launcher_linux.go
@@ -467,7 +467,7 @@ func (l *Launcher) handleVarTmpToTmpSymlink(spec *specs.Spec) {
 // the container's existing passwd/group files. spec.Process.User.[UG]ID must be
 // set correctly before calling.
 func (l *Launcher) prepareEtc(b ocibundle.Bundle, spec *specs.Spec, containerUser bool) error {
-	if err := os.Mkdir(filepath.Join(b.Path(), "etc"), 0o755); err != nil && !os.IsExist(err) {
+	if err := fs.MkdirAt(b.Path(), "etc", 0o755); err != nil && !os.IsExist(err) {
 		return err
 	}
 

--- a/internal/pkg/runtime/launcher/oci/mounts_linux.go
+++ b/internal/pkg/runtime/launcher/oci/mounts_linux.go
@@ -127,13 +127,15 @@ func (l *Launcher) addTmpMounts(mounts *[]specs.Mount) error {
 			return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 		}
 
-		tmpSrc := filepath.Join(workdir, tmpSrcSubdir)
-		vartmpSrc := filepath.Join(workdir, vartmpSrcSubdir)
+		tmpSrcRel := filepath.Clean(tmpSrcSubdir)
+		vartmpSrcRel := filepath.Clean(vartmpSrcSubdir)
+		tmpSrc := filepath.Join(workdir, tmpSrcRel)
+		vartmpSrc := filepath.Join(workdir, vartmpSrcRel)
 
-		if err := fs.Mkdir(tmpSrc, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+		if err := fs.MkdirAt(workdir, tmpSrcRel, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
 			return fmt.Errorf("failed to create %s: %s", tmpSrc, err)
 		}
-		if err := fs.Mkdir(vartmpSrc, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+		if err := fs.MkdirAt(workdir, vartmpSrcRel, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
 			return fmt.Errorf("failed to create %s: %s", vartmpSrc, err)
 		}
 
@@ -489,14 +491,16 @@ func (l *Launcher) addScratchMounts(mounts *[]specs.Mount) error {
 		if err != nil {
 			return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 		}
-		scratchContainerDirPath := filepath.Join(workdir, scratchContainerDirName)
-		if err := fs.Mkdir(scratchContainerDirPath, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+		scratchRel := strings.TrimPrefix(filepath.Clean(scratchContainerDirName), string(os.PathSeparator))
+		scratchContainerDirPath := filepath.Join(workdir, scratchRel)
+		if err := fs.MkdirAt(workdir, scratchRel, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
 			return fmt.Errorf("failed to create %s: %s", scratchContainerDirPath, err)
 		}
 
 		for _, s := range l.cfg.ScratchDirs {
-			scratchDirPath := filepath.Join(scratchContainerDirPath, s)
-			if err := fs.Mkdir(scratchDirPath, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
+			scratchDirRel := filepath.Join(scratchRel, strings.TrimPrefix(filepath.Clean(s), string(os.PathSeparator)))
+			scratchDirPath := filepath.Join(workdir, scratchDirRel)
+			if err := fs.MkdirAt(workdir, scratchDirRel, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
 				return fmt.Errorf("failed to create %s: %s", scratchDirPath, err)
 			}
 

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -247,6 +247,62 @@ func Mkdir(path string, mode os.FileMode) error {
 	return os.Mkdir(path, mode)
 }
 
+// MkdirAt creates a directory below rootPath using os.Root, with mode after
+// umask reset. relPath must be local, and may not escape rootPath.
+func MkdirAt(rootPath, relPath string, mode os.FileMode) error {
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
+	relPath = filepath.Clean(relPath)
+	if !filepath.IsLocal(relPath) {
+		return fmt.Errorf("path %s is not local to root %s", relPath, rootPath)
+	}
+
+	oldmask := syscall.Umask(0)
+	defer syscall.Umask(oldmask)
+
+	if err := root.Mkdir(relPath, mode.Perm()&0o777); err != nil {
+		return err
+	}
+
+	if mode&0o777 == mode {
+		return nil
+	}
+
+	return root.Chmod(relPath, mode)
+}
+
+// MkdirAllAt creates a directory and parents below rootPath using os.Root, with
+// mode after umask reset. relPath must be local, and may not escape rootPath.
+func MkdirAllAt(rootPath, relPath string, mode os.FileMode) error {
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
+	relPath = filepath.Clean(relPath)
+	if !filepath.IsLocal(relPath) {
+		return fmt.Errorf("path %s is not local to root %s", relPath, rootPath)
+	}
+
+	oldmask := syscall.Umask(0)
+	defer syscall.Umask(oldmask)
+
+	if err := root.MkdirAll(relPath, mode.Perm()&0o777); err != nil {
+		return err
+	}
+
+	if mode&0o777 == mode {
+		return nil
+	}
+
+	return root.Chmod(relPath, mode)
+}
+
 // RootDir returns the root directory of path (rootdir of /my/path is /my).
 // Returns "." if path is empty.
 func RootDir(path string) string {

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -426,6 +426,92 @@ func TestMkdir(t *testing.T) {
 	}
 }
 
+func TestMkdirAt(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	tests := []struct {
+		name      string
+		mkdirFn   func(string, string, os.FileMode) error
+		path      string
+		mode      os.FileMode
+		wantError bool
+	}{
+		{
+			name:    "MkdirAt",
+			mkdirFn: MkdirAt,
+			path:    "test",
+			mode:    0o777,
+		},
+		{
+			name:    "MkdirAt sticky",
+			mkdirFn: MkdirAt,
+			path:    "test",
+			mode:    os.ModeSticky | 0o777,
+		},
+		{
+			name:      "MkdirAt escape",
+			mkdirFn:   MkdirAt,
+			path:      filepath.Join("outside", "test"),
+			mode:      0o755,
+			wantError: true,
+		},
+		{
+			name:    "MkdirAllAt",
+			mkdirFn: MkdirAllAt,
+			path:    filepath.Join("test", "inner"),
+			mode:    0o777,
+		},
+		{
+			name:    "MkdirAllAt sticky",
+			mkdirFn: MkdirAllAt,
+			path:    filepath.Join("test", "inner"),
+			mode:    os.ModeSticky | 0o777,
+		},
+		{
+			name:      "MkdirAllAt escape",
+			mkdirFn:   MkdirAllAt,
+			path:      filepath.Join("outside", "test"),
+			mode:      0o755,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpdir := t.TempDir()
+			if tt.wantError {
+				outside := t.TempDir()
+				if err := os.Symlink(outside, filepath.Join(tmpdir, "outside")); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			err := tt.mkdirFn(tmpdir, tt.path, tt.mode)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Error(err)
+			}
+
+			fullPath := filepath.Join(tmpdir, tt.path)
+			fi, err := os.Stat(fullPath)
+			if err != nil {
+				t.Error(err)
+			}
+			// Compare permission bits along with the setuid/setgid/sticky bits.
+			gotMode := fi.Mode() & (os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky)
+			if gotMode != tt.mode {
+				t.Errorf("expected mode %v, got %v", tt.mode, gotMode)
+			}
+		})
+	}
+}
+
 func TestEvalRelative(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/pkg/ocibundle/native/bundle_linux.go
+++ b/pkg/ocibundle/native/bundle_linux.go
@@ -183,7 +183,7 @@ func (b *Bundle) Create(ctx context.Context, ociConfig *specs.Spec) error {
 	}
 
 	bundleRootfs := tools.RootFs(b.bundlePath).Path()
-	if err := os.Mkdir(bundleRootfs, 0o755); err != nil && !os.IsExist(err) {
+	if err := fs.MkdirAt(b.bundlePath, "rootfs", 0o755); err != nil && !os.IsExist(err) {
 		return err
 	}
 

--- a/pkg/ocibundle/ocisif/bundle_linux.go
+++ b/pkg/ocibundle/ocisif/bundle_linux.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sylabs/sif/v2/pkg/sif"
 	"github.com/sylabs/singularity/v4/internal/pkg/ocisif"
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/engine/config/oci/generate"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/overlay"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs/squashfs"
 	"github.com/sylabs/singularity/v4/pkg/ocibundle"
@@ -211,7 +212,7 @@ func (b *Bundle) mountLayers(ctx context.Context, img v1.Image, imgFile string) 
 
 		layerPath := filepath.Join(tools.Layers(b.bundlePath).Path(), strconv.Itoa(i))
 		sylog.Debugf("Mounting layer %d fs from %q to %q", i, imgFile, layerPath)
-		if err := os.Mkdir(layerPath, 0o755); err != nil {
+		if err := fs.MkdirAt(tools.Layers(b.bundlePath).Path(), strconv.Itoa(i), 0o755); err != nil {
 			return fmt.Errorf("while creating layer directory: %w", err)
 		}
 

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -71,8 +71,9 @@ func (s *sifBundle) writeConfig(g *generate.Generator) error {
 	volumes := tools.Volumes(s.bundlePath).Path()
 	for dst := range imgConfig.Volumes {
 		replacer := strings.NewReplacer(string(os.PathSeparator), "_")
-		src := filepath.Join(volumes, replacer.Replace(dst))
-		if err := os.MkdirAll(src, 0o755); err != nil {
+		volumeRel := replacer.Replace(dst)
+		src := filepath.Join(volumes, volumeRel)
+		if err := fs.MkdirAllAt(volumes, volumeRel, 0o755); err != nil {
 			return fmt.Errorf("failed to create volume directory %s: %s", src, err)
 		}
 		g.AddMount(specs.Mount{

--- a/pkg/ocibundle/tools/oci.go
+++ b/pkg/ocibundle/tools/oci.go
@@ -16,6 +16,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/engine/config/oci"
 	"github.com/sylabs/singularity/v4/internal/pkg/runtime/engine/config/oci/generate"
+	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/passwdfile"
 )
 
@@ -72,16 +73,20 @@ func GenerateBundleConfig(bundlePath string, config *specs.Spec) (*generate.Gene
 	oldumask := syscall.Umask(0)
 	defer syscall.Umask(oldumask)
 
+	if err := fs.MkdirAll(bundlePath, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create %s: %s", bundlePath, err)
+	}
+
 	rootFsDir := RootFs(bundlePath).Path()
-	if err := os.MkdirAll(rootFsDir, 0o700); err != nil {
+	if err := fs.MkdirAllAt(bundlePath, "rootfs", 0o700); err != nil {
 		return nil, fmt.Errorf("failed to create %s: %s", rootFsDir, err)
 	}
 	volumesDir := Volumes(bundlePath).Path()
-	if err := os.MkdirAll(volumesDir, 0o755); err != nil {
+	if err := fs.MkdirAllAt(bundlePath, "volumes", 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create %s: %s", volumesDir, err)
 	}
 	layersDir := Layers(bundlePath).Path()
-	if err := os.MkdirAll(layersDir, 0o755); err != nil {
+	if err := fs.MkdirAllAt(bundlePath, "layers", 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create %s: %s", layersDir, err)
 	}
 	defer func() {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add fs.MkdirAt / fs.MkdirAll which are rooted to a specific location using os.Root.

Use them in place of the existing fs.Mkdir / fs.MkdirAll when constructing `--workdir` locations, which shouldn't reasonably be symlinked out of the specified workdir. Also for internal oci bundle and overlay paths, that should never leave the bundle / overlay dirs.
