### PR TITLE
chore/fix: bump go to 1.26.7, 26.04 to tagged release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,7 +476,7 @@ workflows:
       - build-deb:
           matrix:
             parameters:
-              e: ["ubuntu2204", "ubuntu2404"]
+              e: ["ubuntu2204", "ubuntu2404", "ubuntu2604"]
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.26.6'
+    default: '1.26.7'
 
 executors:
   node:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -163,7 +163,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.26.6 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.26.7 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz

--- a/e2e/testdata/Dockerfile.nested
+++ b/e2e/testdata/Dockerfile.nested
@@ -1,6 +1,6 @@
 FROM ubuntu:25.04
 
-ARG GOVERSION="go1.26.6"
+ARG GOVERSION="go1.26.7"
 ARG GOOS="linux"
 ARG GOARCH="amd64"
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin


### PR DESCRIPTION
See https://groups.google.com/g/golang-announce/c/qA6Vpj2UA-4/m/BwmF6KTTBAAJ

Also add ubuntu 26.04 to tagged release job.