### PR TITLE
build: use an os.Root for Mkdir / Writefile operations

### DIFF
--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -14,15 +14,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
-	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 )
@@ -253,41 +252,41 @@ func (pl *BuildApp) createAllApps(b *types.Bundle) error {
 		globalEnv94.WriteString(globalAppEnv(b, app))
 	}
 
-	return fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/env/94-appsbase.sh"), []byte(globalEnv94.String()), 0o755)
+	return b.Rootfs.WriteFile(filepath.Join(".singularity.d", "env", "94-appsbase.sh"), []byte(globalEnv94.String()), 0o755)
 }
 
 func createAppRoot(b *types.Bundle, a *App) error {
-	if err := os.MkdirAll(appBase(b, a), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(appBase(a), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/scif/"), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(filepath.Join(appBase(a), "scif"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/bin/"), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(filepath.Join(appBase(a), "bin"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/lib/"), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(filepath.Join(appBase(a), "lib"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/scif/env/"), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(filepath.Join(appBase(a), "scif", "env"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appData(b, a), "/input/"), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(filepath.Join(appData(a), "input"), 0o755); err != nil {
 		return err
 	}
 
-	return os.MkdirAll(filepath.Join(appData(b, a), "/output/"), 0o755)
+	return b.Rootfs.MkdirAll(filepath.Join(appData(a), "output"), 0o755)
 }
 
 // %appenv and 01-base.sh
 func writeEnvFile(b *types.Bundle, a *App) error {
 	content := fmt.Sprintf(scifEnv01Base, a.Name)
-	if err := fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/env/01-base.sh"), []byte(content), 0o755); err != nil {
+	if err := b.Rootfs.WriteFile(filepath.Join(appMeta(a), "env", "01-base.sh"), []byte(content), 0o755); err != nil {
 		return err
 	}
 
@@ -295,7 +294,7 @@ func writeEnvFile(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	return fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/env/90-environment.sh"), []byte(a.Env), 0o755)
+	return b.Rootfs.WriteFile(filepath.Join(appMeta(a), "env", "90-environment.sh"), []byte(a.Env), 0o755)
 }
 
 func globalAppEnv(b *types.Bundle, a *App) string {
@@ -303,19 +302,19 @@ func globalAppEnv(b *types.Bundle, a *App) string {
 
 	content := fmt.Sprintf(globalEnv94Base, name)
 
-	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/env/90-environment.sh")); err == nil {
+	if _, err := b.Rootfs.Stat(filepath.Join(appMeta(a), "env", "90-environment.sh")); err == nil {
 		content += fmt.Sprintf(globalEnv94AppEnv, name)
 	}
 
-	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/labels.json")); err == nil {
+	if _, err := b.Rootfs.Stat(filepath.Join(appMeta(a), "labels.json")); err == nil {
 		content += fmt.Sprintf(globalEnv94AppLabels, name)
 	}
 
-	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/runscript")); err == nil {
+	if _, err := b.Rootfs.Stat(filepath.Join(appMeta(a), "runscript")); err == nil {
 		content += fmt.Sprintf(globalEnv94AppRun, name)
 	}
 
-	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/startscript")); err == nil {
+	if _, err := b.Rootfs.Stat(filepath.Join(appMeta(a), "startscript")); err == nil {
 		content += fmt.Sprintf(globalEnv94AppStart, name)
 	}
 
@@ -329,7 +328,7 @@ func writeRunscriptFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifRunscriptBase, a.Run)
-	return fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/runscript"), []byte(content), 0o755)
+	return b.Rootfs.WriteFile(filepath.Join(appMeta(a), "runscript"), []byte(content), 0o755)
 }
 
 // %appstart
@@ -339,7 +338,7 @@ func writeStartscriptFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifStartscriptBase, a.Start)
-	return fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/startscript"), []byte(content), 0o755)
+	return b.Rootfs.WriteFile(filepath.Join(appMeta(a), "startscript"), []byte(content), 0o755)
 }
 
 // %apptest
@@ -349,7 +348,7 @@ func writeTestFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifTestBase, a.Test)
-	return fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/test"), []byte(content), 0o755)
+	return b.Rootfs.WriteFile(filepath.Join(appMeta(a), "test"), []byte(content), 0o755)
 }
 
 // %apphelp
@@ -358,7 +357,7 @@ func writeHelpFile(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	return fs.WriteFileNoFollow(filepath.Join(appMeta(b, a), "/runscript.help"), []byte(a.Help), 0o644)
+	return b.Rootfs.WriteFile(filepath.Join(appMeta(a), "runscript.help"), []byte(a.Help), 0o644)
 }
 
 // %appfile
@@ -367,7 +366,6 @@ func copyFiles(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	appBase := filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)
 	for line := range strings.SplitSeq(a.Files, "\n") {
 		// skip empty or comment lines
 		if line = strings.TrimSpace(line); line == "" || strings.Index(line, "#") == 0 {
@@ -388,7 +386,13 @@ func copyFiles(b *types.Bundle, a *App) error {
 			dst = splitLine[1]
 		}
 
-		if err := copyWithfLr(src, filepath.Join(appBase, dst)); err != nil {
+		dstRel := filepath.Join(appBase(a), dst)
+		dst, err := securejoin.SecureJoin(b.RootfsPath, dstRel)
+		if err != nil {
+			return err
+		}
+
+		if err := copyWithfLr(src, dst); err != nil {
 			return err
 		}
 	}
@@ -428,23 +432,22 @@ func writeLabels(b *types.Bundle, a *App) error {
 		return err
 	}
 
-	appBase := filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)
-	err = fs.WriteFileNoFollow(filepath.Join(appBase, "scif/labels.json"), text, 0o644)
+	err = b.Rootfs.WriteFile(filepath.Join(appMeta(a), "labels.json"), text, 0o644)
 	return err
 }
 
 // util funcs
 
-func appBase(b *types.Bundle, a *App) string {
-	return filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)
+func appBase(a *App) string {
+	return filepath.Join("scif", "apps", a.Name)
 }
 
-func appMeta(b *types.Bundle, a *App) string {
-	return filepath.Join(appBase(b, a), "/scif/")
+func appMeta(a *App) string {
+	return filepath.Join(appBase(a), "scif")
 }
 
-func appData(b *types.Bundle, a *App) string {
-	return filepath.Join(b.RootfsPath, "/scif/data/", a.Name)
+func appData(a *App) string {
+	return filepath.Join("scif", "data", a.Name)
 }
 
 func copyWithfLr(src, dst string) error {

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	iofs "io/fs"
 	"maps"
 	"os"
 	"os/exec"
@@ -19,7 +20,6 @@ import (
 	"time"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/buildcfg"
-	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/build/types/parser"
 	"github.com/sylabs/singularity/v4/pkg/image"
@@ -75,16 +75,16 @@ func (s *stage) insertMetadata() error {
 func insertEnvScript(b *types.Bundle) error {
 	if b.RunSection("environment") && b.Recipe.Environment.Script != "" {
 		sylog.Infof("Adding environment to container")
-		envScriptPath := filepath.Join(b.RootfsPath, "/.singularity.d/env/90-environment.sh")
-		_, err := os.Stat(envScriptPath)
+		envScriptPath := filepath.Join(".singularity.d", "env", "90-environment.sh")
+		_, err := b.Rootfs.Stat(envScriptPath)
 		if os.IsNotExist(err) {
-			err := fs.WriteFileNoFollow(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.Environment.Script+"\n"), 0o755)
+			err := b.Rootfs.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.Environment.Script+"\n"), 0o755)
 			if err != nil {
 				return err
 			}
 		} else {
 			// append to script if it already exists
-			f, err := os.OpenFile(envScriptPath, os.O_APPEND|os.O_WRONLY|unix.O_NOFOLLOW, 0o755)
+			f, err := b.Rootfs.OpenFile(envScriptPath, os.O_APPEND|os.O_WRONLY|unix.O_NOFOLLOW, 0o755)
 			if err != nil {
 				return err
 			}
@@ -125,7 +125,7 @@ func insertRunScript(b *types.Bundle) error {
 	if b.RunSection("runscript") && b.Recipe.Runscript.Script != "" {
 		sylog.Infof("Adding runscript")
 		shebang, script := handleShebangScript(b.Recipe.Runscript)
-		err := fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := b.Rootfs.WriteFile(filepath.Join(".singularity.d", "runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func insertStartScript(b *types.Bundle) error {
 	if b.RunSection("startscript") && b.Recipe.Startscript.Script != "" {
 		sylog.Infof("Adding startscript")
 		shebang, script := handleShebangScript(b.Recipe.Startscript)
-		err := fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := b.Rootfs.WriteFile(filepath.Join(".singularity.d", "startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -149,7 +149,7 @@ func insertTestScript(b *types.Bundle) error {
 	if b.RunSection("test") && b.Recipe.Test.Script != "" {
 		sylog.Infof("Adding testscript")
 		shebang, script := handleShebangScript(b.Recipe.Test)
-		err := fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := b.Rootfs.WriteFile(filepath.Join(".singularity.d", "test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -159,10 +159,10 @@ func insertTestScript(b *types.Bundle) error {
 
 func insertHelpScript(b *types.Bundle) error {
 	if b.RunSection("help") && b.Recipe.Help.Script != "" {
-		_, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"))
+		_, err := b.Rootfs.Stat(filepath.Join(".singularity.d", "runscript.help"))
 		if err != nil || b.Opts.Force {
 			sylog.Infof("Adding help info")
-			err := fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.Help.Script+"\n"), 0o644)
+			err := b.Rootfs.WriteFile(filepath.Join(".singularity.d", "runscript.help"), []byte(b.Recipe.Help.Script+"\n"), 0o644)
 			if err != nil {
 				return err
 			}
@@ -175,17 +175,19 @@ func insertHelpScript(b *types.Bundle) error {
 
 func insertDefinition(b *types.Bundle) error {
 	// Check for existing definition and move it to bootstrap history
-	if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity")); err == nil {
+	defPath := filepath.Join(".singularity.d", "Singularity")
+	historyPath := filepath.Join(".singularity.d", "bootstrap_history")
+	if _, err := b.Rootfs.Stat(defPath); err == nil {
 		// make bootstrap_history directory if it doesn't exist
-		if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history")); err != nil {
-			err = os.Mkdir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"), 0o755)
+		if _, err := b.Rootfs.Stat(historyPath); err != nil {
+			err = b.Rootfs.Mkdir(historyPath, 0o755)
 			if err != nil {
 				return err
 			}
 		}
 
 		// look at number of files in bootstrap_history to give correct file name
-		files, err := os.ReadDir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"))
+		files, err := iofs.ReadDir(b.Rootfs.FS(), historyPath)
 		if err != nil {
 			return err
 		}
@@ -194,13 +196,13 @@ func insertDefinition(b *types.Bundle) error {
 		numFiles := strconv.Itoa(len(files))
 		histName := "Singularity" + numFiles
 		// move old definition into bootstrap_history
-		err = os.Rename(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history", histName))
+		err = b.Rootfs.Rename(defPath, filepath.Join(historyPath, histName))
 		if err != nil {
 			return err
 		}
 	}
 
-	err := fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), b.Recipe.FullRaw, 0o644)
+	err := b.Rootfs.WriteFile(defPath, b.Recipe.FullRaw, 0o644)
 	if err != nil {
 		return err
 	}
@@ -217,15 +219,15 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 	}
 
 	// get labels added through SINGULARITY_LABELS environment variables
-	buildLabels := filepath.Join(b.RootfsPath, sLabelsPath)
-	content, err := os.ReadFile(buildLabels)
+	sLabelsRel := strings.TrimPrefix(sLabelsPath, "/")
+	content, err := b.Rootfs.ReadFile(sLabelsRel)
 	if err == nil {
-		if err := os.Remove(filepath.Join(b.RootfsPath, sLabelsPath)); err != nil {
+		if err := b.Rootfs.Remove(sLabelsRel); err != nil {
 			return err
 		}
 		maps.Copy(labels, parser.GetLabels(string(content)))
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("while reading %s: %s", buildLabels, err)
+		return fmt.Errorf("while reading %s: %s", sLabelsRel, err)
 	}
 
 	if err = addBuildLabels(labels, b); err != nil {
@@ -258,7 +260,7 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 		return err
 	}
 
-	err = fs.WriteFileNoFollow(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
+	err = b.Rootfs.WriteFile(filepath.Join(".singularity.d", "labels.json"), []byte(text), 0o644)
 	return err
 }
 
@@ -289,8 +291,8 @@ func insertJSONInspectMetadata(b *types.Bundle) error {
 
 func getExistingLabels(labels map[string]string, b *types.Bundle) error {
 	// check for existing labels in bundle
-	if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json")); err == nil {
-		jsonFile, err := os.Open(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"))
+	if _, err := b.Rootfs.Stat(filepath.Join(".singularity.d", "labels.json")); err == nil {
+		jsonFile, err := b.Rootfs.Open(filepath.Join(".singularity.d", "labels.json"))
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/build/sources/base_environment.go
+++ b/internal/pkg/build/sources/base_environment.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"golang.org/x/sys/unix"
 )
@@ -276,80 +276,80 @@ echo "There is no runscript defined for this container\n";
 `
 )
 
-func makeDirs(rootPath string) error {
-	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "libs"), 0o755); err != nil {
-		return err
+// mkdirAllInRootfs creates dir, and any missing parents, within the bundle
+// rootfs. If the final path already exists it is left untouched. This tolerates
+// images that provide one of these paths as a symlink (e.g. var/tmp -> /tmp);
+// os.Root.MkdirAll returns an error for an existing symlink leaf, whereas the
+// plain os.MkdirAll this replaced resolved and accepted it.
+func mkdirAllInRootfs(b *types.Bundle, dir string) error {
+	if _, err := b.Rootfs.Lstat(dir); err == nil {
+		return nil
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "actions"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "env"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "dev"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "proc"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "root"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "var", "tmp"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "tmp"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "etc"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "sys"), 0o755); err != nil {
-		return err
-	}
-	return os.MkdirAll(filepath.Join(rootPath, "home"), 0o755)
+	return b.Rootfs.MkdirAll(dir, 0o755)
 }
 
-func makeSymlinks(rootPath string) error {
-	if _, err := os.Stat(filepath.Join(rootPath, "singularity")); err != nil {
-		if err = os.Symlink(".singularity.d/runscript", filepath.Join(rootPath, "singularity")); err != nil {
-			return err
-		}
+func makeDirs(b *types.Bundle) error {
+	dirs := []string{
+		filepath.Join(".singularity.d", "libs"),
+		filepath.Join(".singularity.d", "actions"),
+		filepath.Join(".singularity.d", "env"),
+		"dev",
+		"proc",
+		"root",
+		filepath.Join("var", "tmp"),
+		"tmp",
+		"etc",
+		"sys",
+		"home",
 	}
-	if _, err := os.Stat(filepath.Join(rootPath, ".run")); err != nil {
-		if err = os.Symlink(".singularity.d/actions/run", filepath.Join(rootPath, ".run")); err != nil {
-			return err
-		}
-	}
-	if _, err := os.Stat(filepath.Join(rootPath, ".exec")); err != nil {
-		if err = os.Symlink(".singularity.d/actions/exec", filepath.Join(rootPath, ".exec")); err != nil {
-			return err
-		}
-	}
-	if _, err := os.Stat(filepath.Join(rootPath, ".test")); err != nil {
-		if err = os.Symlink(".singularity.d/actions/test", filepath.Join(rootPath, ".test")); err != nil {
-			return err
-		}
-	}
-	if _, err := os.Stat(filepath.Join(rootPath, ".shell")); err != nil {
-		if err = os.Symlink(".singularity.d/actions/shell", filepath.Join(rootPath, ".shell")); err != nil {
-			return err
-		}
-	}
-	if _, err := os.Stat(filepath.Join(rootPath, "environment")); err != nil {
-		if err = os.Symlink(".singularity.d/env/90-environment.sh", filepath.Join(rootPath, "environment")); err != nil {
+	for _, dir := range dirs {
+		if err := mkdirAllInRootfs(b, dir); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func makeFile(name string, perm os.FileMode, s string, overwrite bool) (err error) {
+func makeSymlinks(b *types.Bundle) error {
+	if _, err := b.Rootfs.Stat("singularity"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/runscript", "singularity"); err != nil {
+			return err
+		}
+	}
+	if _, err := b.Rootfs.Stat(".run"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/actions/run", ".run"); err != nil {
+			return err
+		}
+	}
+	if _, err := b.Rootfs.Stat(".exec"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/actions/exec", ".exec"); err != nil {
+			return err
+		}
+	}
+	if _, err := b.Rootfs.Stat(".test"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/actions/test", ".test"); err != nil {
+			return err
+		}
+	}
+	if _, err := b.Rootfs.Stat(".shell"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/actions/shell", ".shell"); err != nil {
+			return err
+		}
+	}
+	if _, err := b.Rootfs.Stat("environment"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/env/90-environment.sh", "environment"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func makeFile(b *types.Bundle, name string, perm os.FileMode, s string, overwrite bool) (err error) {
 	// #4532 - If the file already exists ensure it has requested permissions
 	// as OpenFile won't set on an existing file and some docker
 	// containers have hosts or resolv.conf without write perm.
-	if fs.IsFile(name) {
-		if err = os.Chmod(name, perm); err != nil {
+	if info, statErr := b.Rootfs.Stat(name); statErr == nil && info.Mode().IsRegular() {
+		if err = b.Rootfs.Chmod(name, perm); err != nil {
 			return
 		}
 		if !overwrite {
@@ -359,7 +359,7 @@ func makeFile(name string, perm os.FileMode, s string, overwrite bool) (err erro
 	}
 	// Create the file if it's not in the container, or truncate and write s
 	// into it otherwise.
-	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, perm)
+	f, err := b.Rootfs.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, perm)
 	if err != nil {
 		return
 	}
@@ -369,47 +369,47 @@ func makeFile(name string, perm os.FileMode, s string, overwrite bool) (err erro
 	return
 }
 
-func makeFiles(rootPath string, overwrite bool) error {
-	if err := makeFile(filepath.Join(rootPath, "etc", "hosts"), 0o644, "", overwrite); err != nil {
+func makeFiles(b *types.Bundle, overwrite bool) error {
+	if err := makeFile(b, filepath.Join("etc", "hosts"), 0o644, "", overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, "etc", "resolv.conf"), 0o644, "", overwrite); err != nil {
+	if err := makeFile(b, filepath.Join("etc", "resolv.conf"), 0o644, "", overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "exec"), 0o755, execFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "actions", "exec"), 0o755, execFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "run"), 0o755, runFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "actions", "run"), 0o755, runFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "shell"), 0o755, shellFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "actions", "shell"), 0o755, shellFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "start"), 0o755, startFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "actions", "start"), 0o755, startFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "test"), 0o755, testFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "actions", "test"), 0o755, testFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "01-base.sh"), 0o755, baseShFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "env", "01-base.sh"), 0o755, baseShFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "90-environment.sh"), 0o755, environmentShFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "env", "90-environment.sh"), 0o755, environmentShFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "95-apps.sh"), 0o755, appsShFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "env", "95-apps.sh"), 0o755, appsShFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "99-base.sh"), 0o755, base99ShFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "env", "99-base.sh"), 0o755, base99ShFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "99-runtimevars.sh"), 0o755, base99runtimevarsShFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "env", "99-runtimevars.sh"), 0o755, base99runtimevarsShFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "runscript"), 0o755, runscriptFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "runscript"), 0o755, runscriptFileContent, overwrite); err != nil {
 		return err
 	}
-	return makeFile(filepath.Join(rootPath, ".singularity.d", "startscript"), 0o755, startscriptFileContent, overwrite)
+	return makeFile(b, filepath.Join(".singularity.d", "startscript"), 0o755, startscriptFileContent, overwrite)
 }
 
 // makeBaseEnv inserts Singularity specific directories, symlinks, and files
@@ -417,31 +417,31 @@ func makeFiles(rootPath string, overwrite bool) error {
 // will be overwritten with new content. If overwrite is false, existing files
 // (e.g. where the rootfs has been extracted from an existing image) will not be
 // modified.
-func makeBaseEnv(rootPath string, overwrite bool) (err error) {
+func makeBaseEnv(b *types.Bundle, overwrite bool) (err error) {
 	var info os.FileInfo
 
 	// Ensure we can write into the root of rootPath
-	if info, err = os.Stat(rootPath); err != nil {
+	if info, err = b.Rootfs.Stat("."); err != nil {
 		err = fmt.Errorf("build: failed to stat rootPath: %v", err)
 		return err
 	}
 	if info.Mode()&0o200 == 0 {
-		sylog.Infof("Adding owner write permission to build path: %s\n", rootPath)
-		if err = os.Chmod(rootPath, info.Mode()|0o200); err != nil {
+		sylog.Infof("Adding owner write permission to build path: %s\n", b.RootfsPath)
+		if err = b.Rootfs.Chmod(".", info.Mode()|0o200); err != nil {
 			err = fmt.Errorf("build: failed to make rootPath writable: %v", err)
 			return err
 		}
 	}
 
-	if err = makeDirs(rootPath); err != nil {
+	if err = makeDirs(b); err != nil {
 		err = fmt.Errorf("build: failed to make environment dirs: %v", err)
 		return err
 	}
-	if err = makeSymlinks(rootPath); err != nil {
+	if err = makeSymlinks(b); err != nil {
 		err = fmt.Errorf("build: failed to make environment symlinks: %v", err)
 		return err
 	}
-	if err = makeFiles(rootPath, overwrite); err != nil {
+	if err = makeFiles(b, overwrite); err != nil {
 		err = fmt.Errorf("build: failed to make environment files: %v", err)
 		return err
 	}

--- a/internal/pkg/build/sources/base_environment_test.go
+++ b/internal/pkg/build/sources/base_environment_test.go
@@ -6,21 +6,42 @@
 package sources
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/test"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/v4/pkg/build/types"
 )
 
-func testWithGoodDir(t *testing.T, f func(d string) error) {
-	if err := f(t.TempDir()); err != nil {
+func testBundle(rootfsPath string) (*types.Bundle, error) {
+	rootfs, err := os.OpenRoot(rootfsPath)
+	if err != nil {
+		return nil, err
+	}
+	return &types.Bundle{RootfsPath: rootfsPath, Rootfs: rootfs}, nil
+}
+
+func testWithGoodBundle(t *testing.T, f func(b *types.Bundle) error) {
+	b, err := testBundle(t.TempDir())
+	if err != nil {
+		t.Fatalf("Unexpected failure: %v", err)
+	}
+	defer b.Rootfs.Close()
+
+	if err := f(b); err != nil {
 		t.Fatalf("Unexpected failure: %v", err)
 	}
 }
 
-func testWithBadDir(t *testing.T, f func(d string) error) {
-	if err := f("/this/will/be/a/problem"); err == nil {
+func testWithBadBundle(t *testing.T, f func(b *types.Bundle) error) {
+	b, err := testBundle("/does/not/exist")
+	if err == nil {
+		defer b.Rootfs.Close()
+		err = f(b)
+	}
+	if err == nil {
 		t.Fatalf("Unexpected success with bad directory")
 	}
 }
@@ -29,40 +50,40 @@ func TestMakeDirs(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	testWithGoodDir(t, makeDirs)
-	testWithBadDir(t, makeDirs)
+	testWithGoodBundle(t, makeDirs)
+	testWithBadBundle(t, makeDirs)
 }
 
 func TestMakeSymlinks(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	testWithGoodDir(t, makeSymlinks)
-	testWithBadDir(t, makeSymlinks)
+	testWithGoodBundle(t, makeSymlinks)
+	testWithBadBundle(t, makeSymlinks)
 }
 
 func TestMakeFiles(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	testWithGoodDir(t, func(d string) error {
-		if err := makeDirs(d); err != nil {
+	testWithGoodBundle(t, func(b *types.Bundle) error {
+		if err := makeDirs(b); err != nil {
 			return err
 		}
-		return makeFiles(d, false)
+		return makeFiles(b, false)
 	})
-	testWithBadDir(t, func(d string) error { return makeFiles(d, false) })
+	testWithBadBundle(t, func(b *types.Bundle) error { return makeFiles(b, false) })
 	// #4532 - Check that we can succeed with an existing file that doesn't have
 	// write permission.
-	testWithGoodDir(t, func(d string) error {
-		if err := makeDirs(d); err != nil {
+	testWithGoodBundle(t, func(b *types.Bundle) error {
+		if err := makeDirs(b); err != nil {
 			return err
 		}
-		err := fs.EnsureFileWithPermission(filepath.Join(d, "etc", "hosts"), 0o400)
+		err := fs.EnsureFileWithPermission(filepath.Join(b.RootfsPath, "etc", "hosts"), 0o400)
 		if err != nil {
 			t.Fatalf("Failed to make test hosts file: %s", err)
 		}
-		return makeFiles(d, false)
+		return makeFiles(b, false)
 	})
 }
 
@@ -70,6 +91,6 @@ func TestMakeBaseEnv(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	testWithGoodDir(t, func(d string) error { return makeBaseEnv(d, false) })
-	testWithBadDir(t, func(d string) error { return makeBaseEnv(d, false) })
+	testWithGoodBundle(t, func(b *types.Bundle) error { return makeBaseEnv(b, false) })
+	testWithBadBundle(t, func(b *types.Bundle) error { return makeBaseEnv(b, false) })
 }

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -205,14 +205,14 @@ func (cp *ArchConveyorPacker) getPacConf(pacmanConfURL string) (pacConf string, 
 }
 
 func (cp *ArchConveyorPacker) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *ArchConveyorPacker) insertRunScript() (err error) {
-	err = fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = cp.b.Rootfs.WriteFile(".singularity.d/runscript", []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
 	"golang.org/x/sys/unix"
@@ -78,19 +77,21 @@ func (cp *BusyBoxConveyorPacker) Pack(context.Context) (b *types.Bundle, err err
 }
 
 func (c *BusyBoxConveyor) insertBaseFiles() error {
-	if err := fs.WriteFileNoFollow(filepath.Join(c.b.RootfsPath, "/etc/passwd"), []byte("root:!:0:0:root:/root:/bin/sh"), 0o664); err != nil {
+	if err := c.b.Rootfs.WriteFile("etc/passwd", []byte("root:!:0:0:root:/root:/bin/sh"), 0o664); err != nil {
 		return err
 	}
 
-	if err := fs.WriteFileNoFollow(filepath.Join(c.b.RootfsPath, "/etc/group"), []byte(" root:x:0:"), 0o664); err != nil {
+	if err := c.b.Rootfs.WriteFile("etc/group", []byte(" root:x:0:"), 0o664); err != nil {
 		return err
 	}
 
-	return fs.WriteFileNoFollow(filepath.Join(c.b.RootfsPath, "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0o664)
+	return c.b.Rootfs.WriteFile("etc/hosts", []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0o664)
 }
 
 func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, err error) {
-	os.Mkdir(filepath.Join(c.b.RootfsPath, "/bin"), 0o755)
+	if err := c.b.Rootfs.Mkdir("bin", 0o755); err != nil && !os.IsExist(err) {
+		return "", err
+	}
 
 	resp, err := http.Get(mirrorurl)
 	if err != nil {
@@ -98,7 +99,7 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 	}
 	defer resp.Body.Close()
 
-	f, err := os.OpenFile(filepath.Join(c.b.RootfsPath, "/bin/busybox"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
+	f, err := c.b.Rootfs.OpenFile(filepath.Join("bin", "busybox"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return "", err
 	}
@@ -114,7 +115,7 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 		return "", fmt.Errorf("file received is not the right size. supposed to be: %v actually: %v", resp.ContentLength, bytesWritten)
 	}
 
-	err = os.Chmod(f.Name(), 0o755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return "", err
 	}
@@ -123,14 +124,14 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 }
 
 func (c *BusyBoxConveyor) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(c.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(c.b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *BusyBoxConveyorPacker) insertRunScript() error {
-	return fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	return cp.b.Rootfs.WriteFile(".singularity.d/runscript", []byte("#!/bin/sh\n"), 0o755)
 }
 
 // CleanUp removes any tmpfs owned by the conveyorPacker on the filesystem

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -117,11 +117,12 @@ func (cp *DebootstrapConveyorPacker) prepareFakerootEnv(ctx context.Context) (fu
 					if err := os.Truncate(makedevPath, 0); err != nil {
 						sylog.Warningf("while truncating %s: %s", makedevPath, err)
 					}
-					f, err := os.OpenFile(filepath.Join(cp.b.RootfsPath, "/dev/tty1"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
+					f, err := cp.b.Rootfs.OpenFile(filepath.Join("dev", "tty1"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o644)
 					if err != nil {
 						sylog.Warningf("while creating %s: %s", filepath.Join(cp.b.RootfsPath, "/dev/tty1"), err)
+					} else {
+						f.Close()
 					}
-					f.Close()
 					break
 				}
 			}
@@ -228,7 +229,7 @@ func (cp *DebootstrapConveyorPacker) Get(ctx context.Context, b *types.Bundle) (
 // Pack puts relevant objects in a Bundle!
 func (cp *DebootstrapConveyorPacker) Pack(context.Context) (*types.Bundle, error) {
 	// change root directory permissions to 0755
-	if err := os.Chmod(cp.b.RootfsPath, 0o755); err != nil {
+	if err := cp.b.Rootfs.Chmod(".", 0o755); err != nil {
 		return nil, fmt.Errorf("while changing bundle rootfs perms: %v", err)
 	}
 
@@ -274,14 +275,14 @@ func (cp *DebootstrapConveyorPacker) getRecipeHeaderInfo() (err error) {
 }
 
 func (cp *DebootstrapConveyorPacker) insertBaseEnv(b *types.Bundle) (err error) {
-	if err = makeBaseEnv(b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *DebootstrapConveyorPacker) insertRunScript(b *types.Bundle) (err error) {
-	f, err := os.OpenFile(b.RootfsPath+"/.singularity.d/runscript", os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
+	f, err := b.Rootfs.OpenFile(filepath.Join(".singularity.d", "runscript"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return
 	}
@@ -299,7 +300,7 @@ func (cp *DebootstrapConveyorPacker) insertRunScript(b *types.Bundle) (err error
 
 	f.Sync()
 
-	err = os.Chmod(b.RootfsPath+"/.singularity.d/runscript", 0o755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -87,7 +87,7 @@ func (cp *LibraryConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err 
 	}
 
 	// insert base metadata before unpacking fs
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -112,11 +112,18 @@ func (cp *LocalConveyorPacker) Pack(ctx context.Context) (*types.Bundle, error) 
 		return nil, fmt.Errorf("while unpacking local image: %v", err)
 	}
 
+	// Extraction of a local image may remove and recreate the rootfs directory,
+	// invalidating the bundle's os.Root handle. Re-open it before we make any
+	// rooted modifications below.
+	if err := b.ReopenRootfs(); err != nil {
+		return nil, fmt.Errorf("while reopening rootfs: %v", err)
+	}
+
 	// Insert base metadata after unpacking fs to avoid unsquashfs failure on
 	// existing files/symlink. Call makeBaseEnv with overwrite=false so we don't
 	// overwrite runscripts etc. that were extracted from the image.
 	sylog.Infof("Inserting Singularity configuration...")
-	if err = makeBaseEnv(b.RootfsPath, false); err != nil {
+	if err = makeBaseEnv(b, false); err != nil {
 		return nil, fmt.Errorf("while inserting base environment: %v", err)
 	}
 

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sylabs/singularity/v4/internal/pkg/cache"
 	"github.com/sylabs/singularity/v4/internal/pkg/ociimage"
 	"github.com/sylabs/singularity/v4/internal/pkg/remote/credential/ociauth"
-	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/shell"
 	sytypes "github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/image"
@@ -254,14 +253,14 @@ func (cp *OCIConveyorPacker) unpackRootfs(ctx context.Context) error {
 }
 
 func (cp *OCIConveyorPacker) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		sylog.Errorf("%v", err)
 	}
 	return
 }
 
 func (cp *OCIConveyorPacker) insertRunScript() error {
-	f, err := os.OpenFile(cp.b.RootfsPath+"/.singularity.d/runscript", os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
+	f, err := cp.b.Rootfs.OpenFile(filepath.Join(".singularity.d", "runscript"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return err
 	}
@@ -335,7 +334,7 @@ func (cp *OCIConveyorPacker) insertRunScript() error {
 
 	f.Sync()
 
-	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/runscript", 0o755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return err
 	}
@@ -344,7 +343,7 @@ func (cp *OCIConveyorPacker) insertRunScript() error {
 }
 
 func (cp *OCIConveyorPacker) insertEnv() error {
-	f, err := os.OpenFile(cp.b.RootfsPath+"/.singularity.d/env/10-docker2singularity.sh", os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
+	f, err := cp.b.Rootfs.OpenFile(filepath.Join(".singularity.d", "env", "10-docker2singularity.sh"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return err
 	}
@@ -381,7 +380,7 @@ func (cp *OCIConveyorPacker) insertEnv() error {
 
 	f.Sync()
 
-	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/env/10-docker2singularity.sh", 0o755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return err
 	}
@@ -399,7 +398,7 @@ func (cp *OCIConveyorPacker) insertOCILabels() (err error) {
 		return err
 	}
 
-	err = fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
+	err = cp.b.Rootfs.WriteFile(".singularity.d/labels.json", []byte(text), 0o644)
 	return err
 }
 

--- a/internal/pkg/build/sources/conveyorPacker_oras.go
+++ b/internal/pkg/build/sources/conveyorPacker_oras.go
@@ -52,7 +52,7 @@ func (cp *OrasConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 	}
 
 	// insert base metadata before unpacking fs
-	if err = makeBaseEnv(b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(b, true); err != nil {
 		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 

--- a/internal/pkg/build/sources/conveyorPacker_scratch.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch.go
@@ -8,9 +8,7 @@ package sources
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
-	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 )
 
@@ -47,14 +45,14 @@ func (cp *ScratchConveyorPacker) Pack(context.Context) (b *types.Bundle, err err
 }
 
 func (c *ScratchConveyor) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(c.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(c.b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *ScratchConveyorPacker) insertRunScript() (err error) {
-	err = fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = cp.b.Rootfs.WriteFile(".singularity.d/runscript", []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_shub.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub.go
@@ -41,7 +41,7 @@ func (cp *ShubConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 	}
 
 	// insert base metadata before unpacking fs
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -18,7 +18,6 @@ import (
 	"syscall"
 
 	"github.com/sylabs/singularity/v4/internal/pkg/util/bin"
-	"github.com/sylabs/singularity/v4/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/v4/internal/pkg/util/rpm"
 	"github.com/sylabs/singularity/v4/pkg/build/types"
 	"github.com/sylabs/singularity/v4/pkg/sylog"
@@ -99,7 +98,9 @@ func (c *YumConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
 	}
 
 	// clean up bootstrap packages
-	os.RemoveAll(filepath.Join(c.b.RootfsPath, "/var/cache/yum-bootstrap"))
+	if err := c.b.Rootfs.RemoveAll(filepath.Join("var", "cache", "yum-bootstrap")); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -252,12 +253,12 @@ func (c *YumConveyor) genYumConfig() (err error) {
 		fileContent += "\n"
 	}
 
-	err = os.Mkdir(filepath.Join(c.b.RootfsPath, "/etc"), 0o775)
+	err = c.b.Rootfs.Mkdir("etc", 0o775)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.RootfsPath, "/etc"), err)
 	}
 
-	err = fs.WriteFileNoFollow(filepath.Join(c.b.RootfsPath, yumConf), []byte(fileContent), 0o664)
+	err = c.b.Rootfs.WriteFile(yumConf, []byte(fileContent), 0o664)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.RootfsPath, yumConf), err)
 	}
@@ -340,14 +341,14 @@ func (c *YumConveyor) makePseudoDevices() (err error) {
 }
 
 func (cp *YumConveyorPacker) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *YumConveyorPacker) insertRunScript() (err error) {
-	err = fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = cp.b.Rootfs.WriteFile(".singularity.d/runscript", []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	zypperConf = "/etc/zypp/zypp.conf"
+	zypperConf = "etc/zypp/zypp.conf"
 )
 
 // ZypperConveyorPacker only needs to hold the bundle for the container
@@ -250,24 +250,24 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) error 
 		}
 	}
 	if pgpfile != "" {
-		rpmbase := "/usr/lib/sysimage"
-		rpmsys := "/var/lib"
+		rpmbase := "usr/lib/sysimage"
+		rpmsys := "var/lib"
 		rpmrel := "../.."
 		if iosmajor == 12 {
 			rpmbase = "/var/lib"
 			rpmsys = "/usr/lib/sysimage"
 			rpmrel = "../../.."
 		}
-		if err = os.MkdirAll(cp.b.RootfsPath+rpmbase+`/rpm`, 0o755); err != nil {
+		if err = cp.b.Rootfs.MkdirAll(rpmbase+`/rpm`, 0o755); err != nil {
 			return fmt.Errorf("cannot recreate rpm directories: %v", err)
 		}
-		if err = os.MkdirAll(cp.b.RootfsPath+rpmsys, 0o755); err != nil {
+		if err = cp.b.Rootfs.MkdirAll(rpmsys, 0o755); err != nil {
 			return fmt.Errorf("cannot recreate rpm directories: %v", err)
 		}
-		if err = os.RemoveAll(cp.b.RootfsPath + rpmsys + `/rpm`); err != nil {
+		if err = cp.b.Rootfs.RemoveAll(rpmsys + `/rpm`); err != nil {
 			return fmt.Errorf("cannot remove rpm directory")
 		}
-		if err = os.Symlink(rpmrel+rpmbase+`/rpm`, cp.b.RootfsPath+rpmsys+`/rpm`); err != nil {
+		if err = cp.b.Rootfs.Symlink(rpmrel+rpmbase+`/rpm`, rpmsys+`/rpm`); err != nil {
 			return fmt.Errorf("cannot create rpm symlink")
 		}
 		cmd := exec.CommandContext(ctx, "rpmkeys", `--root`, cp.b.RootfsPath, `--import`, pgpfile)
@@ -364,14 +364,14 @@ func (cp *ZypperConveyorPacker) Pack(context.Context) (b *types.Bundle, err erro
 }
 
 func (cp *ZypperConveyorPacker) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *ZypperConveyorPacker) insertRunScript() (err error) {
-	f, err := os.OpenFile(cp.b.RootfsPath+"/.singularity.d/runscript", os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
+	f, err := cp.b.Rootfs.OpenFile(filepath.Join(".singularity.d", "runscript"), os.O_RDWR|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0o755)
 	if err != nil {
 		return
 	}
@@ -389,7 +389,7 @@ func (cp *ZypperConveyorPacker) insertRunScript() (err error) {
 
 	f.Sync()
 
-	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/runscript", 0o755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return
 	}
@@ -398,12 +398,12 @@ func (cp *ZypperConveyorPacker) insertRunScript() (err error) {
 }
 
 func (cp *ZypperConveyorPacker) genZypperConfig() (err error) {
-	err = os.MkdirAll(filepath.Join(cp.b.RootfsPath, "/etc/zypp"), 0o775)
+	err = cp.b.Rootfs.MkdirAll(filepath.Join("etc", "zypp"), 0o775)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(cp.b.RootfsPath, "/etc/zypp"), err)
 	}
 
-	err = fs.WriteFileNoFollow(filepath.Join(cp.b.RootfsPath, zypperConf), []byte("[main]\ncachedir=/val/cache/zypp-bootstrap\n\n"), 0o664)
+	err = cp.b.Rootfs.WriteFile(zypperConf, []byte("[main]\ncachedir=/val/cache/zypp-bootstrap\n\n"), 0o664)
 	if err != nil {
 		return
 	}

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -31,8 +31,9 @@ type Bundle struct {
 	Recipe      Definition        `json:"rawDeffile"`
 	Opts        Options           `json:"opts"`
 
-	RootfsPath string `json:"rootfsPath"` // where actual fs to chroot will appear
-	TmpDir     string `json:"tmpPath"`    // where temp files required during build will appear
+	RootfsPath string   `json:"rootfsPath"` // where actual fs to chroot will appear
+	Rootfs     *os.Root `json:"-"`          // rooted handle to RootfsPath for confined build modifications
+	TmpDir     string   `json:"tmpPath"`    // where temp files required during build will appear
 
 	parentPath string // parent directory for RootfsPath
 }
@@ -113,8 +114,35 @@ func (b *Bundle) RunSection(s string) bool {
 	return false
 }
 
+// ReopenRootfs re-opens the os.Root handle to RootfsPath. It must be called
+// after any operation that removes and recreates the rootfs directory (e.g.
+// extraction of a local image), as the previous handle then refers to the old,
+// now-unlinked directory inode.
+func (b *Bundle) ReopenRootfs() error {
+	if b.Rootfs != nil {
+		if err := b.Rootfs.Close(); err != nil {
+			sylog.Errorf("Could not close rootfs %q: %v", b.RootfsPath, err)
+		}
+		b.Rootfs = nil
+	}
+
+	rootfsRoot, err := os.OpenRoot(b.RootfsPath)
+	if err != nil {
+		return fmt.Errorf("could not open rootfs %q: %v", b.RootfsPath, err)
+	}
+	b.Rootfs = rootfsRoot
+	return nil
+}
+
 // Remove cleans up any bundle files.
 func (b *Bundle) Remove() error {
+	if b.Rootfs != nil {
+		if err := b.Rootfs.Close(); err != nil {
+			sylog.Errorf("Could not close rootfs %q: %v", b.RootfsPath, err)
+		}
+		b.Rootfs = nil
+	}
+
 	var errors []string
 	for _, dir := range []string{b.TmpDir, b.parentPath} {
 		if err := fs.ForceRemoveAll(dir); err != nil {
@@ -229,11 +257,20 @@ func newBundle(parentPath, tempDir string, keyInfo *cryptkey.KeyInfo) (*Bundle, 
 		}
 	}
 
+	rootfsRoot, err := os.OpenRoot(rootfsPath)
+	if err != nil {
+		cleanupDir(tmpPath)
+		cleanupDir(rootfsPath)
+		cleanupDir(parentPath)
+		return nil, fmt.Errorf("could not open rootfs %q: %v", rootfsPath, err)
+	}
+
 	sylog.Debugf("Created directory %q for the bundle", rootfsPath)
 
 	return &Bundle{
 		parentPath:  parentPath,
 		RootfsPath:  rootfsPath,
+		Rootfs:      rootfsRoot,
 		TmpDir:      tmpPath,
 		JSONObjects: make(map[string][]byte),
 		Opts: Options{


### PR DESCRIPTION
## Description of the Pull Request (PR):

In builds, we frequently create directories and write files into a rootfs dir. We can use os.Root to better restrict these operations to the rootfs directory.

This code was developed out of exploratory work using Claude Code, that has been manually reviewed and edited. The Co-authored-by trailer is added on this basis.

Co-authored-by: Claude Code
