### PR TITLE
e2e: make instance tests more robust

### DIFF
--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -10,7 +10,6 @@ package instance
 import (
 	"bytes"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -45,9 +44,10 @@ type ctx struct {
 func (c *ctx) testBasicEchoServer(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
-	const instanceName = "echo1"
+	instanceName := randomName(t)
+	port := getFreePort(t)
 
-	args := []string{c.env.ImagePath, instanceName, strconv.Itoa(instanceStartPort)}
+	args := []string{c.env.ImagePath, instanceName, strconv.Itoa(port)}
 
 	// Start the instance.
 	c.env.RunSingularity(
@@ -60,7 +60,7 @@ func (c *ctx) testBasicEchoServer(t *testing.T) {
 				return
 			}
 			// Try to contact the instance.
-			echo(t, instanceStartPort, false)
+			echo(t, port, false)
 			c.stopInstance(t, instanceName)
 		}),
 		e2e.ExpectExit(0),
@@ -72,14 +72,15 @@ func (c *ctx) testBasicEchoServer(t *testing.T) {
 func (c *ctx) testAppEchoServer(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
-	const instanceName = "echoApp"
+	instanceName := randomName(t)
+	port := getFreePort(t)
 
 	args := []string{
 		"--app",
 		"foo",
 		c.env.ImagePath,
 		instanceName,
-		strconv.Itoa(instanceStartPort),
+		strconv.Itoa(port),
 	}
 
 	// Start the instance.
@@ -93,7 +94,7 @@ func (c *ctx) testAppEchoServer(t *testing.T) {
 				return
 			}
 			// Try to contact the instance.
-			echo(t, instanceStartPort, true)
+			echo(t, port, true)
 			c.stopInstance(t, instanceName)
 		}),
 		e2e.ExpectExit(0),
@@ -104,7 +105,7 @@ func (c *ctx) testAppEchoServer(t *testing.T) {
 func (c *ctx) testInstanceRun(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
-	const instanceName = "testtrue"
+	instanceName := randomName(t)
 
 	args := []string{c.env.ImagePath, instanceName, "true"}
 
@@ -119,26 +120,18 @@ func (c *ctx) testInstanceRun(t *testing.T) {
 				return
 			}
 			// read the log file to see if runscript was used. (It should record
-			// the text "Running command: true")
-			d, err := os.UserHomeDir()
-			if err != nil {
-				t.Fatal(err)
-			}
+			// the text "Running command: true").
+			hostUser := c.profile.HostUser(t)
 			h, err := os.Hostname()
 			if err != nil {
 				t.Fatal(err)
 			}
-			u, err := user.Current()
-			if err != nil {
-				t.Fatal(err)
-			}
-			ilog := filepath.Join(d, ".singularity", "instances", "logs", h, u.Username, instanceName+".out")
+			ilog := filepath.Join(hostUser.Dir, ".singularity", "instances", "logs", h, hostUser.Name, instanceName+".out")
 			b, err := os.ReadFile(ilog)
 			if err != nil {
 				t.Fatal(err)
 			}
 			s := string(b)
-			echo(t, instanceStartPort, false)
 			c.stopInstance(t, instanceName)
 			if !strings.Contains(s, "Running command: true") {
 				t.Fatal()
@@ -153,11 +146,12 @@ func (c *ctx) testCreateManyInstances(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	const n = 10
+	ports := getFreePorts(t, n)
 
 	// Start n instances.
 	for i := range n {
-		port := instanceStartPort + i
-		instanceName := "echo" + strconv.Itoa(i+1)
+		port := ports[i]
+		instanceName := randomName(t)
 
 		c.env.RunSingularity(
 			t,
@@ -185,7 +179,6 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	const fileName = "hello"
-	const instanceName = "testbasic"
 	const testHostname = "echoserver99"
 	cmdList := [2]string{"instance start", "instance run"}
 	fileContents := []byte("world")
@@ -207,6 +200,9 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 	// Start and Run an instance with the temporary directory as the home
 	// directory.
 	for _, cmd := range cmdList {
+		instanceName := randomName(t)
+		port := getFreePort(t)
+
 		c.env.RunSingularity(
 			t,
 			e2e.WithProfile(c.profile),
@@ -217,7 +213,7 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 				"-e",
 				c.env.ImagePath,
 				instanceName,
-				strconv.Itoa(instanceStartPort),
+				strconv.Itoa(port),
 			),
 			e2e.PostRun(func(t *testing.T) {
 				if t.Failed() {
@@ -254,7 +250,6 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 func (c *ctx) testContain(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
-	const instanceName = "testcontain"
 	const fileName = "thegreattestfile"
 	cmdList := [2]string{"instance start", "instance run"}
 
@@ -267,6 +262,9 @@ func (c *ctx) testContain(t *testing.T) {
 
 	// Start and Run the instance.
 	for _, cmd := range cmdList {
+		instanceName := randomName(t)
+		port := getFreePort(t)
+
 		c.env.RunSingularity(
 			t,
 			e2e.WithProfile(c.profile),
@@ -276,7 +274,7 @@ func (c *ctx) testContain(t *testing.T) {
 				"-W", dir,
 				c.env.ImagePath,
 				instanceName,
-				strconv.Itoa(instanceStartPort),
+				strconv.Itoa(port),
 			),
 			e2e.PostRun(func(t *testing.T) {
 				if t.Failed() {
@@ -303,10 +301,10 @@ func (c *ctx) testContain(t *testing.T) {
 // Test by running directly from URI
 func (c *ctx) testInstanceFromURI(t *testing.T) {
 	e2e.EnsureORASImage(t, c.env)
-	name := "test_from_uri"
-	args := []string{c.env.OrasTestImage, name}
 	cmdList := [2]string{"instance start", "instance run"}
 	for _, cmd := range cmdList {
+		name := randomName(t)
+		args := []string{c.env.OrasTestImage, name}
 		c.env.RunSingularity(
 			t,
 			e2e.WithProfile(c.profile),
@@ -327,7 +325,7 @@ func (c *ctx) testInstanceFromURI(t *testing.T) {
 // Test that custom auth file authentication works with instance start
 func (c *ctx) testInstanceAuthFile(t *testing.T) {
 	e2e.EnsureORASImage(t, c.env)
-	instanceName := "actionAuthTesterInstance"
+	instanceName := randomName(t)
 	localAuthFileName := "./my_local_authfile"
 	authFileArgs := []string{"--authfile", localAuthFileName}
 
@@ -515,8 +513,8 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 				{"Contain", c.testContain},
 				{"InstanceFromURI", c.testInstanceFromURI},
 				{"CreateManyInstances", c.testCreateManyInstances},
-				{"InstanceRun", c.testInstanceRun},
 				{"StopAll", c.testStopAll},
+				{"InstanceRun", c.testInstanceRun},
 				{"GhostInstance", c.testGhostInstance},
 			}
 

--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -17,8 +17,6 @@ import (
 	"github.com/sylabs/singularity/v4/e2e/internal/e2e"
 )
 
-const instanceStartPort = 11372
-
 type instance struct {
 	Image    string `json:"img"`
 	Instance string `json:"instance"`
@@ -27,6 +25,31 @@ type instance struct {
 
 type instanceList struct {
 	Instances []instance `json:"instances"`
+}
+
+func getFreePorts(t *testing.T, n int) []int {
+	t.Helper()
+
+	listeners := make([]net.Listener, 0, n)
+	ports := make([]int, 0, n)
+	for range n {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("failed to allocate a tcp port: %v", err)
+		}
+		listeners = append(listeners, l)
+		//nolint:forcetypeassert
+		ports = append(ports, l.Addr().(*net.TCPAddr).Port)
+	}
+	for _, l := range listeners {
+		l.Close()
+	}
+	return ports
+}
+
+func getFreePort(t *testing.T) int {
+	t.Helper()
+	return getFreePorts(t, 1)[0]
 }
 
 //nolint:unparam
@@ -74,33 +97,59 @@ func (c *ctx) execInstance(t *testing.T, instance string, execArgs ...string) (s
 }
 
 // Check if there is the number of expected instances with the provided name.
+//
+// Poll to a timeout to accommodate delays in instance startup / shutdown on
+// busy systems.
 func (c *ctx) expectInstance(t *testing.T, name string, nb int) {
-	listInstancesFn := func(t *testing.T, r *e2e.SingularityCmdResult) {
-		var instances instanceList
+	t.Helper()
 
-		if err := json.Unmarshal([]byte(r.Stdout), &instances); err != nil {
+	const (
+		timeout  = 10 * time.Second
+		interval = 100 * time.Millisecond
+	)
+
+	deadline := time.Now().Add(timeout)
+	count := -1
+	for {
+		var stdout, stderr string
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(c.profile),
+			e2e.WithCommand("instance list"),
+			e2e.WithArgs("--json", name),
+			e2e.ExpectExit(0, e2e.GetStreams(&stdout, &stderr)),
+		)
+		if t.Failed() {
+			return
+		}
+
+		var instances instanceList
+		if err := json.Unmarshal([]byte(stdout), &instances); err != nil {
 			t.Errorf("Error while decoding JSON from 'instance list': %v", err)
+			return
 		}
-		if nb != len(instances.Instances) {
-			t.Errorf("%d instance %q found, expected %d", len(instances.Instances), name, nb)
+
+		count = len(instances.Instances)
+		if count == nb || time.Now().After(deadline) {
+			break
 		}
+		time.Sleep(interval)
 	}
 
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(c.profile),
-		e2e.WithCommand("instance list"),
-		e2e.WithArgs([]string{"--json", name}...),
-		e2e.ExpectExit(0, listInstancesFn),
-	)
+	if count != nb {
+		t.Errorf("%d instance %q found, expected %d", count, name, nb)
+	}
 }
 
 // Sends a deterministic message to an echo server and expects the same, or a
 // reversed, message in response.
 func echo(t *testing.T, port int, reverse bool) {
+	t.Helper()
+
 	const (
 		message         = "b40cbeaaea293f7e8bd40fb61f389cfca9823467\n"
 		reversedMessage = "7643289acfc983f16bf04db8e7f392aeaaebc04b\n"
+		retries         = 5
 	)
 
 	expectResponse := message
@@ -108,25 +157,38 @@ func echo(t *testing.T, port int, reverse bool) {
 		expectResponse = reversedMessage
 	}
 
-	// give it some time for responding, attempt 10 times by
-	// waiting 100 millisecond between each try
-	for retries := 0; ; retries++ {
-		sock, sockErr := net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(port))
-		if sockErr != nil && retries < 10 {
-			time.Sleep(100 * time.Millisecond)
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	var lastErr error
+	for attempt := range retries {
+		if attempt > 0 {
+			time.Sleep(time.Second)
+		}
+
+		sock, err := net.Dial("tcp", addr)
+		if err != nil {
+			lastErr = fmt.Errorf("dial: %w", err)
 			continue
-		} else if sockErr != nil {
-			t.Errorf("Failed to dial echo server: %v", sockErr)
-			return
 		}
 
-		fmt.Fprint(sock, message)
-
-		response, responseErr := bufio.NewReader(sock).ReadString('\n')
-
-		if responseErr != nil || response != expectResponse {
-			t.Errorf("Bad response: err = %v, response %q != %q", responseErr, response, expectResponse)
+		if _, err := fmt.Fprint(sock, message); err != nil {
+			sock.Close()
+			lastErr = fmt.Errorf("write: %w", err)
+			continue
 		}
-		break
+
+		response, err := bufio.NewReader(sock).ReadString('\n')
+		sock.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("read: %w", err)
+			continue
+		}
+		if response != expectResponse {
+			lastErr = fmt.Errorf("response %q != %q", response, expectResponse)
+			continue
+		}
+
+		return
 	}
+
+	t.Errorf("echo server on port %d did not respond correctly after %d attempts: %v", port, retries, lastErr)
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Address test flakes by:

* Using random names and tcp ports for instances.
* Broadening the retry in the `echo` function.
* Remove an incorrect `echo` call from testInstanceRun. The runscript for the test container does not start an echo server. The `echo` call was actually being performed against an echo server container remaining from other tests.
* Check the correct location for a logfile in `testInstanceRun`. Need to look in the correct homedir for the profile used.

The final two points are bugs, that were testing the wrong thing and only passing due to the presence of instances logs from prior tests. Exposed by the random instance naming / port changes.

### This fixes or addresses the following GitHub issues:

 - Fixes #4153


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/main/CONTRIBUTORS.md)
