### PR TITLE
Fixed Debian build files (rootless mode)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -77,6 +77,7 @@ The following have contributed code and/or documentation to this repository.
 - Marcelo Magallon <marcelo@sylabs.io>
 - Marco Rubin <marco.rubin@protonmail.com>
 - Mark Egan-Fuller <markeganfuller@googlemail.com>
+- Martin Pecka <peci1@seznam.cz>
 - Matt Wiens <mwiens91@gmail.com>
 - Michael Bauer <m@sylabs.io>, <bauerm@umich.edu>
 - Michael Herzberg <michael@mherzberg.de>

--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Standards-Version: 3.9.8
 Homepage: https://sylabs.io/singularity
 Vcs-Git: https://github.com/sylabs/singularity.git
 Vcs-Browser: https://github.com/sylabs/singularity
+Rules-Requires-Root: binary-targets
 
 Package: singularity-ce
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -93,5 +93,5 @@ override_dh_fixperms:
 # after this copy/split has happened.
 	dh_fixperms
 # perms for standard build
-	chown root.root $(CURDIR)/debian/singularity-ce/usr/lib/$(DEB_HOST_MULTIARCH)/singularity/bin/*
+	chown root:root $(CURDIR)/debian/singularity-ce/usr/lib/$(DEB_HOST_MULTIARCH)/singularity/bin/*
 	chmod 4755 $(CURDIR)/debian/singularity-ce/usr/lib/$(DEB_HOST_MULTIARCH)/singularity/bin/*-suid


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes build failures when running the build without fakeroot: https://wiki.debian.org/BuildingWithoutFakeroot . This affects Ubuntu 24.10 and newer with dpkg-buildpackage 1.22.13 and newer.

Without this PR, building a DEB on the newer platforms ends with:

```
make[1]: Entering directory '/<<PKGBUILDDIR>>'
dh_fixperms
chown root.root /<<PKGBUILDDIR>>/debian/singularity-ce/usr/lib/x86_64-linux-gnu/singularity/bin/*
chown: warning: '.' should be ':': 'root.root'
chown: changing ownership of '/<<PKGBUILDDIR>>/debian/singularity-ce/usr/lib/x86_64-linux-gnu/singularity/bin/singularity-buildkitd': Operation not permitted (os error 1)
chown: changing ownership of '/<<PKGBUILDDIR>>/debian/singularity-ce/usr/lib/x86_64-linux-gnu/singularity/bin/squashfuse_ll': Operation not permitted (os error 1)
chown: changing ownership of '/<<PKGBUILDDIR>>/debian/singularity-ce/usr/lib/x86_64-linux-gnu/singularity/bin/starter': Operation not permitted (os error 1)
chown: changing ownership of '/<<PKGBUILDDIR>>/debian/singularity-ce/usr/lib/x86_64-linux-gnu/singularity/bin/starter-suid': Operation not permitted (os error 1)
make[1]: *** [debian/rules:104: override_dh_fixperms] Error 1
make[1]: Leaving directory '/<<PKGBUILDDIR>>'
make: *** [debian/rules:44: binary] Error 2
```

This PR also fixes the warning mentioned in this error output (replacing `root.root` with `root:root` in the `chown` call).

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
