### PR TITLE
user: Add non-CGO lookups for consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,16 @@
 
 ### Developer / API
 
-The following have been removed:
-
-- `UpdateDefinitionRaw()` from `pkg/build/types`.
-- `OptSysCtx()` from `pkg/ocibundle/native/bundle_linux.go`
-- `CreateLoop()` from `pkg/ocibundle/tools/loop.go`
-- `pkg/util/copy`
-- `pkg/util/sysctl`
-- `pkg/util/unix`
+- The following have been removed:
+  - `UpdateDefinitionRaw()` from `pkg/build/types`.
+  - `OptSysCtx()` from `pkg/ocibundle/native/bundle_linux.go`
+  - `CreateLoop()` from `pkg/ocibundle/tools/loop.go`
+  - `pkg/util/copy`
+  - `pkg/util/sysctl`
+  - `pkg/util/unix`
+- The `pkg/build/types` and `pkg/build/types/parser` packages can now be used in
+  programs built without cgo. An `os.user` fallback for `i/p/util/user` lookups
+  is used when CGO is not available.
 
 ## 4.4.2 \[2026-06-04\]
 

--- a/internal/pkg/util/user/cgo_lookup_unix.go
+++ b/internal/pkg/util/user/cgo_lookup_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (aix || darwin || dragonfly || freebsd || (!android && linux) || netbsd || openbsd || solaris) && cgo && !osusergo
+//go:build cgo
 
 // Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the

--- a/internal/pkg/util/user/identity_unix.go
+++ b/internal/pkg/util/user/identity_unix.go
@@ -14,9 +14,9 @@ type User struct {
 	Name  string
 	UID   uint32
 	GID   uint32
-	Gecos string
+	Gecos string // Set to user's name, not full gecos if built without CGO.
 	Dir   string
-	Shell string
+	Shell string // Not set if build without CGO.
 }
 
 // Group represents a Unix group information.

--- a/internal/pkg/util/user/lookup_unix.go
+++ b/internal/pkg/util/user/lookup_unix.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build !cgo
+
+// Non-CGO fallback functions, for any projects that indirectly import this
+// package as a dependency. Is not used from singularity itself. Does not
+// populate the shell field. Sets Gecos field to os/user User.Name.
+
+package user
+
+import (
+	"os/user"
+	"strconv"
+)
+
+func convertUser(u *user.User) (*User, error) {
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	gid, err := strconv.ParseUint(u.Gid, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	return &User{
+		Name:  u.Username,
+		UID:   uint32(uid),
+		GID:   uint32(gid),
+		Gecos: u.Name,
+		Dir:   u.HomeDir,
+	}, nil
+}
+
+func convertGroup(g *user.Group) (*Group, error) {
+	gid, err := strconv.ParseUint(g.Gid, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	return &Group{
+		Name: g.Name,
+		GID:  uint32(gid),
+	}, nil
+}
+
+func current() (*User, error) {
+	u, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	return convertUser(u)
+}
+
+func lookupUser(username string) (*User, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return nil, err
+	}
+	return convertUser(u)
+}
+
+func lookupUserId(uid string) (*User, error) {
+	u, err := user.LookupId(uid)
+	if err != nil {
+		return nil, err
+	}
+	return convertUser(u)
+}
+
+func lookupUnixUid(uid int) (*User, error) {
+	return lookupUserId(strconv.Itoa(uid))
+}
+
+func currentGroup() (*Group, error) {
+	u, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	return lookupGroupId(u.Gid)
+}
+
+func lookupGroup(groupname string) (*Group, error) {
+	g, err := user.LookupGroup(groupname)
+	if err != nil {
+		return nil, err
+	}
+	return convertGroup(g)
+}
+
+func lookupGroupId(gid string) (*Group, error) {
+	g, err := user.LookupGroupId(gid)
+	if err != nil {
+		return nil, err
+	}
+	return convertGroup(g)
+}
+
+func lookupUnixGid(gid int) (*Group, error) {
+	return lookupGroupId(strconv.Itoa(gid))
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

With recent changes, internal/pkg/util/user may now be brought into projects that consume public pkg/ code.

Prior to this PR, the user package only compiles if CGO is enabled. Add non-CGO lookup functions, wrapping os.User when CGO is disabled. This permits import into projects that don't build with CGO.

Closes #4185

When reviewing, check the following now succeeds:

```
CGO_ENABLED=0 go build ./pkg/build/types/... ./pkg/build/types/parser/...
```